### PR TITLE
Stats: Migrate stats to use timing instead of gauge.

### DIFF
--- a/lib/jetmon.js
+++ b/lib/jetmon.js
@@ -221,7 +221,7 @@ function getMoreSites() {
 		var timeSinceStart = new Date().valueOf() - startTime;
 		var timeToNextLoop = ( global.config.get( 'MIN_TIME_BETWEEN_ROUNDS_SEC' ) * SECONDS ) - timeSinceStart;
 
-		statsdClient.gauge( 'round.time', timeSinceStart );
+		statsdClient.timing( 'round.time', timeSinceStart );
 
 		setTimeout( function() {
 				resetVariables();
@@ -517,9 +517,9 @@ function updateStats() {
 			}
 
 			let rtt_avg = Math.round( checkStats[site_status]['rtt']['sum'] / checkStats[site_status]['rtt']['count'] );
-			statsdClient.gauge( `worker.check.${site_status}.rtt.avg`, rtt_avg );
-			statsdClient.gauge( `worker.check.${site_status}.rtt.max`, checkStats[site_status]['rtt']['max'] );
-			statsdClient.gauge( `worker.check.${site_status}.rtt.min`, checkStats[site_status]['rtt']['min'] );
+			statsdClient.timing( `worker.check.${site_status}.rtt.avg`, rtt_avg );
+			statsdClient.timing( `worker.check.${site_status}.rtt.max`, checkStats[site_status]['rtt']['max'] );
+			statsdClient.timing( `worker.check.${site_status}.rtt.min`, checkStats[site_status]['rtt']['min'] );
 		}
 
 		checkStats = {};


### PR DESCRIPTION
We saw some issues with how Gauge stats are shown in Grafana and wanted to move the tracking to use the `timing` flow. 

### To test

1. Apply PR
2. Run Jetmon
3. See if stats appear under the `timing` keys, i.e. `stats.timers.com.jetpack.jetmon.<datacenter>.<host>.round.time`
4. Make sure Jetmon is working correctly