### PR TITLE
Add: Recycle workers after configurable max checks

### DIFF
--- a/config/config-sample.json
+++ b/config/config-sample.json
@@ -1,8 +1,10 @@
 {
-	"DEBUG"          : true,
-	"NUM_WORKERS"    : 60,
-	"NUM_TO_PROCESS" : 40,
-	"DATASET_SIZE"   : 100,
+	"DEBUG"             : true,
+	"NUM_WORKERS"       : 60,
+	"NUM_TO_PROCESS"    : 40,
+	"DATASET_SIZE"      : 100,
+	"WORKER_MAX_CHECKS" : 10000,
+	"WORKER_MAX_MEM_MB" : 53,
 
 	"DB_UPDATES_ENABLE" : false,
 

--- a/config/config.readme
+++ b/config/config.readme
@@ -17,7 +17,7 @@ Set to 0 or a negative value to disable recycling workers based on the number of
 WORKER_MAX_MEM_MB
 The maximum MB of memory that a worker can consume before it stops accepting work and is scheduled to recycle.
 Set to 0 or a negative value to disable recycling workers based on memory usage.
-The following comment was in the worker source code from an early dev on why they chose 45MB as the original value:
+The following comment was in the worker source code from an early dev on why they chose 45MB as the original value. Since then, we moved to a value of 53MB.
 	Empirically ended up with 45MB per worker.
 	They don't get killed off all the time, and on a system with 16GB RAM
 	we end up having ~1.6GB free.

--- a/config/config.readme
+++ b/config/config.readme
@@ -10,6 +10,18 @@ The number of sites that a worker should process in parallel.
 DATASET_SIZE
 The maximum number of sites to send to a worker's queue in a single batch.
 
+WORKER_MAX_CHECKS
+The maximum number of checks that a worker can process before it stops accepting work and is scheduled to recycle.
+Set to 0 or a negative value to disable recycling workers based on the number of checks.
+
+WORKER_MAX_MEM_MB
+The maximum MB of memory that a worker can consume before it stops accepting work and is scheduled to recycle.
+Set to 0 or a negative value to disable recycling workers based on memory usage.
+The following comment was in the worker source code from an early dev on why they chose 45MB as the original value:
+	Empirically ended up with 45MB per worker.
+	They don't get killed off all the time, and on a system with 16GB RAM
+	we end up having ~1.6GB free.
+
 DB_UPDATES_ENABLE
 WARNING: Do not enabled this on production hosts. This should only be enabled on local docker test environments and never in production.
 Set to true to allow Jetmon to update the jetpack_monitor_sites table. Without this, it is difficult to test how effective the code is working when in a local docker test environment.

--- a/lib/httpcheck.js
+++ b/lib/httpcheck.js
@@ -83,7 +83,7 @@ var hostname    = _os.hostname();
 var HttpChecker = {
 	reloadConfig: function() {
 		maxChecks   = config.get( 'WORKER_MAX_CHECKS' ) || 0;
-		maxMemUsage = config.get( 'WORKER_MAX_MEM_MB' ) || 45;
+		maxMemUsage = config.get( 'WORKER_MAX_MEM_MB' ) || 53;
 
 		if ( maxChecks > 0 ) {
 			// If the number of checks is limited, pre-seed totalChecks to a random value.

--- a/lib/httpcheck.js
+++ b/lib/httpcheck.js
@@ -7,10 +7,8 @@ const SITE_CONFIRMED_DOWN = 2;
 
 const SUICIDE_SIGNAL        = 1;
 const EXIT_MAXRAMUSAGE      = 2;
-// Empirically ended up with 53MB per worker.
-// They don't get killed off all the time, and on a system with 16GB RAM
-// we end up having ~1.3GB free.
-const MAX_PROCESS_MEM_USAGE = 53 * 1024 * 1024;
+const EXIT_MAXCHECKS        = 3;
+
 const DEFAULT_HTTP_PORT     = 80;
 
 const JETMON_CHECK        = 1;
@@ -28,11 +26,12 @@ var o_log4js = require( 'log4js' );
 var config   = require( './config' );
 config.load();
 
-var arrCheck      = [];
-var running       = false;
-var askedForWork  = false;
-var suicideSignal = false;
-var pointer       = 0;
+var arrCheck          = [];
+var running           = false;
+var askedForWork      = false;
+var availableForWork  = true;
+var suicideSignal     = false;
+var pointer           = 0;
 
 /**
  * How many checks are currently being processed by the worker.
@@ -40,7 +39,12 @@ var pointer       = 0;
  * @type {number}
  */
 var activeChecks  = 0;
+var totalChecks   = 0;
 var createdTime   = Date.now();
+
+// These values will be set in HttpChecker.reloadConfig.
+var maxChecks   = 0;
+var maxMemUsage = 0;
 
 var workerTotals = {};
 workerTotals[SITE_DOWN] = 0;
@@ -77,6 +81,24 @@ var _os         = require( 'os' );
 var hostname    = _os.hostname();
 
 var HttpChecker = {
+	reloadConfig: function() {
+		maxChecks   = config.get( 'WORKER_MAX_CHECKS' ) || 0;
+		maxMemUsage = config.get( 'WORKER_MAX_MEM_MB' ) || 45;
+
+		if ( maxChecks > 0 ) {
+			// If the number of checks is limited, pre-seed totalChecks to a random value.
+			// This helps prevent all the workers from trying to recycle at the same time.
+			totalChecks = Math.floor( Math.random() * maxChecks );
+		} else {
+			maxChecks = Number.MAX_VALUE;
+		}
+		if ( maxMemUsage > 0 ) {
+			maxMemUsage = maxMemUsage * 1024 * 1024;
+		} else {
+			maxMemUsage = Number.MAX_VALUE;
+		}
+	},
+
 	checkServers: function() {
 		try {
 			var pointerCurrentMax = pointer + config.get( 'NUM_TO_PROCESS' );
@@ -84,6 +106,7 @@ var HttpChecker = {
 				pointerCurrentMax = arrCheck.length;
 			for ( ; pointer < pointerCurrentMax ; pointer++ ) {
 				activeChecks++;
+				totalChecks++;
 				_watcher.http_check( arrCheck[ pointer ].monitor_url, DEFAULT_HTTP_PORT, pointer, HttpChecker.processResultsCallback );
 			}
 		}
@@ -143,9 +166,15 @@ var HttpChecker = {
 
 		if ( pointer < arrCheck.length ) {
 			activeChecks++;
+			totalChecks++;
 			_watcher.http_check( arrCheck[ pointer ].monitor_url, DEFAULT_HTTP_PORT, pointer, HttpChecker.processResultsCallback );
 			pointer++;
 		} else {
+			if ( availableForWork && ( suicideSignal || process.memoryUsage().rss > maxMemUsage || totalChecks > maxChecks ) ) {
+				availableForWork = false;
+				process.send( { msgtype: 'stop_work', worker_pid: process.pid } );
+			}
+
 			 // check if we have any outstanding callbacks
 			var waiting_for = 0;
 			for ( var count in arrCheck ) {
@@ -153,21 +182,22 @@ var HttpChecker = {
 					waiting_for++;
 			}
 
-			if ( ( process.memoryUsage().rss < MAX_PROCESS_MEM_USAGE ) && ( false === askedForWork ) ) {
-				askedForWork = true;
-				process.send( { msgtype: 'send_work', worker_pid: process.pid } );
-			}
-
 			if ( 0 === waiting_for ) {
-				if ( suicideSignal )
+				if ( suicideSignal ) {
 					process.exit( SUICIDE_SIGNAL );
-
-				// If we never asked for work, then it was due to being over the ram limit, to the ether for me...
-				if ( false === askedForWork )
+				} else if ( process.memoryUsage().rss > maxMemUsage ) {
 					process.exit( EXIT_MAXRAMUSAGE );
+				} else if ( totalChecks > maxChecks ) {
+					process.exit( EXIT_MAXCHECKS );
+				}
 
 				arrCheck = [];
 				running = false;
+			}
+
+			if ( availableForWork && ( false === askedForWork ) ) {
+				askedForWork = true;
+				process.send( { msgtype: 'send_work', worker_pid: process.pid } );
 			}
 		}
 
@@ -262,6 +292,9 @@ process.on( 'message', function( msg ) {
 			case 'config-update': {
 				logger.debug( 'worker pid ' + msg.pid + ': updating config settings.' );
 				config.load();
+
+				HttpChecker.reloadConfig();
+
 				break;
 			}
 			default: {
@@ -305,6 +338,7 @@ setInterval( function() {
 			queueLength:  arrCheck.length,
 			pointer:      pointer,
 			activeChecks: activeChecks,
+			totalChecks:  totalChecks,
 			memoryUsage:  process.memoryUsage().rss,
 			checkStats:   checkStats,
 			uptime:       HttpChecker.getAge(),
@@ -315,3 +349,6 @@ setInterval( function() {
 
 	process.send( message );
 }, 1000 );
+
+// Ensure that the variable config values are set properly.
+HttpChecker.reloadConfig();

--- a/lib/jetmon.js
+++ b/lib/jetmon.js
@@ -10,6 +10,7 @@ const HOST_ONLINE         = 1;
 
 const SUICIDE_SIGNAL      = 1;
 const EXIT_MAXRAMUSAGE    = 2;
+const EXIT_MAXCHECKS      = 3;
 
 const NUM_SSL_SERVERS     = 4;
 
@@ -72,6 +73,7 @@ var sitesCount      = 0;
 var arrObjects      = [];
 var localRetries    = [];
 var freeWorkers     = [];
+var haltedWorkers   = [];
 var arrWorkers      = [];
 var workerStats     = {};
 var checkStats      = {};
@@ -101,6 +103,7 @@ process.on( 'uncaughtException', function( errDesc ) {
 	logger.debug( 'uncaughtException error: ' + errDesc );
 });
 
+
 function spawnWorker() {
 	var worker = child_proc.fork('./lib/httpcheck.js' );
 
@@ -113,30 +116,41 @@ function spawnWorker() {
 
 			statsdClient.increment('worker.die.shutdown.count');
 		} else {
+			var respawn = false;
+
 			if ( SUICIDE_SIGNAL == code ) {
 				logger.debug( 'worker thread pid ' + worker.pid + ' was asked to evaporate.' );
 				statsdClient.increment('worker.die.evaporate.count');
-
 			} else if ( EXIT_MAXRAMUSAGE == code ) {
-				logger.debug( 'worker thread pid ' + worker.pid + ' eXited due to reaching mem limit, replacing...' );
+				logger.debug( 'worker thread pid ' + worker.pid + ' exited due to reaching mem limit, replacing...' );
 				statsdClient.increment('worker.die.memlimit.count');
-
-				deleteWorker( worker.pid );
-				spawnWorker();
+				respawn = true;
+			} else if ( EXIT_MAXCHECKS == code ) {
+				logger.debug( 'worker thread pid ' + worker.pid + ' exited due to reaching check limit, replacing...' );
+				statsdClient.increment('worker.die.checklimit.count');
+				respawn = true;
 			} else {
 				if ( 130 == code ) {
 					logger.debug( 'worker thread pid ' + worker.pid + ' shutting down.' );
 					statsdClient.increment('worker.die.code_130.count');
 				} else {
-					statsdClient.increment('worker.die.code_other.count');
-
 					logger.debug( 'worker thread pid ' + worker.pid + ' died (' + code + '), creating a replacement.' );
-					deleteWorker( worker.pid );
-					spawnWorker();
+					statsdClient.increment('worker.die.code_other.count');
+					respawn = true;
 				}
+			}
+
+			deleteWorker( worker.pid );
+
+			if ( respawn ) {
+				spawnWorker();
 			}
 		}
 	} );
+
+	// Ensure that the new worker PID is not in any of the existing arrays.
+	deleteWorker( worker.pid );
+
 	arrWorkers.push( worker );
 }
 
@@ -158,6 +172,8 @@ function deleteWorker( pid ) {
 			break;
 		}
 	}
+	freeWorkers   = freeWorkers.filter( a => a !== pid );
+	haltedWorkers = haltedWorkers.filter( a => a !== pid );
 }
 
 function getWorker( pid ) {
@@ -368,6 +384,15 @@ function workerMsgCallback( msg ) {
 							}
 				});
 				break;
+			case 'stop_work':
+				/**
+				 * Worker asked to no longer receive work so that it can be recycled.
+				 */
+				if ( -1 == haltedWorkers.indexOf( msg.worker_pid ) && null !== getWorker( msg.worker_pid ) ) {
+					haltedWorkers.push( msg.worker_pid );
+					freeWorkers = freeWorkers.filter( a => a !== msg.worker_pid );
+				}
+				break;
 			case 'send_work':
 				/**
 				 * Worker asked for work
@@ -392,7 +417,7 @@ function workerMsgCallback( msg ) {
 					 * There are no URLs in the global queue, let's flag the worker as "free"
 					 * and request more sites from the database, if we haven't done so yet.
 					 */
-					if ( -1 == freeWorkers.indexOf( msg.worker_pid ) ) {
+					if ( -1 == haltedWorkers.indexOf( msg.worker_pid ) && -1 == freeWorkers.indexOf( msg.worker_pid ) ) {
 						freeWorkers.push( msg.worker_pid );
 					}
 					if ( ! gettingSites ) {
@@ -538,6 +563,10 @@ function assign_work_to_worker( pid, size = null ) {
 		return false;
 	}
 
+	if ( -1 != haltedWorkers.indexOf( pid ) ) {
+		return false;
+	}
+
 	worker.send( {
 		pid: worker.pid,
 		request: 'queue-add',
@@ -565,8 +594,11 @@ function updateStats() {
 	try {
 		if ( true === global.config.get( 'DEBUG' ) ) {
 			var nextLoop = ( getRoundDuration() * SECONDS ) - ( new Date().valueOf() - startTime );
-			logger.debug( 'sps = ' + sitesCount + ' - ' + ( arrWorkers.length - freeWorkers.length ) + ' working, ' +
-							freeWorkers.length + ' waiting : next round in ' + ( nextLoop / 1000 ) + 's' );
+			logger.debug( 'sps = ' + sitesCount + ' - ' +
+							( arrWorkers.length - freeWorkers.length ) + ' working, ' +
+							freeWorkers.length + ' waiting, ' +
+							haltedWorkers.length + ' halting : ' +
+							'next round in ' + ( nextLoop / 1000 ) + 's' );
 			if ( nextLoop < -20000 ) {
 				logger.error( 'restarting the getMoreSites loop' );
 				resetVariables();
@@ -598,6 +630,7 @@ function updateStats() {
 		totalFile.once( 'open', function( fd ) {
 			totalFile.write( 'working : ' + ( arrWorkers.length - freeWorkers.length ) + '\n' );
 			totalFile.write( 'waiting : ' + freeWorkers.length + '\n' );
+			totalFile.write( 'halting : ' + haltedWorkers.length + '\n' );
 			totalFile.write( 'error   : ' + localGCountError + '\n' );
 			totalFile.write( 'offline : ' + localGCountOffline + '\n' );
 			totalFile.write( 'total   : ' + localGCountSuccess + '\n' );
@@ -614,6 +647,7 @@ function updateStats() {
 		statsdClient.increment( 'stats.sites.queue.count', arrObjects.length );
 
 		statsdClient.increment( 'stats.workers.free.count', freeWorkers.length );
+		statsdClient.increment( 'stats.workers.halting.count', haltedWorkers.length );
 		statsdClient.increment( 'stats.workers.working.count', ( arrWorkers.length - freeWorkers.length ) );
 
 		for ( let site_status in checkStats ) {


### PR DESCRIPTION
This PR adds a new system to automatically recycle workers after they exceed a specific number of checks controlled by the new `WORKER_MAX_CHECKS` config value. This PR also also changes the static max memory limit for recycling workers to be controlled by a new `WORKER_MAX_MEM_MB` config value. The goal of these changes is to see if the production system is more stable when workers are periodically recycled and to allow for adjusting max memory limits without having to change the code.

If either of these new config values are not specified, the code defaults to the previous behavior by allowing workers to process unlimited checks and to recycle workers when they exceed 53MB of memory usage. If either of these config values are set to values equal to or less than 0, recycling workers based upon the associated metric is disabled.

The suggested `WORKER_MAX_CHECKS` value of `10000` as provided in `config/config-sample.json` was chosen rather arbitrarily. With the current number of checks, a value of `10000` will result in each worker being recycled approximately every hour.

Note that the worker `totalChecks` variable that tracks how many checks have been made is initialized to a random value ranging from `0` to `WORKER_MAX_CHECKS`. This should help prevent a situation where all the workers attempt to recycle around the same time.

The following is a comprehensive list of other changes needed to ensure that this new feature works reliably and has proper logging and statsd metrics:
- Added a new `worker.die.checklimit.count` statsd metric to track when workers are recycled due to exceeding the new max checks.
- Added a new `stats.workers.halting.count` statsd metric to track how many workers are halted but have not exited yet. If this value grows over time without reducing, it could indicate an issue with the new halting system.
- Added a new message to the `logs/jetmon.log` log when recycling a worker due to reaching the max check limit.
- Updated the status message added to `logs/jetmon.log` to include the number of halted workers.
- Added a message that can be sent from a worker to the parent Jetmon process to tell Jetmon to stop sending work to the worker. This message is sent when a worker receives a suicide signal, when a worker exceeds memory limits, or when a worker exceeds max check limits. This should prevent the parent process from continuing to send work to a worker, preventing it from recycling.
- Added a "halting" count to `stats/totals` that tracks the number of workers that are halted.
- Moved the code that causes a worker to request more work to be below the code that determines if the worker can exit. This prevents situations where a worker will request new work and then exit, potentially causing lost work.
- Workers reload these new config values when Jetmon receives a signal to reload the config.
- Updated the `deleteWorker` function to ensure that the PID for the deleted worker is also removed from the `freeWorkers` and `haltedWorkers` arrays.
- When processing an exit event for a worker, the `deleteWorker` function is now always called unless a shut down event is occurring. This should help keep the various worker arrays clean.
- A worker can only be added to the `freeWorkers` array if it is not halted.
- Work can only be assigned to a worker if it is not halted.

## Testing Instructions

1. Check out this PR's branch `add/max-checks-per-worker`.
2. Ensure that the test environment and config is set up in a way to ensure that workers will attempt to recycle in a reasonable amount of time. Here are the key details from my testing environment:
    - Set the following in `config/config.json`:
      - `NUM_WORKERS` to `800`
      - `NUM_TO_PROCESS` to `20`
      - `DATASET_SIZE` to `50`
      - `WORKER_MAX_CHECKS` to `200`
      - `BUCKET_NO_MIN` to `0`
      - `BUCKET_NO_MAX` to `511`
      - `USE_VARIABLE_CHECK_INTERVALS` to `true`
    - Filled my test database with 10,000 test sites, ensuring that a small sampling of them report as down and some will time out.
3. Run Jetmon.
4. With the above setup, you should get some workers recycling each minute.
5. Load up Graphite ([https://localhost::8088](https://localhost::8088)) and watch the `stats.com.jetpack.jetmon.jetmon.docker.worker.die.checklimit.count` metric. You should see a spike in that metric to some non-zero value roughly every minute.
6. Inspect the other metrics to ensure that Jetmon is running stably and that status change events are recorded as expected.
7. Any unexpected behavior or change in stability should be reported.