### PR TITLE
Stats: Add metric buffering

### DIFF
--- a/lib/httpcheck.js
+++ b/lib/httpcheck.js
@@ -29,7 +29,7 @@ var config   = require( './config' );
 config.load();
 
 var arrCheck      = [];
-var running	      = false;
+var running       = false;
 var askedForWork  = false;
 var suicideSignal = false;
 var pointer       = 0;
@@ -46,6 +46,8 @@ var workerTotals = {};
 workerTotals[SITE_DOWN] = 0;
 workerTotals[SITE_RUNNING] = 0;
 workerTotals[SITE_CONFIRMED_DOWN] = 0;
+
+var checkStats = {};
 
 o_log4js.configure( {
   appenders: [ {
@@ -73,8 +75,6 @@ var slogger    = o_log4js.getLogger( 'slog' );
 
 var _os         = require( 'os' );
 var hostname    = _os.hostname();
-
-const statsdClient = require( './statsd.js' );
 
 var HttpChecker = {
 	checkServers: function() {
@@ -173,12 +173,12 @@ var HttpChecker = {
 
 
 		/**
-		 * Log some information in StatsD.
+		 * Store stats data to send to the parent later.
 		 *
 		 * Doing in the end to make sure we send all the data to appropriate consumers first and
 		 * only then we can try to log the data.
 		 */
-		let stats_site_status = server.site_status;
+		let stats_site_status = 'unknown';
 
 		switch ( server.site_status ) {
 			case SITE_RUNNING:
@@ -194,9 +194,28 @@ var HttpChecker = {
 				break;
 		}
 
-		statsdClient.increment( `worker.check.${stats_site_status}.code.${http_code}.count` );
-		statsdClient.timing( `worker.check.${stats_site_status}.rtt`, Math.round( rtt / 1000 ) );
+		const stats_rtt = Math.round( rtt / 1000 );
 
+		if ( checkStats[stats_site_status] ) {
+			checkStats[stats_site_status]['http_code'][http_code] = ( checkStats[stats_site_status]['http_code'][http_code] || 0 ) + 1;
+
+			checkStats[stats_site_status]['rtt']['count']++;
+			checkStats[stats_site_status]['rtt']['sum'] += stats_rtt;
+			checkStats[stats_site_status]['rtt']['max']  = Math.max( checkStats[stats_site_status]['rtt']['max'], stats_rtt );
+			checkStats[stats_site_status]['rtt']['min']  = Math.min( checkStats[stats_site_status]['rtt']['min'], stats_rtt );
+		} else {
+			checkStats[stats_site_status] = {
+				'http_code': {},
+				'rtt':       {
+					'count': 1,
+					'sum':   stats_rtt,
+					'max':   stats_rtt,
+					'min':   stats_rtt
+				}
+			};
+
+			checkStats[stats_site_status]['http_code'][http_code] = 1;
+		}
 	},
 
 	addToQueue: function( arrData ) {
@@ -286,9 +305,12 @@ setInterval( function() {
 			queueLength:  arrCheck.length,
 			pointer:      pointer,
 			activeChecks: activeChecks,
-			memoryUsage:  process.memoryUsage().rss
+			memoryUsage:  process.memoryUsage().rss,
+			checkStats:   checkStats
 		}
 	};
+
+	checkStats = {};
 
 	process.send( message );
 }, 1000 );

--- a/lib/jetmon.js
+++ b/lib/jetmon.js
@@ -74,6 +74,7 @@ var localRetries    = [];
 var freeWorkers     = [];
 var arrWorkers      = [];
 var workerStats     = {};
+var checkStats      = {};
 var gettingSites    = false;
 var endOfRound      = false;
 
@@ -416,6 +417,28 @@ function workerMsgCallback( msg ) {
 
 			case 'stats':
 				if ( msg.stats ) {
+					// Update global checkStats var with data from the worker.
+					for ( let site_status in msg.stats.checkStats ) {
+						if ( checkStats[site_status] ) {
+							for ( let http_code in msg.stats.checkStats[site_status]['http_code'] ) {
+								if ( checkStats[site_status]['http_code'][http_code] ) {
+									checkStats[site_status]['http_code'][http_code] += msg.stats.checkStats[site_status]['http_code'][http_code];
+								} else {
+									checkStats[site_status]['http_code'][http_code] = msg.stats.checkStats[site_status]['http_code'][http_code];
+								}
+							}
+							checkStats[site_status]['rtt']['count'] += msg.stats.checkStats[site_status]['rtt']['count'];
+							checkStats[site_status]['rtt']['sum']   += msg.stats.checkStats[site_status]['rtt']['sum'];
+							checkStats[site_status]['rtt']['max']    = Math.max( checkStats[site_status]['rtt']['max'], msg.stats.checkStats[site_status]['rtt']['max'] );
+							checkStats[site_status]['rtt']['min']    = Math.min( checkStats[site_status]['rtt']['min'], msg.stats.checkStats[site_status]['rtt']['min'] );
+						} else {
+							checkStats[site_status] = msg.stats.checkStats[site_status];
+						}
+					}
+
+					// Remove checkStats as it is not needed for workerStats.
+					delete msg.stats.checkStats;
+
 					workerStats[msg.worker_pid] = msg.stats;
 				}
 				break;
@@ -488,6 +511,18 @@ function updateStats() {
 		statsdClient.increment( 'stats.workers.free.count', freeWorkers.length );
 		statsdClient.increment( 'stats.workers.working.count', ( arrWorkers.length - freeWorkers.length ) );
 
+		for ( let site_status in checkStats ) {
+			for ( let http_code in checkStats[site_status]['http_code'] ) {
+				statsdClient.increment( `worker.check.${site_status}.code.${http_code}.count`, checkStats[site_status]['http_code'][http_code] );
+			}
+
+			let rtt_avg = Math.round( checkStats[site_status]['rtt']['sum'] / checkStats[site_status]['rtt']['count'] );
+			statsdClient.gauge( `worker.check.${site_status}.rtt.avg`, rtt_avg );
+			statsdClient.gauge( `worker.check.${site_status}.rtt.max`, checkStats[site_status]['rtt']['max'] );
+			statsdClient.gauge( `worker.check.${site_status}.rtt.min`, checkStats[site_status]['rtt']['min'] );
+		}
+
+		checkStats = {};
 	}
 	catch  ( Exception ) {
 		logger.error( 'Error updating stats files: ' + Exception.toString() );

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -49,8 +49,7 @@ const statsdClient = {
 		this.maxBufferSize = mtu - 29; // Reduce by 29 to account for packet headers.
 		this.logger        = logger;
 
-		this.buffer       = Buffer.allocUnsafe( this.maxBufferSize );
-		this.bufferLength = 0;
+		this.buffer = '';
 
 		this.socket = dgram.createSocket( 'udp4' );
 		this.socket.on( 'error', (error) => this.logger.error( error ) );
@@ -74,22 +73,20 @@ const statsdClient = {
 
 	send: function( message ) {
 		message = `${this.prefix}${message}\n`;
-		const messageLength = message.length;
 
 		// If the total buffer size is already at the maximum size, flush it first
-		if ( this.bufferLength + messageLength >= this.maxBufferSize ) {
+		if ( this.buffer.length + message.length >= this.maxBufferSize ) {
 			this.flush();
 		}
 
-		// Copy the message to the buffer
-		this.buffer.write(message, this.bufferLength, messageLength);
-		this.bufferLength += messageLength;
+		// Append the message to the buffer
+		this.buffer += message;
 	},
 
 	flush: function() {
-		if ( this.bufferLength > 0 ) {
-			const buffer = this.buffer.slice( 0, this.bufferLength );
-			this.bufferLength = 0;
+		if ( this.buffer.length > 0 ) {
+			const buffer = this.buffer;
+			this.buffer = '';
 			try {
 				this.socket.send( buffer, this.port, this.host, (error) => {
 					if ( error ) {

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -18,53 +18,97 @@ const currentHostname = os.hostname().split( '.' ).slice( 0, 2 ).reverse().join(
 let statsdHostname = '127.0.0.1';
 
 /**
+ * The MTU of the network connection that sends StatsD metrics is used to
+ * determine the max buffer size.
+ */
+let statsdMTU = 65536;
+
+/**
+ * The number of milliseconds that can elapse before buffered StatsD metrics are
+ * flushed.
+ */
+let statsdFlushInterval = 5000;
+
+/**
  * Add a workaround for the local Docker instances, as prod is running statsd proxies on 127.0.0.1,
  * while the Docker nodes run it in the `statsd` container.
  */
 if ( currentHostname === 'jetmon.docker' ) {
 	statsdHostname = 'statsd';
+	statsdMTU = 1500;
 }
 
 const prefix = 'com.jetpack.jetmon.' + currentHostname + '.';
 
-/**
- * Start as null as the send function will recreate the variable as needed.
- */
-let socket = null;
 
 const statsdClient = {
-	increment: function( metric, value ) {
-		if ( typeof value === 'undefined' ) {
-			value = 1;
-		}
-		statsdClient.send( metric, value, 'c' );
+	init: function( prefix, host, port, mtu, flushInterval, logger ) {
+		this.prefix        = prefix;
+		this.host          = host;
+		this.port          = port;
+		this.maxBufferSize = mtu - 29; // Reduce by 29 to account for packet headers.
+		this.logger        = logger;
+
+		this.buffer       = Buffer.allocUnsafe( this.maxBufferSize );
+		this.bufferLength = 0;
+
+		this.socket = dgram.createSocket( 'udp4' );
+		this.socket.on( 'error', (error) => this.logger.error( error ) );
+
+		this.interval = setInterval( () => {
+			this.flush();
+		}, flushInterval );
 	},
 
-	timing: function( metric, time ) {
-		statsdClient.send( metric, time, 'ms' );
+	increment: function( metric, value = 1, sampleRate = 1) {
+		this.send( `${metric}:${value}|c|@${sampleRate}` );
+	},
+
+	timing: function( metric, value, sampleRate = 1 ) {
+		this.send( `${metric}:${value}|ms|@${sampleRate}` );
 	},
 
 	gauge: function( metric, value ) {
-		statsdClient.send( metric, value, 'g' );
+		this.send( `${metric}:${value}|g` );
 	},
 
-	send: function( metric, value, type ) {
-		let message = prefix + metric + ':' + value + '|' + type;
+	send: function( message ) {
+		message = `${this.prefix}${message}\n`;
+		const messageLength = message.length;
 
-		try {
-			if ( ! socket ) {
-				socket = dgram.createSocket( 'udp4' );
+		// If the total buffer size is already at the maximum size, flush it first
+		if ( this.bufferLength + messageLength >= this.maxBufferSize ) {
+			this.flush();
+		}
+
+		// Copy the message to the buffer
+		this.buffer.write(message, this.bufferLength, messageLength);
+		this.bufferLength += messageLength;
+	},
+
+	flush: function() {
+		if ( this.bufferLength > 0 ) {
+			const buffer = this.buffer.slice( 0, this.bufferLength );
+			this.bufferLength = 0;
+			try {
+				this.socket.send( buffer, this.port, this.host, (error) => {
+					if ( error ) {
+						this.logger.error( 'Error when sending to statsd: ' + error.toString() );
+					}
+				});
 			}
-			socket.send( message, 8125, statsdHostname, (err) => {
-				if ( err ) {
-					logger.error( 'Error when sending to statsd: ' + err.toString() );
-				}
-			});
+			catch ( Exception ) {
+				this.logger.error( 'Exception when sending to statsd: ' + Exception.toString() );
+			}
 		}
-		catch ( Exception ) {
-			logger.error( 'Exception when sending to statsd: ' + Exception.toString() );
-		}
+	},
+
+	close: function() {
+		clearInterval( this.interval );
+		this.socket.close();
 	}
 }
+
+statsdClient.init( prefix, statsdHostname, 8125, statsdMTU, statsdFlushInterval, logger );
 
 module.exports = statsdClient;


### PR DESCRIPTION
Per a request from Systems, this PR adds buffering for StatsD metrics. The buffer flushes when one of two conditions is met:

1. Trying to queue a new metric would cause the buffer to grow larger than the max buffer size.
2. A 5-second interval has elapsed and the buffer is not empty.

The max buffer size is calculated from the MTU size of the network connection that sends UDP packets to the StatsD service. The MTU value is currently hard-coded to a value of `65536` and is overridden to `1500` when running in a development Docker environment. The goal of using the MTU value is to ensure that max packet sizes are used to increase efficiency.

This code has some room for some needed enhancements, primarily the ability to control the host, port, MTU, and flush interval via the config file. For simplicity of testing, and the ability to easily apply this change to production, this enhancement has been left out of this PR. However, if making the config change on production can be easily done, this PR should be updated to allow control of those values via the config file.

### Docker Testing

 - Apply the PR.
 - Run Jetmon.
 - Verify that stats still populate in Graphite (`127.0.0.1:8088`). The following are good metrics to check:
   - For increment, verify that `stats_counts.com.jetpack.jetmon.jetmon.docker.stats.workers.free.count` is updating properly.
   - For timing, verify that `stats.timers.com.jetpack.jetmon.jetmon.docker.db.get_next_batch.count` is updating properly.

### Production Server Testing

 - Follow the testing instructions provided by bisko at pMz3w-h0a-p2#comment-106587 to run a local test with `node test.js`. Modify the example code to have the timeout that is long enough to ensure that the 5-second delayed flush can execute.
 - Verify that the test metric shows up in the StatsD data.