### PR TITLE
feat(veriflier): add Go veriflier transport and veriflier2 binary

### DIFF
--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -1,0 +1,107 @@
+package veriflier
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// VeriflierClient sends check batches to a remote Veriflier via gRPC.
+// Until protoc-generated stubs are in place this implementation uses a
+// lightweight JSON-over-HTTP transport on the same port, making it fully
+// functional without a protoc dependency. Swap in the generated gRPC client
+// by replacing the send() method after running `make generate`.
+type VeriflierClient struct {
+	addr      string
+	authToken string
+	httpClient *http.Client
+}
+
+// NewVeriflierClient creates a client targeting the given address (host:port).
+func NewVeriflierClient(addr, authToken string) *VeriflierClient {
+	return &VeriflierClient{
+		addr:      addr,
+		authToken: authToken,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// Addr returns the target address of this client.
+func (c *VeriflierClient) Addr() string {
+	return c.addr
+}
+
+// Check sends a single site check request to the Veriflier and returns the result.
+func (c *VeriflierClient) Check(ctx context.Context, req CheckRequest) (*CheckResult, error) {
+	results, err := c.CheckBatch(ctx, []CheckRequest{req})
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("veriflier returned no results")
+	}
+	return &results[0], nil
+}
+
+// CheckBatch sends multiple check requests to the Veriflier.
+func (c *VeriflierClient) CheckBatch(ctx context.Context, reqs []CheckRequest) ([]CheckResult, error) {
+	type batchReq struct {
+		Sites []CheckRequest `json:"sites"`
+	}
+	type batchResp struct {
+		Results []CheckResult `json:"results"`
+	}
+
+	body, err := json.Marshal(batchReq{Sites: reqs})
+	if err != nil {
+		return nil, err
+	}
+
+	url := fmt.Sprintf("http://%s/check", c.addr)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(body)))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+c.authToken)
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("veriflier request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("veriflier returned %d", resp.StatusCode)
+	}
+
+	var br batchResp
+	if err := json.NewDecoder(resp.Body).Decode(&br); err != nil {
+		return nil, fmt.Errorf("decode veriflier response: %w", err)
+	}
+	return br.Results, nil
+}
+
+// Ping checks whether the Veriflier is reachable and returns its version.
+func (c *VeriflierClient) Ping(ctx context.Context) (string, error) {
+	url := fmt.Sprintf("http://%s/status", c.addr)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var s struct {
+		Status  string `json:"status"`
+		Version string `json:"version"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&s)
+	return s.Version, nil
+}

--- a/internal/veriflier/server.go
+++ b/internal/veriflier/server.go
@@ -1,0 +1,87 @@
+package veriflier
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+)
+
+// Server listens for inbound connections from the Monitor and dispatches
+// check batches to the local checker. Used by the Veriflier binary.
+//
+// This is the server-side counterpart to VeriflierClient. It implements
+// the same JSON-over-HTTP transport and is replaced by a generated gRPC
+// server after running `make generate`.
+type Server struct {
+	authToken string
+	checkFn   func(req CheckRequest) CheckResult
+	addr      string
+	hostname  string
+	version   string
+}
+
+// NewServer creates a Server that calls checkFn for each check request.
+func NewServer(addr, authToken, hostname, version string, checkFn func(CheckRequest) CheckResult) *Server {
+	return &Server{
+		addr:      addr,
+		authToken: authToken,
+		hostname:  hostname,
+		version:   version,
+		checkFn:   checkFn,
+	}
+}
+
+// Listen starts the HTTP server. Blocks until the server exits.
+func (s *Server) Listen() error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/check", s.handleCheck)
+	mux.HandleFunc("/status", s.handleStatus)
+
+	log.Printf("veriflier: listening on %s", s.addr)
+	return http.ListenAndServe(s.addr, mux)
+}
+
+func (s *Server) handleCheck(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	token := r.Header.Get("Authorization")
+	if token != "Bearer "+s.authToken {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	type batchReq struct {
+		Sites []CheckRequest `json:"sites"`
+	}
+	type batchResp struct {
+		Results []CheckResult `json:"results"`
+	}
+
+	var req batchReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("decode: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	results := make([]CheckResult, 0, len(req.Sites))
+	for _, site := range req.Sites {
+		res := s.checkFn(site)
+		res.Host = s.hostname
+		results = append(results, res)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(batchResp{Results: results})
+}
+
+func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"status":  "OK",
+		"version": s.version,
+	})
+}

--- a/internal/veriflier/types.go
+++ b/internal/veriflier/types.go
@@ -1,0 +1,26 @@
+// Package veriflier provides the client and server for Monitor↔Veriflier
+// communication. The current transport is JSON-over-HTTP; types mirror the
+// proto definitions in proto/veriflier.proto. Run `make generate` after
+// installing protoc to replace this with generated gRPC stubs.
+package veriflier
+
+// CheckRequest is a single site to check, sent from Monitor to Veriflier.
+type CheckRequest struct {
+	BlogID         int64
+	URL            string
+	TimeoutSeconds int32
+	Keyword        string
+	CustomHeaders  map[string]string
+	RedirectPolicy string
+}
+
+// CheckResult is a single check outcome returned by the Veriflier.
+type CheckResult struct {
+	BlogID    int64
+	URL       string
+	Host      string
+	Success   bool
+	HTTPCode  int32
+	ErrorCode int32
+	RTTMs     int64
+}

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -1,0 +1,207 @@
+package veriflier
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func newTestServer(checkFn func(CheckRequest) CheckResult) (*Server, *httptest.Server) {
+	srv := NewServer("", "secret", "test-host", "1.0", checkFn)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/check", srv.handleCheck)
+	mux.HandleFunc("/status", srv.handleStatus)
+	ts := httptest.NewServer(mux)
+	return srv, ts
+}
+
+func checkReqBody(t *testing.T, sites []CheckRequest) *bytes.Buffer {
+	t.Helper()
+	body, err := json.Marshal(struct {
+		Sites []CheckRequest `json:"sites"`
+	}{Sites: sites})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return bytes.NewBuffer(body)
+}
+
+func TestServerHandleCheckSuccess(t *testing.T) {
+	_, ts := newTestServer(func(req CheckRequest) CheckResult {
+		return CheckResult{BlogID: req.BlogID, Success: true, HTTPCode: 200}
+	})
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/check", checkReqBody(t, []CheckRequest{
+		{BlogID: 42, URL: "https://example.com"},
+	}))
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var result struct {
+		Results []CheckResult `json:"results"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(result.Results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(result.Results))
+	}
+	if result.Results[0].Host != "test-host" {
+		t.Fatalf("Host = %q, want test-host", result.Results[0].Host)
+	}
+	if result.Results[0].BlogID != 42 {
+		t.Fatalf("BlogID = %d, want 42", result.Results[0].BlogID)
+	}
+}
+
+func TestServerHandleCheckUnauthorized(t *testing.T) {
+	_, ts := newTestServer(func(req CheckRequest) CheckResult { return CheckResult{} })
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/check", checkReqBody(t, []CheckRequest{{BlogID: 1}}))
+	req.Header.Set("Authorization", "Bearer wrong-token")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestServerHandleCheckMethodNotAllowed(t *testing.T) {
+	_, ts := newTestServer(func(req CheckRequest) CheckResult { return CheckResult{} })
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/check", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", resp.StatusCode)
+	}
+}
+
+func TestServerHandleStatus(t *testing.T) {
+	_, ts := newTestServer(func(req CheckRequest) CheckResult { return CheckResult{} })
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/status")
+	if err != nil {
+		t.Fatalf("request error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["status"] != "OK" {
+		t.Fatalf("status field = %q, want OK", body["status"])
+	}
+	if body["version"] != "1.0" {
+		t.Fatalf("version field = %q, want 1.0", body["version"])
+	}
+}
+
+func TestClientServerRoundTrip(t *testing.T) {
+	_, ts := newTestServer(func(req CheckRequest) CheckResult {
+		return CheckResult{BlogID: req.BlogID, Success: true, HTTPCode: 200}
+	})
+	defer ts.Close()
+
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
+	res, err := client.Check(context.Background(), CheckRequest{
+		BlogID: 77,
+		URL:    "https://example.com",
+	})
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	if res.BlogID != 77 {
+		t.Fatalf("BlogID = %d, want 77", res.BlogID)
+	}
+	if res.Host != "test-host" {
+		t.Fatalf("Host = %q, want test-host", res.Host)
+	}
+	if !res.Success {
+		t.Fatal("Success = false, want true")
+	}
+}
+
+func TestClientAddr(t *testing.T) {
+	client := NewVeriflierClient("host1:7803", "token")
+	if client.Addr() != "host1:7803" {
+		t.Fatalf("Addr() = %q, want host1:7803", client.Addr())
+	}
+}
+
+func TestClientPing(t *testing.T) {
+	_, ts := newTestServer(func(req CheckRequest) CheckResult { return CheckResult{} })
+	defer ts.Close()
+
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
+	version, err := client.Ping(context.Background())
+	if err != nil {
+		t.Fatalf("Ping() error = %v", err)
+	}
+	if version != "1.0" {
+		t.Fatalf("version = %q, want 1.0", version)
+	}
+}
+
+func TestClientBatchRoundTrip(t *testing.T) {
+	_, ts := newTestServer(func(req CheckRequest) CheckResult {
+		return CheckResult{BlogID: req.BlogID, Success: true, HTTPCode: 200}
+	})
+	defer ts.Close()
+
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
+	res, err := client.CheckBatch(context.Background(), []CheckRequest{
+		{BlogID: 10, URL: "https://example.com"},
+		{BlogID: 20, URL: "https://example.org"},
+	})
+	if err != nil {
+		t.Fatalf("CheckBatch() error = %v", err)
+	}
+	if len(res) != 2 {
+		t.Fatalf("CheckBatch() len = %d, want 2", len(res))
+	}
+}
+
+func TestClientRejectsUnauthorized(t *testing.T) {
+	_, ts := newTestServer(func(req CheckRequest) CheckResult { return CheckResult{} })
+	defer ts.Close()
+
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "wrong-token")
+	_, err := client.Check(context.Background(), CheckRequest{BlogID: 1, URL: "https://example.com"})
+	if err == nil {
+		t.Fatal("Check() expected error for wrong auth token")
+	}
+}

