### PR TITLE
Stats: Track more worker-specific stats for all the sites - rtt, status code, etc.

### DIFF
--- a/lib/httpcheck.js
+++ b/lib/httpcheck.js
@@ -74,6 +74,8 @@ var slogger = o_log4js.getLogger( 'slog' );
 var _os         = require( 'os' );
 var hostname    = _os.hostname();
 
+const statsdClient = require( './statsd.js' );
+
 var HttpChecker = {
 	checkServers: function() {
 		try {
@@ -100,13 +102,21 @@ var HttpChecker = {
 		server.processed = true;
 		server.lastCheck = new Date().valueOf();	// we use set the value to the milliseconds value
 
-		if ( rtt > 0 && 400 > http_code && 0 != http_code )
+		if ( rtt > 0 && 400 > http_code && 0 != http_code ) {
 			server.site_status = SITE_RUNNING;
-		else if ( ( SITE_RUNNING == server.oldStatus ) ||
-				( SITE_CONFIRMED_DOWN != server.oldStatus ) && ( new Date().valueOf() < ( server.last_status_change + ( config.get( 'TIME_BETWEEN_NOTICES_MIN' ) * MINUTES ) ) ) )
+		}
+		else if (
+			( SITE_RUNNING == server.oldStatus ) ||
+			(
+				( SITE_CONFIRMED_DOWN != server.oldStatus ) &&
+				( new Date().valueOf() < ( server.last_status_change + ( config.get( 'TIME_BETWEEN_NOTICES_MIN' ) * MINUTES ) ) )
+			)
+		) {
 			server.site_status = SITE_DOWN;
-		else
+		}
+		else {
 			server.site_status = SITE_CONFIRMED_DOWN;
+		}
 
 		if ( server.site_status !=  server.oldStatus ) {
 			var resO    = {};
@@ -160,6 +170,33 @@ var HttpChecker = {
 				running = false;
 			}
 		}
+
+
+		/**
+		 * Log some information in StatsD.
+		 *
+		 * Doing in the end to make sure we send all the data to appropriate consumers first and
+		 * only then we can try to log the data.
+		 */
+		let stats_site_status = '';
+
+		switch ( server.SITE_STATUS ) {
+			case SITE_RUNNING:
+				stats_site_status = 'up';
+				break;
+
+			case SITE_DOWN:
+				stats_site_status = 'down';
+				break;
+
+			case SITE_CONFIRMED_DOWN:
+				stats_site_status = 'still_down';
+				break;
+		}
+
+		statsdClient.increment( `worker.check.${stats_site_status}.code.${http_code}.count` );
+		statsdClient.timing( `worker.check.${stats_site_status}.rtt`, Math.round( rtt / 1000 ) );
+
 	},
 
 	addToQueue: function( arrData ) {

--- a/lib/jetmon.js
+++ b/lib/jetmon.js
@@ -62,7 +62,7 @@ var wpcom    = require( './wpcom'    );
 var comms    = require( './comms'    );
 var cluster  = require( 'cluster'    );
 
-// var http     = require( 'http'       );
+const statsdClient = require('./statsd.js');
 
 var gCountSuccess   = 0;
 var gCountError     = 0;
@@ -80,48 +80,6 @@ var endOfRound      = false;
 global.queuedRetries = [];
 
 logger.debug( 'booting jetmon.js' );
-
-/**
- * Used to get the hostname of the current host, so we can have per-host monitoring of things.
- */
-var _os     = require( 'os' );
-
-/**
- * Hostnames on prod look like:
- * 	<node>.<datacenter>.<domain>
- *
- * We only need the first 2 pieces and flip them around to make easier to group/filter things in StatsD later.
- * @type {string}
- */
-const currentHostname = _os.hostname().split( '.' ).slice( 0, 2 ).reverse().join( '.' );
-
-/**
- * Set up the StatD client.
- *
- * All entries are prefixed with `com.jetpack.jetmon.<hostname>.`
- */
-
-var statsdHostname = '127.0.0.1';
-
-/**
- * Add a workaround for the local Docker instances, as prod is running statsd proxies on 127.0.0.1,
- * while the Docker nodes run it in the `statsd` container.
- */
-if ( currentHostname === 'jetmon.docker' ) {
-	statsdHostname = 'statsd';
-}
-
-var StatsD = require( 'hot-shots' );
-var statsdClient = new StatsD( {
-	host: statsdHostname,
-	port: 8125,
-	globalize: true,
-	prefix: 'com.jetpack.jetmon.' + currentHostname + '.',
-	errorHandler: function( error ) {
-		console.log( "Socket errors caught here: ", error );
-		logger.debug( 'Adding error log' + error );
-	},
-} );
 
 process.on( 'SIGINT',  gracefulShutdown );
 process.on( 'EXIT',    gracefulShutdown );

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -1,0 +1,39 @@
+const os = require('os');
+
+/**
+ * Hostnames on prod look like:
+ * 	<node>.<datacenter>.<domain>
+ *
+ * We only need the first 2 pieces and flip them around to make easier to group/filter things in StatsD later.
+ * @type {string}
+ */
+const currentHostname = os.hostname().split( '.' ).slice( 0, 2 ).reverse().join( '.' );
+
+/**
+ * Set up the StatD client.
+ *
+ * All entries are prefixed with `com.jetpack.jetmon.<hostname>.`
+ */
+let statsdHostname = '127.0.0.1';
+
+/**
+ * Add a workaround for the local Docker instances, as prod is running statsd proxies on 127.0.0.1,
+ * while the Docker nodes run it in the `statsd` container.
+ */
+if ( currentHostname === 'jetmon.docker' ) {
+	statsdHostname = 'statsd';
+}
+
+const StatsD = require( 'hot-shots' );
+const statsdClient = new StatsD( {
+	host: statsdHostname,
+	port: 8125,
+	globalize: true,
+	prefix: 'com.jetpack.jetmon.' + currentHostname + '.',
+	errorHandler: function( error ) {
+		console.log( "Socket errors caught here: ", error );
+		logger.debug( 'Adding error log' + error );
+	},
+} );
+
+module.exports = statsdClient;


### PR DESCRIPTION
This PR adds more stats that we would track from the workers, to have better picture of how the service is performing.

Introduces two new metrics:
* Counter: `worker.check.${stats_site_status}.code.${http_code}` - counts of what results we get from different sites
* Timer: `worker.check.${stats_site_status}.rtt` - timings of `rtt` for sites, 

Breakdown for both metrics is by `stats_site_status` ( `up`, `down`, `still_down` ).

Also included in the PR is a refactor of how we include the `hot-shots` library to make it portable between the main Jetmon process and the workers.

### To test

1. Apply PR
2. Run Jetmon
3. Make sure Jetmon is working
4. Make sure Jetmon is spawning workers as expected
5. Make sure the two new metrics show up in the Graphite explorer.