### PR TITLE
WPCOM Notification: add `monitor_url` to the status change notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The Veriflier service, which is written in C++ and uses the QT Framework, does s
 
 Here are the current notification data, Jetmon sends to WPCOM upon detecting a site status change:
 - `blog_id`: The site's WPCOM ID
-- `monitor_url`: The status change URL
+- `monitor_url`: The URL Jetmon checked
 - `status_id`: The site's current status. Enum: `0` is status down, `1` is status running and `2` status confirmed down.
 - `last_check`: The datetime of the last check
 - `last_status_change`: The datetime of the last status change

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The Veriflier service, which is written in C++ and uses the QT Framework, does s
 
 Here are the current notification data, Jetmon sends to WPCOM upon detecting a site status change:
 - `blog_id`: The site's WPCOM ID
+- `monitor_url`: The status change URL
 - `status_id`: The site's current status. Enum: `0` is status down, `1` is status running and `2` status confirmed down.
 - `last_check`: The datetime of the last check
 - `last_status_change`: The datetime of the last status change

--- a/lib/wpcom.js
+++ b/lib/wpcom.js
@@ -11,6 +11,7 @@ var wpcom = {
 		try {
 			var o_request                = {};
 			o_request.blog_id            = serverObject.blog_id;
+			o_request.monitor_url        = serverObject.monitor_url;
 			o_request.status_id          = serverObject.site_status;
 			o_request.last_check         = new Date( serverObject.lastCheck );
 			o_request.last_status_change = new Date( serverObject.last_status_change );
@@ -29,7 +30,7 @@ var wpcom = {
 				rejectUnauthorized: false,
 			};
 
-			logger.trace( 'setting blogid ' + o_request.blog_id + ' status ' + o_request.status_id );
+			logger.trace( 'setting blogid ' + o_request.blog_id + ' status ' + o_request.status_id + ', URL: ' + serverObject.monitor_url );
 
 			var response_handler = function( res ) {
 				res.setEncoding( 'utf8' );

--- a/lib/wpcom.js
+++ b/lib/wpcom.js
@@ -30,7 +30,7 @@ var wpcom = {
 				rejectUnauthorized: false,
 			};
 
-			logger.trace( 'setting blogid ' + o_request.blog_id + ' status ' + o_request.status_id + ', URL: ' + serverObject.monitor_url );
+			logger.trace( 'setting blogid ' + o_request.blog_id + ' status ' + o_request.status_id + ', URL: ' + o_request.monitor_url );
 
 			var response_handler = function( res ) {
 				res.setEncoding( 'utf8' );


### PR DESCRIPTION
### Proposed changes:
- Add `monitor_url` parameter to the status change notification API request

### Product discussion
1203864181845207-as-1203865346770722

### Testing instructions

**Pre-requisites**
- A JN site with Jetpack plugin active and fully connected
- Downtime monitoring should be also on (Jetpack settings -> Downtime monitoring )
- Use your WPCOM sandbox with D100095-code checked out.

**Jetmon status running**
- Update your test site's `site_status` in the DB to be 0: `update jetpack_monitor_sites set site_status=0 where blog_id=WPCOM_SITE_ID`
- Make sure your site is up and running
- Restart jetmon with `docker compose stop jetmon` and `docker compose start jetmon`
- Monitor ES and verify that `monitor_url` is logged correctly

**Jetmon status down**
- You'll need to manually update `PEER_OFFLINE_LIMIT` to 1 in `jetmon.js` [here](https://github.com/Automattic/jetmon/blob/add-ttfb-jetmon/lib/jetmon.js#L26): This determines how many peers have to confirm that the site is down before a notification email is sent. By default it's 3, however on our local envs we only run a single veriflier service, therefore we need to set this to 1 to actually send the monitoring data to WPCOM
- Update your test site's `site_status` in the DB to be 1: `update jetpack_monitor_sites set site_status=1 where blog_id=WPCOM_SITE_ID`
- Bring your site down
- Restart jetmon with `docker compose stop jetmon` and `docker compose start jetmon`
- Monitor ES and verify that `monitor_url` is logged correctly