--- a/proto/veriflier.proto
+++ b/proto/veriflier.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+
+package veriflier;
+
+option go_package = "github.com/Automattic/jetmon/internal/grpc/proto";
+
+// Veriflier is the service implemented by veriflier2 instances.
+// The Monitor sends check batches; the Veriflier returns results.
+service Veriflier {
+    rpc CheckSites(CheckBatch) returns (CheckBatchResult);
+    rpc GetStatus(StatusRequest) returns (StatusResponse);
+}
+
+message CheckRequest {
+    int64  blog_id          = 1;
+    string url              = 2;
+    int32  timeout_seconds  = 3;
+}
+
+message CheckBatch {
+    repeated CheckRequest sites      = 1;
+    string                auth_token = 2;
+}
+
+message CheckResult {
+    int64  blog_id    = 1;
+    string url        = 2;
+    string host       = 3;
+    bool   success    = 4;
+    int32  http_code  = 5;
+    int32  error_code = 6;
+    int64  rtt_ms     = 7;
+}
+
+message CheckBatchResult {
+    repeated CheckResult results = 1;
+}
+
+message StatusRequest {}
+
+message StatusResponse {
+    string status  = 1;
+    string version = 2;
+}

--- a/veriflier2/cmd/main.go
+++ b/veriflier2/cmd/main.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/Automattic/jetmon/internal/checker"
+	"github.com/Automattic/jetmon/internal/veriflier"
+)
+
+var version = "dev"
+
+type veriflierConfig struct {
+	AuthToken string `json:"auth_token"`
+	GRPCPort  string `json:"grpc_port"`
+}
+
+func main() {
+	configPath := envOrDefault("VERIFLIER_CONFIG", "config/veriflier.json")
+
+	cfg, err := loadConfig(configPath)
+	if err != nil {
+		log.Fatalf("load config: %v", err)
+	}
+
+	hostname, _ := os.Hostname()
+
+	// Override auth token and port from environment if set (Docker entrypoint).
+	if v := os.Getenv("VERIFLIER_AUTH_TOKEN"); v != "" {
+		cfg.AuthToken = v
+	}
+	if v := os.Getenv("VERIFLIER_GRPC_PORT"); v != "" {
+		cfg.GRPCPort = v
+	}
+
+	if cfg.GRPCPort == "" {
+		log.Fatalf("VERIFLIER_GRPC_PORT is not set")
+	}
+	addr := fmt.Sprintf(":%s", cfg.GRPCPort)
+
+	srv := veriflier.NewServer(addr, cfg.AuthToken, hostname, version, performCheck)
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		log.Println("veriflier2: shutting down")
+		os.Exit(0)
+	}()
+
+	log.Printf("veriflier2 %s starting on %s", version, addr)
+	if err := srv.Listen(); err != nil {
+		log.Fatalf("listen: %v", err)
+	}
+}
+
+// performCheck runs a single HTTP check and returns the result for the server.
+func performCheck(req veriflier.CheckRequest) veriflier.CheckResult {
+	res := checker.Check(context.Background(), checker.Request{
+		BlogID:         req.BlogID,
+		URL:            req.URL,
+		TimeoutSeconds: int(req.TimeoutSeconds),
+		Keyword:        stringPtr(req.Keyword),
+		CustomHeaders:  req.CustomHeaders,
+		RedirectPolicy: checker.RedirectPolicy(req.RedirectPolicy),
+	})
+
+	return veriflier.CheckResult{
+		BlogID:    res.BlogID,
+		URL:       res.URL,
+		Success:   res.Success,
+		HTTPCode:  int32(res.HTTPCode),
+		ErrorCode: int32(res.ErrorCode),
+		RTTMs:     res.RTT.Milliseconds(),
+	}
+}
+
+func stringPtr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+func loadConfig(path string) (*veriflierConfig, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		// Fall back to environment-only config.
+		return &veriflierConfig{
+			AuthToken: os.Getenv("VERIFLIER_AUTH_TOKEN"),
+			GRPCPort:  envOrDefault("VERIFLIER_GRPC_PORT", "7803"),
+		}, nil
+	}
+	defer f.Close()
+
+	var cfg veriflierConfig
+	if err := json.NewDecoder(f).Decode(&cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func envOrDefault(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}

--- a/veriflier2/config/veriflier-sample.json
+++ b/veriflier2/config/veriflier-sample.json
@@ -1,0 +1,4 @@
+{
+	"auth_token" : "<VERIFLIER_AUTH_TOKEN>",
+	"grpc_port"  : "<VERIFLIER_GRPC_PORT>"
+}


### PR DESCRIPTION
## Scope
- Add veriflier transport/protocol scaffolding (`proto/veriflier.proto`, `internal/veriflier/**`).
- Add `veriflier2/**` Go binary/config as additive implementation.

## Out of Scope
- No legacy veriflier removal or production cutover in this PR.

## Testing
- Included unit tests in `internal/veriflier/veriflier_test.go` with implementation.
- Verified this PR is additive (no legacy deletions).

## Compatibility
- Legacy paths remain available; transport additions are staged for incremental migration.