### PR TITLE
Added error code to differentiate 0 status codes.

### DIFF
--- a/lib/httpcheck.js
+++ b/lib/httpcheck.js
@@ -92,7 +92,7 @@ var HttpChecker = {
 		}
 	},
 
-	processResultsCallback: function( serverArrayIndex, rtt, http_code ) {
+	processResultsCallback: function( serverArrayIndex, rtt, http_code, error_code ) {
 		/**
 		 * Reduce the amount of active checks, as the check has finished.
 		 */
@@ -119,12 +119,13 @@ var HttpChecker = {
 		}
 
 		if ( server.site_status !=  server.oldStatus ) {
-			var resO    = {};
-			resO.type   = JETMON_CHECK;
-			resO.host   = hostname;
-			resO.status = server.site_status;
-			resO.rtt    = Math.round( rtt / 1000 );
-			resO.code   = http_code;
+			var resO        = {};
+			resO.type       = JETMON_CHECK;
+			resO.host       = hostname;
+			resO.status     = server.site_status;
+			resO.rtt        = Math.round( rtt / 1000 );
+			resO.code       = http_code;
+			resO.error_code = error_code;
 			server.checks.push( resO );
 
 			// if site is down and it has not been confirmed
@@ -198,6 +199,9 @@ var HttpChecker = {
 
 		if ( checkStats[stats_site_status] ) {
 			checkStats[stats_site_status]['http_code'][http_code] = ( checkStats[stats_site_status]['http_code'][http_code] || 0 ) + 1;
+			if ( error_code !== 0 ){
+				checkStats[stats_site_status]['error_code'][error_code] = ( checkStats[stats_site_status]['error_code'][error_code] || 0 ) + 1;
+			}
 
 			checkStats[stats_site_status]['rtt']['count']++;
 			checkStats[stats_site_status]['rtt']['sum'] += stats_rtt;
@@ -206,6 +210,7 @@ var HttpChecker = {
 		} else {
 			checkStats[stats_site_status] = {
 				'http_code': {},
+				'error_code': {},
 				'rtt':       {
 					'count': 1,
 					'sum':   stats_rtt,
@@ -215,6 +220,9 @@ var HttpChecker = {
 			};
 
 			checkStats[stats_site_status]['http_code'][http_code] = 1;
+			if ( error_code !== 0 )	{
+				checkStats[stats_site_status]['error_code'][error_code] = 1;
+			}
 		}
 	},
 

--- a/lib/jetmon.js
+++ b/lib/jetmon.js
@@ -292,6 +292,7 @@ function checkHostStatus( veriflier_host, data ) {
 		replyO.status = data.status;
 		replyO.rtt    = data.rtt;
 		replyO.code   = data.code;
+		replyO.error_code   = data.error_code;
 		queuedRetries[ loop ].checks.push( replyO );
 		if ( HOST_OFFLINE == data.status ) {
 			queuedRetries[ loop ].offline_confirms++;
@@ -425,6 +426,13 @@ function workerMsgCallback( msg ) {
 									checkStats[site_status]['http_code'][http_code] += msg.stats.checkStats[site_status]['http_code'][http_code];
 								} else {
 									checkStats[site_status]['http_code'][http_code] = msg.stats.checkStats[site_status]['http_code'][http_code];
+								}
+							}
+							for ( let error_code in msg.stats.checkStats[site_status]['error_code'] ) {
+								if ( checkStats[site_status]['error_code'][error_code] ) {
+									checkStats[site_status]['error_code'][error_code] += msg.stats.checkStats[site_status]['error_code'][error_code];
+								} else {
+									checkStats[site_status]['error_code'][error_code] = msg.stats.checkStats[site_status]['error_code'][error_code];
 								}
 							}
 							checkStats[site_status]['rtt']['count'] += msg.stats.checkStats[site_status]['rtt']['count'];
@@ -619,8 +627,11 @@ function updateStats() {
 		for ( let site_status in checkStats ) {
 			for ( let http_code in checkStats[site_status]['http_code'] ) {
 				statsdClient.increment( `worker.check.${site_status}.code.${http_code}.count`, checkStats[site_status]['http_code'][http_code] );
+			}		
+			for ( let error_code in checkStats[site_status]['error_code'] ) {
+				statsdClient.increment( `worker.check.${site_status}.error_code.${error_code}.count`, checkStats[site_status]['error_code'][error_code] );
 			}
-
+			
 			let rtt_avg = Math.round( checkStats[site_status]['rtt']['sum'] / checkStats[site_status]['rtt']['count'] );
 			statsdClient.timing( `worker.check.${site_status}.rtt.avg`, rtt_avg );
 			statsdClient.timing( `worker.check.${site_status}.rtt.max`, checkStats[site_status]['rtt']['max'] );

--- a/src/http_checker.h
+++ b/src/http_checker.h
@@ -58,6 +58,7 @@ public:
 	void check( std::string p_host_name, int p_port = HTTP_DEFAULT_PORT );
 	time_t get_rtt();
 	int get_response_code() { return m_response_code; }
+	int get_error_code() { return m_error_code; }
 
 private:
 	char m_buf[MAX_TCP_BUFFER];
@@ -71,6 +72,7 @@ private:
 	time_t m_triptime;
 	time_t m_cutofftime;
 	int m_response_code;
+	int m_error_code;
 
 	SSL_CTX *m_ctx;
 	SSL *m_ssl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,12 +28,13 @@ static void http_check_async_fin( uv_work_t *req, int status ) {
 	HandleScope scope( isolate );
 
 	HTTP_Check_Baton *baton = static_cast<HTTP_Check_Baton*>(req->data);
-	Local<Value> argv[3] = { Number::New( isolate, baton->server_id ),
+	Local<Value> argv[4] = { Number::New( isolate, baton->server_id ),
 								Number::New( isolate, baton->http_checker->get_rtt() ),
-								Number::New( isolate, baton->http_checker->get_response_code() ) };
+								Number::New( isolate, baton->http_checker->get_response_code() ),
+								Number::New( isolate, baton->http_checker->get_error_code() ) };
 
 	Local<Function> cb_func = Local<Function>::New( isolate, baton->callback );
-	cb_func->Call( isolate->GetCurrentContext(), isolate->GetCurrentContext()->Global(), 3, argv );
+	cb_func->Call( isolate->GetCurrentContext(), isolate->GetCurrentContext()->Global(), 4, argv );
 	baton->callback.Reset();
 	delete baton->http_checker;
 	delete baton;


### PR DESCRIPTION
This is a different approach to #45  where we don't modify status codes, but when we have errors we add a new variable `error_code`.

This variable is passed to the Jetmon node service and will be added to statsd using the `worker.check.${site_status}.error_code.${error_code}.count` metric. This way we will be able to differentiate timeouts, connection errors and other issues.
The new var will be also passed to the jetmon WPCOM endpoint for future requirements.

### Testing instructions

- Fill the test database, ensuring some of the data will time out and some will not connect.
- Run Jetmon.
- Check the metrics in Graphite to make sure you are getting some values for `stats_counts.com.jetpack.jetmon.jetmon.docker.worker.check.down.error_code.998.count` metric (998 code is the code for Error timeouts) 
and `stats_counts.com.jetpack.jetmon.jetmon.docker.worker.check.down.error_code.995.count` metric (995 code is the code for non connecting errors) 
