### PR TITLE
Stats: Better formatting for hostname, to allow better grouping of nodes in production

### DIFF
--- a/lib/jetmon.js
+++ b/lib/jetmon.js
@@ -86,7 +86,14 @@ logger.debug( 'booting jetmon.js' );
  */
 var _os     = require( 'os' );
 
-var currentHostname = _os.hostname();
+/**
+ * Hostnames on prod look like:
+ * 	jetmon1.dfw.wordpress.com
+ *
+ * We only need the first 2 pieces and flip them around to make easier to group/filter things in StatsD later.
+ * @type {string}
+ */
+const currentHostname = _os.hostname().split( '.' ).slice( 0, 2 ).reverse().join( '.' );
 
 /**
  * Set up the StatD client.
@@ -100,7 +107,7 @@ var statsdHostname = '127.0.0.1';
  * Add a workaround for the local Docker instances, as prod is running statsd proxies on 127.0.0.1,
  * while the Docker nodes run it in the `statsd` container.
  */
-if ( currentHostname === 'docker.jetmon.dev.com' ) {
+if ( currentHostname === 'jetmon.docker' ) {
 	statsdHostname = 'statsd';
 }
 

--- a/lib/jetmon.js
+++ b/lib/jetmon.js
@@ -88,7 +88,7 @@ var _os     = require( 'os' );
 
 /**
  * Hostnames on prod look like:
- * 	jetmon1.dfw.wordpress.com
+ * 	<node>.<datacenter>.<domain>
  *
  * We only need the first 2 pieces and flip them around to make easier to group/filter things in StatsD later.
  * @type {string}


### PR DESCRIPTION
This PR changes how we format the current hostname when we want to use it for logging stats in StatsD to allow better grouping of the data.

### To test

1. Apply PR.
2. Add a `console.log` after the hostname is generated.
3. Make sure it makes sense.