### PR TITLE
WPCOM API: make `last_status_change` nullable

### DIFF
--- a/lib/wpcom.js
+++ b/lib/wpcom.js
@@ -14,7 +14,7 @@ var wpcom = {
 			o_request.monitor_url        = serverObject.monitor_url;
 			o_request.status_id          = serverObject.site_status;
 			o_request.last_check         = new Date( serverObject.lastCheck );
-			o_request.last_status_change = new Date( serverObject.last_status_change );
+			o_request.last_status_change = serverObject.last_status_change ? new Date( serverObject.last_status_change ) : null;
 			o_request.checks             = serverObject.checks;
 			o_request.token              = global.config.get( 'AUTH_TOKEN' );
 


### PR DESCRIPTION
Fixes #19

### Proposed changes:
Adjust the status change API request to send `last_status_change: null` instead of forcing it to the 0-date (1970-01-01).

### Testing instructions
Not quite testable by itself, see D103289-code.