### PR TITLE
Add hostname in monitoring data

### DIFF
--- a/lib/httpcheck.js
+++ b/lib/httpcheck.js
@@ -92,8 +92,10 @@ var HttpChecker = {
 			server.site_status = SITE_CONFIRMED_DOWN;
 
 		if ( server.site_status !=  server.oldStatus ) {
+			var _os     = require( 'os' );
 			var resO    = {};
 			resO.type   = JETMON_CHECK;
+			resO.host   = _os.hostname();
 			resO.status = server.site_status;
 			resO.rtt    = Math.round( rtt / 1000 );
 			resO.code   = http_code;

--- a/lib/jetmon.js
+++ b/lib/jetmon.js
@@ -237,7 +237,7 @@ function freeWorkersToWork() {
 			workerMsgCallback( { msgtype: 'send_work', worker_pid: tmpWorkers[i] } );
 }
 
-function checkHostStatus( data ) {
+function checkHostStatus( veriflier_host, data ) {
 	for( var loop = 0; loop < queuedRetries.length; loop++ ) {
 		if ( queuedRetries[ loop ].blog_id != data.blog_id ) {
 			continue;
@@ -246,6 +246,7 @@ function checkHostStatus( data ) {
 		queuedRetries[ loop ].last_activity = new Date().valueOf();
 		var replyO    = {};
 		replyO.type   = VERIFLIER_CHECK;
+		replyO.host   = veriflier_host;
 		replyO.status = data.status;
 		replyO.rtt    = data.rtt;
 		replyO.code   = data.code;
@@ -278,12 +279,12 @@ function sslWorkerCallBack( msg ) {
 	try {
 		switch ( msg.msgtype ) {
 			case 'host_status': {
-				checkHostStatus( msg.payload );
+				checkHostStatus( msg.payload.veriflier_host, msg.payload );
 				break;
 			}
 			case 'host_status_array': {
 				for( var loop = 0; loop < msg.payload.checks.length; loop++ ) {
-					checkHostStatus( msg.payload.checks[ loop ] );
+					checkHostStatus( msg.payload.veriflier_host, msg.payload.checks[ loop ] );
 				}
 				break;
 			}

--- a/lib/server.js
+++ b/lib/server.js
@@ -74,6 +74,7 @@ var https_server = function() {
 						for ( var count in veriflierArray ) {
 							if ( req.auth_token == veriflierArray[ count ].auth_token ) {
 								veriflier = true;
+								req.veriflier_host = veriflierArray[ count ].host;
 								break;
 							}
 						}
@@ -119,6 +120,7 @@ var https_server = function() {
 				for ( var count in veriflierArray ) {
 					if ( req.auth_token == veriflierArray[ count ].auth_token ) {
 						veriflier = true;
+						req.veriflier_host = veriflierArray[ count ].host;
 						break;
 					}
 				}


### PR DESCRIPTION
Adds veriflier/jetmon hostname in monitoring data we send to WPCOM.

### Testing instructions

**Pre-requisites**
- A JN site with Jetpack plugin active and fully connected
- Downtime monitoring should be also on (Jetpack settings -> Downtime monitoring )

**Jetmon status running**
- Update your test site's `site_status` in the DB to be 0: `update jetpack_monitor_subscription set site_status=0 where blog_id=WPCOM_SITE_ID`
- Make sure your site is up and running
- Restart jetmon with `docker compose stop jetmon` and `docker compose start jetmon`
- Monitor ES and verify that `host` is now logged

**Jetmon status down**
- You'll need to manually update `PEER_OFFLINE_LIMIT` to 1 in `jetmon.js` [here](https://github.com/Automattic/jetmon/blob/add-ttfb-jetmon/lib/jetmon.js#L26): This determines how many peers have to confirm that the site is down before a notification email is sent. By default it's 3, however on our local envs we only run a single veriflier service, therefore we need to set this to 1 to actually send the monitoring data to WPCOM
- Update your test site's `site_status` in the DB to be 1: `update jetpack_monitor_subscription set site_status=1 where blog_id=WPCOM_SITE_ID`
- Bring your site down
- Restart jetmon with `docker compose stop jetmon` and `docker compose start jetmon`
- Monitor ES and verify that `host` is now logged in both Jetmon and Veriflier checks results