### PR TITLE
Improvement/janitorial: Better handling of missing workers

### DIFF
--- a/lib/jetmon.js
+++ b/lib/jetmon.js
@@ -136,15 +136,6 @@ process.on( 'SIGHUP', function() {
 		if ( undefined !== arrWorkers[ count ] )
 			arrWorkers[ count ].send( { pid : arrWorkers[ count ].pid, request : 'config-update' } );
 	}
-
-	// TODO this should be handled periodically, not here
-	var newWorkerCount = global.config.get( 'NUM_WORKERS' );
-	if ( arrWorkers.length < newWorkerCount ) {
-		logger.debug( 'spawning ' + ( newWorkerCount - arrWorkers.length ) + ' new workers' );
-		for ( var loop = 0; loop < ( newWorkerCount - arrWorkers.length ); loop++ ) {
-			spawnWorker();
-		}
-	}
 });
 
 process.on( 'uncaughtException', function( errDesc ) {
@@ -154,7 +145,7 @@ process.on( 'uncaughtException', function( errDesc ) {
 function spawnWorker() {
 	var worker = child_proc.fork('./lib/httpcheck.js' );
 
-	statsdClient.increment('worker.spawn.count');
+	statsdClient.increment('worker.spawn.new.count');
 
 	worker.on( 'message', workerMsgCallback );
 	worker.on( 'exit', function( code, signal ) {
@@ -523,6 +514,9 @@ function updateStats() {
 			totalFile.end();
 		});
 
+		/**
+		 * Push some of the stats to StatsD
+		 */
 		statsdClient.increment( 'stats.sites.sps.count', sitesCount );
 		statsdClient.increment( 'stats.sites.error.count', gCountError );
 		statsdClient.increment( 'stats.sites.offline.count', gCountOffline );
@@ -618,10 +612,41 @@ function processQueuedRetries() {
 		freeWorkersToWork();
 }
 
-// Create all our workers
-for ( var loop = 0; loop < global.config.get( 'NUM_WORKERS' ); loop++ ) {
-	spawnWorker();
+
+
+/**
+ * Ensures that we're always at NUM_WORKERS count.
+ * @param first_usage If this call is the initial spawn of workers when Jetmon has started.
+ */
+function ensure_worker_count( first_usage = false ) {
+	const max_worker_count = global.config.get( 'NUM_WORKERS' );
+	const current_worker_count = arrWorkers.length;
+
+	if ( current_worker_count < max_worker_count ) {
+		const new_worker_count = max_worker_count - current_worker_count;
+
+		logger.debug( `Missing workers, spawning: ${new_worker_count} new workers` );
+
+		/**
+		 * Only log the missing worker count if it's not the first spawn
+		 * after Jetmon has started.
+		 * This is done to avoid polluting the data with the occasional NUM_WORKERS peaks.
+		 */
+		if ( ! first_usage ) {
+			statsdClient.increment( 'worker.spawn.missing.count', new_worker_count );
+		}
+
+		for ( let loop = 0; loop < new_worker_count; loop++ ) {
+			spawnWorker();
+		}
+	}
 }
+
+/**
+ * Spawn the workers and start keeping track of the number of workers.
+ */
+ensure_worker_count( true );
+setInterval( ensure_worker_count, SECONDS );
 
 // Start the SSL cluster
 cluster.setupMaster( {


### PR DESCRIPTION
This PR introduces new logic to keep track of missing workers and respawning them. 

This is a first step in series of PR to unify the track of how many workers are up and to make sure we're always at the proper count.

Follow up PRs would reduce most of the ad-hoc `spawnWorker` calls and centralize the logic to the introduced method.

### Testing instructions

1. Apply PR
2. Run Jetmon
3. Make sure the `NUM_WORKERS` were spawned and the log has the entry for that
4. Go into the Docker container and try to kill random workers.
5. Make sure they are spawned and the appropriate log message was added.