### PR TITLE
feat(data): add config, db, audit, wpcom, and migrations

### DIFF
--- a/config/config-sample.json
+++ b/config/config-sample.json
@@ -1,15 +1,16 @@
 {
-	"DEBUG"             : true,
+	"DEBUG"             : false,
 	"NUM_WORKERS"       : 60,
 	"NUM_TO_PROCESS"    : 40,
 	"DATASET_SIZE"      : 100,
-	"WORKER_MAX_CHECKS" : 10000,
 	"WORKER_MAX_MEM_MB" : 53,
 
 	"DB_UPDATES_ENABLE" : false,
 
-	"BUCKET_NO_MIN"  : 0,
-	"BUCKET_NO_MAX"  : 512,
+	"BUCKET_TOTAL"               : 1000,
+	"BUCKET_TARGET"              : 500,
+	"BUCKET_HEARTBEAT_GRACE_SEC" : 600,
+
 	"BATCH_SIZE"     : 32,
 	"AUTH_TOKEN"     : "<AUTH_TOKEN>",
 
@@ -18,21 +19,27 @@
 	"DB_CONFIG_UPDATES_MIN" : 10,
 	"PEER_OFFLINE_LIMIT"    : 3,
 
-	"NUM_OF_CHECKS"               : 3,
-	"TIME_BETWEEN_CHECKS_SEC"     : 30,
+	"NUM_OF_CHECKS"           : 3,
+	"TIME_BETWEEN_CHECKS_SEC" : 30,
+
+	"ALERT_COOLDOWN_MINUTES" : 30,
 
 	"STATS_UPDATE_INTERVAL_MS"     : 10000,
 	"STATSD_SEND_MEM_USAGE"        : false,
 	"TIME_BETWEEN_NOTICES_MIN"     : 59,
 	"MIN_TIME_BETWEEN_ROUNDS_SEC"  : 300,
-	"TIMEOUT_FOR_REQUESTS_SEC"     : 60,
+	"NET_COMMS_TIMEOUT"            : 10,
 	"USE_VARIABLE_CHECK_INTERVALS" : false,
+
+	"LOG_FORMAT"     : "text",
+	"DASHBOARD_PORT" : 8080,
+	"DEBUG_PORT"     : 6060,
 
 	"VERIFIERS": [
 		{
 			"name"       : "Veriflier 1",
 			"host"       : "veriflier",
-			"port"       : "<VERIFLIER_PORT>",
+			"grpc_port"  : "<VERIFLIER_GRPC_PORT>",
 			"auth_token" : "<VERIFLIER_AUTH_TOKEN>"
 		}
 	]

--- a/config/config.readme
+++ b/config/config.readme
@@ -1,76 +1,81 @@
 DEBUG
-Set to true to enable more verbose log messages in logs/jetmon.log.
+Set to true to enable more verbose log messages. Default: false.
 
 NUM_WORKERS
-The number of forked worker processes to create and maintain.
+Initial number of goroutines in the check pool. The pool auto-scales between 1 and NUM_WORKERS based on queue depth. Default: 60.
 
 NUM_TO_PROCESS
-The number of sites that a worker should process in parallel.
+Number of sites to dispatch per round. Default: 40.
 
 DATASET_SIZE
-The maximum number of sites to send to a worker's queue in a single batch.
-
-WORKER_MAX_CHECKS
-The maximum number of checks that a worker can process before it stops accepting work and is scheduled to recycle.
-Set to 0 or a negative value to disable recycling workers based on the number of checks.
-
-WORKER_MAX_MEM_MB
-The maximum MB of memory that a worker can consume before it stops accepting work and is scheduled to recycle.
-Set to 0 or a negative value to disable recycling workers based on memory usage.
-The following comment was in the worker source code from an early dev on why they chose 45MB as the original value. Since then, we moved to a value of 53MB.
-	Empirically ended up with 45MB per worker.
-	They don't get killed off all the time, and on a system with 16GB RAM
-	we end up having ~1.6GB free.
+Maximum number of sites to fetch from the database per batch. Default: 100.
 
 DB_UPDATES_ENABLE
-WARNING: Do not enabled this on production hosts. This should only be enabled on local docker test environments and never in production.
-Set to true to allow Jetmon to update the jetpack_monitor_sites table. Without this, it is difficult to test how effective the code is working when in a local docker test environment.
+WARNING: Do not enable on production hosts.
+Set to true to allow Jetmon to update the jetpack_monitor_sites table. Only useful in local Docker test environments to observe status-change behaviour.
+Enabling this also requires the environment variable JETMON_UNSAFE_DB_UPDATES=1 to be set, as a second confirmation gate against accidental production use.
 
-BUCKET_NO_MIN
-The first bucket in the range of jetpack_monitor_sites buckets that this host should process when checking sites. Each host should be configured to have a unique set of buckets that it is responsible for.
-The buckets currently range from 0 to 511.
+BUCKET_TOTAL
+Total number of buckets in the system across all hosts. Must match the range of bucket_no values in the jetpack_monitor_sites table. Default: 1000.
 
-BUCKET_NO_MAX
-The last bucket in the range of jetpack_monitor_sites buckets that this host should process when checking sites. Each host should be configured to have a unique set of buckets that it is responsible for.
-The buckets currently range from 0 to 511.
+BUCKET_TARGET
+Number of buckets this host should claim on startup. Used for initial distribution across hosts. Default: 500.
+
+BUCKET_HEARTBEAT_GRACE_SEC
+Seconds after a host's last heartbeat before its buckets are considered available for reclaiming by another host. Default: 600.
 
 BATCH_SIZE
-The number of buckets returned in each batch when running checks.
+Number of buckets fetched per database query when loading sites. Default: 32.
 
 AUTH_TOKEN
-A string used to validate communications between different systems over HTTPS.
+Shared secret used to authenticate outbound WPCOM API calls. Required.
 
 VERIFLIER_BATCH_SIZE
-The maximum number of sites to send to verifliers in a single batch.
-
-SQL_UPDATE_BATCH
-Unknown. Likely not used currently.
-
-DB_CONFIG_UPDATES_MIN
-How frequently in minutes the database library should check for DB config changes in order to reload.
+Maximum number of sites sent to each veriflier per verification request. Default: 200.
 
 PEER_OFFLINE_LIMIT
-The minimum number of verifliers that must confirm that a site is down before changing the site status to down.
+Minimum number of verifliers that must confirm a site is down before it is declared confirmed-down. Default: 3.
 
 NUM_OF_CHECKS
-The number of local checks that must fail before a site is checked by the verifliers.
+Number of consecutive local check failures required before escalating to verifliers. Default: 3.
 
 TIME_BETWEEN_CHECKS_SEC
-The minimum amount of time that must elapse between local checks for a specific site.
+Minimum seconds between checks for a given site. Default: 30.
+
+ALERT_COOLDOWN_MINUTES
+Minimum minutes between repeated down-alerts for the same site. Prevents alert storms during flapping. Default: 30. Can be overridden per-site via alert_cooldown_minutes column.
 
 STATS_UPDATE_INTERVAL_MS
-The minimum delay, in milliseconds, between stats updates to both statsd and stats log files.
+Milliseconds between StatsD metric flushes and stats file updates. Default: 10000.
+
+STATSD_SEND_MEM_USAGE
+Set to true to emit Go runtime memory stats to StatsD each interval. Default: false.
 
 TIME_BETWEEN_NOTICES_MIN
-The minimum delay, in minutes, that must pass before a site can transition from SITE_DOWN to SITE_CONFIRMED_DOWN.
+Minimum minutes between a site going down and a confirmed-down notification being sent. Default: 59.
 
 MIN_TIME_BETWEEN_ROUNDS_SEC
-The minimum delay, in seconds, between check rounds.
-Note: This value has no effect if USE_VARIABLE_CHECK_INTERVALS is set to true.
+Minimum seconds between check rounds. Has no effect when USE_VARIABLE_CHECK_INTERVALS is true. Default: 300.
 
-TIMEOUT_FOR_REQUESTS_SEC
-The amount of time, in seconds, that a site can remain in the queuedRetries array (the queue that holds sites being checked by verifliers) before being purged out of the queue.
+NET_COMMS_TIMEOUT
+Default HTTP request timeout in seconds. Can be overridden per-site via timeout_seconds column. Default: 10.
 
 USE_VARIABLE_CHECK_INTERVALS
-Set to true to enable the variable check intervals as set for each site in the jetpack_monitor_sites table.
-Note: Enabling this disables use of the MIN_TIME_BETWEEN_ROUNDS_SEC config, sets the round loop to execute every minute, and checks each site on the interval as set in the database.
+Set to true to respect the check_interval column per site instead of running all sites every round. Default: false.
+
+LOG_FORMAT
+Log output format. Set to "json" for structured logging (e.g. for log aggregators), or "text" for human-readable output. Default: "text".
+
+DASHBOARD_PORT
+Port for the operator dashboard and internal API. Set to 0 to disable. Default: 8080.
+
+DEBUG_PORT
+Port for the pprof debug server. Only binds to 127.0.0.1 (localhost) — never accessible remotely. Set to 0 to disable. Default: 6060.
+Access via: curl http://localhost:6060/debug/pprof/
+
+VERIFIERS
+Array of veriflier configuration objects. Each entry requires:
+  name       - display name
+  host       - hostname or IP of the veriflier
+  grpc_port  - gRPC/HTTP port (default 7803)
+  auth_token - shared secret for veriflier authentication

--- a/config/db-config-sample.conf
+++ b/config/db-config-sample.conf
@@ -1,6 +1,9 @@
-$db_servers = array(
-	'misc' => array( 
-		array( 'jetmon', 0, 1, 'mysqldb:<MYSQLDB_PORT>', 'mysqldb:<MYSQLDB_PORT>', '<MYSQLDB_DATABASE>', '<MYSQLDB_USER>', '<MYSQLDB_ROOT_PASSWORD>', null, null, 30 ),
-		array( 'jetmon', 1, 0, 'mysqldb:<MYSQLDB_PORT>', 'mysqldb:<MYSQLDB_PORT>', '<MYSQLDB_DATABASE>', '<MYSQLDB_USER>', '<MYSQLDB_ROOT_PASSWORD>', null, null, 30 ),
-	)
-);
+# Database connection environment variables for non-Docker deployments.
+# Copy to /opt/jetmon2/config/jetmon2.env and fill in real values.
+# The systemd unit reads this file via EnvironmentFile.
+
+DB_HOST=localhost
+DB_PORT=3306
+DB_USER=jetmon
+DB_PASSWORD=change_me
+DB_NAME=jetmon_db

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -1,0 +1,103 @@
+package audit
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// Event types written to jetmon_audit_log.
+const (
+	EventCheck            = "check"
+	EventStatusTransition = "status_transition"
+	EventWPCOMSent        = "wpcom_sent"
+	EventWPCOMRetry       = "wpcom_retry"
+	EventRetryDispatched  = "retry_dispatched"
+	EventVeriflierSent    = "veriflier_sent"
+	EventVeriflierResult  = "veriflier_result"
+	EventMaintenanceActive = "maintenance_active"
+	EventAlertSuppressed  = "alert_suppressed"
+	EventConfigChange     = "config_change"
+)
+
+var db *sql.DB
+
+// Init sets the database connection used by the audit log.
+func Init(conn *sql.DB) {
+	db = conn
+}
+
+// Log writes an event to jetmon_audit_log.
+func Log(blogID int64, eventType, source string, httpCode, errorCode int, rttMs int64, detail string) error {
+	if db == nil {
+		return nil
+	}
+	_, err := db.Exec(
+		`INSERT INTO jetmon_audit_log
+		    (blog_id, event_type, source, http_code, error_code, rtt_ms, detail)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		blogID, eventType, source,
+		nullInt(httpCode), nullInt(errorCode), nullInt64(rttMs),
+		nullString(detail),
+	)
+	if err != nil {
+		return fmt.Errorf("audit log insert: %w", err)
+	}
+	return nil
+}
+
+// LogTransition writes a status transition event.
+func LogTransition(blogID int64, oldStatus, newStatus int, reason string) error {
+	if db == nil {
+		return nil
+	}
+	_, err := db.Exec(
+		`INSERT INTO jetmon_audit_log
+		    (blog_id, event_type, source, old_status, new_status, detail)
+		 VALUES (?, ?, 'local', ?, ?, ?)`,
+		blogID, EventStatusTransition, oldStatus, newStatus, reason,
+	)
+	return err
+}
+
+// Query returns audit log entries for a blog within the given time range.
+// The caller must close the returned *sql.Rows.
+func Query(db *sql.DB, blogID int64, since, until string) (*sql.Rows, error) {
+	q := `SELECT id, blog_id, event_type, source, http_code, error_code, rtt_ms,
+	             old_status, new_status, detail, created_at
+	      FROM jetmon_audit_log
+	      WHERE blog_id = ?`
+	args := []any{blogID}
+
+	if since != "" {
+		q += " AND created_at >= ?"
+		args = append(args, since)
+	}
+	if until != "" {
+		q += " AND created_at <= ?"
+		args = append(args, until)
+	}
+	q += " ORDER BY created_at ASC"
+
+	return db.Query(q, args...)
+}
+
+func nullInt(v int) any {
+	if v == 0 {
+		return nil
+	}
+	return v
+}
+
+func nullInt64(v int64) any {
+	if v == 0 {
+		return nil
+	}
+	return v
+}
+
+func nullString(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -1,0 +1,52 @@
+package audit
+
+import "testing"
+
+func TestNullInt(t *testing.T) {
+	if nullInt(0) != nil {
+		t.Fatal("nullInt(0) should be nil")
+	}
+	if nullInt(42) != 42 {
+		t.Fatalf("nullInt(42) = %v, want 42", nullInt(42))
+	}
+}
+
+func TestNullInt64(t *testing.T) {
+	if nullInt64(0) != nil {
+		t.Fatal("nullInt64(0) should be nil")
+	}
+	if nullInt64(100) != int64(100) {
+		t.Fatalf("nullInt64(100) = %v, want 100", nullInt64(100))
+	}
+}
+
+func TestNullString(t *testing.T) {
+	if nullString("") != nil {
+		t.Fatal("nullString(\"\") should be nil")
+	}
+	if nullString("hello") != "hello" {
+		t.Fatalf("nullString(\"hello\") = %v, want \"hello\"", nullString("hello"))
+	}
+}
+
+func TestLogWithNilDB(t *testing.T) {
+	// db is nil in tests — Log must return nil, not panic.
+	if err := Log(1, EventCheck, "test", 200, 0, 50, "detail"); err != nil {
+		t.Fatalf("Log() with nil db = %v, want nil", err)
+	}
+}
+
+func TestLogTransitionWithNilDB(t *testing.T) {
+	if err := LogTransition(1, 1, 2, "recovered"); err != nil {
+		t.Fatalf("LogTransition() with nil db = %v, want nil", err)
+	}
+}
+
+func TestInit(t *testing.T) {
+	orig := db
+	t.Cleanup(func() { db = orig })
+	Init(nil)
+	if db != nil {
+		t.Fatal("Init(nil) should set db to nil")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,204 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"sync"
+)
+
+// VerifierConfig holds connection details for a single Veriflier instance.
+type VerifierConfig struct {
+	Name      string `json:"name"`
+	Host      string `json:"host"`
+	GRPCPort  string `json:"grpc_port"`
+	AuthToken string `json:"auth_token"`
+}
+
+// Config holds all runtime configuration for Jetmon 2.
+type Config struct {
+	Debug   bool `json:"DEBUG"`
+
+	NumWorkers     int `json:"NUM_WORKERS"`
+	NumToProcess   int `json:"NUM_TO_PROCESS"`
+	DatasetSize    int `json:"DATASET_SIZE"`
+	WorkerMaxMemMB int `json:"WORKER_MAX_MEM_MB"`
+
+	DBUpdatesEnable bool `json:"DB_UPDATES_ENABLE"`
+
+	BucketTotal             int `json:"BUCKET_TOTAL"`
+	BucketTarget            int `json:"BUCKET_TARGET"`
+	BucketHeartbeatGraceSec int `json:"BUCKET_HEARTBEAT_GRACE_SEC"`
+
+	BatchSize int    `json:"BATCH_SIZE"`
+	AuthToken string `json:"AUTH_TOKEN"`
+
+	VeriflierBatchSize  int `json:"VERIFLIER_BATCH_SIZE"`
+	SQLUpdateBatch      int `json:"SQL_UPDATE_BATCH"`
+	DBConfigUpdatesMin  int `json:"DB_CONFIG_UPDATES_MIN"`
+	PeerOfflineLimit    int `json:"PEER_OFFLINE_LIMIT"`
+
+	NumOfChecks          int `json:"NUM_OF_CHECKS"`
+	TimeBetweenChecksSec int `json:"TIME_BETWEEN_CHECKS_SEC"`
+
+	AlertCooldownMinutes int `json:"ALERT_COOLDOWN_MINUTES"`
+
+	StatsUpdateIntervalMS     int  `json:"STATS_UPDATE_INTERVAL_MS"`
+	StatsdSendMemUsage        bool `json:"STATSD_SEND_MEM_USAGE"`
+	TimeBetweenNoticesMin     int  `json:"TIME_BETWEEN_NOTICES_MIN"`
+	MinTimeBetweenRoundsSec   int  `json:"MIN_TIME_BETWEEN_ROUNDS_SEC"`
+	NetCommsTimeout           int  `json:"NET_COMMS_TIMEOUT"`
+	UseVariableCheckIntervals bool `json:"USE_VARIABLE_CHECK_INTERVALS"`
+
+	LogFormat     string `json:"LOG_FORMAT"`
+	DashboardPort int    `json:"DASHBOARD_PORT"`
+	DebugPort     int    `json:"DEBUG_PORT"`
+
+	Verifiers []VerifierConfig `json:"VERIFIERS"`
+}
+
+// DBConfig holds MySQL connection parameters loaded from db-config.conf.
+type DBConfig struct {
+	Host     string
+	Port     string
+	User     string
+	Password string
+	Name     string
+}
+
+var (
+	mu      sync.RWMutex
+	current *Config
+	dbConf  *DBConfig
+	path    string
+)
+
+// Load reads the config file at the given path and stores it.
+func Load(configPath string) error {
+	path = configPath
+	return reload()
+}
+
+// Reload re-reads the config file from the path passed to Load.
+func Reload() error {
+	return reload()
+}
+
+func reload() error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open config: %w", err)
+	}
+	defer f.Close()
+
+	cfg := defaults()
+	if err := json.NewDecoder(f).Decode(cfg); err != nil {
+		return fmt.Errorf("parse config: %w", err)
+	}
+
+	if err := validate(cfg); err != nil {
+		return fmt.Errorf("invalid config: %w", err)
+	}
+
+	mu.Lock()
+	current = cfg
+	mu.Unlock()
+	return nil
+}
+
+// Get returns a snapshot of the current config. Safe for concurrent use.
+func Get() *Config {
+	mu.RLock()
+	defer mu.RUnlock()
+	return current
+}
+
+// LoadDB reads the database config from environment variables (set by the
+// Docker entrypoint) or falls back to the legacy db-config.conf format.
+func LoadDB() *DBConfig {
+	db := &DBConfig{
+		Host:     envOrDefault("DB_HOST", "localhost"),
+		Port:     envOrDefault("DB_PORT", "3306"),
+		User:     envOrDefault("DB_USER", "root"),
+		Password: envOrDefault("DB_PASSWORD", ""),
+		Name:     envOrDefault("DB_NAME", "jetmon_db"),
+	}
+	mu.Lock()
+	dbConf = db
+	mu.Unlock()
+	return db
+}
+
+// GetDB returns the database config.
+func GetDB() *DBConfig {
+	mu.RLock()
+	defer mu.RUnlock()
+	return dbConf
+}
+
+func defaults() *Config {
+	return &Config{
+		NumWorkers:              60,
+		NumToProcess:            40,
+		DatasetSize:             100,
+		WorkerMaxMemMB:          53,
+		BucketTotal:             1000,
+		BucketTarget:            500,
+		BucketHeartbeatGraceSec: 600,
+		BatchSize:               32,
+		VeriflierBatchSize:      200,
+		SQLUpdateBatch:          1,
+		DBConfigUpdatesMin:      10,
+		PeerOfflineLimit:        3,
+		NumOfChecks:             3,
+		TimeBetweenChecksSec:    30,
+		AlertCooldownMinutes:    30,
+		StatsUpdateIntervalMS:   10000,
+		TimeBetweenNoticesMin:   59,
+		MinTimeBetweenRoundsSec: 300,
+		NetCommsTimeout:         10,
+		LogFormat:               "text",
+		DashboardPort:           8080,
+		DebugPort:               6060,
+	}
+}
+
+func validate(cfg *Config) error {
+	if cfg.AuthToken == "" {
+		return fmt.Errorf("AUTH_TOKEN is required")
+	}
+	if cfg.NumWorkers <= 0 {
+		return fmt.Errorf("NUM_WORKERS must be > 0")
+	}
+	if cfg.BucketTotal <= 0 {
+		return fmt.Errorf("BUCKET_TOTAL must be > 0")
+	}
+	if cfg.BucketTarget <= 0 || cfg.BucketTarget > cfg.BucketTotal {
+		return fmt.Errorf("BUCKET_TARGET must be between 1 and BUCKET_TOTAL")
+	}
+	if cfg.NetCommsTimeout <= 0 {
+		return fmt.Errorf("NET_COMMS_TIMEOUT must be > 0")
+	}
+	if cfg.LogFormat != "text" && cfg.LogFormat != "json" {
+		return fmt.Errorf("LOG_FORMAT must be 'text' or 'json'")
+	}
+	return nil
+}
+
+// Debugf logs a debug message when DEBUG is true in the current config.
+func Debugf(format string, args ...any) {
+	mu.RLock()
+	d := current != nil && current.Debug
+	mu.RUnlock()
+	if d {
+		log.Printf("[DEBUG] "+format, args...)
+	}
+}
+
+func envOrDefault(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,333 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestValidate(t *testing.T) {
+	base := func() *Config {
+		return &Config{
+			AuthToken:       "token",
+			NumWorkers:      10,
+			BucketTotal:     100,
+			BucketTarget:    50,
+			NetCommsTimeout: 10,
+			LogFormat:       "text",
+		}
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*Config)
+		wantErr bool
+	}{
+		{
+			name:   "valid config",
+			mutate: func(_ *Config) {},
+		},
+		{
+			name:    "missing auth token",
+			mutate:  func(c *Config) { c.AuthToken = "" },
+			wantErr: true,
+		},
+		{
+			name:    "num workers zero",
+			mutate:  func(c *Config) { c.NumWorkers = 0 },
+			wantErr: true,
+		},
+		{
+			name:    "num workers negative",
+			mutate:  func(c *Config) { c.NumWorkers = -1 },
+			wantErr: true,
+		},
+		{
+			name:    "bucket total zero",
+			mutate:  func(c *Config) { c.BucketTotal = 0 },
+			wantErr: true,
+		},
+		{
+			name:    "bucket target zero",
+			mutate:  func(c *Config) { c.BucketTarget = 0 },
+			wantErr: true,
+		},
+		{
+			name:    "bucket target exceeds bucket total",
+			mutate:  func(c *Config) { c.BucketTarget = 101 },
+			wantErr: true,
+		},
+		{
+			name:    "bucket target equals bucket total is valid",
+			mutate:  func(c *Config) { c.BucketTarget = 100 },
+			wantErr: false,
+		},
+		{
+			name:    "net comms timeout zero",
+			mutate:  func(c *Config) { c.NetCommsTimeout = 0 },
+			wantErr: true,
+		},
+		{
+			name:    "net comms timeout negative",
+			mutate:  func(c *Config) { c.NetCommsTimeout = -1 },
+			wantErr: true,
+		},
+		{
+			name:    "invalid log format",
+			mutate:  func(c *Config) { c.LogFormat = "xml" },
+			wantErr: true,
+		},
+		{
+			name:   "json log format is valid",
+			mutate: func(c *Config) { c.LogFormat = "json" },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := base()
+			tt.mutate(cfg)
+			err := validate(cfg)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func saveConfigState(t *testing.T) {
+	t.Helper()
+	origPath := path
+	origCurrent := current
+	t.Cleanup(func() {
+		mu.Lock()
+		path = origPath
+		current = origCurrent
+		mu.Unlock()
+	})
+}
+
+func writeConfigFile(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp("", "config-*.json")
+	if err != nil {
+		t.Fatalf("create temp config: %v", err)
+	}
+	t.Cleanup(func() { os.Remove(f.Name()) })
+	if _, err := fmt.Fprint(f, content); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	f.Close()
+	return f.Name()
+}
+
+func TestLoadAndGet(t *testing.T) {
+	saveConfigState(t)
+
+	p := writeConfigFile(t, `{
+		"AUTH_TOKEN": "loaded-token",
+		"NUM_WORKERS": 7,
+		"BUCKET_TOTAL": 100,
+		"BUCKET_TARGET": 50,
+		"NET_COMMS_TIMEOUT": 10,
+		"LOG_FORMAT": "json"
+	}`)
+
+	if err := Load(p); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	cfg := Get()
+	if cfg == nil {
+		t.Fatal("Get() = nil after Load")
+	}
+	if cfg.AuthToken != "loaded-token" {
+		t.Fatalf("AuthToken = %q, want loaded-token", cfg.AuthToken)
+	}
+	if cfg.NumWorkers != 7 {
+		t.Fatalf("NumWorkers = %d, want 7", cfg.NumWorkers)
+	}
+	if cfg.LogFormat != "json" {
+		t.Fatalf("LogFormat = %q, want json", cfg.LogFormat)
+	}
+}
+
+func TestLoadInvalidConfigReturnsError(t *testing.T) {
+	saveConfigState(t)
+
+	p := writeConfigFile(t, `{"AUTH_TOKEN": "", "NUM_WORKERS": 5, "BUCKET_TOTAL": 100, "BUCKET_TARGET": 50, "NET_COMMS_TIMEOUT": 10, "LOG_FORMAT": "text"}`)
+
+	if err := Load(p); err == nil {
+		t.Fatal("Load() expected error for invalid config (empty AUTH_TOKEN)")
+	}
+}
+
+func TestLoadNonExistentFileReturnsError(t *testing.T) {
+	saveConfigState(t)
+	if err := Load("/does/not/exist/config.json"); err == nil {
+		t.Fatal("Load() expected error for missing file")
+	}
+}
+
+func TestReload(t *testing.T) {
+	saveConfigState(t)
+
+	p := writeConfigFile(t, `{
+		"AUTH_TOKEN": "first",
+		"NUM_WORKERS": 5,
+		"BUCKET_TOTAL": 100,
+		"BUCKET_TARGET": 50,
+		"NET_COMMS_TIMEOUT": 10,
+		"LOG_FORMAT": "text"
+	}`)
+
+	if err := Load(p); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if Get().AuthToken != "first" {
+		t.Fatalf("AuthToken before reload = %q, want first", Get().AuthToken)
+	}
+
+	if err := os.WriteFile(p, []byte(`{
+		"AUTH_TOKEN": "second",
+		"NUM_WORKERS": 10,
+		"BUCKET_TOTAL": 100,
+		"BUCKET_TARGET": 50,
+		"NET_COMMS_TIMEOUT": 10,
+		"LOG_FORMAT": "text"
+	}`), 0600); err != nil {
+		t.Fatalf("overwrite config: %v", err)
+	}
+
+	if err := Reload(); err != nil {
+		t.Fatalf("Reload() error = %v", err)
+	}
+	cfg := Get()
+	if cfg.AuthToken != "second" {
+		t.Fatalf("AuthToken after reload = %q, want second", cfg.AuthToken)
+	}
+	if cfg.NumWorkers != 10 {
+		t.Fatalf("NumWorkers after reload = %d, want 10", cfg.NumWorkers)
+	}
+}
+
+func TestDebugrLogsWhenEnabled(t *testing.T) {
+	origCurrent := current
+	t.Cleanup(func() {
+		mu.Lock()
+		current = origCurrent
+		mu.Unlock()
+	})
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+
+	mu.Lock()
+	current = &Config{Debug: true}
+	mu.Unlock()
+
+	Debugf("test message %d", 42)
+
+	if !strings.Contains(buf.String(), "[DEBUG]") {
+		t.Fatalf("Debugf did not log [DEBUG] when Debug=true, got: %q", buf.String())
+	}
+	if !strings.Contains(buf.String(), "test message 42") {
+		t.Fatalf("Debugf missing message body, got: %q", buf.String())
+	}
+}
+
+func TestDebugfSilentWhenDisabled(t *testing.T) {
+	origCurrent := current
+	t.Cleanup(func() {
+		mu.Lock()
+		current = origCurrent
+		mu.Unlock()
+	})
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+
+	mu.Lock()
+	current = &Config{Debug: false}
+	mu.Unlock()
+
+	Debugf("should not appear")
+
+	if buf.Len() != 0 {
+		t.Fatalf("Debugf logged when Debug=false: %q", buf.String())
+	}
+}
+
+func TestLoadDBAndGetDB(t *testing.T) {
+	mu.Lock()
+	origDB := dbConf
+	mu.Unlock()
+	t.Cleanup(func() {
+		mu.Lock()
+		dbConf = origDB
+		mu.Unlock()
+	})
+
+	t.Setenv("DB_HOST", "testhost")
+	t.Setenv("DB_PORT", "3307")
+	t.Setenv("DB_USER", "testuser")
+	t.Setenv("DB_PASSWORD", "testpass")
+	t.Setenv("DB_NAME", "testdb")
+
+	cfg := LoadDB()
+	if cfg == nil {
+		t.Fatal("LoadDB() = nil")
+	}
+	if cfg.Host != "testhost" {
+		t.Fatalf("Host = %q, want testhost", cfg.Host)
+	}
+	if cfg.Port != "3307" {
+		t.Fatalf("Port = %q, want 3307", cfg.Port)
+	}
+
+	got := GetDB()
+	if got == nil {
+		t.Fatal("GetDB() = nil after LoadDB")
+	}
+	if got.User != "testuser" {
+		t.Fatalf("GetDB().User = %q, want testuser", got.User)
+	}
+}
+
+func TestEnvOrDefaultConfig(t *testing.T) {
+	const key = "JETMON_CONFIG_TEST_VAR"
+	t.Setenv(key, "")
+
+	if got := envOrDefault(key, "default"); got != "default" {
+		t.Fatalf("envOrDefault() = %q, want default", got)
+	}
+
+	t.Setenv(key, "override")
+	if got := envOrDefault(key, "default"); got != "override" {
+		t.Fatalf("envOrDefault() = %q, want override", got)
+	}
+}
+
+func TestDefaults(t *testing.T) {
+	cfg := defaults()
+	if cfg.NumWorkers <= 0 {
+		t.Fatalf("defaults().NumWorkers = %d, want > 0", cfg.NumWorkers)
+	}
+	if cfg.BucketTotal <= 0 {
+		t.Fatalf("defaults().BucketTotal = %d, want > 0", cfg.BucketTotal)
+	}
+	if cfg.BucketTarget <= 0 || cfg.BucketTarget > cfg.BucketTotal {
+		t.Fatalf("defaults().BucketTarget = %d out of range [1, %d]", cfg.BucketTarget, cfg.BucketTotal)
+	}
+	if cfg.NetCommsTimeout <= 0 {
+		t.Fatalf("defaults().NetCommsTimeout = %d, want > 0", cfg.NetCommsTimeout)
+	}
+	if cfg.LogFormat != "text" && cfg.LogFormat != "json" {
+		t.Fatalf("defaults().LogFormat = %q, want text or json", cfg.LogFormat)
+	}
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,0 +1,108 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+
+	"github.com/Automattic/jetmon/internal/config"
+)
+
+var db *sql.DB
+
+// Site mirrors the jetpack_monitor_sites row plus new Jetmon 2 columns.
+type Site struct {
+	ID               int64
+	BlogID           int64
+	BucketNo         int
+	MonitorURL       string
+	MonitorActive    bool
+	SiteStatus       int
+	LastStatusChange time.Time
+	CheckInterval    int
+	LastCheckedAt    *time.Time
+
+	SSLExpiryDate        *time.Time
+	CheckKeyword         *string
+	MaintenanceStart     *time.Time
+	MaintenanceEnd       *time.Time
+	CustomHeaders        *string // raw JSON
+	TimeoutSeconds       *int
+	RedirectPolicy       string
+	AlertCooldownMinutes *int
+	LastAlertSentAt      *time.Time
+}
+
+// Connect opens the MySQL connection pool using the loaded DBConfig.
+func Connect() error {
+	cfg := config.GetDB()
+	if cfg == nil {
+		cfg = config.LoadDB()
+	}
+
+	// Use mysql.Config.FormatDSN so the password is never interpolated into
+	// a format string (prevents accidental exposure in error chains or logs).
+	mc := mysql.NewConfig()
+	mc.User = cfg.User
+	mc.Passwd = cfg.Password
+	mc.Net = "tcp"
+	mc.Addr = cfg.Host + ":" + cfg.Port
+	mc.DBName = cfg.Name
+	mc.ParseTime = true
+	mc.Timeout = 10 * time.Second
+	mc.ReadTimeout = 30 * time.Second
+	mc.WriteTimeout = 30 * time.Second
+
+	var err error
+	db, err = sql.Open("mysql", mc.FormatDSN())
+	if err != nil {
+		return fmt.Errorf("open db: %w", err)
+	}
+
+	db.SetMaxOpenConns(10)
+	db.SetMaxIdleConns(5)
+	db.SetConnMaxLifetime(5 * time.Minute)
+
+	return db.Ping()
+}
+
+// ConnectWithRetry retries Connect with exponential backoff.
+func ConnectWithRetry(maxAttempts int) error {
+	var err error
+	for i := range maxAttempts {
+		err = Connect()
+		if err == nil {
+			return nil
+		}
+		wait := time.Duration(1<<i) * time.Second
+		if wait > 30*time.Second {
+			wait = 30 * time.Second
+		}
+		log.Printf("db connect attempt %d failed: %v, retrying in %s", i+1, err, wait)
+		time.Sleep(wait)
+	}
+	return fmt.Errorf("db connect failed after %d attempts: %w", maxAttempts, err)
+}
+
+// DB returns the underlying *sql.DB for direct use when needed.
+func DB() *sql.DB {
+	return db
+}
+
+// Ping checks database connectivity.
+func Ping() error {
+	return db.Ping()
+}
+
+// Hostname returns the system hostname used as the host_id in jetmon_hosts.
+func Hostname() string {
+	h, err := os.Hostname()
+	if err != nil {
+		return "unknown"
+	}
+	return h
+}

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -1,0 +1,123 @@
+package db
+
+import (
+	"fmt"
+	"log"
+)
+
+// migration holds a single idempotent schema change.
+type migration struct {
+	id  int
+	sql string
+}
+
+var migrations = []migration{
+	{1, `CREATE TABLE IF NOT EXISTS jetmon_schema_migrations (
+		id           INT UNSIGNED NOT NULL PRIMARY KEY,
+		applied_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
+
+	{2, `ALTER TABLE jetpack_monitor_sites
+		ADD COLUMN IF NOT EXISTS ssl_expiry_date        DATE NULL,
+		ADD COLUMN IF NOT EXISTS check_keyword          VARCHAR(500) NULL,
+		ADD COLUMN IF NOT EXISTS maintenance_start      DATETIME NULL,
+		ADD COLUMN IF NOT EXISTS maintenance_end        DATETIME NULL,
+		ADD COLUMN IF NOT EXISTS custom_headers         JSON NULL,
+		ADD COLUMN IF NOT EXISTS timeout_seconds        TINYINT UNSIGNED NULL,
+		ADD COLUMN IF NOT EXISTS redirect_policy        ENUM('follow','alert','fail') NULL DEFAULT 'follow',
+		ADD COLUMN IF NOT EXISTS alert_cooldown_minutes SMALLINT UNSIGNED NULL`},
+
+	{3, `CREATE TABLE IF NOT EXISTS jetmon_hosts (
+		host_id        VARCHAR(255) NOT NULL PRIMARY KEY,
+		bucket_min     SMALLINT UNSIGNED NOT NULL,
+		bucket_max     SMALLINT UNSIGNED NOT NULL,
+		last_heartbeat TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		status         ENUM('active','draining') NOT NULL DEFAULT 'active'
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
+
+	{4, `CREATE TABLE IF NOT EXISTS jetmon_audit_log (
+		id           BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		blog_id      BIGINT UNSIGNED NOT NULL,
+		event_type   VARCHAR(64) NOT NULL,
+		source       VARCHAR(255) NOT NULL DEFAULT 'local',
+		http_code    SMALLINT NULL,
+		error_code   TINYINT NULL,
+		rtt_ms       INT NULL,
+		old_status   TINYINT NULL,
+		new_status   TINYINT NULL,
+		detail       TEXT NULL,
+		created_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		INDEX idx_blog_id_created (blog_id, created_at)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
+
+	{5, `CREATE TABLE IF NOT EXISTS jetmon_check_history (
+		id         BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		blog_id    BIGINT UNSIGNED NOT NULL,
+		http_code  SMALLINT NULL,
+		error_code TINYINT NULL,
+		rtt_ms     INT NULL,
+		dns_ms     INT NULL,
+		tcp_ms     INT NULL,
+		tls_ms     INT NULL,
+		ttfb_ms    INT NULL,
+		checked_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		INDEX idx_blog_id_checked (blog_id, checked_at)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
+
+	{6, `CREATE TABLE IF NOT EXISTS jetmon_false_positives (
+		id         BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		blog_id    BIGINT UNSIGNED NOT NULL,
+		http_code  SMALLINT NULL,
+		error_code TINYINT NULL,
+		rtt_ms     INT NULL,
+		created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		INDEX idx_blog_id (blog_id)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
+
+	{7, `ALTER TABLE jetpack_monitor_sites
+		ADD COLUMN IF NOT EXISTS last_checked_at DATETIME NULL,
+		ADD COLUMN IF NOT EXISTS last_alert_sent_at DATETIME NULL,
+		ADD INDEX IF NOT EXISTS idx_bucket_monitor_last_checked (bucket_no, monitor_active, last_checked_at)`},
+}
+
+// Migrate applies all pending migrations idempotently.
+func Migrate() error {
+	// Ensure the migrations table exists first (migration 1 is special).
+	if _, err := db.Exec(migrations[0].sql); err != nil {
+		return fmt.Errorf("create migrations table: %w", err)
+	}
+	if err := markApplied(migrations[0].id); err != nil {
+		return err
+	}
+
+	for _, m := range migrations[1:] {
+		applied, err := isApplied(m.id)
+		if err != nil {
+			return err
+		}
+		if applied {
+			continue
+		}
+		log.Printf("applying migration %d", m.id)
+		if _, err := db.Exec(m.sql); err != nil {
+			return fmt.Errorf("migration %d: %w", m.id, err)
+		}
+		if err := markApplied(m.id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func isApplied(id int) (bool, error) {
+	var count int
+	err := db.QueryRow(`SELECT COUNT(*) FROM jetmon_schema_migrations WHERE id = ?`, id).Scan(&count)
+	return count > 0, err
+}
+
+func markApplied(id int) error {
+	_, err := db.Exec(
+		`INSERT IGNORE INTO jetmon_schema_migrations (id) VALUES (?)`, id,
+	)
+	return err
+}

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -1,0 +1,256 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"time"
+)
+
+// GetSitesForBucket fetches active sites within the given bucket range.
+func GetSitesForBucket(ctx context.Context, bucketMin, bucketMax, batchSize int, useVariableIntervals bool) ([]Site, error) {
+	query := `
+		SELECT
+			jetpack_monitor_site_id, blog_id, bucket_no, monitor_url,
+			monitor_active, site_status, last_status_change, check_interval, last_checked_at,
+			ssl_expiry_date, check_keyword, maintenance_start, maintenance_end,
+			custom_headers, timeout_seconds, redirect_policy, alert_cooldown_minutes, last_alert_sent_at
+		FROM jetpack_monitor_sites
+		WHERE monitor_active = 1
+		  AND bucket_no BETWEEN ? AND ?`
+	if useVariableIntervals {
+		query += `
+		  AND (
+			last_checked_at IS NULL
+			OR DATE_ADD(last_checked_at, INTERVAL GREATEST(check_interval, 1) MINUTE) <= NOW()
+		  )`
+	}
+	query += `
+		ORDER BY
+			COALESCE(last_checked_at, TIMESTAMP('1970-01-01 00:00:00')) ASC,
+			blog_id ASC
+		LIMIT ?`
+
+	rows, err := db.QueryContext(ctx, query, bucketMin, bucketMax, batchSize)
+	if err != nil {
+		return nil, fmt.Errorf("query sites: %w", err)
+	}
+	defer rows.Close()
+
+	var sites []Site
+	for rows.Next() {
+		var s Site
+		var redirectPolicy sql.NullString
+		err := rows.Scan(
+			&s.ID, &s.BlogID, &s.BucketNo, &s.MonitorURL,
+			&s.MonitorActive, &s.SiteStatus, &s.LastStatusChange, &s.CheckInterval, &s.LastCheckedAt,
+			&s.SSLExpiryDate, &s.CheckKeyword, &s.MaintenanceStart, &s.MaintenanceEnd,
+			&s.CustomHeaders, &s.TimeoutSeconds, &redirectPolicy, &s.AlertCooldownMinutes, &s.LastAlertSentAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("scan site: %w", err)
+		}
+		if redirectPolicy.Valid {
+			s.RedirectPolicy = redirectPolicy.String
+		} else {
+			s.RedirectPolicy = "follow"
+		}
+		sites = append(sites, s)
+	}
+	return sites, rows.Err()
+}
+
+// UpdateSiteStatus updates site_status and last_status_change for a site.
+func UpdateSiteStatus(ctx context.Context, blogID int64, status int, changedAt time.Time) error {
+	_, err := db.ExecContext(ctx,
+		`UPDATE jetpack_monitor_sites SET site_status = ?, last_status_change = ? WHERE blog_id = ?`,
+		status, changedAt.UTC(), blogID,
+	)
+	return err
+}
+
+// MarkSiteChecked records when a site was last checked.
+func MarkSiteChecked(ctx context.Context, blogID int64, checkedAt time.Time) error {
+	_, err := db.ExecContext(ctx,
+		`UPDATE jetpack_monitor_sites SET last_checked_at = ? WHERE blog_id = ?`,
+		checkedAt.UTC(), blogID,
+	)
+	return err
+}
+
+// UpdateLastAlertSent records when an alert was last sent for a site.
+func UpdateLastAlertSent(ctx context.Context, blogID int64, sentAt time.Time) error {
+	_, err := db.ExecContext(ctx,
+		`UPDATE jetpack_monitor_sites SET last_alert_sent_at = ? WHERE blog_id = ?`,
+		sentAt.UTC(), blogID,
+	)
+	return err
+}
+
+// UpdateSSLExpiry records the SSL certificate expiry date for a site.
+func UpdateSSLExpiry(ctx context.Context, blogID int64, expiry time.Time) error {
+	_, err := db.ExecContext(ctx,
+		`UPDATE jetpack_monitor_sites SET ssl_expiry_date = ? WHERE blog_id = ?`,
+		expiry, blogID,
+	)
+	return err
+}
+
+// ClaimBuckets registers this host in jetmon_hosts, claiming uncovered bucket
+// ranges from expired peers. Returns the claimed min/max bucket numbers.
+func ClaimBuckets(hostID string, bucketTotal, bucketTarget int, graceSec int) (int, int, error) {
+	tx, err := db.Begin()
+	if err != nil {
+		return 0, 0, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	// Remove expired hosts.
+	_, err = tx.Exec(
+		`DELETE FROM jetmon_hosts WHERE last_heartbeat < DATE_SUB(NOW(), INTERVAL ? SECOND) AND host_id != ?`,
+		graceSec, hostID,
+	)
+	if err != nil {
+		return 0, 0, fmt.Errorf("delete expired hosts: %w", err)
+	}
+
+	rows, err := tx.Query(`SELECT host_id FROM jetmon_hosts WHERE host_id != ? AND status = 'active' FOR UPDATE`, hostID)
+	if err != nil {
+		return 0, 0, fmt.Errorf("query hosts: %w", err)
+	}
+	hostIDs := []string{hostID}
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return 0, 0, err
+		}
+		hostIDs = append(hostIDs, id)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, 0, err
+	}
+	sort.Strings(hostIDs)
+
+	assignments := assignBucketRanges(hostIDs, bucketTotal, bucketTarget)
+
+	for _, id := range hostIDs {
+		rng := assignments[id]
+		_, err = tx.Exec(
+			`INSERT INTO jetmon_hosts (host_id, bucket_min, bucket_max, last_heartbeat, status)
+			 VALUES (?, ?, ?, NOW(), 'active')
+			 ON DUPLICATE KEY UPDATE bucket_min = VALUES(bucket_min), bucket_max = VALUES(bucket_max),
+			 last_heartbeat = NOW(), status = 'active'`,
+			id, rng[0], rng[1],
+		)
+		if err != nil {
+			return 0, 0, fmt.Errorf("upsert host %s: %w", id, err)
+		}
+	}
+
+	rng := assignments[hostID]
+	return rng[0], rng[1], tx.Commit()
+}
+
+func assignBucketRanges(hostIDs []string, bucketTotal, bucketTarget int) map[string][2]int {
+	assignments := make(map[string][2]int, len(hostIDs))
+	nextBucket := 0
+	for i, id := range hostIDs {
+		if nextBucket >= bucketTotal {
+			assignments[id] = [2]int{0, -1}
+			continue
+		}
+
+		remainingBuckets := bucketTotal - nextBucket
+		remainingHosts := len(hostIDs) - i
+		size := (remainingBuckets + remainingHosts - 1) / remainingHosts
+		if size > bucketTarget {
+			size = bucketTarget
+		}
+		if size < 1 {
+			assignments[id] = [2]int{0, -1}
+			continue
+		}
+
+		assignments[id] = [2]int{nextBucket, nextBucket + size - 1}
+		nextBucket += size
+	}
+	return assignments
+}
+
+// Heartbeat updates last_heartbeat for this host.
+func Heartbeat(ctx context.Context, hostID string) error {
+	_, err := db.ExecContext(ctx,
+		`UPDATE jetmon_hosts SET last_heartbeat = NOW(), status = 'active' WHERE host_id = ?`,
+		hostID,
+	)
+	return err
+}
+
+// MarkHostDraining marks a host as draining before it releases its buckets.
+func MarkHostDraining(ctx context.Context, hostID string) error {
+	_, err := db.ExecContext(ctx,
+		`UPDATE jetmon_hosts SET status = 'draining', last_heartbeat = NOW() WHERE host_id = ?`,
+		hostID,
+	)
+	return err
+}
+
+// ReleaseHost removes this host's row from jetmon_hosts on graceful shutdown.
+func ReleaseHost(ctx context.Context, hostID string) error {
+	_, err := db.ExecContext(ctx, `DELETE FROM jetmon_hosts WHERE host_id = ?`, hostID)
+	return err
+}
+
+// GetAllHosts returns all rows from jetmon_hosts for operator visibility.
+func GetAllHosts() ([]HostRow, error) {
+	rows, err := db.Query(
+		`SELECT host_id, bucket_min, bucket_max, last_heartbeat, status FROM jetmon_hosts ORDER BY bucket_min`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var hosts []HostRow
+	for rows.Next() {
+		var h HostRow
+		if err := rows.Scan(&h.HostID, &h.BucketMin, &h.BucketMax, &h.LastHeartbeat, &h.Status); err != nil {
+			return nil, err
+		}
+		hosts = append(hosts, h)
+	}
+	return hosts, rows.Err()
+}
+
+// HostRow represents a row in jetmon_hosts.
+type HostRow struct {
+	HostID        string
+	BucketMin     int
+	BucketMax     int
+	LastHeartbeat time.Time
+	Status        string
+}
+
+// RecordFalsePositive inserts a false positive event.
+func RecordFalsePositive(blogID int64, httpCode, errorCode int, rttMs int64) error {
+	_, err := db.Exec(
+		`INSERT INTO jetmon_false_positives (blog_id, http_code, error_code, rtt_ms, created_at)
+		 VALUES (?, ?, ?, ?, NOW())`,
+		blogID, httpCode, errorCode, rttMs,
+	)
+	return err
+}
+
+// RecordCheckHistory inserts a check timing sample.
+func RecordCheckHistory(blogID int64, httpCode, errorCode int, rttMs, dnsMs, tcpMs, tlsMs, ttfbMs int64) error {
+	_, err := db.Exec(
+		`INSERT INTO jetmon_check_history
+		    (blog_id, http_code, error_code, rtt_ms, dns_ms, tcp_ms, tls_ms, ttfb_ms, checked_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, NOW())`,
+		blogID, httpCode, errorCode, rttMs, dnsMs, tcpMs, tlsMs, ttfbMs,
+	)
+	return err
+}

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -1,0 +1,68 @@
+package db
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAssignBucketRanges(t *testing.T) {
+	tests := []struct {
+		name         string
+		hostIDs      []string
+		bucketTotal  int
+		bucketTarget int
+		want         map[string][2]int
+	}{
+		{
+			name:         "single host claims all buckets up to target",
+			hostIDs:      []string{"host-a"},
+			bucketTotal:  10,
+			bucketTarget: 10,
+			want: map[string][2]int{
+				"host-a": {0, 9},
+			},
+		},
+		{
+			name:         "multiple hosts split coverage evenly",
+			hostIDs:      []string{"host-a", "host-b", "host-c"},
+			bucketTotal:  10,
+			bucketTarget: 10,
+			want: map[string][2]int{
+				"host-a": {0, 3},
+				"host-b": {4, 6},
+				"host-c": {7, 9},
+			},
+		},
+		{
+			name:         "bucket target caps allocation",
+			hostIDs:      []string{"host-a", "host-b", "host-c"},
+			bucketTotal:  12,
+			bucketTarget: 4,
+			want: map[string][2]int{
+				"host-a": {0, 3},
+				"host-b": {4, 7},
+				"host-c": {8, 11},
+			},
+		},
+		{
+			name:         "extra hosts get empty ranges",
+			hostIDs:      []string{"host-a", "host-b", "host-c"},
+			bucketTotal:  2,
+			bucketTarget: 2,
+			want: map[string][2]int{
+				"host-a": {0, 0},
+				"host-b": {1, 1},
+				"host-c": {0, -1},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := assignBucketRanges(tt.hostIDs, tt.bucketTotal, tt.bucketTarget)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("assignBucketRanges() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/wpcom/client.go
+++ b/internal/wpcom/client.go
@@ -1,0 +1,176 @@
+package wpcom
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const (
+	notifyEndpoint = "https://public-api.wordpress.com/wpcom/v2/jetpack-monitor/status-change"
+
+	cbMaxFailures  = 5
+	cbResetTimeout = 60 * time.Second
+	queueMaxSize   = 1000
+)
+
+// CheckEntry represents a single check result included in a notification.
+type CheckEntry struct {
+	Type   int    `json:"type"`   // 1=local, 2=veriflier
+	Host   string `json:"host"`
+	Status int    `json:"status"`
+	RTT    int64  `json:"rtt"`
+	Code   int    `json:"code"`
+}
+
+// Notification is the payload sent to the WPCOM API on a status change.
+type Notification struct {
+	BlogID           int64        `json:"blog_id"`
+	MonitorURL       string       `json:"monitor_url"`
+	StatusID         int          `json:"status_id"`
+	LastCheck        string       `json:"last_check"`
+	LastStatusChange string       `json:"last_status_change"`
+	StatusType       string       `json:"status_type"`
+	Checks           []CheckEntry `json:"checks"`
+}
+
+// Client sends notifications to the WPCOM API with circuit breaker protection.
+type Client struct {
+	authToken  string
+	notifyURL  string // overrides notifyEndpoint when set (used in tests)
+	httpClient *http.Client
+	hostname   string
+
+	mu            sync.Mutex
+	failures      int
+	circuitOpen   bool
+	circuitOpenAt time.Time
+	queue         []queuedNotification
+}
+
+type queuedNotification struct {
+	n       Notification
+	queuedAt time.Time
+}
+
+// New creates a new WPCOM client.
+func New(authToken, hostname string) *Client {
+	return &Client{
+		authToken: authToken,
+		hostname:  hostname,
+		httpClient: &http.Client{
+			Timeout: 15 * time.Second,
+		},
+	}
+}
+
+// Notify sends a status change notification. If the circuit is open, the
+// notification is queued and retried when the circuit closes.
+// The mutex is never held during HTTP calls to avoid blocking callers.
+func (c *Client) Notify(n Notification) error {
+	c.mu.Lock()
+
+	if c.circuitOpen {
+		if time.Since(c.circuitOpenAt) > cbResetTimeout {
+			log.Printf("wpcom: circuit breaker resetting after timeout")
+			c.circuitOpen = false
+			c.failures = 0
+			// Drain the queue outside the lock; send the current notification normally below.
+			toFlush := c.queue
+			c.queue = nil
+			c.mu.Unlock()
+			c.sendFlush(toFlush)
+		} else {
+			c.enqueue(n)
+			c.mu.Unlock()
+			return fmt.Errorf("wpcom circuit open, notification queued")
+		}
+	} else {
+		c.mu.Unlock()
+	}
+
+	if err := c.send(n); err != nil {
+		c.mu.Lock()
+		c.failures++
+		if c.failures >= cbMaxFailures {
+			c.circuitOpen = true
+			c.circuitOpenAt = time.Now()
+			log.Printf("wpcom: circuit breaker opened after %d failures", c.failures)
+		}
+		c.mu.Unlock()
+		return err
+	}
+
+	c.mu.Lock()
+	c.failures = 0
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *Client) send(n Notification) error {
+	body, err := json.Marshal(n)
+	if err != nil {
+		return fmt.Errorf("marshal notification: %w", err)
+	}
+
+	url := c.notifyURL
+	if url == "" {
+		url = notifyEndpoint
+	}
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.authToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("post notification: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("wpcom returned %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func (c *Client) enqueue(n Notification) {
+	if len(c.queue) >= queueMaxSize {
+		log.Printf("wpcom: queue full, dropping oldest notification for blog_id=%d", c.queue[0].n.BlogID)
+		c.queue = c.queue[1:]
+	}
+	c.queue = append(c.queue, queuedNotification{n: n, queuedAt: time.Now()})
+}
+
+// sendFlush sends previously queued notifications without holding the mutex.
+func (c *Client) sendFlush(queue []queuedNotification) {
+	if len(queue) == 0 {
+		return
+	}
+	log.Printf("wpcom: flushing %d queued notifications", len(queue))
+	for _, q := range queue {
+		if err := c.send(q.n); err != nil {
+			log.Printf("wpcom: flush failed for blog_id=%d: %v", q.n.BlogID, err)
+		}
+	}
+}
+
+// IsCircuitOpen reports whether the circuit breaker is currently open.
+func (c *Client) IsCircuitOpen() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.circuitOpen
+}
+
+// QueueDepth returns the number of queued notifications.
+func (c *Client) QueueDepth() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.queue)
+}

--- a/internal/wpcom/client_test.go
+++ b/internal/wpcom/client_test.go
@@ -1,0 +1,224 @@
+package wpcom
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+	"time"
+)
+
+func newTestClient(t *testing.T, handler http.HandlerFunc) (*Client, func()) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	c := &Client{
+		authToken:  "test-token",
+		notifyURL:  srv.URL,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+	return c, srv.Close
+}
+
+func testNotification(blogID int64) Notification {
+	return Notification{BlogID: blogID, MonitorURL: "https://example.com", StatusType: "success"}
+}
+
+func TestNotifySuccess(t *testing.T) {
+	c, close := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Errorf("Authorization header = %q, want Bearer test-token", r.Header.Get("Authorization"))
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	defer close()
+
+	if err := c.Notify(testNotification(1)); err != nil {
+		t.Fatalf("Notify() error = %v", err)
+	}
+	if c.IsCircuitOpen() {
+		t.Fatal("circuit should be closed after success")
+	}
+	if c.failures != 0 {
+		t.Fatalf("failures = %d, want 0", c.failures)
+	}
+}
+
+func TestNotifyResetsFailureCountOnSuccess(t *testing.T) {
+	calls := 0
+	c, close := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls < 3 {
+			w.WriteHeader(http.StatusBadGateway)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+	defer close()
+
+	_ = c.Notify(testNotification(1))
+	_ = c.Notify(testNotification(2))
+	if c.failures != 2 {
+		t.Fatalf("failures = %d, want 2", c.failures)
+	}
+
+	_ = c.Notify(testNotification(3))
+	if c.failures != 0 {
+		t.Fatalf("failures after success = %d, want 0", c.failures)
+	}
+}
+
+func TestNotifyOpensCircuitAfterMaxFailures(t *testing.T) {
+	c, close := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	})
+	defer close()
+
+	for range cbMaxFailures {
+		_ = c.Notify(testNotification(1))
+	}
+
+	if !c.IsCircuitOpen() {
+		t.Fatal("circuit should be open after max failures")
+	}
+}
+
+func TestNotifyQueuesAndReturnsErrorWhenCircuitOpen(t *testing.T) {
+	c, close := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	defer close()
+
+	c.circuitOpen = true
+	c.circuitOpenAt = time.Now()
+
+	err := c.Notify(testNotification(42))
+	if err == nil {
+		t.Fatal("Notify() expected error when circuit is open")
+	}
+	if c.QueueDepth() != 1 {
+		t.Fatalf("QueueDepth() = %d, want 1", c.QueueDepth())
+	}
+}
+
+func TestNotifyResetsCircuitAfterTimeout(t *testing.T) {
+	var flushed []int64
+	c, close := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		var n Notification
+		if err := json.NewDecoder(r.Body).Decode(&n); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		flushed = append(flushed, n.BlogID)
+		w.WriteHeader(http.StatusOK)
+	})
+	defer close()
+
+	// Open circuit and pre-load a queued notification.
+	c.circuitOpen = true
+	c.circuitOpenAt = time.Now().Add(-(cbResetTimeout + time.Second))
+	c.failures = cbMaxFailures
+	c.queue = []queuedNotification{{n: testNotification(99)}}
+	_ = flushed
+
+	// Next Notify call should reset the circuit and flush the queue.
+	err := c.Notify(testNotification(1))
+	if err != nil {
+		t.Fatalf("Notify() after timeout error = %v", err)
+	}
+	if c.IsCircuitOpen() {
+		t.Fatal("circuit should be closed after reset timeout")
+	}
+	if c.QueueDepth() != 0 {
+		t.Fatalf("QueueDepth() = %d, want 0 after flush", c.QueueDepth())
+	}
+	if !slices.Equal(flushed, []int64{99, 1}) {
+		t.Fatalf("flushed notifications = %v, want [99 1]", flushed)
+	}
+}
+
+func TestNew(t *testing.T) {
+	c := New("my-token", "my-host")
+	if c == nil {
+		t.Fatal("New() = nil")
+	}
+	if c.authToken != "my-token" {
+		t.Fatalf("authToken = %q, want my-token", c.authToken)
+	}
+	if c.hostname != "my-host" {
+		t.Fatalf("hostname = %q, want my-host", c.hostname)
+	}
+}
+
+func TestSendFlushContinuesAfterError(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		if calls == 1 {
+			w.WriteHeader(http.StatusBadGateway)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+
+	c := &Client{
+		authToken:  "test-token",
+		notifyURL:  srv.URL,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+
+	c.sendFlush([]queuedNotification{
+		{n: testNotification(1)},
+		{n: testNotification(2)},
+	})
+
+	if calls != 2 {
+		t.Fatalf("send calls = %d, want 2 (flush should continue after first error)", calls)
+	}
+}
+
+func TestSendFlushEmptyIsNoop(t *testing.T) {
+	c := &Client{}
+	c.sendFlush(nil)
+	c.sendFlush([]queuedNotification{})
+}
+
+func TestNotifySendNetworkError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+	url := srv.URL
+	srv.Close() // close before sending — forces a connection error
+
+	c := &Client{
+		authToken:  "token",
+		notifyURL:  url,
+		httpClient: &http.Client{Timeout: time.Second},
+	}
+
+	err := c.Notify(testNotification(1))
+	if err == nil {
+		t.Fatal("Notify() expected error for closed server")
+	}
+	if c.failures != 1 {
+		t.Fatalf("failures = %d after network error, want 1", c.failures)
+	}
+}
+
+func TestEnqueueDropsOldestWhenFull(t *testing.T) {
+	c := &Client{}
+	for i := range queueMaxSize {
+		c.enqueue(Notification{BlogID: int64(i)})
+	}
+	if c.QueueDepth() != queueMaxSize {
+		t.Fatalf("QueueDepth() = %d, want %d", c.QueueDepth(), queueMaxSize)
+	}
+
+	c.enqueue(Notification{BlogID: queueMaxSize})
+
+	if c.QueueDepth() != queueMaxSize {
+		t.Fatalf("QueueDepth() after overflow = %d, want %d", c.QueueDepth(), queueMaxSize)
+	}
+	if c.queue[0].n.BlogID != 1 {
+		t.Fatalf("oldest entry BlogID = %d, want 1 (entry 0 should have been dropped)", c.queue[0].n.BlogID)
+	}
+}

--- a/migrations/001_jetmon2.sql
+++ b/migrations/001_jetmon2.sql
@@ -1,0 +1,73 @@
+-- Jetmon 2 schema migrations.
+-- Applied automatically by `jetmon2 migrate` via internal/db/migrations.go.
+-- This file is provided for reference and manual application if needed.
+
+CREATE TABLE IF NOT EXISTS jetmon_schema_migrations (
+    id           INT UNSIGNED NOT NULL PRIMARY KEY,
+    applied_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- New columns on jetpack_monitor_sites (additive only).
+ALTER TABLE jetpack_monitor_sites
+    ADD COLUMN IF NOT EXISTS ssl_expiry_date        DATE NULL,
+    ADD COLUMN IF NOT EXISTS check_keyword          VARCHAR(500) NULL,
+    ADD COLUMN IF NOT EXISTS maintenance_start      DATETIME NULL,
+    ADD COLUMN IF NOT EXISTS maintenance_end        DATETIME NULL,
+    ADD COLUMN IF NOT EXISTS custom_headers         JSON NULL,
+    ADD COLUMN IF NOT EXISTS timeout_seconds        TINYINT UNSIGNED NULL,
+    ADD COLUMN IF NOT EXISTS redirect_policy        ENUM('follow','alert','fail') NULL DEFAULT 'follow',
+    ADD COLUMN IF NOT EXISTS alert_cooldown_minutes SMALLINT UNSIGNED NULL,
+    ADD COLUMN IF NOT EXISTS last_checked_at        DATETIME NULL,
+    ADD COLUMN IF NOT EXISTS last_alert_sent_at     DATETIME NULL,
+    ADD INDEX IF NOT EXISTS idx_bucket_monitor_last_checked (bucket_no, monitor_active, last_checked_at);
+
+-- MySQL-coordinated bucket ownership.
+CREATE TABLE IF NOT EXISTS jetmon_hosts (
+    host_id        VARCHAR(255) NOT NULL PRIMARY KEY,
+    bucket_min     SMALLINT UNSIGNED NOT NULL,
+    bucket_max     SMALLINT UNSIGNED NOT NULL,
+    last_heartbeat TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    status         ENUM('active','draining') NOT NULL DEFAULT 'active'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Full event history per site.
+CREATE TABLE IF NOT EXISTS jetmon_audit_log (
+    id           BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    blog_id      BIGINT UNSIGNED NOT NULL,
+    event_type   VARCHAR(64) NOT NULL,
+    source       VARCHAR(255) NOT NULL DEFAULT 'local',
+    http_code    SMALLINT NULL,
+    error_code   TINYINT NULL,
+    rtt_ms       INT NULL,
+    old_status   TINYINT NULL,
+    new_status   TINYINT NULL,
+    detail       TEXT NULL,
+    created_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_blog_id_created (blog_id, created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- RTT and timing samples for trending.
+CREATE TABLE IF NOT EXISTS jetmon_check_history (
+    id         BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    blog_id    BIGINT UNSIGNED NOT NULL,
+    http_code  SMALLINT NULL,
+    error_code TINYINT NULL,
+    rtt_ms     INT NULL,
+    dns_ms     INT NULL,
+    tcp_ms     INT NULL,
+    tls_ms     INT NULL,
+    ttfb_ms    INT NULL,
+    checked_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_blog_id_checked (blog_id, checked_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Veriflier non-confirmation events (false positives).
+CREATE TABLE IF NOT EXISTS jetmon_false_positives (
+    id         BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    blog_id    BIGINT UNSIGNED NOT NULL,
+    http_code  SMALLINT NULL,
+    error_code TINYINT NULL,
+    rtt_ms     INT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_blog_id (blog_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## Scope
- Add config loading/hot-reload support (`internal/config/**`) and config sample/readme updates.
- Add DB layer, queries, and migrations wiring (`internal/db/**`).
- Add audit and WPCOM clients (`internal/audit/**`, `internal/wpcom/**`).
- Add SQL migration `migrations/001_jetmon2.sql`.

## Out of Scope
- No top-level command/orchestrator cutover and no legacy code removal.

## Testing
- Included tests across config/db/audit/wpcom packages.
- Verified migration and config/doc updates are limited to data/config scope.

## Compatibility
- Uses additive schema migration and keeps external compatibility requirements intact.