### PR TITLE
feat(checker): add Go checker pool and metrics

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -1,0 +1,249 @@
+package checker
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptrace"
+	"strings"
+	"time"
+)
+
+// ErrorCode mirrors the status change email types from the original Jetmon.
+const (
+	ErrorNone          = 0
+	ErrorTimeout       = 1
+	ErrorConnect       = 2
+	ErrorSSL           = 3
+	ErrorRedirect      = 4
+	ErrorKeyword       = 5
+	ErrorTLSExpired    = 6
+	ErrorTLSDeprecated = 7
+)
+
+// RedirectPolicy controls how redirect responses are handled.
+type RedirectPolicy string
+
+const (
+	RedirectFollow RedirectPolicy = "follow"
+	RedirectAlert  RedirectPolicy = "alert"
+	RedirectFail   RedirectPolicy = "fail"
+)
+
+// Request holds the parameters for a single HTTP check.
+type Request struct {
+	BlogID         int64
+	URL            string
+	TimeoutSeconds int
+	Keyword        *string
+	CustomHeaders  map[string]string
+	RedirectPolicy RedirectPolicy
+}
+
+// Result holds the outcome of a single HTTP check.
+type Result struct {
+	BlogID    int64
+	URL       string
+	Success   bool
+	HTTPCode  int
+	ErrorCode int
+
+	RTT  time.Duration
+	DNS  time.Duration
+	TCP  time.Duration
+	TLS  time.Duration
+	TTFB time.Duration
+
+	SSLExpiry       *time.Time
+	TLSVersion      uint16
+	RedirectChanged bool
+
+	Timestamp time.Time
+}
+
+// StatusType maps the result to a WPCOM status change email type.
+func (r *Result) StatusType() string {
+	switch {
+	case r.Success:
+		return "success"
+	case r.ErrorCode == ErrorSSL || r.ErrorCode == ErrorTLSExpired:
+		return "https"
+	case r.ErrorCode == ErrorTimeout:
+		return "intermittent"
+	case r.ErrorCode == ErrorRedirect:
+		return "redirect"
+	case r.HTTPCode == 403:
+		return "blocked"
+	case r.HTTPCode >= 500:
+		return "server"
+	case r.HTTPCode >= 400:
+		return "client"
+	default:
+		return "intermittent"
+	}
+}
+
+// IsFailure reports whether the result should enter the downtime pipeline.
+func (r *Result) IsFailure() bool {
+	if !r.Success {
+		return true
+	}
+	switch r.ErrorCode {
+	case ErrorNone, ErrorTLSDeprecated:
+		return false
+	default:
+		return true
+	}
+}
+
+// Check performs an HTTP check and returns the result.
+func Check(ctx context.Context, req Request) Result {
+	res := Result{
+		BlogID:    req.BlogID,
+		URL:       req.URL,
+		Timestamp: time.Now(),
+	}
+
+	timeout := time.Duration(req.TimeoutSeconds) * time.Second
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var (
+		dnsStart, tcpStart, tlsStart, reqStart time.Time
+		dnsEnd, tcpEnd, tlsEnd                 time.Time
+	)
+
+	trace := &httptrace.ClientTrace{
+		DNSStart:             func(_ httptrace.DNSStartInfo) { dnsStart = time.Now() },
+		DNSDone:              func(_ httptrace.DNSDoneInfo) { dnsEnd = time.Now() },
+		ConnectStart:         func(_, _ string) { tcpStart = time.Now() },
+		ConnectDone:          func(_, _ string, _ error) { tcpEnd = time.Now() },
+		TLSHandshakeStart:    func() { tlsStart = time.Now() },
+		TLSHandshakeDone:     func(_ tls.ConnectionState, _ error) { tlsEnd = time.Now() },
+		WroteRequest:         func(_ httptrace.WroteRequestInfo) { reqStart = time.Now() },
+		GotFirstResponseByte: func() { res.TTFB = time.Since(reqStart) },
+	}
+	ctx = httptrace.WithClientTrace(ctx, trace)
+
+	headers := make(map[string]string)
+	for k, v := range req.CustomHeaders {
+		headers[k] = v
+	}
+
+	redirectCount := 0
+	redirectPolicyStr := string(req.RedirectPolicy)
+	if redirectPolicyStr == "" {
+		redirectPolicyStr = string(RedirectFollow)
+	}
+
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: false},
+	}
+
+	client := &http.Client{
+		Transport: transport,
+		CheckRedirect: func(r *http.Request, via []*http.Request) error {
+			redirectCount++
+			if redirectPolicyStr == string(RedirectFail) {
+				return fmt.Errorf("redirect policy: fail")
+			}
+			if redirectCount > 10 {
+				return fmt.Errorf("too many redirects")
+			}
+			return nil
+		},
+		Timeout: timeout,
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, req.URL, nil)
+	if err != nil {
+		res.ErrorCode = ErrorConnect
+		return res
+	}
+
+	httpReq.Header.Set("User-Agent", "jetmon/2.0 (Jetpack Site Uptime Monitor by WordPress.com)")
+	for k, v := range headers {
+		httpReq.Header.Set(k, v)
+	}
+
+	start := time.Now()
+	resp, err := client.Do(httpReq)
+	res.RTT = time.Since(start)
+
+	if !dnsStart.IsZero() {
+		res.DNS = dnsEnd.Sub(dnsStart)
+	}
+	if !tcpStart.IsZero() {
+		res.TCP = tcpEnd.Sub(tcpStart)
+	}
+	if !tlsStart.IsZero() {
+		res.TLS = tlsEnd.Sub(tlsStart)
+	}
+
+	if err != nil {
+		if ctx.Err() != nil {
+			res.ErrorCode = ErrorTimeout
+		} else if strings.Contains(err.Error(), "redirect") {
+			res.ErrorCode = ErrorRedirect
+		} else if strings.Contains(err.Error(), "tls") || strings.Contains(err.Error(), "certificate") {
+			res.ErrorCode = ErrorSSL
+		} else {
+			res.ErrorCode = ErrorConnect
+		}
+		return res
+	}
+	defer resp.Body.Close()
+
+	res.HTTPCode = resp.StatusCode
+
+	// Inspect TLS state if available.
+	if resp.TLS != nil {
+		res.TLSVersion = resp.TLS.Version
+		if len(resp.TLS.PeerCertificates) > 0 {
+			cert := resp.TLS.PeerCertificates[0]
+			expiry := cert.NotAfter
+			res.SSLExpiry = &expiry
+			if time.Now().After(expiry) {
+				res.ErrorCode = ErrorTLSExpired
+				return res
+			}
+		}
+		// Flag deprecated TLS versions (TLS 1.0 = 0x0301, TLS 1.1 = 0x0302).
+		if resp.TLS.Version <= tls.VersionTLS11 {
+			res.ErrorCode = ErrorTLSDeprecated
+		}
+	}
+
+	if redirectPolicyStr == string(RedirectAlert) && redirectCount > 0 {
+		res.RedirectChanged = true
+	}
+
+	// Keyword check — read body only if keyword is configured.
+	if req.Keyword != nil && *req.Keyword != "" {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		if !strings.Contains(string(body), *req.Keyword) {
+			res.ErrorCode = ErrorKeyword
+			return res
+		}
+	}
+
+	res.Success = res.HTTPCode > 0 && res.HTTPCode < 400
+	return res
+}
+
+// ParseCustomHeaders deserialises a JSON custom headers string into a map.
+func ParseCustomHeaders(raw *string) map[string]string {
+	if raw == nil || *raw == "" {
+		return nil
+	}
+	var m map[string]string
+	_ = json.Unmarshal([]byte(*raw), &m)
+	return m
+}

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -1,0 +1,522 @@
+package checker
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestResultStatusType(t *testing.T) {
+	tests := []struct {
+		name string
+		res  Result
+		want string
+	}{
+		{name: "success", res: Result{Success: true}, want: "success"},
+		{name: "ssl error", res: Result{ErrorCode: ErrorSSL}, want: "https"},
+		{name: "tls expired", res: Result{ErrorCode: ErrorTLSExpired}, want: "https"},
+		{name: "timeout", res: Result{ErrorCode: ErrorTimeout}, want: "intermittent"},
+		{name: "redirect", res: Result{ErrorCode: ErrorRedirect}, want: "redirect"},
+		{name: "403 blocked", res: Result{HTTPCode: 403}, want: "blocked"},
+		{name: "500 server error", res: Result{HTTPCode: 500}, want: "server"},
+		{name: "503 server error", res: Result{HTTPCode: 503}, want: "server"},
+		{name: "400 client error", res: Result{HTTPCode: 400}, want: "client"},
+		{name: "404 client error", res: Result{HTTPCode: 404}, want: "client"},
+		{name: "connect error fallthrough", res: Result{ErrorCode: ErrorConnect}, want: "intermittent"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.res.StatusType(); got != tt.want {
+				t.Fatalf("StatusType() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseCustomHeaders(t *testing.T) {
+	if got := ParseCustomHeaders(nil); got != nil {
+		t.Fatalf("ParseCustomHeaders(nil) = %v, want nil", got)
+	}
+
+	empty := ""
+	if got := ParseCustomHeaders(&empty); got != nil {
+		t.Fatalf("ParseCustomHeaders(\"\") = %v, want nil", got)
+	}
+
+	invalid := "not json"
+	if got := ParseCustomHeaders(&invalid); got != nil {
+		t.Fatalf("ParseCustomHeaders(invalid) = %v, want nil", got)
+	}
+
+	valid := `{"X-Foo":"bar","X-Baz":"qux"}`
+	got := ParseCustomHeaders(&valid)
+	if len(got) != 2 {
+		t.Fatalf("ParseCustomHeaders() len = %d, want 2", len(got))
+	}
+	if got["X-Foo"] != "bar" {
+		t.Fatalf("ParseCustomHeaders()[\"X-Foo\"] = %q, want %q", got["X-Foo"], "bar")
+	}
+}
+
+func TestResultIsFailure(t *testing.T) {
+	tests := []struct {
+		name string
+		res  Result
+		want bool
+	}{
+		{
+			name: "plain success",
+			res:  Result{Success: true, ErrorCode: ErrorNone},
+			want: false,
+		},
+		{
+			name: "deprecated tls is advisory",
+			res:  Result{Success: true, ErrorCode: ErrorTLSDeprecated},
+			want: false,
+		},
+		{
+			name: "keyword failure is hard failure",
+			res:  Result{Success: true, ErrorCode: ErrorKeyword},
+			want: true,
+		},
+		{
+			name: "transport failure is hard failure",
+			res:  Result{Success: false, ErrorCode: ErrorConnect},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.res.IsFailure(); got != tt.want {
+				t.Fatalf("IsFailure() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPoolDrainWorkers(t *testing.T) {
+	p := NewPool(3, 1, 3)
+	t.Cleanup(p.Drain)
+
+	if drained := p.DrainWorkers(2); drained != 2 {
+		t.Fatalf("DrainWorkers() = %d, want 2", drained)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if p.WorkerCount() == 1 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("worker count = %d, want 1 after retirement", p.WorkerCount())
+}
+
+func TestPoolDrainWaitsForInflightCheck(t *testing.T) {
+	orig := poolCheckFunc
+	started := make(chan struct{})
+	release := make(chan struct{})
+	poolCheckFunc = func(_ context.Context, req Request) Result {
+		close(started)
+		<-release
+		return Result{BlogID: req.BlogID}
+	}
+	t.Cleanup(func() { poolCheckFunc = orig })
+
+	p := NewPool(1, 1, 1)
+	if !p.Submit(Request{BlogID: 1}) {
+		t.Fatal("Submit() returned false")
+	}
+
+	<-started
+
+	drained := make(chan struct{})
+	go func() {
+		p.Drain()
+		close(drained)
+	}()
+
+	select {
+	case <-drained:
+		t.Fatal("Drain returned before in-flight check completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+
+	select {
+	case <-drained:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Drain did not return after in-flight check completed")
+	}
+}
+
+func TestSubmitReturnsFalseAfterDrain(t *testing.T) {
+	p := NewPool(1, 1, 1)
+	p.Drain()
+	if p.Submit(Request{BlogID: 1, URL: "https://example.com"}) {
+		t.Fatal("Submit() returned true after Drain, want false")
+	}
+}
+
+func TestSetMaxSizeRetireExcessWorkers(t *testing.T) {
+	p := NewPool(5, 1, 5)
+	t.Cleanup(p.Drain)
+
+	p.SetMaxSize(2)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if p.WorkerCount() <= 2 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("worker count = %d after SetMaxSize(2), want <= 2", p.WorkerCount())
+}
+
+func TestDrainCalledTwice(t *testing.T) {
+	p := NewPool(1, 1, 1)
+	p.Drain()
+	p.Drain() // second Drain must be a no-op, not block or panic
+}
+
+func TestSubmitDropsWhenQueueFull(t *testing.T) {
+	// Zero workers means nothing drains the channel. Channel capacity = max*2 = 4.
+	p := NewPool(0, 0, 2)
+	t.Cleanup(p.Drain)
+
+	const cap = 4 // max*2
+	for i := range cap {
+		if !p.Submit(Request{BlogID: int64(i), URL: "x"}) {
+			t.Fatalf("Submit %d returned false on non-full queue", i)
+		}
+	}
+	if p.Submit(Request{BlogID: 99, URL: "overflow"}) {
+		t.Fatal("Submit returned true on full queue, want false")
+	}
+}
+
+func TestDrainWorkersAtMinimum(t *testing.T) {
+	p := NewPool(1, 1, 1) // size == minSize
+	t.Cleanup(p.Drain)
+
+	// Nothing above minSize to retire.
+	if drained := p.DrainWorkers(5); drained != 0 {
+		t.Fatalf("DrainWorkers(5) at minSize = %d, want 0", drained)
+	}
+}
+
+func TestDrainWorkersExceedsAvailable(t *testing.T) {
+	p := NewPool(3, 1, 3)
+	t.Cleanup(p.Drain)
+
+	// 2 workers above minSize (3-1=2), requesting 10 — should cap at 2.
+	drained := p.DrainWorkers(10)
+	if drained != 2 {
+		t.Fatalf("DrainWorkers(10) = %d, want 2 (capped at available)", drained)
+	}
+}
+
+// --- checker.Check() ---
+
+func TestCheckHTTP200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	res := Check(context.Background(), Request{BlogID: 1, URL: srv.URL, TimeoutSeconds: 5})
+	if !res.Success {
+		t.Fatalf("Success = false, want true")
+	}
+	if res.HTTPCode != 200 {
+		t.Fatalf("HTTPCode = %d, want 200", res.HTTPCode)
+	}
+	if res.ErrorCode != ErrorNone {
+		t.Fatalf("ErrorCode = %d, want ErrorNone", res.ErrorCode)
+	}
+}
+
+func TestCheckHTTP500(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	res := Check(context.Background(), Request{BlogID: 1, URL: srv.URL, TimeoutSeconds: 5})
+	if res.Success {
+		t.Fatal("Success = true for 500 response, want false")
+	}
+	if res.HTTPCode != 500 {
+		t.Fatalf("HTTPCode = %d, want 500", res.HTTPCode)
+	}
+}
+
+func TestCheckTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-time.After(5 * time.Second):
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	res := Check(context.Background(), Request{BlogID: 1, URL: srv.URL, TimeoutSeconds: 1})
+	if res.ErrorCode != ErrorTimeout {
+		t.Fatalf("ErrorCode = %d, want ErrorTimeout", res.ErrorCode)
+	}
+}
+
+func TestCheckKeywordMatch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("hello jetpack world"))
+	}))
+	defer srv.Close()
+
+	kw := "jetpack"
+	res := Check(context.Background(), Request{BlogID: 1, URL: srv.URL, TimeoutSeconds: 5, Keyword: &kw})
+	if !res.Success {
+		t.Fatalf("Success = false for keyword match, want true")
+	}
+	if res.ErrorCode != ErrorNone {
+		t.Fatalf("ErrorCode = %d for keyword match, want ErrorNone", res.ErrorCode)
+	}
+}
+
+func TestCheckKeywordMiss(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("hello world"))
+	}))
+	defer srv.Close()
+
+	kw := "jetpack"
+	res := Check(context.Background(), Request{BlogID: 1, URL: srv.URL, TimeoutSeconds: 5, Keyword: &kw})
+	if res.ErrorCode != ErrorKeyword {
+		t.Fatalf("ErrorCode = %d, want ErrorKeyword", res.ErrorCode)
+	}
+}
+
+func TestCheckRedirectFail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			http.Redirect(w, r, "/final", http.StatusMovedPermanently)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	res := Check(context.Background(), Request{BlogID: 1, URL: srv.URL, TimeoutSeconds: 5, RedirectPolicy: RedirectFail})
+	if res.ErrorCode != ErrorRedirect {
+		t.Fatalf("ErrorCode = %d, want ErrorRedirect", res.ErrorCode)
+	}
+}
+
+func TestCheckCustomHeadersForwarded(t *testing.T) {
+	var receivedHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeader = r.Header.Get("X-Custom-Test")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	res := Check(context.Background(), Request{
+		BlogID:         1,
+		URL:            srv.URL,
+		TimeoutSeconds: 5,
+		CustomHeaders:  map[string]string{"X-Custom-Test": "hello"},
+	})
+	if !res.Success {
+		t.Fatalf("Success = false, want true")
+	}
+	if receivedHeader != "hello" {
+		t.Fatalf("X-Custom-Test = %q, want hello", receivedHeader)
+	}
+}
+
+func TestCheckRedirectAlert(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			http.Redirect(w, r, "/final", http.StatusMovedPermanently)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	res := Check(context.Background(), Request{
+		BlogID:         1,
+		URL:            srv.URL,
+		TimeoutSeconds: 5,
+		RedirectPolicy: RedirectAlert,
+	})
+	if !res.RedirectChanged {
+		t.Fatal("RedirectChanged = false for redirect-alert policy, want true")
+	}
+}
+
+func TestCheckInvalidURL(t *testing.T) {
+	res := Check(context.Background(), Request{BlogID: 1, URL: "://invalid-url", TimeoutSeconds: 5})
+	if res.ErrorCode != ErrorConnect {
+		t.Fatalf("ErrorCode = %d, want ErrorConnect for invalid URL", res.ErrorCode)
+	}
+}
+
+func TestCheckConnectionRefused(t *testing.T) {
+	// Start a server to get a free port, then stop it so connections are refused.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+
+	res := Check(context.Background(), Request{BlogID: 1, URL: url, TimeoutSeconds: 5})
+	if res.ErrorCode != ErrorConnect {
+		t.Fatalf("ErrorCode = %d, want ErrorConnect", res.ErrorCode)
+	}
+}
+
+// --- Pool scale(), Results(), QueueDepth(), ActiveCount() ---
+
+func TestScaleUpWhenQueueDeep(t *testing.T) {
+	orig := poolCheckFunc
+	block := make(chan struct{})
+	poolCheckFunc = func(_ context.Context, req Request) Result {
+		<-block
+		return Result{BlogID: req.BlogID}
+	}
+
+	p := NewPool(1, 1, 5)
+	// Register Drain first so it runs second (LIFO): close(block) unblocks workers, then Drain completes.
+	t.Cleanup(p.Drain)
+	t.Cleanup(func() {
+		poolCheckFunc = orig
+		close(block)
+	})
+
+	// Submit enough work to ensure queue > current worker count.
+	for range 4 {
+		p.Submit(Request{BlogID: 1, URL: "x"})
+	}
+	time.Sleep(10 * time.Millisecond)
+
+	p.scale()
+
+	if p.WorkerCount() <= 1 {
+		t.Fatalf("WorkerCount = %d after scale-up, want > 1", p.WorkerCount())
+	}
+}
+
+func TestScaleDownGraduallyWhenIdle(t *testing.T) {
+	p := NewPool(3, 1, 3)
+	t.Cleanup(p.Drain)
+
+	p.scale()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if p.WorkerCount() < 3 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("WorkerCount = %d after idle scale-down, want < 3", p.WorkerCount())
+}
+
+func TestScaleDownExcessAboveMax(t *testing.T) {
+	p := NewPool(5, 1, 5)
+	t.Cleanup(p.Drain)
+
+	p.mu.Lock()
+	p.maxSize = 3
+	p.mu.Unlock()
+
+	p.scale()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if p.WorkerCount() <= 3 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("WorkerCount = %d after maxSize reduction, want <= 3", p.WorkerCount())
+}
+
+func TestResults(t *testing.T) {
+	orig := poolCheckFunc
+	poolCheckFunc = func(_ context.Context, req Request) Result {
+		return Result{BlogID: req.BlogID, Success: true, HTTPCode: 200}
+	}
+	t.Cleanup(func() { poolCheckFunc = orig })
+
+	p := NewPool(1, 1, 1)
+	t.Cleanup(p.Drain)
+
+	p.Submit(Request{BlogID: 42, URL: "https://example.com"})
+
+	select {
+	case res := <-p.Results():
+		if res.BlogID != 42 {
+			t.Fatalf("result BlogID = %d, want 42", res.BlogID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for result")
+	}
+}
+
+func TestQueueDepth(t *testing.T) {
+	orig := poolCheckFunc
+	release := make(chan struct{})
+	poolCheckFunc = func(_ context.Context, req Request) Result {
+		<-release
+		return Result{BlogID: req.BlogID}
+	}
+
+	p := NewPool(1, 1, 1)
+	t.Cleanup(p.Drain)
+	t.Cleanup(func() {
+		poolCheckFunc = orig
+		close(release)
+	})
+
+	p.Submit(Request{BlogID: 1, URL: "a"})
+	time.Sleep(10 * time.Millisecond) // let worker pick up first request
+	p.Submit(Request{BlogID: 2, URL: "b"})
+
+	if d := p.QueueDepth(); d != 1 {
+		t.Fatalf("QueueDepth() = %d, want 1", d)
+	}
+}
+
+func TestActiveCount(t *testing.T) {
+	orig := poolCheckFunc
+	started := make(chan struct{})
+	release := make(chan struct{})
+	poolCheckFunc = func(_ context.Context, req Request) Result {
+		close(started)
+		<-release
+		return Result{BlogID: req.BlogID}
+	}
+
+	p := NewPool(1, 1, 1)
+	t.Cleanup(p.Drain)
+	t.Cleanup(func() {
+		poolCheckFunc = orig
+		close(release)
+	})
+
+	p.Submit(Request{BlogID: 1, URL: "x"})
+	<-started
+
+	if p.ActiveCount() != 1 {
+		t.Fatalf("ActiveCount() = %d, want 1", p.ActiveCount())
+	}
+}

--- a/internal/checker/pool.go
+++ b/internal/checker/pool.go
@@ -1,0 +1,221 @@
+package checker
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+var poolCheckFunc = Check
+
+// Pool is an auto-scaling goroutine pool for HTTP checks.
+type Pool struct {
+	work    chan Request
+	results chan Result
+	retire  chan struct{}
+	cancel  context.CancelFunc
+	ctx     context.Context
+	closed  atomic.Bool
+
+	size   atomic.Int64
+	active atomic.Int64
+
+	mu      sync.Mutex
+	workMu  sync.RWMutex
+	wg      sync.WaitGroup
+	minSize int
+	maxSize int
+}
+
+// NewPool creates a Pool with the given initial, min, and max worker counts.
+func NewPool(initial, min, max int) *Pool {
+	ctx, cancel := context.WithCancel(context.Background())
+	p := &Pool{
+		work:    make(chan Request, max*2),
+		results: make(chan Result, max*2),
+		retire:  make(chan struct{}, max),
+		cancel:  cancel,
+		ctx:     ctx,
+		minSize: min,
+		maxSize: max,
+	}
+	for range initial {
+		p.spawnWorker()
+	}
+	go p.autoScale()
+	return p
+}
+
+// Submit enqueues a check request. Non-blocking; drops if queue is full.
+func (p *Pool) Submit(req Request) bool {
+	p.workMu.RLock()
+	defer p.workMu.RUnlock()
+	if p.closed.Load() {
+		return false
+	}
+	select {
+	case p.work <- req:
+		return true
+	default:
+		return false
+	}
+}
+
+// Results returns the channel on which completed results are delivered.
+func (p *Pool) Results() <-chan Result {
+	return p.results
+}
+
+// QueueDepth returns the number of pending requests.
+func (p *Pool) QueueDepth() int {
+	return len(p.work)
+}
+
+// ActiveCount returns the number of goroutines currently running a check.
+func (p *Pool) ActiveCount() int {
+	return int(p.active.Load())
+}
+
+// WorkerCount returns the total number of live worker goroutines.
+func (p *Pool) WorkerCount() int {
+	return int(p.size.Load())
+}
+
+// Drain stops accepting new work and waits for in-flight checks to complete.
+func (p *Pool) Drain() {
+	if !p.closed.CompareAndSwap(false, true) {
+		return
+	}
+	p.workMu.Lock()
+	close(p.work)
+	p.workMu.Unlock()
+	p.wg.Wait()
+	p.cancel()
+}
+
+func (p *Pool) spawnWorker() {
+	p.size.Add(1)
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		defer p.size.Add(-1)
+		for {
+			select {
+			case <-p.ctx.Done():
+				return
+			case <-p.retire:
+				return
+			case req, ok := <-p.work:
+				if !ok {
+					return
+				}
+				p.active.Add(1)
+				res := poolCheckFunc(context.Background(), req)
+				p.active.Add(-1)
+				if p.closed.Load() {
+					continue
+				}
+				select {
+				case p.results <- res:
+				case <-p.ctx.Done():
+					return
+				default:
+					// Avoid deadlocking shutdown if the result consumer has stopped.
+				}
+			}
+		}
+	}()
+}
+
+// autoScale adjusts the pool size every 5 seconds based on queue depth and
+// process memory usage.
+func (p *Pool) autoScale() {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-p.ctx.Done():
+			return
+		case <-ticker.C:
+			p.scale()
+		}
+	}
+}
+
+func (p *Pool) scale() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed.Load() {
+		return
+	}
+
+	current := int(p.size.Load())
+	queue := len(p.work)
+
+	// Scale up: queue depth exceeds current worker count.
+	if queue > current && current < p.maxSize {
+		add := min(queue-current, p.maxSize-current)
+		for range add {
+			p.spawnWorker()
+		}
+		return
+	}
+
+	// Scale down gradually when demand is low or the max size has been lowered.
+	if current > p.maxSize {
+		p.retireWorkers(current - p.maxSize)
+		return
+	}
+	if queue == 0 && current > p.minSize {
+		p.retireWorkers(1)
+	}
+}
+
+// SetMaxSize updates the autoscaler ceiling after config reload.
+func (p *Pool) SetMaxSize(max int) {
+	if max < 1 {
+		max = 1
+	}
+	p.mu.Lock()
+	p.maxSize = max
+	current := int(p.size.Load())
+	if current > p.maxSize {
+		p.retireWorkers(current - p.maxSize)
+	}
+	p.mu.Unlock()
+}
+
+// DrainWorkers gracefully reduces the pool size by up to n idle workers.
+func (p *Pool) DrainWorkers(n int) int {
+	if n < 1 {
+		return 0
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.retireWorkers(n)
+}
+
+func (p *Pool) retireWorkers(n int) int {
+	if n < 1 {
+		return 0
+	}
+	current := int(p.size.Load())
+	available := current - p.minSize
+	if available < 1 {
+		return 0
+	}
+	if n > available {
+		n = available
+	}
+	retired := 0
+	for range n {
+		select {
+		case p.retire <- struct{}{}:
+			retired++
+		default:
+			return retired
+		}
+	}
+	return retired
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,86 @@
+package metrics
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Client sends StatsD metrics via UDP and writes stats files.
+type Client struct {
+	prefix string
+	conn   net.Conn
+	mu     sync.Mutex
+}
+
+var global *Client
+
+// Init creates the global StatsD client.
+// host:port is the StatsD server address (e.g. "statsd:8125").
+// hostname is used to build the metric prefix.
+func Init(addr, hostname string) error {
+	conn, err := net.Dial("udp", addr)
+	if err != nil {
+		return fmt.Errorf("statsd dial %s: %w", addr, err)
+	}
+	global = &Client{
+		prefix: "com.jetpack.jetmon." + sanitize(hostname),
+		conn:   conn,
+	}
+	return nil
+}
+
+// Client returns the global metrics client. Panics if Init was not called.
+func Global() *Client {
+	return global
+}
+
+// Increment sends a counter metric.
+func (c *Client) Increment(stat string, value int) {
+	c.send(fmt.Sprintf("%s.%s:%d|c", c.prefix, stat, value))
+}
+
+// Gauge sends a gauge metric.
+func (c *Client) Gauge(stat string, value int) {
+	c.send(fmt.Sprintf("%s.%s:%d|g", c.prefix, stat, value))
+}
+
+// Timing sends a timer metric in milliseconds.
+func (c *Client) Timing(stat string, d time.Duration) {
+	c.send(fmt.Sprintf("%s.%s:%d|ms", c.prefix, stat, d.Milliseconds()))
+}
+
+func (c *Client) send(msg string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_, _ = fmt.Fprintln(c.conn, msg)
+}
+
+// EmitMemStats optionally sends process RSS as a gauge.
+func (c *Client) EmitMemStats() {
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	c.Gauge("process.rss_mb", int(ms.Sys/1024/1024))
+	c.Gauge("process.heap_alloc_mb", int(ms.HeapAlloc/1024/1024))
+}
+
+// WriteStatsFiles writes sitespersec, sitesqueue, and totals to the stats/
+// directory so existing monitoring and the README examples continue to work.
+func WriteStatsFiles(sitesPerSec, queueSize, totalChecked int) {
+	writeFile("stats/sitespersec", strconv.Itoa(sitesPerSec))
+	writeFile("stats/sitesqueue", strconv.Itoa(queueSize))
+	writeFile("stats/totals", strconv.Itoa(totalChecked))
+}
+
+func writeFile(path, content string) {
+	_ = os.WriteFile(path, []byte(content+"\n"), 0644)
+}
+
+func sanitize(s string) string {
+	return strings.NewReplacer(".", "_", "-", "_").Replace(s)
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,36 @@
+package metrics
+
+import "testing"
+
+func TestSanitize(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"simple", "simple"},
+		{"host.name", "host_name"},
+		{"my-host", "my_host"},
+		{"a.b-c.d", "a_b_c_d"},
+	}
+	for _, tt := range tests {
+		if got := sanitize(tt.input); got != tt.want {
+			t.Fatalf("sanitize(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestGlobalNilBeforeInit(t *testing.T) {
+	orig := global
+	global = nil
+	defer func() { global = orig }()
+
+	if Global() != nil {
+		t.Fatal("Global() = non-nil before Init, want nil")
+	}
+}
+
+func TestWriteStatsFilesDoesNotPanic(t *testing.T) {
+	// stats/ directory may not exist in test context; errors are silently
+	// ignored by design — just verify this does not panic.
+	WriteStatsFiles(10, 5, 1000)
+}


### PR DESCRIPTION
## Scope
- Add Go checker implementation and worker pool (`internal/checker/**`).
- Add metrics client/reporting package (`internal/metrics/**`).
- Include checker and metrics tests.

## Out of Scope
- No orchestrator wiring/cutover or legacy runtime removal.

## Testing
- Included package tests in `internal/checker/*_test.go` and `internal/metrics/*_test.go`.
- Verified diff scope is checker/metrics only.

## Compatibility
- Preserves compatibility targets while introducing additive checker/metrics components.