### PR TITLE
Separated status codes 0 into new codes

### DIFF
--- a/src/http_checker.cpp
+++ b/src/http_checker.cpp
@@ -4,6 +4,12 @@
 
 using namespace std;
 
+const int ERROR_STATUS_CODE_UNKNOWN = 999;
+const int ERROR_TIMEOUT = 998;
+const int ERROR_REDIRECT_LOCATION = 997;
+const int ERROR_CONNECT_REDIRECT_HOST = 996;
+const int ERROR_CONNECT_HOST = 995;
+
 HTTP_Checker::HTTP_Checker() : m_sock( -1 ), m_host_name( "" ), m_host_dir( "" ), m_port( HTTP_DEFAULT_PORT ),
 		m_is_ssl( false ), m_triptime( 0 ), m_response_code( 0 ), m_ctx( NULL ), m_ssl( NULL ), m_sbio( NULL ) {
 	gettimeofday( &m_tstart, &m_tzone );
@@ -37,7 +43,12 @@ void HTTP_Checker::check( string p_host_name, int p_port ) {
 		this->parse_host_values();
 		if ( connect() ) {
 			this->set_host_response( 0 );
-		}
+		} else {
+#if DEBUG_MODE
+				cerr << "Unable to connect to host" << endl;
+#endif
+				m_response_code = ERROR_CONNECT_HOST;
+			}
 	}
 	catch( exception &ex ) {
 		cerr << "exception in HTTP_Checker::check(): for host '" << p_host_name.c_str() << "'" << endl;
@@ -51,7 +62,7 @@ void HTTP_Checker::set_host_response( int redirects ) {
 #if DEBUG_MODE
 			cerr << "no response - timed out" << endl;
 #endif
-			m_response_code = 0;
+			m_response_code = ERROR_TIMEOUT;
 			return;
 		}
 
@@ -59,7 +70,7 @@ void HTTP_Checker::set_host_response( int redirects ) {
 #if DEBUG_MODE
 			cerr << "Status code unknown" << endl;
 #endif
-			m_response_code = 999;
+			m_response_code = ERROR_STATUS_CODE_UNKNOWN;
 			return;
 		}
 
@@ -80,7 +91,7 @@ void HTTP_Checker::set_host_response( int redirects ) {
 #if DEBUG_MODE
 				cerr << "Unable to parse redirect location" << endl;
 #endif
-				m_response_code = 0;
+				m_response_code = ERROR_REDIRECT_LOCATION;
 				return;
 			}
 			this->disconnect();
@@ -90,7 +101,7 @@ void HTTP_Checker::set_host_response( int redirects ) {
 #if DEBUG_MODE
 				cerr << "Unable to connect to redirect host" << endl;
 #endif
-				m_response_code = 0;
+				m_response_code = ERROR_CONNECT_REDIRECT_HOST;
 			}
 		}
 

--- a/src/http_checker.cpp
+++ b/src/http_checker.cpp
@@ -45,10 +45,10 @@ void HTTP_Checker::check( string p_host_name, int p_port ) {
 			this->set_host_response( 0 );
 		} else {
 #if DEBUG_MODE
-				cerr << "Unable to connect to host" << endl;
+			cerr << "Unable to connect to host" << endl;
 #endif
-				m_response_code = ERROR_CONNECT_HOST;
-			}
+			m_response_code = ERROR_CONNECT_HOST;
+		}
 	}
 	catch( exception &ex ) {
 		cerr << "exception in HTTP_Checker::check(): for host '" << p_host_name.c_str() << "'" << endl;


### PR DESCRIPTION
We are seeing a big number of 0 status code in the Jetmon health Dashboard.

Separating the errors will give us visibility on the specific cause for the old 0 status codes.

Also added a response code different to 0 when unable to connect prior to redirecting.

I had conversations with @chrisbliss18 regarding adding a new variable so that error codes were separated from the actual response codes. I had a diff with it, but I discarded it since it seems that creating a new var added more clutter to the code and then we would need to also add some more stats to measure them separately. Please let me know if this approach still feels hacky and I would update by adding a new var like `error_code` to pass the info between the c++ addon and the Jetmon Service.

### Testing instructions

- Fill the test database, ensuring some will time out.
- Run Jetmon.
- Check the metrics in Graphite to make sure you are getting some values on the `stats.com.jetpack.jetmon.jetmon.docker.worker.check.check.down.code.998.count` metric (998 code is the code for Error timeouts)



