### PR TITLE
Update Docker MySQL image from 5.7 to 8.0 for ARM64 compatibility

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
     mysqldb:
-        image: mysql:5.7
+        image: mysql:8.0
         restart: unless-stopped
         env_file:
           - .env


### PR DESCRIPTION
## Summary

The `mysql:5.7` Docker image lacks ARM64 support, causing `docker compose up -d` to fail on Apple Silicon Macs with:

> no matching manifest for linux/arm64/v8 in the manifest list entries

Upgrading to `mysql:8.0` provides multi-architecture images (both `linux/amd64` and `linux/arm64`) while remaining fully compatible with x86_64 production environments.

## Changes

- `docker/docker-compose.yml`: Changed MySQL image from `mysql:5.7` to `mysql:8.0`

## Affected Components

- Docker development environment only

## Testing

- Verified `docker compose up -d` succeeds on Apple Silicon (ARM64)
- The `mysql2` npm package (v3.16.3) used by Jetmon fully supports MySQL 8.0 authentication (`caching_sha2_password`)

## Deployment Notes

This is a development-only change (Docker config). No production impact.