### PR TITLE
Up the memory limit for workers

### DIFF
--- a/lib/httpcheck.js
+++ b/lib/httpcheck.js
@@ -7,10 +7,10 @@ const SITE_CONFIRMED_DOWN = 2;
 
 const SUICIDE_SIGNAL        = 1;
 const EXIT_MAXRAMUSAGE      = 2;
-// Empirically ended up with 45MB per worker.
+// Empirically ended up with 53MB per worker.
 // They don't get killed off all the time, and on a system with 16GB RAM
-// we end up having ~1.6GB free.
-const MAX_PROCESS_MEM_USAGE = 45 * 1024 * 1024;
+// we end up having ~1.3GB free.
+const MAX_PROCESS_MEM_USAGE = 53 * 1024 * 1024;
 const DEFAULT_HTTP_PORT     = 80;
 
 const JETMON_CHECK        = 1;


### PR DESCRIPTION
After some testing and balancing in production, we have found a better balance of workers and threads to keep the service as performant as possible.

### To test

1. Apply PR
2. Make sure Jetmon is working correctly.