### PR TITLE
feat(orchestrator): add Jetmon2 command, orchestrator, and dashboard

### DIFF
--- a/cmd/jetmon2/main.go
+++ b/cmd/jetmon2/main.go
@@ -1,0 +1,366 @@
+package main
+
+import (
+	"database/sql"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/Automattic/jetmon/internal/audit"
+	"github.com/Automattic/jetmon/internal/config"
+	"github.com/Automattic/jetmon/internal/dashboard"
+	"github.com/Automattic/jetmon/internal/db"
+	"github.com/Automattic/jetmon/internal/metrics"
+	"github.com/Automattic/jetmon/internal/orchestrator"
+	"github.com/Automattic/jetmon/internal/wpcom"
+)
+
+// Injected at build time via -ldflags.
+var (
+	version   = "dev"
+	buildDate = "unknown"
+	goVersion = "unknown"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		runServe()
+		return
+	}
+
+	switch os.Args[1] {
+	case "version":
+		fmt.Printf("jetmon2 %s (built %s with %s)\n", version, buildDate, goVersion)
+	case "migrate":
+		cmdMigrate()
+	case "validate-config":
+		cmdValidateConfig()
+	case "status":
+		cmdStatus()
+	case "audit":
+		cmdAudit()
+	case "drain":
+		cmdDrain()
+	case "reload":
+		cmdReload()
+	default:
+		runServe()
+	}
+}
+
+// runServe is the main entry point for the monitoring service.
+func runServe() {
+	configPath := envOrDefault("JETMON_CONFIG", "config/config.json")
+
+	if err := config.Load(configPath); err != nil {
+		log.Fatalf("load config: %v", err)
+	}
+	cfg := config.Get()
+
+	if cfg.DBUpdatesEnable && os.Getenv("JETMON_UNSAFE_DB_UPDATES") != "1" {
+		log.Fatalf("DB_UPDATES_ENABLE is true but JETMON_UNSAFE_DB_UPDATES=1 is not set — refusing to start. This setting must only be used in local test environments.")
+	}
+
+	config.LoadDB()
+	if err := db.ConnectWithRetry(10); err != nil {
+		log.Fatalf("db connect: %v", err)
+	}
+
+	pidPath := envOrDefault("JETMON_PID_FILE", "/run/jetmon2/jetmon2.pid")
+	if err := writePIDFile(pidPath); err != nil {
+		log.Printf("warning: could not write PID file %s: %v", pidPath, err)
+	} else {
+		defer removePIDFile(pidPath)
+	}
+
+	audit.Init(db.DB())
+
+	if err := metrics.Init("statsd:8125", db.Hostname()); err != nil {
+		log.Printf("warning: statsd init failed: %v", err)
+	}
+
+	wp := wpcom.New(cfg.AuthToken, db.Hostname())
+
+	orch := orchestrator.New(cfg, wp)
+	if err := orch.ClaimBuckets(); err != nil {
+		log.Fatalf("claim buckets: %v", err)
+	}
+
+	var dash *dashboard.Server
+	if cfg.DashboardPort > 0 {
+		dash = dashboard.New(db.Hostname())
+		go func() {
+			addr := fmt.Sprintf(":%d", cfg.DashboardPort)
+			if err := dash.Listen(addr); err != nil {
+				log.Printf("dashboard: %v", err)
+			}
+		}()
+	}
+
+	// pprof on localhost only — never expose this on a public interface.
+	if cfg.DebugPort > 0 {
+		go func() {
+			addr := fmt.Sprintf("127.0.0.1:%d", cfg.DebugPort)
+			if err := dashboard.ListenDebug(addr); err != nil {
+				log.Printf("debug server: %v", err)
+			}
+		}()
+	}
+
+	// Push dashboard state every stats interval.
+	if dash != nil {
+		go func() {
+			ticker := time.NewTicker(time.Duration(cfg.StatsUpdateIntervalMS) * time.Millisecond)
+			defer ticker.Stop()
+			for range ticker.C {
+				bMin, bMax := orch.BucketRange()
+				dash.Update(dashboard.State{
+					WorkerCount:      orch.WorkerCount(),
+					ActiveChecks:     orch.ActiveChecks(),
+					QueueDepth:       orch.QueueDepth(),
+					RetryQueueSize:   orch.RetryQueueSize(),
+					SitesPerSec:      0,
+					WPCOMCircuitOpen: wp.IsCircuitOpen(),
+					WPCOMQueueDepth:  wp.QueueDepth(),
+					BucketMin:        bMin,
+					BucketMax:        bMax,
+				})
+			}
+		}()
+	}
+
+	// Signal handling.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+
+	go func() {
+		for sig := range sigCh {
+			switch sig {
+			case syscall.SIGHUP:
+				log.Println("received SIGHUP, reloading config")
+				if err := config.Reload(); err != nil {
+					log.Printf("config reload failed: %v", err)
+				} else {
+					log.Println("config reloaded")
+				}
+			case syscall.SIGINT, syscall.SIGTERM:
+				log.Println("received shutdown signal, draining")
+				orch.Stop()
+				// Hard kill if drain takes too long (e.g. a stalled HTTP check).
+				time.AfterFunc(30*time.Second, func() {
+					log.Println("jetmon2: shutdown timeout exceeded, forcing exit")
+					os.Exit(1)
+				})
+			}
+		}
+	}()
+
+	orch.Run()
+	log.Println("jetmon2: shutdown complete")
+}
+
+func cmdMigrate() {
+	config.LoadDB()
+	if err := db.ConnectWithRetry(5); err != nil {
+		log.Fatalf("db connect: %v", err)
+	}
+	if err := db.Migrate(); err != nil {
+		log.Fatalf("migrate: %v", err)
+	}
+	fmt.Println("migrations applied successfully")
+}
+
+func cmdValidateConfig() {
+	configPath := envOrDefault("JETMON_CONFIG", "config/config.json")
+	if err := config.Load(configPath); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL config parse: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("PASS config parse")
+
+	config.LoadDB()
+	if err := db.ConnectWithRetry(3); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL db connect: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("PASS db connect")
+
+	cfg := config.Get()
+	for _, v := range cfg.Verifiers {
+		addr := fmt.Sprintf("%s:%s", v.Host, v.GRPCPort)
+		// Ping check is best-effort; don't fail validation on veriflier unavailability.
+		fmt.Printf("INFO veriflier %q at %s\n", v.Name, addr)
+	}
+
+	fmt.Println("\nvalidation passed")
+}
+
+func cmdStatus() {
+	// Connect to the running instance's internal API.
+	port := envOrDefault("DASHBOARD_PORT", "8080")
+	resp, err := httpGet(fmt.Sprintf("http://localhost:%s/api/state", port))
+	if err != nil {
+		log.Fatalf("status: %v", err)
+	}
+	fmt.Println(resp)
+}
+
+func cmdAudit() {
+	fs := flag.NewFlagSet("audit", flag.ExitOnError)
+	blogID := fs.Int64("blog-id", 0, "blog ID to query")
+	since := fs.String("since", "", "start time (RFC3339 or duration like 24h)")
+	until := fs.String("until", "", "end time (RFC3339)")
+	_ = fs.Parse(os.Args[2:])
+
+	if *blogID == 0 {
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 audit --blog-id <id> [--since <time>] [--until <time>]")
+		os.Exit(1)
+	}
+
+	config.LoadDB()
+	if err := db.ConnectWithRetry(3); err != nil {
+		log.Fatalf("db: %v", err)
+	}
+
+	sinceStr := resolveSince(*since)
+	rows, err := audit.Query(db.DB(), *blogID, sinceStr, *until)
+	if err != nil {
+		log.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+
+	fmt.Printf("Audit log for blog_id=%d\n", *blogID)
+	fmt.Printf("%-25s %-22s %-15s %s\n", "TIMESTAMP", "EVENT", "SOURCE", "DETAIL")
+	fmt.Println(repeat("-", 90))
+
+	for rows.Next() {
+		var (
+			id        int64
+			bid       int64
+			eventType string
+			source    string
+			httpCode  sql.NullInt64
+			errorCode sql.NullInt64
+			rttMs     sql.NullInt64
+			oldStatus sql.NullInt64
+			newStatus sql.NullInt64
+			detail    sql.NullString
+			createdAt time.Time
+		)
+		if err := rows.Scan(&id, &bid, &eventType, &source, &httpCode, &errorCode,
+			&rttMs, &oldStatus, &newStatus, &detail, &createdAt); err != nil {
+			log.Printf("scan: %v", err)
+			continue
+		}
+		det := ""
+		if detail.Valid {
+			det = detail.String
+		}
+		if httpCode.Valid {
+			det = fmt.Sprintf("http=%d err=%d rtt=%dms %s", httpCode.Int64, errorCode.Int64, rttMs.Int64, det)
+		}
+		if oldStatus.Valid {
+			det = fmt.Sprintf("status %d→%d %s", oldStatus.Int64, newStatus.Int64, det)
+		}
+		fmt.Printf("%-25s %-22s %-15s %s\n",
+			createdAt.Format("2006-01-02 15:04:05.000"),
+			eventType, source, det)
+	}
+}
+
+func cmdDrain() {
+	pid := readPIDFile()
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		log.Fatalf("find process %d: %v", pid, err)
+	}
+	if err := proc.Signal(syscall.SIGINT); err != nil {
+		log.Fatalf("signal: %v", err)
+	}
+	fmt.Printf("SIGINT sent to pid %d — jetmon2 will drain and exit\n", pid)
+}
+
+func cmdReload() {
+	pid := readPIDFile()
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		log.Fatalf("find process %d: %v", pid, err)
+	}
+	if err := proc.Signal(syscall.SIGHUP); err != nil {
+		log.Fatalf("signal: %v", err)
+	}
+	fmt.Printf("SIGHUP sent to pid %d\n", pid)
+}
+
+func readPIDFile() int {
+	pidPath := envOrDefault("JETMON_PID_FILE", "/run/jetmon2/jetmon2.pid")
+	data, err := os.ReadFile(pidPath)
+	if err != nil {
+		log.Fatalf("read pid file %s: %v (is jetmon2 running?)", pidPath, err)
+	}
+	var pid int
+	if _, err := fmt.Sscan(string(data), &pid); err != nil || pid <= 0 {
+		log.Fatalf("invalid pid in %s", pidPath)
+	}
+	return pid
+}
+
+func writePIDFile(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(fmt.Sprintf("%d\n", os.Getpid())), 0644)
+}
+
+func removePIDFile(path string) {
+	_ = os.Remove(path)
+}
+
+func envOrDefault(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func httpGet(url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode >= 400 {
+		return "", fmt.Errorf("http %d: %s", resp.StatusCode, string(body))
+	}
+	return string(body), nil
+}
+
+func resolveSince(s string) string {
+	if s == "" {
+		return ""
+	}
+	d, err := time.ParseDuration(s)
+	if err == nil {
+		return time.Now().Add(-d).Format("2006-01-02 15:04:05")
+	}
+	return s
+}
+
+func repeat(s string, n int) string {
+	out := ""
+	for range n {
+		out += s
+	}
+	return out
+}

--- a/cmd/jetmon2/main_test.go
+++ b/cmd/jetmon2/main_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHTTPGet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	body, err := httpGet(srv.URL)
+	if err != nil {
+		t.Fatalf("httpGet() error = %v", err)
+	}
+	if strings.TrimSpace(body) != "ok" {
+		t.Fatalf("httpGet() body = %q, want %q", body, "ok")
+	}
+}
+
+func TestHTTPGetErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	_, err := httpGet(srv.URL)
+	if err == nil {
+		t.Fatalf("httpGet() expected error")
+	}
+	if !strings.Contains(err.Error(), "502") {
+		t.Fatalf("httpGet() error = %v, want status code", err)
+	}
+}
+
+func TestEnvOrDefault(t *testing.T) {
+	const key = "JETMON_TEST_ENV_OR_DEFAULT"
+	t.Setenv(key, "")
+
+	if got := envOrDefault(key, "fallback"); got != "fallback" {
+		t.Fatalf("envOrDefault() = %q, want fallback", got)
+	}
+
+	t.Setenv(key, "set-value")
+	if got := envOrDefault(key, "fallback"); got != "set-value" {
+		t.Fatalf("envOrDefault() = %q, want set-value", got)
+	}
+}
+
+func TestRepeat(t *testing.T) {
+	if got := repeat("-", 5); got != "-----" {
+		t.Fatalf("repeat(\"-\", 5) = %q, want -----", got)
+	}
+	if got := repeat("ab", 3); got != "ababab" {
+		t.Fatalf("repeat(\"ab\", 3) = %q, want ababab", got)
+	}
+	if got := repeat("x", 0); got != "" {
+		t.Fatalf("repeat(\"x\", 0) = %q, want empty", got)
+	}
+}
+
+func TestReadPIDFile(t *testing.T) {
+	dir := t.TempDir()
+	pidPath := filepath.Join(dir, "test.pid")
+	if err := os.WriteFile(pidPath, []byte("12345\n"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	t.Setenv("JETMON_PID_FILE", pidPath)
+
+	pid := readPIDFile()
+	if pid != 12345 {
+		t.Fatalf("readPIDFile() = %d, want 12345", pid)
+	}
+}
+
+func TestWriteAndRemovePIDFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.pid")
+	if err := writePIDFile(path); err != nil {
+		t.Fatalf("writePIDFile() error = %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	var pid int
+	if _, err := fmt.Sscan(string(data), &pid); err != nil || pid <= 0 {
+		t.Fatalf("invalid PID in file: %q", string(data))
+	}
+
+	removePIDFile(path)
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("PID file still exists after removePIDFile()")
+	}
+}
+
+func TestResolveSince(t *testing.T) {
+	if got := resolveSince(""); got != "" {
+		t.Fatalf("resolveSince(\"\") = %q, want empty", got)
+	}
+
+	// Duration input: result should be a timestamp just before now.
+	before := time.Now()
+	got := resolveSince("1h")
+	after := time.Now()
+
+	ts, err := time.ParseInLocation("2006-01-02 15:04:05", got, time.Local)
+	if err != nil {
+		t.Fatalf("resolveSince(\"1h\") = %q, not a valid timestamp: %v", got, err)
+	}
+	if ts.Before(before.Add(-time.Hour-time.Second)) || ts.After(after.Add(-time.Hour+time.Second)) {
+		t.Fatalf("resolveSince(\"1h\") = %q, out of expected range", got)
+	}
+
+	// Non-duration string passes through unchanged.
+	const literal = "2024-01-15 10:00:00"
+	if got := resolveSince(literal); got != literal {
+		t.Fatalf("resolveSince(%q) = %q, want passthrough", literal, got)
+	}
+}

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -1,0 +1,251 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	_ "net/http/pprof"
+	"runtime"
+	"sync"
+	"time"
+)
+
+// State holds the real-time metrics snapshot served by the dashboard.
+type State struct {
+	WorkerCount      int       `json:"worker_count"`
+	ActiveChecks     int       `json:"active_checks"`
+	QueueDepth       int       `json:"queue_depth"`
+	RetryQueueSize   int       `json:"retry_queue_size"`
+	SitesPerSec      int       `json:"sites_per_sec"`
+	RoundDurationMs  int64     `json:"round_duration_ms"`
+	WPCOMCircuitOpen bool      `json:"wpcom_circuit_open"`
+	WPCOMQueueDepth  int       `json:"wpcom_queue_depth"`
+	MemRSSMB         int       `json:"mem_rss_mb"`
+	BucketMin        int       `json:"bucket_min"`
+	BucketMax        int       `json:"bucket_max"`
+	Hostname         string    `json:"hostname"`
+	UpdatedAt        time.Time `json:"updated_at"`
+}
+
+// HealthEntry represents one external dependency's status.
+type HealthEntry struct {
+	Name      string    `json:"name"`
+	Status    string    `json:"status"` // "green", "amber", "red"
+	Latency   int64     `json:"latency_ms,omitempty"`
+	LastError string    `json:"last_error,omitempty"`
+	CheckedAt time.Time `json:"checked_at"`
+}
+
+// Server is the operator dashboard HTTP server.
+type Server struct {
+	mu       sync.RWMutex
+	state    State
+	health   []HealthEntry
+	sseClients map[string]chan string
+	sseMu    sync.Mutex
+	hostname string
+}
+
+// New creates a new dashboard Server.
+func New(hostname string) *Server {
+	return &Server{
+		hostname:   hostname,
+		sseClients: make(map[string]chan string),
+	}
+}
+
+// Update replaces the current dashboard state and pushes an SSE event.
+func (s *Server) Update(st State) {
+	st.Hostname = s.hostname
+	st.UpdatedAt = time.Now()
+
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	st.MemRSSMB = int(ms.Sys / 1024 / 1024)
+
+	s.mu.Lock()
+	s.state = st
+	s.mu.Unlock()
+
+	s.broadcast(st)
+}
+
+// UpdateHealth replaces the health entries and pushes an SSE event.
+func (s *Server) UpdateHealth(entries []HealthEntry) {
+	s.mu.Lock()
+	s.health = entries
+	s.mu.Unlock()
+}
+
+// Listen starts the dashboard HTTP server. Blocks until the server exits.
+func (s *Server) Listen(addr string) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", s.handleIndex)
+	mux.HandleFunc("/events", s.handleSSE)
+	mux.HandleFunc("/api/state", s.handleState)
+	mux.HandleFunc("/api/health", s.handleHealth)
+
+	log.Printf("dashboard: listening on %s", addr)
+	return http.ListenAndServe(addr, mux)
+}
+
+// ListenDebug starts a localhost-only pprof/debug server on the given address.
+// pprof can expose in-memory credentials; never expose this on a public interface.
+func ListenDebug(addr string) error {
+	// net/http/pprof registers itself on http.DefaultServeMux via init().
+	log.Printf("debug: pprof listening on %s (localhost only)", addr)
+	return http.ListenAndServe(addr, http.DefaultServeMux)
+}
+
+func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
+	s.mu.RLock()
+	st := s.state
+	s.mu.RUnlock()
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(st)
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	s.mu.RLock()
+	h := s.health
+	s.mu.RUnlock()
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(h)
+}
+
+func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	ch := make(chan string, 16)
+	id := fmt.Sprintf("%p", ch)
+
+	s.sseMu.Lock()
+	s.sseClients[id] = ch
+	s.sseMu.Unlock()
+
+	defer func() {
+		s.sseMu.Lock()
+		delete(s.sseClients, id)
+		s.sseMu.Unlock()
+	}()
+
+	// Send current state immediately on connect.
+	s.mu.RLock()
+	if b, err := json.Marshal(s.state); err == nil {
+		fmt.Fprintf(w, "data: %s\n\n", b)
+		flusher.Flush()
+	}
+	s.mu.RUnlock()
+
+	for {
+		select {
+		case msg := <-ch:
+			fmt.Fprintf(w, "data: %s\n\n", msg)
+			flusher.Flush()
+		case <-r.Context().Done():
+			return
+		}
+	}
+}
+
+func (s *Server) broadcast(st State) {
+	b, err := json.Marshal(st)
+	if err != nil {
+		return
+	}
+	msg := string(b)
+
+	s.sseMu.Lock()
+	defer s.sseMu.Unlock()
+	for _, ch := range s.sseClients {
+		select {
+		case ch <- msg:
+		default:
+			// Slow client — drop the event rather than block.
+		}
+	}
+}
+
+func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprint(w, dashboardHTML)
+}
+
+const dashboardHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Jetmon 2 — Operator Dashboard</title>
+<style>
+  body { font-family: monospace; background: #1a1a1a; color: #e0e0e0; margin: 2rem; }
+  h1 { color: #7ec8e3; }
+  h2 { color: #aaa; font-size: 1rem; margin-top: 2rem; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 1rem; }
+  .card { background: #2a2a2a; padding: 1rem; border-radius: 4px; }
+  .card .label { font-size: 0.75rem; color: #888; }
+  .card .value { font-size: 1.5rem; color: #7ec8e3; margin-top: 0.25rem; }
+  .health-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 0.5rem; margin-top: 1rem; }
+  .health-item { padding: 0.5rem 1rem; border-radius: 4px; font-size: 0.85rem; }
+  .green  { background: #1a3a1a; border-left: 4px solid #4caf50; }
+  .amber  { background: #3a2a00; border-left: 4px solid #ff9800; }
+  .red    { background: #3a1a1a; border-left: 4px solid #f44336; }
+  #updated { font-size: 0.75rem; color: #555; margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Jetmon 2</h1>
+<div id="host"></div>
+
+<h2>CHECK POOL</h2>
+<div class="grid">
+  <div class="card"><div class="label">GOROUTINES</div><div class="value" id="workers">—</div></div>
+  <div class="card"><div class="label">ACTIVE CHECKS</div><div class="value" id="active">—</div></div>
+  <div class="card"><div class="label">QUEUE DEPTH</div><div class="value" id="queue">—</div></div>
+  <div class="card"><div class="label">RETRY QUEUE</div><div class="value" id="retry">—</div></div>
+</div>
+
+<h2>THROUGHPUT</h2>
+<div class="grid">
+  <div class="card"><div class="label">SITES/SEC</div><div class="value" id="sps">—</div></div>
+  <div class="card"><div class="label">ROUND TIME</div><div class="value" id="round">—</div></div>
+  <div class="card"><div class="label">BUCKETS</div><div class="value" id="buckets">—</div></div>
+  <div class="card"><div class="label">RSS</div><div class="value" id="rss">—</div></div>
+</div>
+
+<h2>EXTERNAL DEPENDENCIES</h2>
+<div class="grid">
+  <div class="card"><div class="label">WPCOM CIRCUIT</div><div class="value" id="wpcom">—</div></div>
+  <div class="card"><div class="label">WPCOM QUEUE</div><div class="value" id="wpcomq">—</div></div>
+</div>
+
+<div id="updated"></div>
+
+<script>
+const src = new EventSource('/events');
+src.onmessage = function(e) {
+  const d = JSON.parse(e.data);
+  document.getElementById('host').textContent    = d.hostname;
+  document.getElementById('workers').textContent = d.worker_count;
+  document.getElementById('active').textContent  = d.active_checks;
+  document.getElementById('queue').textContent   = d.queue_depth;
+  document.getElementById('retry').textContent   = d.retry_queue_size;
+  document.getElementById('sps').textContent     = d.sites_per_sec;
+  document.getElementById('round').textContent   = (d.round_duration_ms / 1000).toFixed(1) + 's';
+  document.getElementById('buckets').textContent = d.bucket_min + '–' + d.bucket_max;
+  document.getElementById('rss').textContent     = d.mem_rss_mb + 'MB';
+  document.getElementById('wpcom').textContent   = d.wpcom_circuit_open ? 'OPEN' : 'closed';
+  document.getElementById('wpcomq').textContent  = d.wpcom_queue_depth;
+  document.getElementById('updated').textContent = 'Updated: ' + new Date(d.updated_at).toLocaleTimeString();
+};
+</script>
+</body>
+</html>`

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -1,0 +1,186 @@
+package dashboard
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHandleState(t *testing.T) {
+	srv := New("test-host")
+	srv.Update(State{WorkerCount: 5, QueueDepth: 3})
+
+	r := httptest.NewRequest(http.MethodGet, "/api/state", nil)
+	w := httptest.NewRecorder()
+	srv.handleState(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var st State
+	if err := json.NewDecoder(w.Body).Decode(&st); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if st.WorkerCount != 5 {
+		t.Fatalf("WorkerCount = %d, want 5", st.WorkerCount)
+	}
+	if st.Hostname != "test-host" {
+		t.Fatalf("Hostname = %q, want test-host", st.Hostname)
+	}
+}
+
+func TestHandleHealth(t *testing.T) {
+	srv := New("test-host")
+	srv.UpdateHealth([]HealthEntry{
+		{Name: "db", Status: "green"},
+		{Name: "wpcom", Status: "amber"},
+	})
+
+	r := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	w := httptest.NewRecorder()
+	srv.handleHealth(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var entries []HealthEntry
+	if err := json.NewDecoder(w.Body).Decode(&entries); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("entries len = %d, want 2", len(entries))
+	}
+	if entries[0].Name != "db" || entries[0].Status != "green" {
+		t.Fatalf("entries[0] = %+v, want {db green}", entries[0])
+	}
+}
+
+func TestHandleIndex(t *testing.T) {
+	srv := New("test-host")
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	srv.handleIndex(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "text/html; charset=utf-8" {
+		t.Fatalf("Content-Type = %q, want text/html; charset=utf-8", ct)
+	}
+	if !strings.Contains(w.Body.String(), "Jetmon") {
+		t.Fatal("body does not contain expected HTML content")
+	}
+}
+
+func TestUpdateSetsHostnameAndTimestamp(t *testing.T) {
+	srv := New("my-host")
+	srv.Update(State{WorkerCount: 7, QueueDepth: 2})
+
+	srv.mu.RLock()
+	st := srv.state
+	srv.mu.RUnlock()
+
+	if st.Hostname != "my-host" {
+		t.Fatalf("Hostname = %q, want my-host", st.Hostname)
+	}
+	if st.WorkerCount != 7 {
+		t.Fatalf("WorkerCount = %d, want 7", st.WorkerCount)
+	}
+	if st.UpdatedAt.IsZero() {
+		t.Fatal("UpdatedAt is zero after Update")
+	}
+}
+
+func TestUpdateHealthStoresEntries(t *testing.T) {
+	srv := New("test-host")
+	srv.UpdateHealth([]HealthEntry{{Name: "redis", Status: "red"}})
+
+	srv.mu.RLock()
+	h := srv.health
+	srv.mu.RUnlock()
+
+	if len(h) != 1 || h[0].Name != "redis" {
+		t.Fatalf("health = %v, want [{redis red}]", h)
+	}
+}
+
+func TestBroadcastDeliverstToSSEClients(t *testing.T) {
+	srv := New("test-host")
+
+	ch := make(chan string, 1)
+	id := "test-client"
+	srv.sseMu.Lock()
+	srv.sseClients[id] = ch
+	srv.sseMu.Unlock()
+
+	srv.broadcast(State{WorkerCount: 9})
+
+	select {
+	case msg := <-ch:
+		var st State
+		if err := json.Unmarshal([]byte(msg), &st); err != nil {
+			t.Fatalf("unmarshal broadcast: %v", err)
+		}
+		if st.WorkerCount != 9 {
+			t.Fatalf("WorkerCount = %d, want 9", st.WorkerCount)
+		}
+	default:
+		t.Fatal("no message received by SSE client")
+	}
+}
+
+func TestHandleSSESendsInitialStateAndCleanup(t *testing.T) {
+	srv := New("test-host")
+	srv.Update(State{WorkerCount: 7})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/events", srv.handleSSE)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/events", nil)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	reader := bufio.NewReader(resp.Body)
+	var event strings.Builder
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read SSE line: %v", err)
+		}
+		event.WriteString(line)
+		if line == "\n" {
+			break
+		}
+	}
+	data := event.String()
+	if !strings.Contains(data, "data:") {
+		t.Fatalf("initial SSE response = %q, want data: prefix", data)
+	}
+
+	// Disconnect the client — handleSSE should return via r.Context().Done().
+	cancel()
+}
+
+func TestBroadcastDropsOnSlowClient(t *testing.T) {
+	srv := New("test-host")
+
+	// Channel capacity 0 — client is always "slow".
+	ch := make(chan string)
+	srv.sseMu.Lock()
+	srv.sseClients["slow"] = ch
+	srv.sseMu.Unlock()
+
+	// Should not block.
+	srv.broadcast(State{WorkerCount: 1})
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1,0 +1,656 @@
+package orchestrator
+
+import (
+	stdctx "context"
+	"fmt"
+	"log"
+	runtimemetrics "runtime/metrics"
+	"sync"
+	"time"
+
+	"github.com/Automattic/jetmon/internal/audit"
+	"github.com/Automattic/jetmon/internal/checker"
+	"github.com/Automattic/jetmon/internal/config"
+	"github.com/Automattic/jetmon/internal/db"
+	"github.com/Automattic/jetmon/internal/metrics"
+	"github.com/Automattic/jetmon/internal/veriflier"
+	"github.com/Automattic/jetmon/internal/wpcom"
+)
+
+const (
+	statusRunning       = 1
+	statusConfirmedDown = 2
+)
+
+var (
+	nowFunc               = time.Now
+	dbClaimBuckets        = db.ClaimBuckets
+	dbHeartbeat           = db.Heartbeat
+	dbReleaseHost         = db.ReleaseHost
+	dbMarkHostDraining    = db.MarkHostDraining
+	dbGetSitesForBucket   = db.GetSitesForBucket
+	dbMarkSiteChecked     = db.MarkSiteChecked
+	dbRecordCheckHistory  = db.RecordCheckHistory
+	dbUpdateSSLExpiry     = db.UpdateSSLExpiry
+	dbUpdateSiteStatus    = db.UpdateSiteStatus
+	dbRecordFalsePositive = db.RecordFalsePositive
+	dbUpdateLastAlertSent = db.UpdateLastAlertSent
+	veriflierCheckFunc    = func(c *veriflier.VeriflierClient, ctx stdctx.Context, req veriflier.CheckRequest) (*veriflier.CheckResult, error) {
+		return c.Check(ctx, req)
+	}
+	wpcomNotifyFunc     = func(c *wpcom.Client, n wpcom.Notification) error { return c.Notify(n) }
+	currentMemoryMBFunc = currentMemoryMB
+)
+
+// Orchestrator drives the main check loop.
+type Orchestrator struct {
+	pool             *checker.Pool
+	retries          *retryQueue
+	wpcom            *wpcom.Client
+	veriflierClients []*veriflier.VeriflierClient
+	veriflierAddrs   []string // parallel slice of "addr|token" for change detection
+	veriflierMu      sync.RWMutex
+	hostname         string
+	bucketMin        int
+	bucketMax        int
+
+	totalChecked int
+	roundStart   time.Time
+
+	ctx    stdctx.Context
+	cancel stdctx.CancelFunc
+}
+
+// New creates an Orchestrator. Call Run to start the check loop.
+func New(cfg *config.Config, wp *wpcom.Client) *Orchestrator {
+	ctx, cancel := stdctx.WithCancel(stdctx.Background())
+	pool := checker.NewPool(cfg.NumWorkers/2, 1, cfg.NumWorkers)
+
+	o := &Orchestrator{
+		pool:     pool,
+		retries:  newRetryQueue(),
+		wpcom:    wp,
+		hostname: db.Hostname(),
+		ctx:      ctx,
+		cancel:   cancel,
+	}
+
+	o.refreshVeriflierClients(cfg)
+	if len(o.veriflierClients) == 0 {
+		log.Println("orchestrator: warning: no verifliers configured — down confirmations rely on local checks only")
+	}
+
+	return o
+}
+
+// ClaimBuckets registers this host in jetmon_hosts and sets the bucket range.
+func (o *Orchestrator) ClaimBuckets() error {
+	cfg := config.Get()
+	min, max, err := dbClaimBuckets(
+		o.hostname,
+		cfg.BucketTotal,
+		cfg.BucketTarget,
+		cfg.BucketHeartbeatGraceSec,
+	)
+	if err != nil {
+		return err
+	}
+	o.bucketMin = min
+	o.bucketMax = max
+	log.Printf("orchestrator: claimed buckets %d-%d", min, max)
+	return nil
+}
+
+// Run starts the main orchestration loop. Blocks until ctx is cancelled.
+func (o *Orchestrator) Run() {
+	log.Printf("orchestrator: starting, host=%s buckets=%d-%d", o.hostname, o.bucketMin, o.bucketMax)
+	for {
+		select {
+		case <-o.ctx.Done():
+			log.Println("orchestrator: shutting down")
+			if err := dbMarkHostDraining(stdctx.Background(), o.hostname); err != nil {
+				log.Printf("orchestrator: mark draining: %v", err)
+			}
+			o.pool.Drain()
+			if err := dbReleaseHost(stdctx.Background(), o.hostname); err != nil {
+				log.Printf("orchestrator: release host: %v", err)
+			}
+			return
+		default:
+		}
+
+		cfg := config.Get()
+		o.pool.SetMaxSize(cfg.NumWorkers)
+		o.refreshVeriflierClients(cfg)
+
+		o.roundStart = time.Now()
+		o.runRound()
+
+		elapsed := time.Since(o.roundStart)
+		minInterval := time.Duration(cfg.MinTimeBetweenRoundsSec) * time.Second
+		if elapsed < minInterval {
+			select {
+			case <-time.After(minInterval - elapsed):
+			case <-o.ctx.Done():
+			}
+		}
+	}
+}
+
+// Stop signals the orchestrator to shut down after the current round.
+func (o *Orchestrator) Stop() {
+	o.cancel()
+}
+
+func (o *Orchestrator) runRound() {
+	cfg := config.Get()
+
+	// Update heartbeat.
+	if err := dbHeartbeat(o.ctx, o.hostname); err != nil {
+		log.Printf("orchestrator: heartbeat failed: %v", err)
+	}
+	// Re-claim every round so bucket ranges rebalance automatically when hosts
+	// join or leave the cluster.
+	if err := o.ClaimBuckets(); err != nil {
+		log.Printf("orchestrator: bucket rebalance failed: %v", err)
+	}
+
+	// Fetch sites.
+	sites, err := dbGetSitesForBucket(o.ctx, o.bucketMin, o.bucketMax, cfg.DatasetSize, cfg.UseVariableCheckIntervals)
+	if err != nil {
+		log.Printf("orchestrator: fetch sites failed: %v", err)
+		return
+	}
+
+	if len(sites) == 0 {
+		return
+	}
+
+	log.Printf("orchestrator: checking %d sites", len(sites))
+
+	// Dispatch checks.
+	dispatched := 0
+	for _, site := range sites {
+		timeout := cfg.NetCommsTimeout
+		if site.TimeoutSeconds != nil {
+			timeout = *site.TimeoutSeconds
+		}
+
+		req := checker.Request{
+			BlogID:         site.BlogID,
+			URL:            site.MonitorURL,
+			TimeoutSeconds: timeout,
+			Keyword:        site.CheckKeyword,
+			CustomHeaders:  checker.ParseCustomHeaders(site.CustomHeaders),
+			RedirectPolicy: checker.RedirectPolicy(site.RedirectPolicy),
+		}
+		if req.RedirectPolicy == "" {
+			req.RedirectPolicy = checker.RedirectFollow
+		}
+
+		if o.pool.Submit(req) {
+			dispatched++
+		} else {
+			log.Printf("orchestrator: dropped check blog_id=%d queue_depth=%d", site.BlogID, o.pool.QueueDepth())
+		}
+	}
+
+	// Collect results with a deadline.
+	deadline := time.NewTimer(time.Duration(cfg.NetCommsTimeout+5) * time.Second)
+	defer deadline.Stop()
+
+	results := make(map[int64]checker.Result, dispatched)
+	for len(results) < dispatched {
+		select {
+		case res := <-o.pool.Results():
+			results[res.BlogID] = res
+		case <-deadline.C:
+			log.Printf("orchestrator: round deadline reached, %d results outstanding", dispatched-len(results))
+			goto process
+		case <-o.ctx.Done():
+			return
+		}
+	}
+
+process:
+	siteMap := make(map[int64]db.Site, len(sites))
+	for _, s := range sites {
+		siteMap[s.BlogID] = s
+	}
+
+	o.processResults(results, siteMap)
+	o.totalChecked += len(results)
+
+	// Emit metrics and update stats files.
+	roundDuration := time.Since(o.roundStart)
+	m := metrics.Global()
+	if m != nil {
+		m.Timing("round.complete.time", roundDuration)
+		m.Gauge("worker.queue.active", o.pool.ActiveCount())
+		m.Gauge("worker.queue.queue_size", o.pool.QueueDepth())
+		m.Gauge("retry.queue.size", o.retries.size())
+		m.Increment("round.sites.count", len(results))
+
+		sps := 0
+		if roundDuration.Seconds() > 0 {
+			sps = int(float64(len(results)) / roundDuration.Seconds())
+		}
+		m.Gauge("round.sps.count", sps)
+
+		if cfg.StatsdSendMemUsage {
+			m.EmitMemStats()
+		}
+
+		metrics.WriteStatsFiles(sps, o.pool.QueueDepth(), o.totalChecked)
+	}
+
+	o.applyMemoryPressure(cfg)
+}
+
+func (o *Orchestrator) processResults(results map[int64]checker.Result, sites map[int64]db.Site) {
+	for blogID, res := range results {
+		site, ok := sites[blogID]
+		if !ok {
+			continue
+		}
+		if err := dbMarkSiteChecked(o.ctx, blogID, res.Timestamp); err != nil {
+			log.Printf("orchestrator: mark checked blog_id=%d: %v", blogID, err)
+		}
+
+		// Log timing data.
+		if err := dbRecordCheckHistory(
+			blogID,
+			res.HTTPCode, res.ErrorCode,
+			res.RTT.Milliseconds(),
+			res.DNS.Milliseconds(),
+			res.TCP.Milliseconds(),
+			res.TLS.Milliseconds(),
+			res.TTFB.Milliseconds(),
+		); err != nil {
+			log.Printf("orchestrator: record history blog_id=%d: %v", blogID, err)
+		}
+
+		// Update SSL expiry if available.
+		if res.SSLExpiry != nil {
+			if err := dbUpdateSSLExpiry(o.ctx, blogID, *res.SSLExpiry); err != nil {
+				log.Printf("orchestrator: update ssl expiry blog_id=%d: %v", blogID, err)
+			}
+			o.checkSSLAlerts(site, *res.SSLExpiry)
+		}
+
+		o.auditLog(blogID, audit.EventCheck, o.hostname,
+			res.HTTPCode, res.ErrorCode, res.RTT.Milliseconds(), "")
+
+		if !res.IsFailure() {
+			o.handleRecovery(site, res)
+		} else {
+			o.handleFailure(site, res)
+		}
+	}
+}
+
+func (o *Orchestrator) handleRecovery(site db.Site, res checker.Result) {
+	entry := o.retries.get(site.BlogID)
+	if entry == nil && site.SiteStatus == statusRunning {
+		return // was already up, nothing to do
+	}
+
+	o.retries.clear(site.BlogID)
+
+	if site.SiteStatus != statusRunning {
+		changeTime := nowFunc().UTC()
+		log.Printf("orchestrator: blog_id=%d recovered", site.BlogID)
+		o.auditTransition(site.BlogID, site.SiteStatus, statusRunning, "site recovered")
+
+		if config.Get().DBUpdatesEnable {
+			_ = dbUpdateSiteStatus(o.ctx, site.BlogID, statusRunning, changeTime)
+		}
+
+		if inMaintenance(site) {
+			o.auditLog(site.BlogID, audit.EventMaintenanceActive, "local", 0, 0, 0, "recovery suppressed during maintenance")
+		} else if !o.isAlertSuppressed(site) {
+			o.sendNotification(site, res, statusRunning, changeTime, nil)
+		}
+	}
+}
+
+func (o *Orchestrator) handleFailure(site db.Site, res checker.Result) {
+	entry := o.retries.record(res)
+
+	if entry.failCount < config.Get().NumOfChecks {
+		o.auditLog(site.BlogID, audit.EventRetryDispatched, o.hostname,
+			res.HTTPCode, res.ErrorCode, res.RTT.Milliseconds(),
+			fmt.Sprintf("retry %d of %d", entry.failCount, config.Get().NumOfChecks))
+		return
+	}
+
+	// Escalate to verifliers.
+	o.escalateToVerifliers(site, entry)
+}
+
+func (o *Orchestrator) escalateToVerifliers(site db.Site, entry *retryEntry) {
+	clients := o.veriflierSnapshot()
+	if len(clients) == 0 {
+		o.confirmDown(site, entry, nil)
+		return
+	}
+
+	o.auditLog(site.BlogID, audit.EventVeriflierSent, o.hostname, 0, 0, 0,
+		fmt.Sprintf("escalating to %d verifliers", len(clients)))
+
+	req := veriflier.CheckRequest{
+		BlogID:         site.BlogID,
+		URL:            site.MonitorURL,
+		TimeoutSeconds: int32(timeoutForSite(config.Get(), site)),
+		Keyword:        stringPtrValue(site.CheckKeyword),
+		CustomHeaders:  checker.ParseCustomHeaders(site.CustomHeaders),
+		RedirectPolicy: site.RedirectPolicy,
+	}
+
+	type vResult struct {
+		host string
+		res  *veriflier.CheckResult
+		err  error
+	}
+	ch := make(chan vResult, len(clients))
+
+	for _, client := range clients {
+		c := client
+		go func() {
+			res, err := veriflierCheckFunc(c, o.ctx, req)
+			ch <- vResult{host: c.Addr(), res: res, err: err}
+		}()
+	}
+
+	var vResults []veriflier.CheckResult
+	healthyVerifliers := 0
+	confirmations := 0
+
+	for range clients {
+		vr := <-ch
+		if vr.err != nil {
+			log.Printf("orchestrator: veriflier %s error: %v", vr.host, vr.err)
+			continue
+		}
+		healthyVerifliers++
+		o.auditLog(site.BlogID, audit.EventVeriflierResult, vr.host,
+			int(vr.res.HTTPCode), int(vr.res.ErrorCode), vr.res.RTTMs, "")
+		vResults = append(vResults, *vr.res)
+		if !vr.res.Success {
+			confirmations++
+		}
+	}
+
+	// Adjust quorum floor to healthy verifliers, but minimum 1.
+	quorum := config.Get().PeerOfflineLimit
+	if healthyVerifliers < quorum {
+		quorum = healthyVerifliers
+	}
+	if quorum < 1 {
+		quorum = 1
+	}
+
+	if confirmations >= quorum {
+		o.confirmDown(site, entry, vResults)
+	} else {
+		// Verifliers did not confirm — false positive.
+		log.Printf("orchestrator: blog_id=%d verifliers did not confirm down (%d/%d)", site.BlogID, confirmations, quorum)
+		_ = dbRecordFalsePositive(site.BlogID, entry.lastResult.HTTPCode, entry.lastResult.ErrorCode,
+			entry.lastResult.RTT.Milliseconds())
+		o.retries.clear(site.BlogID)
+	}
+}
+
+func (o *Orchestrator) confirmDown(site db.Site, entry *retryEntry, vResults []veriflier.CheckResult) {
+	newStatus := statusConfirmedDown
+	changeTime := nowFunc().UTC()
+
+	log.Printf("orchestrator: blog_id=%d confirmed down", site.BlogID)
+	o.auditTransition(site.BlogID, site.SiteStatus, newStatus, "confirmed down")
+
+	if config.Get().DBUpdatesEnable {
+		_ = dbUpdateSiteStatus(o.ctx, site.BlogID, newStatus, changeTime)
+	}
+
+	if inMaintenance(site) {
+		o.auditLog(site.BlogID, audit.EventMaintenanceActive, "local", 0, 0, 0, "downtime suppressed during maintenance")
+	} else if !o.isAlertSuppressed(site) {
+		o.sendNotification(site, entry.lastResult, newStatus, changeTime, vResults)
+	} else {
+		o.auditLog(site.BlogID, audit.EventAlertSuppressed, "local", 0, 0, 0, "cooldown active")
+	}
+
+	o.retries.clear(site.BlogID)
+}
+
+func (o *Orchestrator) sendNotification(site db.Site, res checker.Result, status int, changeTime time.Time, vResults []veriflier.CheckResult) {
+	checks := []wpcom.CheckEntry{
+		{
+			Type:   1,
+			Host:   o.hostname,
+			Status: statusFromBool(res.Success),
+			RTT:    res.RTT.Milliseconds(),
+			Code:   res.HTTPCode,
+		},
+	}
+	for _, vr := range vResults {
+		checks = append(checks, wpcom.CheckEntry{
+			Type:   2,
+			Host:   vr.Host,
+			Status: statusFromBool(vr.Success),
+			RTT:    vr.RTTMs,
+			Code:   int(vr.HTTPCode),
+		})
+	}
+
+	n := wpcom.Notification{
+		BlogID:           site.BlogID,
+		MonitorURL:       site.MonitorURL,
+		StatusID:         status,
+		LastCheck:        res.Timestamp.UTC().Format(time.RFC3339),
+		LastStatusChange: changeTime.UTC().Format(time.RFC3339),
+		StatusType:       res.StatusType(),
+		Checks:           checks,
+	}
+
+	o.auditLog(site.BlogID, audit.EventWPCOMSent, "local", 0, 0, 0,
+		fmt.Sprintf("status=%d type=%s", status, n.StatusType))
+
+	if err := wpcomNotifyFunc(o.wpcom, n); err != nil {
+		log.Printf("orchestrator: wpcom notify failed for blog_id=%d: %v", site.BlogID, err)
+		o.auditLog(site.BlogID, audit.EventWPCOMRetry, "local", 0, 0, 0, err.Error())
+
+		// Single retry.
+		if retryErr := wpcomNotifyFunc(o.wpcom, n); retryErr != nil {
+			log.Printf("orchestrator: wpcom notify retry failed for blog_id=%d: %v", site.BlogID, retryErr)
+			return
+		}
+	}
+	if err := dbUpdateLastAlertSent(o.ctx, site.BlogID, nowFunc().UTC()); err != nil {
+		log.Printf("orchestrator: update last alert sent blog_id=%d: %v", site.BlogID, err)
+	}
+}
+
+func (o *Orchestrator) checkSSLAlerts(site db.Site, expiry time.Time) {
+	thresholds := []int{30, 14, 7}
+	daysUntil := int(time.Until(expiry).Hours() / 24)
+	for _, t := range thresholds {
+		if daysUntil == t {
+			log.Printf("orchestrator: blog_id=%d SSL cert expires in %d days", site.BlogID, daysUntil)
+			o.auditLog(site.BlogID, audit.EventCheck, "local", 0, checker.ErrorTLSExpired, 0,
+				fmt.Sprintf("ssl certificate expires in %d days", daysUntil))
+		}
+	}
+}
+
+func (o *Orchestrator) isAlertSuppressed(site db.Site) bool {
+	cfg := config.Get()
+	cooldown := cfg.AlertCooldownMinutes
+	if site.AlertCooldownMinutes != nil {
+		cooldown = *site.AlertCooldownMinutes
+	}
+	if cooldown <= 0 {
+		return false
+	}
+	if site.LastAlertSentAt == nil || site.LastAlertSentAt.IsZero() {
+		return false
+	}
+	return time.Since(*site.LastAlertSentAt) < time.Duration(cooldown)*time.Minute
+}
+
+// RetryQueueSize returns the number of sites currently in local retry.
+func (o *Orchestrator) RetryQueueSize() int {
+	return o.retries.size()
+}
+
+// BucketRange returns the current bucket min/max for this host.
+func (o *Orchestrator) BucketRange() (int, int) {
+	return o.bucketMin, o.bucketMax
+}
+
+// WorkerCount returns the live worker count.
+func (o *Orchestrator) WorkerCount() int {
+	return o.pool.WorkerCount()
+}
+
+// ActiveChecks returns the active-check count.
+func (o *Orchestrator) ActiveChecks() int {
+	return o.pool.ActiveCount()
+}
+
+// QueueDepth returns the work queue depth.
+func (o *Orchestrator) QueueDepth() int {
+	return o.pool.QueueDepth()
+}
+
+func (o *Orchestrator) auditLog(blogID int64, event, source string, httpCode, errorCode int, rttMs int64, detail string) {
+	if err := audit.Log(blogID, event, source, httpCode, errorCode, rttMs, detail); err != nil {
+		log.Printf("audit: blog_id=%d event=%s: %v", blogID, event, err)
+	}
+}
+
+func (o *Orchestrator) auditTransition(blogID int64, from, to int, detail string) {
+	if err := audit.LogTransition(blogID, from, to, detail); err != nil {
+		log.Printf("audit: blog_id=%d transition %d->%d: %v", blogID, from, to, err)
+	}
+}
+
+func inMaintenance(site db.Site) bool {
+	now := time.Now()
+	if site.MaintenanceStart == nil || site.MaintenanceEnd == nil {
+		return false
+	}
+	return now.After(*site.MaintenanceStart) && now.Before(*site.MaintenanceEnd)
+}
+
+func statusFromBool(success bool) int {
+	if success {
+		return statusRunning
+	}
+	return 0
+}
+
+func (o *Orchestrator) refreshVeriflierClients(cfg *config.Config) {
+	newAddrs := make([]string, 0, len(cfg.Verifiers))
+	for _, v := range cfg.Verifiers {
+		newAddrs = append(newAddrs, fmt.Sprintf("%s:%s|%s", v.Host, v.GRPCPort, v.AuthToken))
+	}
+
+	o.veriflierMu.RLock()
+	unchanged := slicesEqual(o.veriflierAddrs, newAddrs)
+	o.veriflierMu.RUnlock()
+	if unchanged {
+		return
+	}
+
+	clients := make([]*veriflier.VeriflierClient, 0, len(cfg.Verifiers))
+	for _, v := range cfg.Verifiers {
+		addr := fmt.Sprintf("%s:%s", v.Host, v.GRPCPort)
+		clients = append(clients, veriflier.NewVeriflierClient(addr, v.AuthToken))
+	}
+	o.veriflierMu.Lock()
+	o.veriflierClients = clients
+	o.veriflierAddrs = newAddrs
+	o.veriflierMu.Unlock()
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (o *Orchestrator) veriflierSnapshot() []*veriflier.VeriflierClient {
+	o.veriflierMu.RLock()
+	defer o.veriflierMu.RUnlock()
+	out := make([]*veriflier.VeriflierClient, len(o.veriflierClients))
+	copy(out, o.veriflierClients)
+	return out
+}
+
+func timeoutForSite(cfg *config.Config, site db.Site) int {
+	timeout := cfg.NetCommsTimeout
+	if site.TimeoutSeconds != nil {
+		timeout = *site.TimeoutSeconds
+	}
+	return timeout
+}
+
+func stringPtrValue(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func (o *Orchestrator) applyMemoryPressure(cfg *config.Config) {
+	if cfg.WorkerMaxMemMB <= 0 {
+		return
+	}
+
+	rssMB := currentMemoryMBFunc()
+	if rssMB <= 0 || rssMB <= cfg.WorkerMaxMemMB {
+		return
+	}
+
+	current := o.pool.WorkerCount()
+	toDrain := current / 10
+	if toDrain < 1 {
+		toDrain = 1
+	}
+	drained := o.pool.DrainWorkers(toDrain)
+	if drained == 0 {
+		return
+	}
+
+	// Lower the autoscaler ceiling for the rest of this round to avoid
+	// immediately respawning the workers we just drained.
+	o.pool.SetMaxSize(max(1, current-drained))
+	log.Printf(
+		"orchestrator: memory pressure %dMB > %dMB, draining %d workers",
+		rssMB,
+		cfg.WorkerMaxMemMB,
+		drained,
+	)
+}
+
+func currentMemoryMB() int {
+	samples := []runtimemetrics.Sample{
+		{Name: "/memory/classes/total:bytes"},
+		{Name: "/memory/classes/heap/released:bytes"},
+	}
+	runtimemetrics.Read(samples)
+
+	total := samples[0].Value.Uint64()
+	released := samples[1].Value.Uint64()
+	if total <= released {
+		return 0
+	}
+	return int((total - released) / 1024 / 1024)
+}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1,0 +1,930 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Automattic/jetmon/internal/checker"
+	"github.com/Automattic/jetmon/internal/config"
+	"github.com/Automattic/jetmon/internal/db"
+	"github.com/Automattic/jetmon/internal/veriflier"
+	"github.com/Automattic/jetmon/internal/wpcom"
+)
+
+var orchestratorConfigTestMu sync.Mutex
+
+func TestIsAlertSuppressedUsesLastAlertSent(t *testing.T) {
+	now := time.Now().UTC()
+	recent := now.Add(-5 * time.Minute)
+	old := now.Add(-31 * time.Minute)
+
+	setTestConfig(t)
+
+	o := &Orchestrator{}
+
+	if o.isAlertSuppressed(db.Site{}) {
+		t.Fatalf("zero site should not be suppressed")
+	}
+	if o.isAlertSuppressed(db.Site{LastAlertSentAt: &old}) {
+		t.Fatalf("old alert should not be suppressed")
+	}
+	if !o.isAlertSuppressed(db.Site{LastAlertSentAt: &recent}) {
+		t.Fatalf("recent alert should be suppressed")
+	}
+}
+
+func TestTimeoutForSite(t *testing.T) {
+	cfg := &config.Config{NetCommsTimeout: 10}
+
+	if got := timeoutForSite(cfg, db.Site{}); got != 10 {
+		t.Fatalf("timeoutForSite() = %d, want 10", got)
+	}
+
+	override := 3
+	if got := timeoutForSite(cfg, db.Site{TimeoutSeconds: &override}); got != 3 {
+		t.Fatalf("timeoutForSite() with override = %d, want 3", got)
+	}
+}
+
+func TestInMaintenance(t *testing.T) {
+	now := time.Now()
+	past := now.Add(-1 * time.Hour)
+	future := now.Add(1 * time.Hour)
+
+	if inMaintenance(db.Site{}) {
+		t.Fatal("nil window should not be in maintenance")
+	}
+	if inMaintenance(db.Site{MaintenanceStart: &past}) {
+		t.Fatal("nil end should not be in maintenance")
+	}
+	if inMaintenance(db.Site{MaintenanceEnd: &future}) {
+		t.Fatal("nil start should not be in maintenance")
+	}
+	if !inMaintenance(db.Site{MaintenanceStart: &past, MaintenanceEnd: &future}) {
+		t.Fatal("active window should be in maintenance")
+	}
+	if inMaintenance(db.Site{MaintenanceStart: &past, MaintenanceEnd: &past}) {
+		t.Fatal("expired window should not be in maintenance")
+	}
+	if inMaintenance(db.Site{MaintenanceStart: &future, MaintenanceEnd: &future}) {
+		t.Fatal("future window should not be in maintenance")
+	}
+}
+
+func TestSlicesEqual(t *testing.T) {
+	if !slicesEqual(nil, nil) {
+		t.Fatal("nil slices should be equal")
+	}
+	if !slicesEqual([]string{"a", "b"}, []string{"a", "b"}) {
+		t.Fatal("identical slices should be equal")
+	}
+	if slicesEqual([]string{"a"}, []string{"b"}) {
+		t.Fatal("different content should not be equal")
+	}
+	if slicesEqual([]string{"a"}, []string{"a", "b"}) {
+		t.Fatal("different lengths should not be equal")
+	}
+}
+
+func TestRefreshVeriflierClientsReusesUnchangedClients(t *testing.T) {
+	cfg := &config.Config{
+		Verifiers: []config.VerifierConfig{
+			{Name: "a", Host: "host1", GRPCPort: "7803", AuthToken: "token1"},
+			{Name: "b", Host: "host2", GRPCPort: "7804", AuthToken: "token2"},
+		},
+	}
+
+	o := New(cfg, nil)
+	before := append([]*veriflier.VeriflierClient(nil), o.veriflierClients...)
+
+	o.refreshVeriflierClients(cfg)
+
+	for i := range before {
+		if before[i] != o.veriflierClients[i] {
+			t.Fatalf("client %d was rebuilt for unchanged config", i)
+		}
+	}
+}
+
+func TestRefreshVeriflierClientsRebuildsChangedClients(t *testing.T) {
+	cfg := &config.Config{
+		Verifiers: []config.VerifierConfig{
+			{Name: "a", Host: "host1", GRPCPort: "7803", AuthToken: "token1"},
+		},
+	}
+
+	o := New(cfg, nil)
+	before := o.veriflierClients[0]
+
+	updated := &config.Config{
+		Verifiers: []config.VerifierConfig{
+			{Name: "a", Host: "host1", GRPCPort: "7803", AuthToken: "token2"},
+		},
+	}
+
+	o.refreshVeriflierClients(updated)
+
+	if before == o.veriflierClients[0] {
+		t.Fatalf("client was reused after config changed")
+	}
+}
+
+func TestSendNotificationRetriesAndUpdatesAlertTimestamp(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+
+	setTestConfig(t)
+
+	var notifyCalls int
+	wpcomNotifyFunc = func(_ *wpcom.Client, _ wpcom.Notification) error {
+		notifyCalls++
+		if notifyCalls == 1 {
+			return fmt.Errorf("first failure")
+		}
+		return nil
+	}
+
+	var updatedBlogID int64
+	dbUpdateLastAlertSent = func(_ context.Context, blogID int64, _ time.Time) error {
+		updatedBlogID = blogID
+		return nil
+	}
+
+	o := &Orchestrator{
+		wpcom:    &wpcom.Client{},
+		hostname: "local-host",
+		ctx:      context.Background(),
+	}
+
+	res := checkerResultSuccess(123)
+	o.sendNotification(db.Site{BlogID: 123, MonitorURL: "https://example.com"}, res, statusRunning, res.Timestamp, nil)
+
+	if notifyCalls != 2 {
+		t.Fatalf("notify calls = %d, want 2", notifyCalls)
+	}
+	if updatedBlogID != 123 {
+		t.Fatalf("updated blog_id = %d, want 123", updatedBlogID)
+	}
+}
+
+func TestConfirmDownSuppressedDuringCooldown(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+
+	setTestConfig(t)
+
+	recent := time.Now().UTC().Add(-5 * time.Minute)
+	var notifyCalls int
+	wpcomNotifyFunc = func(_ *wpcom.Client, _ wpcom.Notification) error {
+		notifyCalls++
+		return nil
+	}
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		hostname: "local-host",
+		ctx:      context.Background(),
+	}
+	o.retries.record(checkerResultFailure(123))
+
+	entry := o.retries.get(123)
+	o.confirmDown(db.Site{
+		BlogID:          123,
+		SiteStatus:      statusRunning,
+		LastAlertSentAt: &recent,
+	}, entry, nil)
+
+	if notifyCalls != 0 {
+		t.Fatalf("notify calls = %d, want 0", notifyCalls)
+	}
+	if o.retries.get(123) != nil {
+		t.Fatal("retry entry should be cleared after confirmDown")
+	}
+}
+
+func TestEscalateToVerifliersConfirmsWhenQuorumReached(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+
+	cfg := setTestConfig(t)
+	cfg.PeerOfflineLimit = 2
+
+	var notifyCalls int
+	wpcomNotifyFunc = func(_ *wpcom.Client, _ wpcom.Notification) error {
+		notifyCalls++
+		return nil
+	}
+	dbUpdateLastAlertSent = func(context.Context, int64, time.Time) error { return nil }
+
+	veriflierCheckFunc = func(c *veriflier.VeriflierClient, _ context.Context, req veriflier.CheckRequest) (*veriflier.CheckResult, error) {
+		return &veriflier.CheckResult{
+			BlogID:   req.BlogID,
+			Host:     c.Addr(),
+			Success:  false,
+			HTTPCode: 500,
+		}, nil
+	}
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		ctx:      context.Background(),
+		hostname: "local-host",
+		veriflierClients: []*veriflier.VeriflierClient{
+			veriflier.NewVeriflierClient("v1", ""),
+			veriflier.NewVeriflierClient("v2", ""),
+		},
+	}
+
+	fail := checkerResultFailure(321)
+	o.retries.record(fail)
+	entry := o.retries.get(321)
+	o.escalateToVerifliers(db.Site{BlogID: 321, MonitorURL: "https://example.com", SiteStatus: statusRunning}, entry)
+
+	if notifyCalls != 1 {
+		t.Fatalf("notify calls = %d, want 1", notifyCalls)
+	}
+	if o.retries.get(321) != nil {
+		t.Fatal("retry entry should be cleared after confirmed down")
+	}
+}
+
+func TestEscalateToVerifliersRecordsFalsePositiveWhenQuorumMissed(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+
+	cfg := setTestConfig(t)
+	cfg.PeerOfflineLimit = 2
+
+	var falsePositiveBlogID int64
+	dbRecordFalsePositive = func(blogID int64, _ int, _ int, _ int64) error {
+		falsePositiveBlogID = blogID
+		return nil
+	}
+	wpcomNotifyFunc = func(_ *wpcom.Client, _ wpcom.Notification) error {
+		t.Fatal("notification should not be sent for false positive")
+		return nil
+	}
+
+	call := 0
+	veriflierCheckFunc = func(c *veriflier.VeriflierClient, _ context.Context, req veriflier.CheckRequest) (*veriflier.CheckResult, error) {
+		call++
+		return &veriflier.CheckResult{
+			BlogID:   req.BlogID,
+			Host:     c.Addr(),
+			Success:  call != 1,
+			HTTPCode: 200,
+		}, nil
+	}
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		ctx:      context.Background(),
+		hostname: "local-host",
+		veriflierClients: []*veriflier.VeriflierClient{
+			veriflier.NewVeriflierClient("v1", ""),
+			veriflier.NewVeriflierClient("v2", ""),
+		},
+	}
+
+	fail := checkerResultFailure(654)
+	o.retries.record(fail)
+	entry := o.retries.get(654)
+	o.escalateToVerifliers(db.Site{BlogID: 654, MonitorURL: "https://example.com", SiteStatus: statusRunning}, entry)
+
+	if falsePositiveBlogID != 654 {
+		t.Fatalf("false positive blog_id = %d, want 654", falsePositiveBlogID)
+	}
+	if o.retries.get(654) != nil {
+		t.Fatal("retry entry should be cleared after false positive")
+	}
+}
+
+func stubOrchestratorDeps() func() {
+	origNow := nowFunc
+	origDBUpdateStatus := dbUpdateSiteStatus
+	origDBUpdateLastAlert := dbUpdateLastAlertSent
+	origDBRecordFalsePositive := dbRecordFalsePositive
+	origDBMarkSiteChecked := dbMarkSiteChecked
+	origDBRecordCheckHistory := dbRecordCheckHistory
+	origDBUpdateSSLExpiry := dbUpdateSSLExpiry
+	origNotify := wpcomNotifyFunc
+	origVeriflierCheck := veriflierCheckFunc
+
+	nowFunc = time.Now
+	dbUpdateSiteStatus = func(context.Context, int64, int, time.Time) error { return nil }
+	dbUpdateLastAlertSent = func(context.Context, int64, time.Time) error { return nil }
+	dbRecordFalsePositive = func(int64, int, int, int64) error { return nil }
+	dbMarkSiteChecked = func(context.Context, int64, time.Time) error { return nil }
+	dbRecordCheckHistory = func(int64, int, int, int64, int64, int64, int64, int64) error { return nil }
+	dbUpdateSSLExpiry = func(context.Context, int64, time.Time) error { return nil }
+	wpcomNotifyFunc = func(_ *wpcom.Client, _ wpcom.Notification) error { return nil }
+	veriflierCheckFunc = func(c *veriflier.VeriflierClient, ctx context.Context, req veriflier.CheckRequest) (*veriflier.CheckResult, error) {
+		return c.Check(ctx, req)
+	}
+
+	return func() {
+		nowFunc = origNow
+		dbUpdateSiteStatus = origDBUpdateStatus
+		dbUpdateLastAlertSent = origDBUpdateLastAlert
+		dbRecordFalsePositive = origDBRecordFalsePositive
+		dbMarkSiteChecked = origDBMarkSiteChecked
+		dbRecordCheckHistory = origDBRecordCheckHistory
+		dbUpdateSSLExpiry = origDBUpdateSSLExpiry
+		wpcomNotifyFunc = origNotify
+		veriflierCheckFunc = origVeriflierCheck
+	}
+}
+
+func setTestConfig(t *testing.T) *config.Config {
+	t.Helper()
+	orchestratorConfigTestMu.Lock()
+	t.Cleanup(func() {
+		_ = config.Load("../../config/config-sample.json")
+		orchestratorConfigTestMu.Unlock()
+	})
+	if err := config.Load("../../config/config-sample.json"); err != nil {
+		t.Fatalf("config.Load() error = %v", err)
+	}
+	cfg := config.Get()
+	cfg.AlertCooldownMinutes = 30
+	cfg.NumOfChecks = 3
+	cfg.PeerOfflineLimit = 2
+	cfg.DBUpdatesEnable = false
+	return cfg
+}
+
+func checkerResultSuccess(blogID int64) checker.Result {
+	return checker.Result{
+		BlogID:    blogID,
+		Success:   true,
+		Timestamp: time.Now().UTC(),
+	}
+}
+
+func checkerResultFailure(blogID int64) checker.Result {
+	return checker.Result{
+		BlogID:    blogID,
+		Success:   false,
+		HTTPCode:  500,
+		ErrorCode: checker.ErrorConnect,
+		RTT:       100 * time.Millisecond,
+		Timestamp: time.Now().UTC(),
+	}
+}
+
+func TestHandleRecoverySendsNotificationWhenSiteWasDown(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	setTestConfig(t)
+
+	var notifiedStatus int
+	wpcomNotifyFunc = func(_ *wpcom.Client, n wpcom.Notification) error {
+		notifiedStatus = n.StatusID
+		return nil
+	}
+	dbUpdateLastAlertSent = func(context.Context, int64, time.Time) error { return nil }
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		hostname: "local",
+		ctx:      context.Background(),
+	}
+
+	o.handleRecovery(db.Site{BlogID: 1, SiteStatus: statusConfirmedDown}, checkerResultSuccess(1))
+
+	if notifiedStatus != statusRunning {
+		t.Fatalf("notification StatusID = %d, want %d (statusRunning)", notifiedStatus, statusRunning)
+	}
+	if o.retries.get(1) != nil {
+		t.Fatal("retry entry should be cleared after recovery")
+	}
+}
+
+func TestHandleRecoveryIsNoopWhenSiteAlreadyRunning(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	setTestConfig(t)
+
+	var notifyCalls int
+	wpcomNotifyFunc = func(_ *wpcom.Client, _ wpcom.Notification) error {
+		notifyCalls++
+		return nil
+	}
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		hostname: "local",
+		ctx:      context.Background(),
+	}
+
+	// No retry entry, site already running — should be a complete no-op.
+	o.handleRecovery(db.Site{BlogID: 1, SiteStatus: statusRunning}, checkerResultSuccess(1))
+
+	if notifyCalls != 0 {
+		t.Fatalf("notify calls = %d, want 0", notifyCalls)
+	}
+}
+
+func TestHandleRecoveryClearsRetryEntryEvenWhenAlreadyRunning(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	setTestConfig(t)
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		hostname: "local",
+		ctx:      context.Background(),
+	}
+
+	// Site has a stale retry entry (e.g. from a previous partial failure) but
+	// is now reported as running. The entry must be cleared.
+	o.retries.record(checkerResultFailure(1))
+	o.handleRecovery(db.Site{BlogID: 1, SiteStatus: statusRunning}, checkerResultSuccess(1))
+
+	if o.retries.get(1) != nil {
+		t.Fatal("stale retry entry should be cleared on recovery even when status was already running")
+	}
+}
+
+func TestHandleFailureBelowThresholdDoesNotEscalate(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	setTestConfig(t)
+	config.Get().NumOfChecks = 3
+
+	var escalated bool
+	veriflierCheckFunc = func(_ *veriflier.VeriflierClient, _ context.Context, _ veriflier.CheckRequest) (*veriflier.CheckResult, error) {
+		escalated = true
+		return &veriflier.CheckResult{Success: false}, nil
+	}
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		hostname: "local",
+		ctx:      context.Background(),
+	}
+
+	// First failure only — failCount (1) < NumOfChecks (3).
+	o.handleFailure(db.Site{BlogID: 1}, checkerResultFailure(1))
+
+	if escalated {
+		t.Fatal("escalated to verifliers after only 1 failure, want NumOfChecks (3) failures first")
+	}
+	if o.retries.get(1) == nil {
+		t.Fatal("retry entry should exist after first failure")
+	}
+}
+
+func TestProcessResultsMarksChecked(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	setTestConfig(t)
+
+	var markedBlogID int64
+	dbMarkSiteChecked = func(_ context.Context, blogID int64, _ time.Time) error {
+		markedBlogID = blogID
+		return nil
+	}
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		hostname: "local",
+		ctx:      context.Background(),
+	}
+
+	res := checkerResultSuccess(42)
+	sites := map[int64]db.Site{42: {BlogID: 42, SiteStatus: statusRunning}}
+	o.processResults(map[int64]checker.Result{42: res}, sites)
+
+	if markedBlogID != 42 {
+		t.Fatalf("MarkSiteChecked blog_id = %d, want 42", markedBlogID)
+	}
+}
+
+func TestProcessResultsSkipsUnknownSite(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	setTestConfig(t)
+
+	var markCalled bool
+	dbMarkSiteChecked = func(_ context.Context, _ int64, _ time.Time) error {
+		markCalled = true
+		return nil
+	}
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		hostname: "local",
+		ctx:      context.Background(),
+	}
+
+	res := checkerResultSuccess(99)
+	o.processResults(map[int64]checker.Result{99: res}, map[int64]db.Site{})
+
+	if markCalled {
+		t.Fatal("MarkSiteChecked called for unknown blog_id, want skipped")
+	}
+}
+
+func TestProcessResultsUpdatesSSLExpiry(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	setTestConfig(t)
+
+	var updatedExpiry time.Time
+	dbUpdateSSLExpiry = func(_ context.Context, _ int64, expiry time.Time) error {
+		updatedExpiry = expiry
+		return nil
+	}
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		hostname: "local",
+		ctx:      context.Background(),
+	}
+
+	expiry := time.Now().Add(30 * 24 * time.Hour)
+	res := checkerResultSuccess(1)
+	res.SSLExpiry = &expiry
+
+	sites := map[int64]db.Site{1: {BlogID: 1, SiteStatus: statusRunning}}
+	o.processResults(map[int64]checker.Result{1: res}, sites)
+
+	if updatedExpiry.IsZero() {
+		t.Fatal("UpdateSSLExpiry not called")
+	}
+}
+
+func TestCheckSSLAlertsAtThresholds(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+
+	o := &Orchestrator{hostname: "local"}
+
+	// Test each threshold and a non-threshold day; verify no panic.
+	for _, days := range []int{30, 14, 7, 31, 15} {
+		expiry := time.Now().Add(time.Duration(days)*24*time.Hour + 30*time.Minute)
+		o.checkSSLAlerts(db.Site{BlogID: 1}, expiry)
+	}
+}
+
+func TestApplyMemoryPressureNoActionBelowLimit(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	setTestConfig(t)
+
+	origFn := currentMemoryMBFunc
+	currentMemoryMBFunc = func() int { return 10 }
+	defer func() { currentMemoryMBFunc = origFn }()
+
+	p := checker.NewPool(5, 1, 5)
+	t.Cleanup(p.Drain)
+
+	o := &Orchestrator{pool: p, ctx: context.Background()}
+	cfg := config.Get()
+	cfg.WorkerMaxMemMB = 100
+
+	o.applyMemoryPressure(cfg)
+
+	if p.WorkerCount() != 5 {
+		t.Fatalf("WorkerCount = %d under limit, want 5", p.WorkerCount())
+	}
+}
+
+func TestApplyMemoryPressureNoActionWhenDisabled(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	setTestConfig(t)
+
+	origFn := currentMemoryMBFunc
+	currentMemoryMBFunc = func() int { return 9999 }
+	defer func() { currentMemoryMBFunc = origFn }()
+
+	p := checker.NewPool(5, 1, 5)
+	t.Cleanup(p.Drain)
+
+	o := &Orchestrator{pool: p, ctx: context.Background()}
+	cfg := config.Get()
+	cfg.WorkerMaxMemMB = 0
+
+	o.applyMemoryPressure(cfg)
+
+	if p.WorkerCount() != 5 {
+		t.Fatalf("WorkerCount = %d when disabled, want 5", p.WorkerCount())
+	}
+}
+
+func TestApplyMemoryPressureDrainsWorkersOverLimit(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	setTestConfig(t)
+
+	origFn := currentMemoryMBFunc
+	currentMemoryMBFunc = func() int { return 500 }
+	defer func() { currentMemoryMBFunc = origFn }()
+
+	p := checker.NewPool(10, 1, 10)
+	t.Cleanup(p.Drain)
+
+	o := &Orchestrator{pool: p, ctx: context.Background()}
+	cfg := config.Get()
+	cfg.WorkerMaxMemMB = 50
+
+	initial := p.WorkerCount()
+	o.applyMemoryPressure(cfg)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if p.WorkerCount() < initial {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("WorkerCount = %d after memory pressure, want < %d", p.WorkerCount(), initial)
+}
+
+func TestOrchestratorAccessors(t *testing.T) {
+	p := checker.NewPool(3, 1, 3)
+	defer p.Drain()
+
+	o := &Orchestrator{
+		retries:   newRetryQueue(),
+		bucketMin: 10,
+		bucketMax: 99,
+		pool:      p,
+	}
+	o.retries.record(checkerResultFailure(1))
+
+	if o.RetryQueueSize() != 1 {
+		t.Fatalf("RetryQueueSize() = %d, want 1", o.RetryQueueSize())
+	}
+	min, max := o.BucketRange()
+	if min != 10 || max != 99 {
+		t.Fatalf("BucketRange() = %d-%d, want 10-99", min, max)
+	}
+	if o.WorkerCount() != 3 {
+		t.Fatalf("WorkerCount() = %d, want 3", o.WorkerCount())
+	}
+	if o.ActiveChecks() != 0 {
+		t.Fatalf("ActiveChecks() = %d, want 0", o.ActiveChecks())
+	}
+	if o.QueueDepth() != 0 {
+		t.Fatalf("QueueDepth() = %d, want 0", o.QueueDepth())
+	}
+}
+
+func TestRetryQueueAllBlogIDs(t *testing.T) {
+	q := newRetryQueue()
+	q.record(checkerResultFailure(1))
+	q.record(checkerResultFailure(2))
+	q.record(checkerResultFailure(3))
+
+	ids := q.allBlogIDs()
+	if len(ids) != 3 {
+		t.Fatalf("allBlogIDs() len = %d, want 3", len(ids))
+	}
+}
+
+func TestStringPtrValue(t *testing.T) {
+	if got := stringPtrValue(nil); got != "" {
+		t.Fatalf("stringPtrValue(nil) = %q, want empty", got)
+	}
+	s := "hello"
+	if got := stringPtrValue(&s); got != "hello" {
+		t.Fatalf("stringPtrValue(&\"hello\") = %q, want hello", got)
+	}
+}
+
+func TestStatusFromBool(t *testing.T) {
+	if got := statusFromBool(true); got != statusRunning {
+		t.Fatalf("statusFromBool(true) = %d, want %d", got, statusRunning)
+	}
+	if got := statusFromBool(false); got != 0 {
+		t.Fatalf("statusFromBool(false) = %d, want 0", got)
+	}
+}
+
+func TestIsAlertSuppressedCustomCooldown(t *testing.T) {
+	setTestConfig(t)
+
+	recent := time.Now().UTC().Add(-2 * time.Minute)
+	customCooldown := 60
+
+	o := &Orchestrator{}
+	// Custom per-site cooldown of 60 min, last alert 2 min ago → suppressed.
+	if !o.isAlertSuppressed(db.Site{LastAlertSentAt: &recent, AlertCooldownMinutes: &customCooldown}) {
+		t.Fatal("expected suppressed with custom 60-min cooldown and 2-min-old alert")
+	}
+	// Custom cooldown of 0 → never suppressed.
+	zeroCooldown := 0
+	if o.isAlertSuppressed(db.Site{LastAlertSentAt: &recent, AlertCooldownMinutes: &zeroCooldown}) {
+		t.Fatal("expected not suppressed when custom cooldown = 0")
+	}
+}
+
+func TestSendNotificationBothRetriesFail(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	setTestConfig(t)
+
+	calls := 0
+	wpcomNotifyFunc = func(_ *wpcom.Client, _ wpcom.Notification) error {
+		calls++
+		return fmt.Errorf("always fails")
+	}
+
+	var updateAlertCalled bool
+	dbUpdateLastAlertSent = func(context.Context, int64, time.Time) error {
+		updateAlertCalled = true
+		return nil
+	}
+
+	o := &Orchestrator{
+		wpcom:    &wpcom.Client{},
+		hostname: "local",
+		ctx:      context.Background(),
+	}
+	o.sendNotification(db.Site{BlogID: 1, MonitorURL: "https://example.com"}, checkerResultFailure(1), statusConfirmedDown, time.Now(), nil)
+
+	if calls != 2 {
+		t.Fatalf("notify calls = %d, want 2 (initial + retry)", calls)
+	}
+	if updateAlertCalled {
+		t.Fatal("dbUpdateLastAlertSent should not be called when both retries fail")
+	}
+}
+
+func TestEscalateToVerifliersNoClients(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	setTestConfig(t)
+
+	var confirmed bool
+	wpcomNotifyFunc = func(_ *wpcom.Client, _ wpcom.Notification) error {
+		confirmed = true
+		return nil
+	}
+	dbUpdateLastAlertSent = func(context.Context, int64, time.Time) error { return nil }
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		ctx:      context.Background(),
+		hostname: "local",
+		// veriflierClients is empty
+	}
+	fail := checkerResultFailure(55)
+	o.retries.record(fail)
+	entry := o.retries.get(55)
+	o.escalateToVerifliers(db.Site{BlogID: 55, MonitorURL: "https://example.com", SiteStatus: statusRunning}, entry)
+
+	if !confirmed {
+		t.Fatal("expected confirmDown (and notification) when no verifliers are configured")
+	}
+}
+
+func TestConfirmDownInMaintenance(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	setTestConfig(t)
+
+	wpcomNotifyFunc = func(_ *wpcom.Client, _ wpcom.Notification) error {
+		t.Fatal("notification should not be sent during maintenance")
+		return nil
+	}
+
+	now := time.Now()
+	past := now.Add(-1 * time.Hour)
+	future := now.Add(1 * time.Hour)
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		ctx:      context.Background(),
+		hostname: "local",
+	}
+	fail := checkerResultFailure(77)
+	o.retries.record(fail)
+	entry := o.retries.get(77)
+
+	o.confirmDown(db.Site{
+		BlogID:           77,
+		SiteStatus:       statusRunning,
+		MaintenanceStart: &past,
+		MaintenanceEnd:   &future,
+	}, entry, nil)
+
+	if o.retries.get(77) != nil {
+		t.Fatal("retry entry should be cleared after confirmDown in maintenance")
+	}
+}
+
+func TestHandleRecoveryInMaintenance(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	setTestConfig(t)
+
+	wpcomNotifyFunc = func(_ *wpcom.Client, _ wpcom.Notification) error {
+		t.Fatal("notification should not be sent during maintenance")
+		return nil
+	}
+
+	now := time.Now()
+	past := now.Add(-1 * time.Hour)
+	future := now.Add(1 * time.Hour)
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		ctx:      context.Background(),
+		hostname: "local",
+	}
+
+	o.handleRecovery(db.Site{
+		BlogID:           1,
+		SiteStatus:       statusConfirmedDown,
+		MaintenanceStart: &past,
+		MaintenanceEnd:   &future,
+	}, checkerResultSuccess(1))
+}
+
+func TestProcessResultsLogsErrorsFromDB(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	setTestConfig(t)
+
+	// Make all DB calls return errors to exercise the log.Printf branches in processResults.
+	dbMarkSiteChecked = func(context.Context, int64, time.Time) error {
+		return fmt.Errorf("mark checked error")
+	}
+	dbRecordCheckHistory = func(int64, int, int, int64, int64, int64, int64, int64) error {
+		return fmt.Errorf("history error")
+	}
+	dbUpdateSSLExpiry = func(context.Context, int64, time.Time) error {
+		return fmt.Errorf("ssl expiry error")
+	}
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		hostname: "local",
+		ctx:      context.Background(),
+	}
+
+	expiry := time.Now().Add(30 * 24 * time.Hour)
+	res := checkerResultSuccess(1)
+	res.SSLExpiry = &expiry
+	sites := map[int64]db.Site{1: {BlogID: 1, SiteStatus: statusRunning}}
+
+	// Should not panic despite all DB calls failing.
+	o.processResults(map[int64]checker.Result{1: res}, sites)
+}
+
+func TestHandleFailureEscalatesAfterThreshold(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	setTestConfig(t)
+	cfg := config.Get()
+	cfg.NumOfChecks = 2
+	cfg.PeerOfflineLimit = 1
+
+	var escalated bool
+	wpcomNotifyFunc = func(_ *wpcom.Client, _ wpcom.Notification) error { return nil }
+	dbUpdateLastAlertSent = func(context.Context, int64, time.Time) error { return nil }
+	veriflierCheckFunc = func(_ *veriflier.VeriflierClient, _ context.Context, req veriflier.CheckRequest) (*veriflier.CheckResult, error) {
+		escalated = true
+		return &veriflier.CheckResult{BlogID: req.BlogID, Success: false, HTTPCode: 500}, nil
+	}
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		hostname: "local",
+		ctx:      context.Background(),
+		veriflierClients: []*veriflier.VeriflierClient{
+			veriflier.NewVeriflierClient("v1", ""),
+		},
+	}
+
+	// Two failures reaches NumOfChecks (2) and triggers escalation.
+	for range cfg.NumOfChecks {
+		o.handleFailure(db.Site{BlogID: 1, SiteStatus: statusRunning}, checkerResultFailure(1))
+	}
+
+	if !escalated {
+		t.Fatal("expected escalation to verifliers after NumOfChecks failures")
+	}
+}

--- a/internal/orchestrator/retry.go
+++ b/internal/orchestrator/retry.go
@@ -1,0 +1,81 @@
+package orchestrator
+
+import (
+	"sync"
+	"time"
+
+	"github.com/Automattic/jetmon/internal/checker"
+)
+
+// retryEntry tracks local retry state for a site that has failed at least once.
+type retryEntry struct {
+	blogID       int64
+	url          string
+	failCount    int
+	firstFailAt  time.Time
+	lastResult   checker.Result
+	checks       []checker.Result // all check results since first failure
+}
+
+// retryQueue holds sites awaiting local retry or veriflier escalation.
+// It persists between rounds — never flushed at round start.
+type retryQueue struct {
+	mu      sync.Mutex
+	entries map[int64]*retryEntry
+}
+
+func newRetryQueue() *retryQueue {
+	return &retryQueue{entries: make(map[int64]*retryEntry)}
+}
+
+// record adds a failed check result to the queue. Returns the updated entry.
+func (q *retryQueue) record(res checker.Result) *retryEntry {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	e, exists := q.entries[res.BlogID]
+	if !exists {
+		e = &retryEntry{
+			blogID:      res.BlogID,
+			url:         res.URL,
+			firstFailAt: res.Timestamp,
+		}
+		q.entries[res.BlogID] = e
+	}
+	e.failCount++
+	e.lastResult = res
+	e.checks = append(e.checks, res)
+	return e
+}
+
+// clear removes a site from the retry queue (site recovered or confirmed down).
+func (q *retryQueue) clear(blogID int64) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	delete(q.entries, blogID)
+}
+
+// get returns the entry for a site, or nil if not in the queue.
+func (q *retryQueue) get(blogID int64) *retryEntry {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.entries[blogID]
+}
+
+// allBlogIDs returns the blog IDs of all sites currently in retry.
+func (q *retryQueue) allBlogIDs() []int64 {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	ids := make([]int64, 0, len(q.entries))
+	for id := range q.entries {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// size returns the number of sites in the queue.
+func (q *retryQueue) size() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return len(q.entries)
+}

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -1,0 +1,102 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Automattic/jetmon/internal/checker"
+)
+
+func TestRetryQueueRecord(t *testing.T) {
+	q := newRetryQueue()
+	res := checker.Result{BlogID: 1, URL: "https://example.com", Timestamp: time.Now()}
+
+	e := q.record(res)
+	if e.failCount != 1 {
+		t.Fatalf("failCount = %d, want 1", e.failCount)
+	}
+	if e.blogID != 1 {
+		t.Fatalf("blogID = %d, want 1", e.blogID)
+	}
+
+	e = q.record(res)
+	if e.failCount != 2 {
+		t.Fatalf("failCount after second record = %d, want 2", e.failCount)
+	}
+}
+
+func TestRetryQueueRecordAccumulatesChecks(t *testing.T) {
+	q := newRetryQueue()
+	res := checker.Result{BlogID: 1, Timestamp: time.Now()}
+
+	for range 3 {
+		q.record(res)
+	}
+
+	e := q.get(1)
+	if len(e.checks) != 3 {
+		t.Fatalf("checks length = %d, want 3", len(e.checks))
+	}
+}
+
+func TestRetryQueueGet(t *testing.T) {
+	q := newRetryQueue()
+
+	if got := q.get(99); got != nil {
+		t.Fatalf("get() = %v, want nil for unknown blog_id", got)
+	}
+
+	q.record(checker.Result{BlogID: 99, Timestamp: time.Now()})
+	if got := q.get(99); got == nil {
+		t.Fatalf("get() = nil after record, want entry")
+	}
+}
+
+func TestRetryQueueClear(t *testing.T) {
+	q := newRetryQueue()
+	q.record(checker.Result{BlogID: 1, Timestamp: time.Now()})
+	q.record(checker.Result{BlogID: 2, Timestamp: time.Now()})
+
+	q.clear(1)
+
+	if q.get(1) != nil {
+		t.Fatalf("get() after clear returned entry, want nil")
+	}
+	if q.get(2) == nil {
+		t.Fatalf("get() for uncleared entry returned nil")
+	}
+}
+
+func TestRetryQueueSize(t *testing.T) {
+	q := newRetryQueue()
+	if q.size() != 0 {
+		t.Fatalf("size() = %d, want 0", q.size())
+	}
+
+	q.record(checker.Result{BlogID: 1, Timestamp: time.Now()})
+	q.record(checker.Result{BlogID: 2, Timestamp: time.Now()})
+	if q.size() != 2 {
+		t.Fatalf("size() = %d, want 2", q.size())
+	}
+
+	q.clear(1)
+	if q.size() != 1 {
+		t.Fatalf("size() after clear = %d, want 1", q.size())
+	}
+}
+
+func TestRetryQueuePersistsBetweenRounds(t *testing.T) {
+	q := newRetryQueue()
+	q.record(checker.Result{BlogID: 5, Timestamp: time.Now()})
+
+	// Simulate a new round: record should accumulate, not reset.
+	q.record(checker.Result{BlogID: 5, Timestamp: time.Now()})
+
+	e := q.get(5)
+	if e == nil {
+		t.Fatal("entry missing after second round")
+	}
+	if e.failCount != 2 {
+		t.Fatalf("failCount = %d, want 2 — queue was flushed between rounds", e.failCount)
+	}
+}


### PR DESCRIPTION
## Scope
- Add Jetmon2 command entrypoint and tests (`cmd/jetmon2/**`).
- Add orchestrator and retry flow (`internal/orchestrator/**`).
- Add operator dashboard package and tests (`internal/dashboard/**`).

## Out of Scope
- No legacy runtime removals or deployment cleanup in this PR.

## Testing
- Included command/orchestrator/dashboard tests.
- Verified scope is command/orchestrator/dashboard integration layer only.

## Compatibility
- Preserves staged migration plan; external compatibility constraints remain targeted by the new implementation.