### PR TITLE
Stats: Add information about the queue sizes in the workers and how many active checks are running at the moment.

### DIFF
--- a/lib/httpcheck.js
+++ b/lib/httpcheck.js
@@ -306,7 +306,8 @@ setInterval( function() {
 			pointer:      pointer,
 			activeChecks: activeChecks,
 			memoryUsage:  process.memoryUsage().rss,
-			checkStats:   checkStats
+			checkStats:   checkStats,
+			uptime:       HttpChecker.getAge(),
 		}
 	};
 

--- a/lib/jetmon.js
+++ b/lib/jetmon.js
@@ -397,12 +397,13 @@ function workerMsgCallback( msg ) {
 					 * There are items in the global queue, let's send them to the worker.
 					 */
 					var w = getWorker( msg.worker_pid );
-					if ( null !== w )
+					if ( null !== w ) {
 						w.send( {
-							pid     : msg.worker_pid,
-							request : 'queue-add',
-							payload : arrObjects.splice( 0, Math.min( arrObjects.length, global.config.get( 'DATASET_SIZE' ) ) )
-					} );
+								pid     : msg.worker_pid,
+								request : 'queue-add',
+								payload : arrObjects.splice( 0, Math.min( arrObjects.length, global.config.get( 'DATASET_SIZE' ) ) )
+						} );
+					}
 				}
 				break;
 			case 'recheck':
@@ -440,6 +441,17 @@ function workerMsgCallback( msg ) {
 					delete msg.stats.checkStats;
 
 					workerStats[msg.worker_pid] = msg.stats;
+
+					const workerUptime = msg.stats.uptime;
+					if ( workerUptime > 5000 ) {
+						/**
+						 * Log only if the worker has been up for at least 5 seconds, to make sure we don't log
+						 * empty values at the beginning when the worker has just started, but hasn't received any work.
+						 */
+						statsdClient.increment( 'worker.queue.active', msg.stats.activeChecks )
+						statsdClient.increment( 'worker.queue.queue_size', msg.stats.queueLength );
+					}
+
 				}
 				break;
 			default:


### PR DESCRIPTION
This PR adds more stats that we can monitor about the workers health.

Introduces two new stats:

* `worker.queue.active` - how many items in the queue are currently being processed
* `worker.queue.queue_size` - how many items are in the queue currently for the worker.

### To test

* Apply PR
* Start Jetmon
* Make sure Jetmon works correctly
* Look for the new stats in the local Graphite browser

### Deploy notes

This will add about (# workers)*2 new datapoints each second. We need to make sure CPU usage doesn't go too high when deploying this PR.