### PR TITLE
Jetmon worker: Fix memory leak by properly exiting when worker reaches max memory limit

### DIFF
--- a/lib/httpcheck.js
+++ b/lib/httpcheck.js
@@ -192,15 +192,18 @@ var HttpChecker = {
 			}
 
 			if ( 0 === waiting_for ) {
-				if ( suicideSignal ) {
-//					HttpChecker.sendStats();
-					process.exit( SUICIDE_SIGNAL );
-				} else if ( process.memoryUsage().rss > maxMemUsage ) {
-//					HttpChecker.sendStats();
-					process.exit( EXIT_MAXRAMUSAGE );
-				} else if ( totalChecks > maxChecks ) {
-//					HttpChecker.sendStats();
-					process.exit( EXIT_MAXCHECKS );
+				// No outstanding callbacks and not available for work. Time to die!
+				if ( false === availableForWork ) {
+					if ( suicideSignal ) {
+	//					HttpChecker.sendStats();
+						process.exit( SUICIDE_SIGNAL );
+					} else if ( totalChecks > maxChecks ) {
+	//					HttpChecker.sendStats();
+						process.exit( EXIT_MAXCHECKS );
+					} else {
+ 	//				HttpChecker.sendStats();
+						process.exit( EXIT_MAXRAMUSAGE );
+					}
 				}
 
 				arrCheck = [];

--- a/lib/httpcheck.js
+++ b/lib/httpcheck.js
@@ -194,14 +194,12 @@ var HttpChecker = {
 			if ( 0 === waiting_for ) {
 				// No outstanding callbacks and not available for work. Time to die!
 				if ( false === availableForWork ) {
+					// HttpChecker.sendStats();
 					if ( suicideSignal ) {
-	//					HttpChecker.sendStats();
 						process.exit( SUICIDE_SIGNAL );
 					} else if ( totalChecks > maxChecks ) {
-	//					HttpChecker.sendStats();
 						process.exit( EXIT_MAXCHECKS );
 					} else {
- 	//				HttpChecker.sendStats();
 						process.exit( EXIT_MAXRAMUSAGE );
 					}
 				}


### PR DESCRIPTION
When a [worker reaches its memory limit](https://github.com/Automattic/jetmon/blob/master/lib/httpcheck.js#L183) it sends a signal to the parent process (jetmon) to stop sending it work and marks itself as not `availableForWork`.
Then it checks [if there are any outstanding callbacks](https://github.com/Automattic/jetmon/blob/master/lib/httpcheck.js#L187), aka if all the URL checks it spawned are completed.
When there are pending URL checks it will keep working till all the checks are done.
When all the checks are finally done, it will check once more if one of the reasons to exit is satisfied. In our case [it used to check once more](https://github.com/Automattic/jetmon/blob/master/lib/httpcheck.js#L198) using `process.memoryUsage().rss > maxMemUsage`.
The caveat here is that by the time it reaches this check it's very possible that the memory usage dropped already below the limit.
This leaves us with a worker that is unavailable for work but is also not exiting, aka only exists to be pretty and send stats.
We believe this could be the reason (or at least one of the reasons) that the memory usage on production servers is creeping up.