### PR TITLE
WPCOM API: log response errors

### DIFF
--- a/lib/jetmon.js
+++ b/lib/jetmon.js
@@ -305,13 +305,13 @@ function checkHostStatus( veriflier_host, data ) {
 				wpcom.notifyStatusChange( queuedRetries[ loop ],
 						function( reply ) {
 							if ( ! reply.success ) {
-								logger.error( 'error posting status change, retrying...' );
+								logger.error( 'error posting status change, retrying: ' + ( reply?.data || 'no error message' ) );
 								wpcom.notifyStatusChange( queuedRetries[ loop ],
 										function( reply ) {
 											if ( reply.success )
 												logger.trace( 'posted successfully' );
 											else
-												logger.error( 'error posting status change.' );
+												logger.error( 'error posting status change: ' + ( reply?.data || 'no error message' ) );
 								});
 							}
 				});
@@ -362,13 +362,13 @@ function workerMsgCallback( msg ) {
 				wpcom.notifyStatusChange( msg.server,
 						function( reply ) {
 							if ( ! reply.success ) {
-								logger.error( 'error posting status change, retrying...' );
+								logger.error( 'error posting status change, retrying: ' + ( reply?.data || 'no error message' ) );
 								wpcom.notifyStatusChange( msg.server,
 										function( reply ) {
 											if ( reply.success )
 												logger.trace( 'posted successfully' );
 											else
-												logger.error( 'error posting status change.' );
+												logger.error( 'error posting status change: ' + ( reply?.data || 'no error message' ) );
 								});
 							}
 				});

--- a/lib/wpcom.js
+++ b/lib/wpcom.js
@@ -36,22 +36,20 @@ var wpcom = {
 				res.setEncoding( 'utf8' );
 				var reply_data = {};
 
-				if ( 200 == res.statusCode ) {
-					res.on( 'data', function ( response_data ) {
-						try {
-							reply_data = JSON.parse( response_data );
-						}
-						catch ( Exception ) {
-							logger.error( 'error parsing the server response.' );
-							reply_data.success = false;
-						}
-						callBack( reply_data );
-					});
-				} else {
-					logger.error( 'incorrect status code from the server: ' + res.statusCode );
-					reply_data.success = false;
-					callBack( reply_data );
+				if ( 200 != res.statusCode ) {
+					logger.error('incorrect status code from the server: ' + res.statusCode);
 				}
+
+				res.on( 'data', function ( response_data ) {
+					try {
+						reply_data = JSON.parse( response_data );
+					}
+					catch ( Exception ) {
+						logger.error( 'error parsing the server response.' );
+						reply_data.success = false;
+					}
+					callBack( reply_data );
+				});
 			};
 
 			var error_handler = function( err ) {


### PR DESCRIPTION
Log error messages returned by the WPCOM endpoint.
The WPCOM counterpart: D106241-code

### Testing instructions
1. Checkout the diff D106241-code, switch to WPCOM sandbox (or wait until it's deployed).
2. Edit the token to an invalid one.
3. Change a site status in some way to make Jetmon send an API request.
4. Check the `jetmon.log` and confirm that you see the `Invalid token` errors:
```
error posting status change, retrying: Invalid token.
...
error posting status change: Invalid token.
```