### PR TITLE
Fix: Corrected site_status var and set default val

### DIFF
--- a/lib/httpcheck.js
+++ b/lib/httpcheck.js
@@ -178,9 +178,9 @@ var HttpChecker = {
 		 * Doing in the end to make sure we send all the data to appropriate consumers first and
 		 * only then we can try to log the data.
 		 */
-		let stats_site_status = '';
+		let stats_site_status = 'unknown';
 
-		switch ( server.SITE_STATUS ) {
+		switch ( server.site_status ) {
 			case SITE_RUNNING:
 				stats_site_status = 'up';
 				break;

--- a/lib/httpcheck.js
+++ b/lib/httpcheck.js
@@ -178,7 +178,7 @@ var HttpChecker = {
 		 * Doing in the end to make sure we send all the data to appropriate consumers first and
 		 * only then we can try to log the data.
 		 */
-		let stats_site_status = 'unknown';
+		let stats_site_status = server.site_status;
 
 		switch ( server.site_status ) {
 			case SITE_RUNNING:


### PR DESCRIPTION
This PR fixes a couple issues with the site status tracking in `httpcheck.js`. One usage of `server.site_status` incorrectly capitalized it as `server.SITE_STATUS`. The `stats_site_status` variable didn't have a default value. This caused bad metric names such as `com.jetpack.jetmon.dca.jetmon1.worker.check..code.200.count`. The update sets a default value of the raw `server.site_status` value. This should aid in debugging when unhandled values are found.

### Testing

 - Apply the PR.
 - Run Jetmon.
 - Verify that `worker.check` metrics, such as `stats.com.jetpack.jetmon.jetmon.docker.worker.check.up.code.200.count` are populating.