### PR TITLE
Add: GET request support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 lib/jetmon.node
 .env
 .idea
+.codex

--- a/lib/database.js
+++ b/lib/database.js
@@ -93,12 +93,12 @@ var database = {
 			 * If variable check intervals are enabled, use a different query to
 			 * spread out the sites across one-minute intervals.
 			 */
-			var query = 'SELECT `blog_id`, `monitor_url`, `site_status`, `last_status_change` ' +
+			var query = 'SELECT `blog_id`, `monitor_url`, `site_status`, `last_status_change`, `check_mode` ' +
 				'FROM `jetpack_monitor_sites` WHERE `bucket_no` >= ' +
 				fromBucketNo + ' AND `bucket_no` <= ' + toBucketNo + ' AND `monitor_active` = 1 AND ' +
 				'MOD(MINUTE(NOW()) + `jetpack_monitor_site_id`, `check_interval`) = 0;';
 		} else {
-			var query = 'SELECT `blog_id`, `monitor_url`, `site_status`, `last_status_change` ' +
+			var query = 'SELECT `blog_id`, `monitor_url`, `site_status`, `last_status_change`, `check_mode` ' +
 				'FROM `jetpack_monitor_sites` WHERE `bucket_no` >= ' +
 				fromBucketNo + ' AND `bucket_no` <= ' + toBucketNo + ' AND `monitor_active` = 1';
 		}

--- a/lib/httpcheck.js
+++ b/lib/httpcheck.js
@@ -14,6 +14,10 @@ const DEFAULT_HTTP_PORT     = 80;
 const JETMON_CHECK        = 1;
 const VERIFLIER_CHECK     = 2;
 
+const CHECK_MODE_HEAD    = 0;
+const CHECK_MODE_COMPARE = 1;
+const CHECK_MODE_GET     = 2;
+
 const SECONDS = 1000;
 const MINUTES = 60 * SECONDS;
 const HOURS   = 60 * MINUTES;
@@ -32,6 +36,8 @@ var askedForWork      = false;
 var availableForWork  = true;
 var suicideSignal     = false;
 var pointer           = 0;
