### PR TITLE
Stats: Track how long each round takes

### DIFF
--- a/lib/jetmon.js
+++ b/lib/jetmon.js
@@ -217,7 +217,11 @@ function resetVariables() {
 function getMoreSites() {
 	gettingSites = true;
 	if ( endOfRound ) {
-		var timeToNextLoop = ( global.config.get( 'MIN_TIME_BETWEEN_ROUNDS_SEC' ) * SECONDS ) - ( new Date().valueOf() - startTime );
+		var timeSinceStart = new Date().valueOf() - startTime;
+		var timeToNextLoop = ( global.config.get( 'MIN_TIME_BETWEEN_ROUNDS_SEC' ) * SECONDS ) - timeSinceStart;
+
+		statsdClient.gauge( 'round.time', timeSinceStart );
+
 		setTimeout( function() {
 				resetVariables();
 				getMoreSites();


### PR DESCRIPTION
This PR adds a new stat, `round.time`, which tracks how long a complete round of checks takes. This information can be derived from other stats, but I thought it would be helpful to have a new stat that explicitly tracks this value.

I'm tracking the value using the gauge feature of StatsD. The timer feature didn't seem appropriate as, at most, one value per flush interval will be present, negating most of the benefit of that feature. If someone has a better idea of how to track this value, feel free to submit your change to this PR.

### Testing
 - Apply the PR.
 - Run Jetmon.
 - Verify that the `stats.gauges.com.jetpack.jetmon.jetmon.docker.round.time` metric is present in Graphite and updating each round to indicate how long that round took in ms.