### PR TITLE
Stats: Add more stats to track the queue state when fetching new batch from the DB

### DIFF
--- a/lib/jetmon.js
+++ b/lib/jetmon.js
@@ -277,12 +277,23 @@ function getMoreSites() {
 		);
 		return;
 	}
+
+	/**
+	 * Write out how many items were still in the queue when we requested new batch of data
+	 */
+	statsdClient.increment( 'queue.items_left_in_queue_when_fetching_new.count', arrObjects.length );
+
+	const startTimeGetDbBatch = new Date().valueOf();
+
 	endOfRound = db_mysql.getNextBatch(
 		function( rows ) {
 			if ( ( undefined === rows ) || ( 0 === rows.length ) ) {
 				getMoreSites();
 				return;
 			}
+
+			const endTimeGetDbBatch = new Date().valueOf();
+			statsdClient.timing( 'db.get_next_batch', endTimeGetDbBatch - startTimeGetDbBatch );
 
 			for ( var i = 0; i < rows.length; i++ ) {
 				var server = rows[i];
@@ -397,6 +408,13 @@ function workerMsgCallback( msg ) {
 				});
 				break;
 			case 'send_work':
+				/**
+				 * Worker asked for work
+				 */
+
+				/**
+				 * There are more workers than needed, kindly ask the worker to shut down.
+				 */
 				if ( arrWorkers.length > global.config.get( 'NUM_WORKERS' ) ) {
 					var w = getWorker( msg.worker_pid );
 					if ( null !== w )
@@ -407,14 +425,23 @@ function workerMsgCallback( msg ) {
 						} );
 					break;
 				}
+
 				if ( 0 == arrObjects.length ) {
-					if ( -1 == freeWorkers.indexOf( msg.worker_pid ) )
+					/**
+					 * There are no URLs in the global queue, let's flag the worker as "free"
+					 * and request more sites from the database, if we haven't done so yet.
+					 */
+					if ( -1 == freeWorkers.indexOf( msg.worker_pid ) ) {
 						freeWorkers.push( msg.worker_pid );
+					}
 					if ( ! gettingSites ) {
 						gettingSites = true;
 						getMoreSites();
 					}
 				} else {
+					/**
+					 * There are items in the global queue, let's send them to the worker.
+					 */
 					var w = getWorker( msg.worker_pid );
 					if ( null !== w )
 						w.send( {


### PR DESCRIPTION
This PR adds two new metrics:

* Timer: `db.get_next_batch` - track how fast we fetch data from the database.
* Count: `queue.items_left_in_queue_when_fetching_new` - to track how many items are still in the queue when we fetch new batches of data. 

### To test

1. Apply PR
2. See if the new stats appear in the Graphite browser.