+
+var pendingComparisons = {};
 
 /**
  * How many checks are currently being processed by the worker.
@@ -107,9 +113,18 @@ var HttpChecker = {
 			if ( pointerCurrentMax > arrCheck.length )
 				pointerCurrentMax = arrCheck.length;
 			for ( ; pointer < pointerCurrentMax ; pointer++ ) {
+				var server = arrCheck[ pointer ];
 				activeChecks++;
 				totalChecks++;
-				_watcher.http_check( arrCheck[ pointer ].monitor_url, DEFAULT_HTTP_PORT, pointer, HttpChecker.processResultsCallback );
+				if ( CHECK_MODE_COMPARE == server.check_mode ) {
+					pendingComparisons[ pointer ] = { url: server.monitor_url, headCode: null, headErrorCode: null, getCode: null, getErrorCode: null, headDone: false, getDone: false, headRaw: null, getRaw: null };
+					activeChecks++; // extra for the GET comparison check
+					totalChecks++;
+					_watcher.http_check( server.monitor_url, DEFAULT_HTTP_PORT, pointer, HttpChecker.processResultsCallback, false );
+					_watcher.http_check( server.monitor_url, DEFAULT_HTTP_PORT, pointer, HttpChecker.processCompareCallback, true );
+				} else {
+					_watcher.http_check( server.monitor_url, DEFAULT_HTTP_PORT, pointer, HttpChecker.processResultsCallback, CHECK_MODE_GET == server.check_mode );
+				}
 			}
 		}
 		catch ( Exception ) {
@@ -125,7 +140,60 @@ var HttpChecker = {
 		workerTotals[SITE_CONFIRMED_DOWN] = 0;
 	},
 
-	processResultsCallback: function( serverArrayIndex, rtt, http_code, error_code ) {
+	/**
+	 * Callback for the supplementary GET request fired in CHECK_MODE_COMPARE.
+	 * Compares the GET result against the already-recorded HEAD result and logs any mismatch.
+	 * Does not affect uptime determination — that is handled by processResultsCallback.
+	 */
+	processCompareCallback: function( serverArrayIndex, rtt, http_code, error_code, raw_response ) {
+		activeChecks--;
+
+		var comp = pendingComparisons[ serverArrayIndex ];
+		if ( comp ) {
+			comp.getCode      = http_code;
+			comp.getErrorCode = error_code;
+			comp.getRaw       = raw_response;
+			comp.getDone      = true;
+
+			if ( comp.headDone ) {
+				if ( comp.headCode !== comp.getCode || comp.headErrorCode !== comp.getErrorCode ) {
+					slogger.trace( 'check_mode_compare: HEAD=' + comp.headCode + ' (err=' + comp.headErrorCode + ') GET=' + comp.getCode + ' (err=' + comp.getErrorCode + ') url=' + comp.url + ' head_raw="' + comp.headRaw.replace( /\r\n/g, '\\r\\n' ) + '" get_raw="' + comp.getRaw.replace( /\r\n/g, '\\r\\n' ) + '"' );
+				}
+				delete pendingComparisons[ serverArrayIndex ];
+			}
+		}
+
+		if ( pointer >= arrCheck.length ) {
+			if ( availableForWork && ( suicideSignal || process.memoryUsage().rss > maxMemUsage || totalChecks > maxChecks ) ) {
+				availableForWork = false;
+				process.send( { msgtype: 'stop_work', worker_pid: process.pid } );
+			}
+
+			if ( 0 === activeChecks ) {
+				if ( false === availableForWork ) {
+					// HttpChecker.sendStats();
+					if ( suicideSignal ) {
+						process.exit( SUICIDE_SIGNAL );
+					} else if ( totalChecks > maxChecks ) {
+						process.exit( EXIT_MAXCHECKS );
+					} else {
+						process.exit( EXIT_MAXRAMUSAGE );
+					}
+				}
+
+				arrCheck = [];
+				pendingComparisons = {};
+				running = false;
+
+				if ( availableForWork && ( false === askedForWork ) ) {
+					askedForWork = true;
+					process.send( { msgtype: 'send_work', worker_pid: process.pid } );
+				}
+			}
+		}
+	},
+
+	processResultsCallback: function( serverArrayIndex, rtt, http_code, error_code, raw_response ) {
 		/**
 		 * Reduce the amount of active checks, as the check has finished.
 		 */
@@ -134,6 +202,21 @@ var HttpChecker = {
 		var server = arrCheck[ serverArrayIndex ];
 		server.processed = true;
 		server.lastCheck = new Date().valueOf();	// we use set the value to the milliseconds value
+
+		// If this is the HEAD check of a COMPARE mode site, record the result for comparison
+		var comp = pendingComparisons[ serverArrayIndex ];
+		if ( comp ) {
+			comp.headCode      = http_code;
+			comp.headErrorCode = error_code;
+			comp.headRaw       = raw_response;
+			comp.headDone      = true;
+			if ( comp.getDone ) {
+				if ( comp.headCode !== comp.getCode || comp.headErrorCode !== comp.getErrorCode ) {
+					slogger.trace( 'check_mode_compare: HEAD=' + comp.headCode + ' (err=' + comp.headErrorCode + ') GET=' + comp.getCode + ' (err=' + comp.getErrorCode + ') url=' + comp.url + ' head_raw="' + comp.headRaw.replace( /\r\n/g, '\\r\\n' ) + '" get_raw="' + comp.getRaw.replace( /\r\n/g, '\\r\\n' ) + '"' );
+				}
+				delete pendingComparisons[ serverArrayIndex ];
+			}
+		}
 
 		if ( rtt > 0 && 400 > http_code && 0 != http_code ) {
 			server.site_status = SITE_RUNNING;
@@ -176,9 +259,18 @@ var HttpChecker = {
 		workerTotals[server.site_status]++;
 
 		if ( pointer < arrCheck.length ) {
+			var nextServer = arrCheck[ pointer ];
 			activeChecks++;
 			totalChecks++;
-			_watcher.http_check( arrCheck[ pointer ].monitor_url, DEFAULT_HTTP_PORT, pointer, HttpChecker.processResultsCallback );
+			if ( CHECK_MODE_COMPARE == nextServer.check_mode ) {
+				pendingComparisons[ pointer ] = { url: nextServer.monitor_url, headCode: null, headErrorCode: null, getCode: null, getErrorCode: null, headDone: false, getDone: false, headRaw: null, getRaw: null };
+				activeChecks++; // extra for the GET comparison check
+				totalChecks++;
+				_watcher.http_check( nextServer.monitor_url, DEFAULT_HTTP_PORT, pointer, HttpChecker.processResultsCallback, false );
+				_watcher.http_check( nextServer.monitor_url, DEFAULT_HTTP_PORT, pointer, HttpChecker.processCompareCallback, true );
+			} else {
+				_watcher.http_check( nextServer.monitor_url, DEFAULT_HTTP_PORT, pointer, HttpChecker.processResultsCallback, CHECK_MODE_GET == nextServer.check_mode );
+			}
 			pointer++;
 		} else {
 			if ( availableForWork && ( suicideSignal || process.memoryUsage().rss > maxMemUsage || totalChecks > maxChecks ) ) {
@@ -186,14 +278,8 @@ var HttpChecker = {
 				process.send( { msgtype: 'stop_work', worker_pid: process.pid } );
 			}
 
-			 // check if we have any outstanding callbacks
-			var waiting_for = 0;
-			for ( var count in arrCheck ) {
-				if ( ! arrCheck[ count ].processed )
-					waiting_for++;
-			}
-
-			if ( 0 === waiting_for ) {
+			// check if we have any outstanding callbacks
+			if ( 0 === activeChecks ) {
 				// No outstanding callbacks and not available for work. Time to die!
 				if ( false === availableForWork ) {
 					// HttpChecker.sendStats();
@@ -207,12 +293,13 @@ var HttpChecker = {
 				}
 
 				arrCheck = [];
+				pendingComparisons = {};
 				running = false;
-			}
 
-			if ( availableForWork && ( false === askedForWork ) ) {
-				askedForWork = true;
-				process.send( { msgtype: 'send_work', worker_pid: process.pid } );
+				if ( availableForWork && ( false === askedForWork ) ) {
+					askedForWork = true;
+					process.send( { msgtype: 'send_work', worker_pid: process.pid } );
+				}
 			}
 		}
 
@@ -243,7 +330,7 @@ var HttpChecker = {
 
 		if ( checkStats[stats_site_status] ) {
 			checkStats[stats_site_status]['http_code'][http_code] = ( checkStats[stats_site_status]['http_code'][http_code] || 0 ) + 1;
-			if ( error_code !== 0 ){
+			if ( error_code !== 0 ) {
 				checkStats[stats_site_status]['error_code'][error_code] = ( checkStats[stats_site_status]['error_code'][error_code] || 0 ) + 1;
 			}
 
@@ -264,7 +351,7 @@ var HttpChecker = {
 			};
 
 			checkStats[stats_site_status]['http_code'][http_code] = 1;
-			if ( error_code !== 0 )	{
+			if ( error_code !== 0 ) {
 				checkStats[stats_site_status]['error_code'][error_code] = 1;
 			}
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,222 @@
+{
+  "name": "jetmon",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "jetmon",
+      "version": "0.0.1",
+      "dependencies": {
+        "log4js": "^6.9.1",
+        "mysql2": "^3.16.3"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/date-format": {
+      "version": "4.0.14",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "license": "ISC"
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "license": "ISC"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/log4js": {
+      "version": "6.9.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "date-format": "^4.0.14",
+        "debug": "^4.3.4",
+        "flatted": "^3.2.7",
+        "rfdc": "^1.3.0",
+        "streamroller": "^3.1.5"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.4",
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "license": "MIT"
+    },
+    "node_modules/mysql2": {
+      "version": "3.22.1",
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.2",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.7.2",
+        "long": "^5.3.2",
+        "lru.min": "^1.1.4",
+        "named-placeholders": "^1.1.6",
+        "sql-escaper": "^1.3.3"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 8"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.6",
+      "license": "MIT",
+      "dependencies": {
+        "lru.min": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "license": "MIT"
+    },
+    "node_modules/sql-escaper": {
+      "version": "1.3.3",
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=2.0.0",
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
+      }
+    },
+    "node_modules/streamroller": {
+      "version": "3.1.5",
+      "license": "MIT",
+      "dependencies": {
+        "date-format": "^4.0.14",
+        "debug": "^4.3.4",
+        "fs-extra": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    }
+  }
+}

--- a/src/http_checker.cpp
+++ b/src/http_checker.cpp
@@ -11,7 +11,8 @@ const int ERROR_CONNECT_REDIRECT_HOST = 996;
 const int ERROR_CONNECT_HOST = 995;
 
 HTTP_Checker::HTTP_Checker() : m_sock( -1 ), m_host_name( "" ), m_host_dir( "" ), m_port( HTTP_DEFAULT_PORT ),
-		m_is_ssl( false ), m_triptime( 0 ), m_response_code( 0 ), m_ctx( NULL ), m_ssl( NULL ), m_sbio( NULL ), m_error_code( 0 ) {
+		m_is_ssl( false ), m_use_get( false ), m_raw_response( "" ), m_tzone(), m_tstart(), m_triptime( 0 ),
+		m_cutofftime( 0 ), m_response_code( 0 ), m_error_code( 0 ), m_ctx( NULL ), m_ssl( NULL ), m_sbio( NULL ) {
 	gettimeofday( &m_tstart, &m_tzone );
 	memset( m_buf, 0, MAX_TCP_BUFFER );
 	m_cutofftime = time( NULL );
@@ -34,11 +35,12 @@ time_t HTTP_Checker::get_rtt() {
 	return m_tend.tv_sec * 1000000 + ( m_tend.tv_usec );
 }
 
-void HTTP_Checker::check( string p_host_name, int p_port ) {
+void HTTP_Checker::check( string p_host_name, int p_port, bool p_use_get ) {
 	try {
 		m_host_name = p_host_name;
 		m_port = p_port;
 		m_host_dir = '/';
+		m_use_get = p_use_get;
 
 		this->parse_host_values();
 		if ( connect() ) {
@@ -57,7 +59,8 @@ void HTTP_Checker::check( string p_host_name, int p_port ) {
 
 void HTTP_Checker::set_host_response( int redirects ) {
 	try {
-		string response = this->send_http_get();
+		string response = this->send_http_request();
+		m_raw_response = response.substr( 0, 512 );
 		if ( 0 >= response.size() ) {
 #if DEBUG_MODE
 			cerr << "no response - timed out" << endl;
@@ -194,15 +197,13 @@ void HTTP_Checker::parse_host_values() {
 	}
 }
 
-string HTTP_Checker::send_http_get() {
-	string s_tmp = "HEAD " + m_host_dir + " HTTP/1.1\r\n";
+string HTTP_Checker::send_http_request() {
+	string s_tmp = ( m_use_get ? "GET" : "HEAD" ) + ( " " + m_host_dir + " HTTP/1.1\r\n" );
 			s_tmp += "Host: " + m_host_name + "\r\n";
 			s_tmp += "User-Agent: jetmon/1.0 (Jetpack Site Uptime Monitor by WordPress.com)\r\n";
 			s_tmp += "Connection: close\r\n\r\n";
 
-	strcpy( m_buf, s_tmp.c_str() );
-
-	if ( send_bytes( m_buf, s_tmp.length() ) ) {
+	if ( send_bytes( s_tmp.c_str(), s_tmp.length() ) ) {
 		s_tmp = get_response();
 	} else {
 		s_tmp = "";
@@ -239,6 +240,9 @@ string HTTP_Checker::get_response() {
 				if ( received < MAX_TCP_BUFFER ) {
 					m_buf[ received ] = '\0';
 					ret_val += m_buf;
+					// We only need headers for status/redirect parsing, not the body.
+					if ( string::npos != ret_val.find( "\r\n\r\n" ) )
+						break;
 				}
 				do
 				{
@@ -917,8 +921,16 @@ bool HTTP_Checker::disconnect() {
 				}
 				int res = SSL_shutdown( m_ssl );
 				while ( 1 != res && waittime > time( NULL ) ) {
+					fd_set read_fds;
+					FD_ZERO( &read_fds );
+					FD_SET( m_sock, &read_fds );
+					struct timeval tv;
+					tv.tv_sec = waittime - time( NULL );
+					tv.tv_usec = 0;
+					if ( tv.tv_sec <= 0 )
+						break;
+					::select( m_sock + 1, &read_fds, NULL, NULL, &tv );
 					res = SSL_shutdown( m_ssl );
-					sleep( 1 );
 				}
 #if DEBUG_MODE
 				if ( 1 == res ) {
@@ -952,7 +964,7 @@ bool HTTP_Checker::disconnect() {
 	}
 }
 
-bool HTTP_Checker::send_bytes( char* p_packet, size_t p_packet_length ) {
+bool HTTP_Checker::send_bytes( const char* p_packet, size_t p_packet_length ) {
 	try {
 		ssize_t bytes_left = p_packet_length;
 		ssize_t bytes_sent = 0;
@@ -1012,4 +1024,3 @@ bool HTTP_Checker::send_bytes( char* p_packet, size_t p_packet_length ) {
 		return false;
 	}
 }
-

--- a/src/http_checker.h
+++ b/src/http_checker.h
@@ -55,10 +55,11 @@ public:
 	HTTP_Checker();
 	~HTTP_Checker();
 
-	void check( std::string p_host_name, int p_port = HTTP_DEFAULT_PORT );
+	void check( std::string p_host_name, int p_port = HTTP_DEFAULT_PORT, bool p_use_get = false );
 	time_t get_rtt();
 	int get_response_code() { return m_response_code; }
 	int get_error_code() { return m_error_code; }
+	std::string get_raw_response() { return m_raw_response; }
 
 private:
 	char m_buf[MAX_TCP_BUFFER];
@@ -67,6 +68,8 @@ private:
 	std::string m_host_dir;
 	int m_port;
 	bool m_is_ssl;
+	bool m_use_get;
+	std::string m_raw_response;
 	struct timezone m_tzone;
 	struct timeval m_tstart;
 	time_t m_triptime;
@@ -90,8 +93,8 @@ private:
 #if NON_BLOCKING_IO
 	void disconnect_ssl();
 #endif
-	std::string send_http_get();
-	bool send_bytes( char* p_packet, size_t p_packet_length );
+	std::string send_http_request();
+	bool send_bytes( const char* p_packet, size_t p_packet_length );
 	std::string get_response();
 	void set_host_response( int redirects );
 	bool set_redirect_host_values( std::string p_content );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@ struct HTTP_Check_Baton {
 	std::string server;
 	int port;
 	int server_id;
+	bool use_get;
 	Isolate* isolate;
 };
 
@@ -30,15 +31,16 @@ static void http_check_async_fin( uv_work_t *req, int status ) {
 	Isolate* isolate = baton->isolate;
 	HandleScope scope( isolate );
 	Local<Context> ctx = isolate->GetCurrentContext();
-	Local<Value> argv[4] = {
+	Local<Value> argv[5] = {
 		Number::New(isolate, baton->server_id),
 		Number::New(isolate, baton->http_checker->get_rtt()),
 		Number::New(isolate, baton->http_checker->get_response_code()),
-		Number::New(isolate, baton->http_checker->get_error_code())
+		Number::New(isolate, baton->http_checker->get_error_code()),
+		String::NewFromUtf8( isolate, baton->http_checker->get_raw_response().c_str() ).ToLocalChecked()
 	};
 
 	Local<Function> cb_func = baton->callback.Get( isolate );
-	(void) cb_func->Call( ctx, ctx->Global(), 4, argv );
+	(void) cb_func->Call( ctx, ctx->Global(), 5, argv );
 	baton->callback.Reset();
 
 	delete baton->http_checker;
@@ -48,7 +50,7 @@ static void http_check_async_fin( uv_work_t *req, int status ) {
 
 void http_check_async( uv_work_t *req ) {
 	HTTP_Check_Baton *baton = static_cast<HTTP_Check_Baton*>( req->data );
-	baton->http_checker->check( baton->server, baton->port );
+	baton->http_checker->check( baton->server, baton->port, baton->use_get );
 }
 
 void http_check( const FunctionCallbackInfo<Value>& args ) {
@@ -56,7 +58,7 @@ void http_check( const FunctionCallbackInfo<Value>& args ) {
 	Isolate* isolate = args.GetIsolate();
 	HandleScope scope( isolate );
 
-	if ( args.Length() < 4 ) {
+	if ( args.Length() < 4 || args.Length() > 5 ) {
 		isolate->ThrowException( Exception::TypeError(
 			String::NewFromUtf8( isolate, "Wrong number of arguments" ).ToLocalChecked() ) );
 		return;
@@ -90,6 +92,7 @@ void http_check( const FunctionCallbackInfo<Value>& args ) {
 	baton->port = args[1]->ToInteger( isolate->GetCurrentContext() ).ToLocalChecked()->Value();
 	baton->server_id = (int) args[2]->ToInteger( isolate->GetCurrentContext() ).ToLocalChecked()->Value();
 
+	baton->use_get = ( args.Length() == 5 ) ? args[4]->BooleanValue( isolate ) : false;
 	baton->isolate = isolate;
 	baton->callback.Reset( isolate, args[3].As<Function>() );
 

--- a/veriflier/headers/http_checker.h
+++ b/veriflier/headers/http_checker.h
@@ -61,7 +61,7 @@ private:
 
 	void connect();
 	void closeConnection();
-	bool send_http_get();
+	bool send_http_request();
 	void process_response();
 	void finish_request();
 	bool set_redirect_host_values( QString p_content );

--- a/veriflier/source/http_checker.cpp
+++ b/veriflier/source/http_checker.cpp
@@ -143,7 +143,7 @@ void HTTP_Checker::parse_response_code( QByteArray a_data ) {
 	}
 }
 
-bool HTTP_Checker::send_http_get() {
+bool HTTP_Checker::send_http_request() {
 	QString m_buf = "HEAD " + m_host_dir + " HTTP/1.1\r\n";
 			m_buf += "Host: " + m_host_name + "\r\n";
 			m_buf += "User-Agent: jetmon/1.0 (Jetpack Site Uptime Monitor by WordPress.com)\r\n";
@@ -177,7 +177,7 @@ void HTTP_Checker::connected() {
 			finish_request();
 			return;
 		}
-		send_http_get();
+		send_http_request();
 	}
 	catch( exception &ex ) {
 		LOG( QString( "exception in HTTP_Checker::connected(): for host '" ) + m_host_name + "' : " + ex.what() );
@@ -228,4 +228,3 @@ void HTTP_Checker::finish_request() {
 		emit finished( this, m_hc );
 	}
 }
-


### PR DESCRIPTION
Part of the Jetpack Monitor: Full Site Sight project.

# Proposed changes

This change adds per-site HTTP check modes to Jetmon so checks can run as HEAD, GET, or COMPARE. The mode is fetched from `jetpack_monitor_sites.check_mode`, passed through the `worker/native-addon` boundary, and used by workers when scheduling requests.

In COMPARE mode, Jetmon performs the normal HEAD check for uptime determination and sends a parallel GET request only for observability. If the HEAD and GET results differ, the mismatch is logged with the truncated raw response headers. This is intended to help identify sites where HEAD handling differs from GET without changing current monitor behavior for those sites.

The native checker was updated to support optional GET requests and to return a small raw-response payload to the worker for compare-mode logging. Redirect parsing was kept compatible with existing behavior by reading through the full response headers before deciding whether to follow a redirect. Veriflier behavior remains HEAD-based.

# Testing instructions

1. Please verify the intended rollout and valid values for check_mode.
2. Please confirm redirect behavior is still acceptable, especially when the redirect-follow limit is exceeded.
3. Please review compare-mode logging volume and whether the current trace logging is sufficient or too noisy.
4. Please focus testing on sites that behave differently for HEAD vs GET, plus redirect-heavy endpoints.