### PR TITLE
Workers: Push work to the worker if it's queue is not saturated enough

### DIFF
--- a/lib/httpcheck.js
+++ b/lib/httpcheck.js
@@ -102,9 +102,6 @@ var HttpChecker = {
 		server.processed = true;
 		server.lastCheck = new Date().valueOf();	// we use set the value to the milliseconds value
 
-
-		process.send( { msgtype: 'processed', worker_pid: process.pid, item: server, pointer: pointer, queue_size: arrCheck.length } );
-
 		if ( rtt > 0 && 400 > http_code && 0 != http_code ) {
 			server.site_status = SITE_RUNNING;
 		}

--- a/lib/httpcheck.js
+++ b/lib/httpcheck.js
@@ -102,6 +102,9 @@ var HttpChecker = {
 		server.processed = true;
 		server.lastCheck = new Date().valueOf();	// we use set the value to the milliseconds value
 
+
+		process.send( { msgtype: 'processed', worker_pid: process.pid, item: server, pointer: pointer, queue_size: arrCheck.length } );
+
 		if ( rtt > 0 && 400 > http_code && 0 != http_code ) {
 			server.site_status = SITE_RUNNING;
 		}

--- a/lib/jetmon.js
+++ b/lib/jetmon.js
@@ -457,13 +457,9 @@ function workerMsgCallback( msg ) {
 					const maxParallel = global.config.get( 'NUM_TO_PROCESS' )
 
 					if ( queueLeftToProcess < maxParallel ) {
-						console.log( 'Worker has ', queueLeftToProcess, 'sending', global.config.get( 'DATASET_SIZE' ) - queueLeftToProcess );
 						assign_work_to_worker( msg.worker_pid, global.config.get( 'DATASET_SIZE' ) - queueLeftToProcess );
 					}
 				}
-				break;
-			case 'processed':
-				console.log('Processed from ', msg.worker_pid, msg.pointer, msg.queue_size);
 				break;
 			default:
 		}
@@ -511,8 +507,6 @@ function assign_work_to_worker( pid, size = null ) {
 	if ( !worker ) {
 		return false;
 	}
-
-	console.log( 'Sending items to ', worker.pid, dataset.length );
 
 	worker.send( {
 		pid: worker.pid,

--- a/lib/jetmon.js
+++ b/lib/jetmon.js
@@ -447,10 +447,19 @@ function workerMsgCallback( msg ) {
 
 					/**
 					 * Check if the worker's queue is less than what we want.
+					 *
+					 * If the worker's queue has less than NUM_TO_PROCESS items in there, we want to
+					 * push more, as it might be waiting for some longer-running ones to finish, before continuing.
+					 * This will keep the worker busier than before.
 					 */
+						// Math.max used to make sure that we don't go below zero and make crazy assumptions
+					const queueLeftToProcess = Math.max( 0, msg.stats.queueLength - msg.stats.pointer );
+					const maxParallel = global.config.get( 'NUM_TO_PROCESS' )
 
-					//console.log( 'Queue size for: ', msg.worker_pid, msg.stats.queueLength );
-
+					if ( queueLeftToProcess < maxParallel ) {
+						console.log( 'Worker has ', queueLeftToProcess, 'sending', global.config.get( 'DATASET_SIZE' ) - queueLeftToProcess );
+						assign_work_to_worker( msg.worker_pid, global.config.get( 'DATASET_SIZE' ) - queueLeftToProcess );
+					}
 				}
 				break;
 			case 'processed':

--- a/lib/jetmon.js
+++ b/lib/jetmon.js
@@ -396,14 +396,7 @@ function workerMsgCallback( msg ) {
 					/**
 					 * There are items in the global queue, let's send them to the worker.
 					 */
-					var w = getWorker( msg.worker_pid );
-					if ( null !== w ) {
-						w.send( {
-								pid     : msg.worker_pid,
-								request : 'queue-add',
-								payload : arrObjects.splice( 0, Math.min( arrObjects.length, global.config.get( 'DATASET_SIZE' ) ) )
-						} );
-					}
+					assign_work_to_worker( msg.worker_pid );
 				}
 				break;
 			case 'recheck':
@@ -452,7 +445,16 @@ function workerMsgCallback( msg ) {
 						statsdClient.increment( 'worker.queue.queue_size', msg.stats.queueLength );
 					}
 
+					/**
+					 * Check if the worker's queue is less than what we want.
+					 */
+
+					//console.log( 'Queue size for: ', msg.worker_pid, msg.stats.queueLength );
+
 				}
+				break;
+			case 'processed':
+				console.log('Processed from ', msg.worker_pid, msg.pointer, msg.queue_size);
 				break;
 			default:
 		}
@@ -460,6 +462,54 @@ function workerMsgCallback( msg ) {
 	catch ( Exception ) {
 		logger.error( "Error receiving worker's message: ", Exception, msg );
 	}
+}
+
+/**
+ * Get a work batch dataset to send to a worker.
+ * @param int size The batch size. If the number is invalid, negative or more than `DATASET_SIZE`, return `DATASET_SIZE` items.
+ *
+ * @returns {*[]|boolean}
+ */
+function get_work_dataset( size ) {
+	// Make sure that we don't give too little or too much work.
+	if ( !size || size < 1 || size > global.config.get( 'DATASET_SIZE' ) ) {
+		size = global.config.get( 'DATASET_SIZE' );
+	}
+
+	if ( arrObjects.length < 1 ) {
+		return [];
+	}
+
+	const data = arrObjects.splice( 0, Math.min( arrObjects.length, size ) )
+
+	return data;
+}
+
+/**
+ * Assigns (sends) a variable amount of work to a specific worker.
+ *
+ * @param int pid The Worker's PID
+ * @param int|null size The number of items to send to the worker. @see get_work_dataset()
+ * @returns {null}
+ */
+function assign_work_to_worker( pid, size = null ) {
+	const dataset = get_work_dataset( size );
+	if ( !dataset || dataset.length === 0 ) {
+		return false;
+	}
+
+	const worker = getWorker( pid );
+	if ( !worker ) {
+		return false;
+	}
+
+	console.log( 'Sending items to ', worker.pid, dataset.length );
+
+	worker.send( {
+		pid: worker.pid,
+		request: 'queue-add',
+		payload: dataset,
+	} );
 }
 
 function host_check_request( server ) {


### PR DESCRIPTION
This PR adds the ability of Jetmon to monitor the workers' queues and make sure that they are saturated enough.

The problem that we noticed in the graphs is that the nodes sometimes sit idle when we have longer running pings and waiting for them to finish before asking for work. This PR makes sure that we're monitoring this from outside and if the worker gets in a state like this, we'll push more work to it, so they're saturated enough and not sit idle, while waiting for the longer pings to finish.

### To test

* Apply PR
* Start Jetmon
* Make sure Jetmon is working
* Make sure the workers are spawned correctly
* Make sure workers are pinging sites as expected
* Make sure the worker's queues get saturated if they get below the `NUM_TO_PROCESS` size.