### PR TITLE
Improve round time calcuation and add additional round-related metrics

### DIFF
--- a/lib/jetmon.js
+++ b/lib/jetmon.js
@@ -317,8 +317,6 @@ function maybeEndRound() {
 		statsdClient.timing( 'round.time', timeSinceStart );
 
 		roundSitesCount = 0;
-
-		console.log( 'Round end' );
 	}
 }
 


### PR DESCRIPTION
This PR improves the accuracy of the round time metric.

Currently, the end of a round is measured when the parent process sends all the sites for that round to the workers. This method results in a value that is always too short to accurately reflect how long all the checks take to complete each round.

In this PR, the end of a round is measured when all the worker processes are free after running their checks. This ensures that the round time metric better reflects how long a round takes to actually complete all the checks.

The following metric is changed:
- `round.time` - This metric now tracks when all the checks for a round are complete, not when the parent process completes sending all checks to the workers. Note, that I indicate in a comment that this metric should be considered deprecated and removed at a later time. This is because the metric is renamed to `round.complete.time` to better match other round-related metric names. This metric is left in a deprecated state to allow for tracking how this reported data compares to existing data after updating production.

The following metrics are added:

- `round.done_sending_work.time` - This metric tracks when the parent is done sending checks to the workers in the same way that the `round.time` metric used to. This new metric is added in case tracking this data point could still be useful.
- `round.complete.time` - The new name for the `round.time` metric and using the new method of calculating the value.
- `round.next.time` - The time, in MS, before the next round starts as measured from the moment that the round ends. As this metric approaches `0`, it indicates that the service is nearing capacity on that host.
- `round.sites.count` - The number of sites checked in the just-finished round.
- `round.sps.count` - The number of sites checked per second in the just-finished round.

The following notes may be of interest for the future:
- The `inRound` variable was added since, without it, sometimes the code for handling the end of the round logic would run more than once per round. Adding this flag variable ensures that it should only run once each round.
- The `maybeEndRound` call inside the `stop_work` worker message handler was added to handle potential edge cases where a worker being recycled also happens to be the last worker to send a message to the parent after all checks have completed. I was unable to create this edge case in my testing, but I believe that it is possible, so I added a call to this message handler in addition to the `send_work` handler.
- The `round.sites.count` metric value may be overcounting checks. I ran some numbers on the values, and they seemed slightly elevated from expectations (for example, on a round that I expected to have `2320` checks, `2323` checks were reported by the `round.sites.count` metric). I did not spend time verifying that these numbers were inaccurate nor checking on potential sources for the discrepancy.

## Testing Instructions

1. Check out the latest `master` branch.
2. Ensure that the test environment and config is set up in a way to ensure that workers will attempt to recycle in a reasonable amount of time. Here are the key details from my testing environment:
    - Set the following in `config/config.json`:
      - `NUM_WORKERS` to `800`
      - `NUM_TO_PROCESS` to `20`
      - `DATASET_SIZE` to `50`
      - `WORKER_MAX_CHECKS` to `200`
      - `BUCKET_NO_MIN` to `0`
      - `BUCKET_NO_MAX` to `511`
      - `STATS_UPDATE_INTERVAL_MS` to `10000`
      - `USE_VARIABLE_CHECK_INTERVALS` to `true`
    - Filled my test database with 10,000 test sites to ensure that child processes recycle frequently just due to the number of sites processed.
3. Run Jetmon.
4. Load up Graphite ([https://localhost::8088](https://localhost::8088)) and note the reported `stats.timers.com.jetpack.jetmon.jetmon.docker.round.time.upper` values for new checks.
5. Checkout out this PR's `fix/round-time-calculation` branch.
6. Stop and restart Jetmon.
7. Load up Graphite ([https://localhost::8088](https://localhost::8088)) and note the reported `stats.timers.com.jetpack.jetmon.jetmon.docker.round.time.upper` values for new checks. These values should be higher than the values reported in step 4.
8. Verify that the following metrics are reported and have values:
    - `stats.timers.com.jetpack.jetmon.jetmon.docker.round.complete.time.upper`
    - `stats.timers.com.jetpack.jetmon.jetmon.docker.round.done_sending_work.time.upper`
    - `stats.timers.com.jetpack.jetmon.jetmon.docker.round.next.time.upper`
    - `stats.com.jetpack.jetmon.jetmon.docker.round.sites.count`
    - `stats.com.jetpack.jetmon.jetmon.docker.round.sps.count`