### PR TITLE
Move hostname definition outside of processResultsCallback

### DIFF
--- a/lib/httpcheck.js
+++ b/lib/httpcheck.js
@@ -64,7 +64,7 @@ var logger  = o_log4js.getLogger( 'flog' );
 var slogger = o_log4js.getLogger( 'slog' );
 
 var _os         = require( 'os' );
-var hostname = _os.hostname();
+var hostname    = _os.hostname();
 
 var HttpChecker = {
 	checkServers: function() {

--- a/lib/httpcheck.js
+++ b/lib/httpcheck.js
@@ -63,6 +63,9 @@ o_log4js.PatternLayout = '%d{HH:mm:ss,SSS} p m';
 var logger  = o_log4js.getLogger( 'flog' );
 var slogger = o_log4js.getLogger( 'slog' );
 
+var _os         = require( 'os' );
+var hostname = _os.hostname();
+
 var HttpChecker = {
 	checkServers: function() {
 		try {
@@ -92,10 +95,9 @@ var HttpChecker = {
 			server.site_status = SITE_CONFIRMED_DOWN;
 
 		if ( server.site_status !=  server.oldStatus ) {
-			var _os     = require( 'os' );
 			var resO    = {};
 			resO.type   = JETMON_CHECK;
-			resO.host   = _os.hostname();
+			resO.host   = hostname;
 			resO.status = server.site_status;
 			resO.rtt    = Math.round( rtt / 1000 );
 			resO.code   = http_code;


### PR DESCRIPTION
No reason to define the hostname inside processResultsCallback.

Make jetmon more performant by defining the hostname once, in the beginning of `httpcheck.js` instead