### PR TITLE
feat(events): add site-event lifecycle model and orchestrator hooks

### DIFF
--- a/EVENTS.md
+++ b/EVENTS.md
@@ -36,7 +36,7 @@ Keeping these separate avoids conflating "this got worse" with "this is a differ
 
 ### Identity and idempotency
 
-Event `id` is derived from a stable set of inputs — typically `(site_id, probe_type, start_timestamp_bucket)` or equivalent — so that repeated probe results for the same underlying condition resolve to the same event row. This makes writes idempotent: a retried probe result updates the existing event rather than creating a new one.
+Event `id` is derived from a stable set of inputs — typically `(site_id, check_type, start_timestamp_bucket)` or equivalent — so that repeated check results for the same underlying condition resolve to the same event row. This makes writes idempotent: a retried check result updates the existing event rather than creating a new one.
 
 ## Lifecycle
 
@@ -59,12 +59,12 @@ No active event. Probes are succeeding.
 A probe has failed but the verifier has not yet confirmed. This is a **real state**, not an implementation detail — dashboards show it, alert rules can key off it, and it has its own severity range.
 
 The verifier path has two outcomes:
-- **Confirmed** → transition to `Down`.
+- **Confirmed** → close `Seems Down` with `resolution_reason = promoted_to_confirmed_down`, then open a new `Down` event carrying the same original `start_timestamp`.
 - **Disagreed** → event ends with `resolution_reason = false_alarm`, site returns to `Up`.
 
 ### Down
 
-Outage confirmed. Severity may continue to evolve in place as additional probes report.
+Outage confirmed. The event row remains immutable except closure fields (`end_timestamp`, `resolution_reason`); worsening conditions should close/open distinct events per lifecycle policy.
 
 ### Resolved
 
@@ -106,6 +106,7 @@ New probe types plug into this runner. They do not implement their own dedup.
 
 Every event close records why. Current reasons:
 
+- `promoted_to_confirmed_down` — Seems Down was verifier-confirmed and transitioned to a Down event.
 - `verifier_cleared` — verifier confirms the site is back up.
 - `false_alarm` — verifier disagreed with the initial failure signal.
 - `manual_override` — an operator closed the event.

--- a/TAXONOMY.md
+++ b/TAXONOMY.md
@@ -432,7 +432,7 @@ sites (includes derived state for fast reads):
 
 - **Severity and state are separate fields.** Severity is the numeric, comparable value used for rollup (e.g., 1=Warning, 2=Degraded, 3=Seems Down, 4=Down). State is the human-readable category. Keeping them separate lets you add new states without breaking rollup logic.
 
-- **Open events are updated in place, not replaced.** A Seems Down event that gets verifier-confirmed to Down updates the same row with a severity change. The event's `started_at` remains the original detection timestamp. This keeps "how long has this been broken" honest — incident duration starts from first failure, not from verifier confirmation.
+- **Seems Down to Down is an immutable close+open transition.** When verifier confirmation arrives, close the open Seems Down event and open a new confirmed Down event in the same transaction. Copy the original `started_at` into the Down event so incident duration still starts at first failure, not at verifier confirmation.
 
 - **Event identity is idempotent.** If the same check fails twice in a row, it's the same event, not two events. Key events by `(site_id, endpoint_id, check_type, [optional discriminator])` so repeated detection of the same failure updates the existing open event rather than creating a new one. Deduplication logic lives in the shared probe runner, not in individual checks.
 
@@ -446,7 +446,7 @@ The Seems Down state is the key transient between first failure detection and ve
 
 1. First failure detected → open event at severity Seems Down, `started_at` = now
 2. Verifier runs (retry-on-failure, multi-location confirmation, etc.)
-3a. If verifier confirms failure → **update the same event** to severity Down, `started_at` unchanged
+3a. If verifier confirms failure → **close Seems Down and open Down** in one transaction, carrying forward the original `started_at`
 3b. If verifier succeeds → **close the event** with `resolution_reason = "false_positive"`, `ended_at` = now
 
 This pattern makes "events that opened at Seems Down and closed without promotion" a direct measure of detection noise, useful for tuning false-positive rates.
@@ -565,7 +565,7 @@ A consolidated list of architectural decisions made across the conversation hist
 7. **Unknown state exists specifically to prevent monitor-side failures from being reported as customer-site downtime.**
 8. **Event-sourced architecture** with derived site state denormalized for read performance.
 9. **Severity and state are separate fields**; severity is numeric and comparable, state is human-readable.
-10. **Seems Down promotes in place** to Down on verifier confirmation; `started_at` stays at first-failure time.
+10. **Seems Down transitions immutably** to Down via close+open on verifier confirmation; `started_at` stays at first-failure time.
 11. **Event identity is idempotent** via `(site_id, endpoint_id, check_type, discriminator)`.
 12. **Deduplication lives in the shared probe runner**, not in individual checks.
 13. **Resolution reason is recorded on event close** for accurate uptime reporting.

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/Automattic/jetmon
 go 1.22
 
 require github.com/go-sql-driver/mysql v1.7.1
+
+require github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,5 @@
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrtU8EI=
 github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -3,14 +3,12 @@ package db
 import (
 	"fmt"
 	"log"
-	"strings"
 )
 
 // migration holds a single idempotent schema change.
 type migration struct {
-	id    int
-	sql   string
-	apply func() error
+	id  int
+	sql string
 }
 
 var migrations = []migration{
@@ -96,21 +94,26 @@ var migrations = []migration{
 	{id: 9, sql: `CREATE TABLE IF NOT EXISTS jetmon_site_events (
 		id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
 		jetpack_monitor_site_id BIGINT UNSIGNED NOT NULL,
+		endpoint_id BIGINT UNSIGNED NULL,
+		check_type TINYINT UNSIGNED NULL,
 		event_type TINYINT UNSIGNED NOT NULL,
 		severity TINYINT UNSIGNED NOT NULL,
 		started_at DATETIME NOT NULL,
 		ended_at DATETIME NULL,
+		cause_event_id BIGINT UNSIGNED NULL,
+		resolution_reason TINYINT UNSIGNED NULL,
+		metadata JSON NULL,
 		created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-		updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+		updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 		INDEX idx_site_event_type (jetpack_monitor_site_id, event_type),
 		INDEX idx_event_type_started (event_type, started_at),
+		INDEX idx_site_event_open (jetpack_monitor_site_id, check_type, ended_at),
+		INDEX idx_endpoint_check_open (endpoint_id, check_type, ended_at),
 		CONSTRAINT fk_jetmon_site_events_site
 			FOREIGN KEY (jetpack_monitor_site_id)
 			REFERENCES jetpack_monitor_sites (jetpack_monitor_site_id)
 			ON DELETE CASCADE
 	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
-
-	{id: 10, apply: migrateSiteEventsSchema},
 }
 
 // Migrate applies all pending migrations idempotently.
@@ -132,14 +135,8 @@ func Migrate() error {
 			continue
 		}
 		log.Printf("applying migration %d", m.id)
-		if m.apply != nil {
-			if err := m.apply(); err != nil {
-				return fmt.Errorf("migration %d: %w", m.id, err)
-			}
-		} else {
-			if _, err := db.Exec(m.sql); err != nil {
-				return fmt.Errorf("migration %d: %w", m.id, err)
-			}
+		if _, err := db.Exec(m.sql); err != nil {
+			return fmt.Errorf("migration %d: %w", m.id, err)
 		}
 		if err := markApplied(m.id); err != nil {
 			return err
@@ -159,124 +156,4 @@ func markApplied(id int) error {
 		`INSERT IGNORE INTO jetmon_schema_migrations (id) VALUES (?)`, id,
 	)
 	return err
-}
-
-func migrateSiteEventsSchema() error {
-	const table = "jetmon_site_events"
-
-	if err := ensureColumnExists(table, "endpoint_id", "BIGINT UNSIGNED NULL"); err != nil {
-		return err
-	}
-	if err := ensureColumnExists(table, "check_type", "TINYINT UNSIGNED NULL"); err != nil {
-		return err
-	}
-	if err := ensureColumnExists(table, "cause_event_id", "BIGINT UNSIGNED NULL"); err != nil {
-		return err
-	}
-	if err := ensureColumnExists(table, "resolution_reason", "TINYINT UNSIGNED NULL"); err != nil {
-		return err
-	}
-	if err := ensureColumnExists(table, "metadata", "JSON NULL"); err != nil {
-		return err
-	}
-
-	if err := ensureIndexExists(table, "idx_site_event_open", "(jetpack_monitor_site_id, check_type, ended_at)"); err != nil {
-		return err
-	}
-	if err := ensureIndexExists(table, "idx_event_type_started", "(event_type, started_at)"); err != nil {
-		return err
-	}
-	if err := ensureIndexExists(table, "idx_endpoint_check_open", "(endpoint_id, check_type, ended_at)"); err != nil {
-		return err
-	}
-
-	onUpdate, err := columnHasOnUpdate(table, "updated_at")
-	if err != nil {
-		return err
-	}
-	if onUpdate {
-		if _, err := db.Exec(`ALTER TABLE jetmon_site_events MODIFY COLUMN updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP`); err != nil {
-			return fmt.Errorf("modify jetmon_site_events.updated_at: %w", err)
-		}
-	}
-
-	return nil
-}
-
-func ensureColumnExists(table, column, definition string) error {
-	exists, err := columnExists(table, column)
-	if err != nil {
-		return err
-	}
-	if exists {
-		return nil
-	}
-	stmt := fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s", table, column, definition)
-	if _, err := db.Exec(stmt); err != nil {
-		return fmt.Errorf("add column %s.%s: %w", table, column, err)
-	}
-	return nil
-}
-
-func ensureIndexExists(table, index, definition string) error {
-	exists, err := indexExists(table, index)
-	if err != nil {
-		return err
-	}
-	if exists {
-		return nil
-	}
-	stmt := fmt.Sprintf("ALTER TABLE %s ADD INDEX %s %s", table, index, definition)
-	if _, err := db.Exec(stmt); err != nil {
-		return fmt.Errorf("add index %s.%s: %w", table, index, err)
-	}
-	return nil
-}
-
-func columnExists(table, column string) (bool, error) {
-	var count int
-	err := db.QueryRow(
-		`SELECT COUNT(*)
-		 FROM information_schema.COLUMNS
-		 WHERE TABLE_SCHEMA = DATABASE()
-		   AND TABLE_NAME = ?
-		   AND COLUMN_NAME = ?`,
-		table, column,
-	).Scan(&count)
-	if err != nil {
-		return false, fmt.Errorf("check column %s.%s: %w", table, column, err)
-	}
-	return count > 0, nil
-}
-
-func indexExists(table, index string) (bool, error) {
-	var count int
-	err := db.QueryRow(
-		`SELECT COUNT(*)
-		 FROM information_schema.STATISTICS
-		 WHERE TABLE_SCHEMA = DATABASE()
-		   AND TABLE_NAME = ?
-		   AND INDEX_NAME = ?`,
-		table, index,
-	).Scan(&count)
-	if err != nil {
-		return false, fmt.Errorf("check index %s.%s: %w", table, index, err)
-	}
-	return count > 0, nil
-}
-
-func columnHasOnUpdate(table, column string) (bool, error) {
-	var extra string
-	err := db.QueryRow(
-		`SELECT EXTRA
-		 FROM information_schema.COLUMNS
-		 WHERE TABLE_SCHEMA = DATABASE()
-		   AND TABLE_NAME = ?
-		   AND COLUMN_NAME = ?`,
-		table, column,
-	).Scan(&extra)
-	if err != nil {
-		return false, fmt.Errorf("check on update for %s.%s: %w", table, column, err)
-	}
-	return strings.Contains(strings.ToLower(extra), "on update"), nil
 }

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -3,21 +3,23 @@ package db
 import (
 	"fmt"
 	"log"
+	"strings"
 )
 
 // migration holds a single idempotent schema change.
 type migration struct {
-	id  int
-	sql string
+	id    int
+	sql   string
+	apply func() error
 }
 
 var migrations = []migration{
-	{1, `CREATE TABLE IF NOT EXISTS jetmon_schema_migrations (
+	{id: 1, sql: `CREATE TABLE IF NOT EXISTS jetmon_schema_migrations (
 		id           INT UNSIGNED NOT NULL PRIMARY KEY,
 		applied_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
 
-	{2, `CREATE TABLE IF NOT EXISTS jetpack_monitor_sites (
+	{id: 2, sql: `CREATE TABLE IF NOT EXISTS jetpack_monitor_sites (
 		jetpack_monitor_site_id  BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
 		blog_id                  BIGINT UNSIGNED NOT NULL,
 		bucket_no                SMALLINT UNSIGNED NOT NULL DEFAULT 0,
@@ -29,7 +31,7 @@ var migrations = []migration{
 		INDEX idx_bucket_active (bucket_no, monitor_active)
 	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
 
-	{3, `ALTER TABLE jetpack_monitor_sites
+	{id: 3, sql: `ALTER TABLE jetpack_monitor_sites
 		ADD COLUMN ssl_expiry_date        DATE NULL,
 		ADD COLUMN check_keyword          VARCHAR(500) NULL,
 		ADD COLUMN maintenance_start      DATETIME NULL,
@@ -39,7 +41,7 @@ var migrations = []migration{
 		ADD COLUMN redirect_policy        ENUM('follow','alert','fail') NULL DEFAULT 'follow',
 		ADD COLUMN alert_cooldown_minutes SMALLINT UNSIGNED NULL`},
 
-	{4, `CREATE TABLE IF NOT EXISTS jetmon_hosts (
+	{id: 4, sql: `CREATE TABLE IF NOT EXISTS jetmon_hosts (
 		host_id        VARCHAR(255) NOT NULL PRIMARY KEY,
 		bucket_min     SMALLINT UNSIGNED NOT NULL,
 		bucket_max     SMALLINT UNSIGNED NOT NULL,
@@ -47,7 +49,7 @@ var migrations = []migration{
 		status         ENUM('active','draining') NOT NULL DEFAULT 'active'
 	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
 
-	{5, `CREATE TABLE IF NOT EXISTS jetmon_audit_log (
+	{id: 5, sql: `CREATE TABLE IF NOT EXISTS jetmon_audit_log (
 		id           BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
 		blog_id      BIGINT UNSIGNED NOT NULL,
 		event_type   VARCHAR(64) NOT NULL,
@@ -62,7 +64,7 @@ var migrations = []migration{
 		INDEX idx_blog_id_created (blog_id, created_at)
 	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
 
-	{6, `CREATE TABLE IF NOT EXISTS jetmon_check_history (
+	{id: 6, sql: `CREATE TABLE IF NOT EXISTS jetmon_check_history (
 		id         BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
 		blog_id    BIGINT UNSIGNED NOT NULL,
 		http_code  SMALLINT NULL,
@@ -76,7 +78,7 @@ var migrations = []migration{
 		INDEX idx_blog_id_checked (blog_id, checked_at)
 	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
 
-	{7, `CREATE TABLE IF NOT EXISTS jetmon_false_positives (
+	{id: 7, sql: `CREATE TABLE IF NOT EXISTS jetmon_false_positives (
 		id         BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
 		blog_id    BIGINT UNSIGNED NOT NULL,
 		http_code  SMALLINT NULL,
@@ -86,12 +88,12 @@ var migrations = []migration{
 		INDEX idx_blog_id (blog_id)
 	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
 
-	{8, `ALTER TABLE jetpack_monitor_sites
+	{id: 8, sql: `ALTER TABLE jetpack_monitor_sites
 		ADD COLUMN last_checked_at DATETIME NULL,
 		ADD COLUMN last_alert_sent_at DATETIME NULL,
 		ADD INDEX idx_bucket_monitor_last_checked (bucket_no, monitor_active, last_checked_at)`},
 
-	{9, `CREATE TABLE IF NOT EXISTS jetmon_site_events (
+	{id: 9, sql: `CREATE TABLE IF NOT EXISTS jetmon_site_events (
 		id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
 		jetpack_monitor_site_id BIGINT UNSIGNED NOT NULL,
 		event_type TINYINT UNSIGNED NOT NULL,
@@ -107,6 +109,8 @@ var migrations = []migration{
 			REFERENCES jetpack_monitor_sites (jetpack_monitor_site_id)
 			ON DELETE CASCADE
 	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
+
+	{id: 10, apply: migrateSiteEventsSchema},
 }
 
 // Migrate applies all pending migrations idempotently.
@@ -128,8 +132,14 @@ func Migrate() error {
 			continue
 		}
 		log.Printf("applying migration %d", m.id)
-		if _, err := db.Exec(m.sql); err != nil {
-			return fmt.Errorf("migration %d: %w", m.id, err)
+		if m.apply != nil {
+			if err := m.apply(); err != nil {
+				return fmt.Errorf("migration %d: %w", m.id, err)
+			}
+		} else {
+			if _, err := db.Exec(m.sql); err != nil {
+				return fmt.Errorf("migration %d: %w", m.id, err)
+			}
 		}
 		if err := markApplied(m.id); err != nil {
 			return err
@@ -149,4 +159,124 @@ func markApplied(id int) error {
 		`INSERT IGNORE INTO jetmon_schema_migrations (id) VALUES (?)`, id,
 	)
 	return err
+}
+
+func migrateSiteEventsSchema() error {
+	const table = "jetmon_site_events"
+
+	if err := ensureColumnExists(table, "endpoint_id", "BIGINT UNSIGNED NULL"); err != nil {
+		return err
+	}
+	if err := ensureColumnExists(table, "check_type", "TINYINT UNSIGNED NULL"); err != nil {
+		return err
+	}
+	if err := ensureColumnExists(table, "cause_event_id", "BIGINT UNSIGNED NULL"); err != nil {
+		return err
+	}
+	if err := ensureColumnExists(table, "resolution_reason", "TINYINT UNSIGNED NULL"); err != nil {
+		return err
+	}
+	if err := ensureColumnExists(table, "metadata", "JSON NULL"); err != nil {
+		return err
+	}
+
+	if err := ensureIndexExists(table, "idx_site_event_open", "(jetpack_monitor_site_id, check_type, ended_at)"); err != nil {
+		return err
+	}
+	if err := ensureIndexExists(table, "idx_event_type_started", "(event_type, started_at)"); err != nil {
+		return err
+	}
+	if err := ensureIndexExists(table, "idx_endpoint_check_open", "(endpoint_id, check_type, ended_at)"); err != nil {
+		return err
+	}
+
+	onUpdate, err := columnHasOnUpdate(table, "updated_at")
+	if err != nil {
+		return err
+	}
+	if onUpdate {
+		if _, err := db.Exec(`ALTER TABLE jetmon_site_events MODIFY COLUMN updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP`); err != nil {
+			return fmt.Errorf("modify jetmon_site_events.updated_at: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func ensureColumnExists(table, column, definition string) error {
+	exists, err := columnExists(table, column)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+	stmt := fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s", table, column, definition)
+	if _, err := db.Exec(stmt); err != nil {
+		return fmt.Errorf("add column %s.%s: %w", table, column, err)
+	}
+	return nil
+}
+
+func ensureIndexExists(table, index, definition string) error {
+	exists, err := indexExists(table, index)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+	stmt := fmt.Sprintf("ALTER TABLE %s ADD INDEX %s %s", table, index, definition)
+	if _, err := db.Exec(stmt); err != nil {
+		return fmt.Errorf("add index %s.%s: %w", table, index, err)
+	}
+	return nil
+}
+
+func columnExists(table, column string) (bool, error) {
+	var count int
+	err := db.QueryRow(
+		`SELECT COUNT(*)
+		 FROM information_schema.COLUMNS
+		 WHERE TABLE_SCHEMA = DATABASE()
+		   AND TABLE_NAME = ?
+		   AND COLUMN_NAME = ?`,
+		table, column,
+	).Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("check column %s.%s: %w", table, column, err)
+	}
+	return count > 0, nil
+}
+
+func indexExists(table, index string) (bool, error) {
+	var count int
+	err := db.QueryRow(
+		`SELECT COUNT(*)
+		 FROM information_schema.STATISTICS
+		 WHERE TABLE_SCHEMA = DATABASE()
+		   AND TABLE_NAME = ?
+		   AND INDEX_NAME = ?`,
+		table, index,
+	).Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("check index %s.%s: %w", table, index, err)
+	}
+	return count > 0, nil
+}
+
+func columnHasOnUpdate(table, column string) (bool, error) {
+	var extra string
+	err := db.QueryRow(
+		`SELECT EXTRA
+		 FROM information_schema.COLUMNS
+		 WHERE TABLE_SCHEMA = DATABASE()
+		   AND TABLE_NAME = ?
+		   AND COLUMN_NAME = ?`,
+		table, column,
+	).Scan(&extra)
+	if err != nil {
+		return false, fmt.Errorf("check on update for %s.%s: %w", table, column, err)
+	}
+	return strings.Contains(strings.ToLower(extra), "on update"), nil
 }

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -90,6 +90,23 @@ var migrations = []migration{
 		ADD COLUMN last_checked_at DATETIME NULL,
 		ADD COLUMN last_alert_sent_at DATETIME NULL,
 		ADD INDEX idx_bucket_monitor_last_checked (bucket_no, monitor_active, last_checked_at)`},
+
+	{9, `CREATE TABLE IF NOT EXISTS jetmon_site_events (
+		id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		jetpack_monitor_site_id BIGINT UNSIGNED NOT NULL,
+		event_type TINYINT UNSIGNED NOT NULL,
+		severity TINYINT UNSIGNED NOT NULL,
+		started_at DATETIME NOT NULL,
+		ended_at DATETIME NULL,
+		created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+		INDEX idx_site_event_type (jetpack_monitor_site_id, event_type),
+		INDEX idx_event_type_started (event_type, started_at),
+		CONSTRAINT fk_jetmon_site_events_site
+			FOREIGN KEY (jetpack_monitor_site_id)
+			REFERENCES jetpack_monitor_sites (jetpack_monitor_site_id)
+			ON DELETE CASCADE
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
 }
 
 // Migrate applies all pending migrations idempotently.

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -97,6 +97,45 @@ func UpdateSSLExpiry(ctx context.Context, blogID int64, expiry time.Time) error 
 	return err
 }
 
+// OpenSiteEvent inserts a new open event for the site if none is currently open.
+func OpenSiteEvent(ctx context.Context, siteID int64, eventType, severity uint8, startedAt time.Time) error {
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO jetmon_site_events
+			(jetpack_monitor_site_id, event_type, severity, started_at)
+		 SELECT ?, ?, ?, ?
+		 WHERE NOT EXISTS (
+			SELECT 1
+			FROM jetmon_site_events
+			WHERE jetpack_monitor_site_id = ?
+			  AND ended_at IS NULL
+		 )`,
+		siteID, eventType, severity, startedAt.UTC(), siteID,
+	)
+	return err
+}
+
+// UpgradeOpenSiteEvent updates type/severity on the currently open event for a site.
+func UpgradeOpenSiteEvent(ctx context.Context, siteID int64, eventType, severity uint8) error {
+	_, err := db.ExecContext(ctx,
+		`UPDATE jetmon_site_events
+		 SET event_type = ?, severity = ?
+		 WHERE jetpack_monitor_site_id = ? AND ended_at IS NULL`,
+		eventType, severity, siteID,
+	)
+	return err
+}
+
+// CloseOpenSiteEvent sets ended_at on the currently open event for a site.
+func CloseOpenSiteEvent(ctx context.Context, siteID int64, endedAt time.Time) error {
+	_, err := db.ExecContext(ctx,
+		`UPDATE jetmon_site_events
+		 SET ended_at = ?
+		 WHERE jetpack_monitor_site_id = ? AND ended_at IS NULL`,
+		endedAt.UTC(), siteID,
+	)
+	return err
+}
+
 // ClaimBuckets registers this host in jetmon_hosts, claiming uncovered bucket
 // ranges from expired peers. Returns the claimed min/max bucket numbers.
 func ClaimBuckets(hostID string, bucketTotal, bucketTarget int, graceSec int) (int, int, error) {

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -99,7 +99,7 @@ func UpdateSSLExpiry(ctx context.Context, blogID int64, expiry time.Time) error 
 	return err
 }
 
-// OpenSiteEvent inserts a new open event for the site if none is currently open.
+// OpenSiteEvent inserts a new open event for the site/event-type if none is currently open.
 func OpenSiteEvent(ctx context.Context, siteID int64, endpointID *int64, checkType CheckType, eventType EventType, severity EventSeverity, startedAt time.Time) (bool, error) {
 	res, err := db.ExecContext(ctx,
 		`INSERT INTO jetmon_site_events
@@ -111,10 +111,11 @@ func OpenSiteEvent(ctx context.Context, siteID int64, endpointID *int64, checkTy
 			WHERE jetpack_monitor_site_id = ?
 			  AND endpoint_id <=> ?
 			  AND check_type = ?
+			  AND event_type = ?
 			  AND ended_at IS NULL
 		 )`,
 		siteID, endpointID, checkType, eventType, severity, startedAt.UTC(),
-		siteID, endpointID, checkType,
+		siteID, endpointID, checkType, eventType,
 	)
 	if err != nil {
 		return false, err
@@ -126,16 +127,17 @@ func OpenSiteEvent(ctx context.Context, siteID int64, endpointID *int64, checkTy
 	return rows > 0, nil
 }
 
-// UpgradeOpenSiteEvent updates type/severity on the currently open event for a site.
-func UpgradeOpenSiteEvent(ctx context.Context, siteID int64, endpointID *int64, checkType CheckType, eventType EventType, severity EventSeverity) (bool, error) {
+// CloseOpenSiteEventType sets ended_at on the currently open event of the given type.
+func CloseOpenSiteEventType(ctx context.Context, siteID int64, endpointID *int64, checkType CheckType, eventType EventType, endedAt time.Time, reason ResolutionReason) (bool, error) {
 	res, err := db.ExecContext(ctx,
 		`UPDATE jetmon_site_events
-		 SET event_type = ?, severity = ?
+		 SET ended_at = ?, resolution_reason = ?
 		 WHERE jetpack_monitor_site_id = ?
 		   AND endpoint_id <=> ?
 		   AND check_type = ?
+		   AND event_type = ?
 		   AND ended_at IS NULL`,
-		eventType, severity, siteID, endpointID, checkType,
+		endedAt.UTC(), reason, siteID, endpointID, checkType, eventType,
 	)
 	if err != nil {
 		return false, err
@@ -147,7 +149,7 @@ func UpgradeOpenSiteEvent(ctx context.Context, siteID int64, endpointID *int64, 
 	return rows > 0, nil
 }
 
-// CloseOpenSiteEvent sets ended_at on the currently open event for a site.
+// CloseOpenSiteEvent sets ended_at on all currently open events for a site identity.
 func CloseOpenSiteEvent(ctx context.Context, siteID int64, endpointID *int64, checkType CheckType, endedAt time.Time, reason ResolutionReason) (bool, error) {
 	res, err := db.ExecContext(ctx,
 		`UPDATE jetmon_site_events
@@ -168,16 +170,53 @@ func CloseOpenSiteEvent(ctx context.Context, siteID int64, endpointID *int64, ch
 	return rows > 0, nil
 }
 
-// ConfirmDownTx upgrades the open event and updates site status atomically.
+// ConfirmDownTx immutably transitions seems_down to confirmed_down and updates site status atomically.
 func ConfirmDownTx(ctx context.Context, siteID, blogID int64, endpointID *int64, checkType CheckType, eventType EventType, severity EventSeverity, changedAt time.Time, dbUpdatesEnabled bool) error {
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin confirm-down tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
+	_ = eventType
+	_ = severity
 
-	if _, err := upgradeOpenSiteEventTx(ctx, tx, siteID, endpointID, checkType, eventType, severity); err != nil {
-		return fmt.Errorf("upgrade site event in tx: %w", err)
+	startedAt := changedAt.UTC()
+	var openSeemsDownStartedAt time.Time
+	err = tx.QueryRowContext(ctx,
+		`SELECT started_at
+		 FROM jetmon_site_events
+		 WHERE jetpack_monitor_site_id = ?
+		   AND endpoint_id <=> ?
+		   AND check_type = ?
+		   AND event_type = ?
+		   AND ended_at IS NULL
+		 ORDER BY started_at ASC
+		 LIMIT 1
+		 FOR UPDATE`,
+		siteID, endpointID, checkType, EventTypeSeemsDown,
+	).Scan(&openSeemsDownStartedAt)
+	if err != nil {
+		if err != sql.ErrNoRows {
+			return fmt.Errorf("load open seems_down event in tx: %w", err)
+		}
+	} else {
+		startedAt = openSeemsDownStartedAt.UTC()
+		if _, err := closeOpenSiteEventTypeTx(
+			ctx,
+			tx,
+			siteID,
+			endpointID,
+			checkType,
+			EventTypeSeemsDown,
+			changedAt,
+			ResolutionReasonPromotedToConfirmedDown,
+		); err != nil {
+			return fmt.Errorf("close seems_down site event in tx: %w", err)
+		}
+	}
+
+	if _, err := openSiteEventTx(ctx, tx, siteID, endpointID, checkType, EventTypeConfirmedDown, EventSeverityHigh, startedAt); err != nil {
+		return fmt.Errorf("open confirmed_down site event in tx: %w", err)
 	}
 
 	if dbUpdatesEnabled {
@@ -195,15 +234,43 @@ func ConfirmDownTx(ctx context.Context, siteID, blogID int64, endpointID *int64,
 	return nil
 }
 
-func upgradeOpenSiteEventTx(ctx context.Context, tx *sql.Tx, siteID int64, endpointID *int64, checkType CheckType, eventType EventType, severity EventSeverity) (bool, error) {
+func openSiteEventTx(ctx context.Context, tx *sql.Tx, siteID int64, endpointID *int64, checkType CheckType, eventType EventType, severity EventSeverity, startedAt time.Time) (bool, error) {
+	res, err := tx.ExecContext(ctx,
+		`INSERT INTO jetmon_site_events
+			(jetpack_monitor_site_id, endpoint_id, check_type, event_type, severity, started_at)
+		 SELECT ?, ?, ?, ?, ?, ?
+		 WHERE NOT EXISTS (
+			SELECT 1
+			FROM jetmon_site_events
+			WHERE jetpack_monitor_site_id = ?
+			  AND endpoint_id <=> ?
+			  AND check_type = ?
+			  AND event_type = ?
+			  AND ended_at IS NULL
+		 )`,
+		siteID, endpointID, checkType, eventType, severity, startedAt.UTC(),
+		siteID, endpointID, checkType, eventType,
+	)
+	if err != nil {
+		return false, err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rows > 0, nil
+}
+
+func closeOpenSiteEventTypeTx(ctx context.Context, tx *sql.Tx, siteID int64, endpointID *int64, checkType CheckType, eventType EventType, endedAt time.Time, reason ResolutionReason) (bool, error) {
 	res, err := tx.ExecContext(ctx,
 		`UPDATE jetmon_site_events
-		 SET event_type = ?, severity = ?
+		 SET ended_at = ?, resolution_reason = ?
 		 WHERE jetpack_monitor_site_id = ?
 		   AND endpoint_id <=> ?
 		   AND check_type = ?
+		   AND event_type = ?
 		   AND ended_at IS NULL`,
-		eventType, severity, siteID, endpointID, checkType,
+		endedAt.UTC(), reason, siteID, endpointID, checkType, eventType,
 	)
 	if err != nil {
 		return false, err

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -8,6 +8,8 @@ import (
 	"time"
 )
 
+const statusConfirmedDown = 2
+
 // GetSitesForBucket fetches active sites within the given bucket range.
 func GetSitesForBucket(ctx context.Context, bucketMin, bucketMax, batchSize int, useVariableIntervals bool) ([]Site, error) {
 	query := `
@@ -98,42 +100,119 @@ func UpdateSSLExpiry(ctx context.Context, blogID int64, expiry time.Time) error 
 }
 
 // OpenSiteEvent inserts a new open event for the site if none is currently open.
-func OpenSiteEvent(ctx context.Context, siteID int64, eventType, severity uint8, startedAt time.Time) error {
-	_, err := db.ExecContext(ctx,
+func OpenSiteEvent(ctx context.Context, siteID int64, endpointID *int64, checkType CheckType, eventType EventType, severity EventSeverity, startedAt time.Time) (bool, error) {
+	res, err := db.ExecContext(ctx,
 		`INSERT INTO jetmon_site_events
-			(jetpack_monitor_site_id, event_type, severity, started_at)
-		 SELECT ?, ?, ?, ?
+			(jetpack_monitor_site_id, endpoint_id, check_type, event_type, severity, started_at)
+		 SELECT ?, ?, ?, ?, ?, ?
 		 WHERE NOT EXISTS (
 			SELECT 1
 			FROM jetmon_site_events
 			WHERE jetpack_monitor_site_id = ?
+			  AND endpoint_id <=> ?
+			  AND check_type = ?
 			  AND ended_at IS NULL
 		 )`,
-		siteID, eventType, severity, startedAt.UTC(), siteID,
+		siteID, endpointID, checkType, eventType, severity, startedAt.UTC(),
+		siteID, endpointID, checkType,
 	)
-	return err
+	if err != nil {
+		return false, err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rows > 0, nil
 }
 
 // UpgradeOpenSiteEvent updates type/severity on the currently open event for a site.
-func UpgradeOpenSiteEvent(ctx context.Context, siteID int64, eventType, severity uint8) error {
-	_, err := db.ExecContext(ctx,
+func UpgradeOpenSiteEvent(ctx context.Context, siteID int64, endpointID *int64, checkType CheckType, eventType EventType, severity EventSeverity) (bool, error) {
+	res, err := db.ExecContext(ctx,
 		`UPDATE jetmon_site_events
 		 SET event_type = ?, severity = ?
-		 WHERE jetpack_monitor_site_id = ? AND ended_at IS NULL`,
-		eventType, severity, siteID,
+		 WHERE jetpack_monitor_site_id = ?
+		   AND endpoint_id <=> ?
+		   AND check_type = ?
+		   AND ended_at IS NULL`,
+		eventType, severity, siteID, endpointID, checkType,
 	)
-	return err
+	if err != nil {
+		return false, err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rows > 0, nil
 }
 
 // CloseOpenSiteEvent sets ended_at on the currently open event for a site.
-func CloseOpenSiteEvent(ctx context.Context, siteID int64, endedAt time.Time) error {
-	_, err := db.ExecContext(ctx,
+func CloseOpenSiteEvent(ctx context.Context, siteID int64, endpointID *int64, checkType CheckType, endedAt time.Time, reason ResolutionReason) (bool, error) {
+	res, err := db.ExecContext(ctx,
 		`UPDATE jetmon_site_events
-		 SET ended_at = ?
-		 WHERE jetpack_monitor_site_id = ? AND ended_at IS NULL`,
-		endedAt.UTC(), siteID,
+		 SET ended_at = ?, resolution_reason = ?
+		 WHERE jetpack_monitor_site_id = ?
+		   AND endpoint_id <=> ?
+		   AND check_type = ?
+		   AND ended_at IS NULL`,
+		endedAt.UTC(), reason, siteID, endpointID, checkType,
 	)
-	return err
+	if err != nil {
+		return false, err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rows > 0, nil
+}
+
+// ConfirmDownTx upgrades the open event and updates site status atomically.
+func ConfirmDownTx(ctx context.Context, siteID, blogID int64, endpointID *int64, checkType CheckType, eventType EventType, severity EventSeverity, changedAt time.Time, dbUpdatesEnabled bool) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin confirm-down tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := upgradeOpenSiteEventTx(ctx, tx, siteID, endpointID, checkType, eventType, severity); err != nil {
+		return fmt.Errorf("upgrade site event in tx: %w", err)
+	}
+
+	if dbUpdatesEnabled {
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE jetpack_monitor_sites SET site_status = ?, last_status_change = ? WHERE blog_id = ?`,
+			statusConfirmedDown, changedAt.UTC(), blogID,
+		); err != nil {
+			return fmt.Errorf("update site status in tx: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit confirm-down tx: %w", err)
+	}
+	return nil
+}
+
+func upgradeOpenSiteEventTx(ctx context.Context, tx *sql.Tx, siteID int64, endpointID *int64, checkType CheckType, eventType EventType, severity EventSeverity) (bool, error) {
+	res, err := tx.ExecContext(ctx,
+		`UPDATE jetmon_site_events
+		 SET event_type = ?, severity = ?
+		 WHERE jetpack_monitor_site_id = ?
+		   AND endpoint_id <=> ?
+		   AND check_type = ?
+		   AND ended_at IS NULL`,
+		eventType, severity, siteID, endpointID, checkType,
+	)
+	if err != nil {
+		return false, err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rows > 0, nil
 }
 
 // ClaimBuckets registers this host in jetmon_hosts, claiming uncovered bucket

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -1,8 +1,13 @@
 package db
 
 import (
+	"context"
 	"reflect"
+	"regexp"
 	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
 )
 
 func TestAssignBucketRanges(t *testing.T) {
@@ -64,5 +69,187 @@ func TestAssignBucketRanges(t *testing.T) {
 				t.Fatalf("assignBucketRanges() = %#v, want %#v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestOpenSiteEventDedupesByEventType(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	oldDB := db
+	db = mockDB
+	t.Cleanup(func() {
+		db = oldDB
+		_ = mockDB.Close()
+	})
+
+	query := regexp.QuoteMeta(`INSERT INTO jetmon_site_events
+			(jetpack_monitor_site_id, endpoint_id, check_type, event_type, severity, started_at)
+		 SELECT ?, ?, ?, ?, ?, ?
+		 WHERE NOT EXISTS (
+			SELECT 1
+			FROM jetmon_site_events
+			WHERE jetpack_monitor_site_id = ?
+			  AND endpoint_id <=> ?
+			  AND check_type = ?
+			  AND event_type = ?
+			  AND ended_at IS NULL
+		 )`)
+
+	ctx := context.Background()
+	startedAt := time.Date(2026, time.April, 24, 10, 0, 0, 0, time.UTC)
+	siteID := int64(101)
+	var endpointID *int64
+
+	mock.ExpectExec(query).
+		WithArgs(siteID, endpointID, CheckTypeHTTP, EventTypeSeemsDown, EventSeverityLow, startedAt.UTC(), siteID, endpointID, CheckTypeHTTP, EventTypeSeemsDown).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(query).
+		WithArgs(siteID, endpointID, CheckTypeHTTP, EventTypeConfirmedDown, EventSeverityHigh, startedAt.UTC(), siteID, endpointID, CheckTypeHTTP, EventTypeConfirmedDown).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(query).
+		WithArgs(siteID, endpointID, CheckTypeHTTP, EventTypeSeemsDown, EventSeverityLow, startedAt.UTC(), siteID, endpointID, CheckTypeHTTP, EventTypeSeemsDown).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	insertedSeemsDown, err := OpenSiteEvent(ctx, siteID, endpointID, CheckTypeHTTP, EventTypeSeemsDown, EventSeverityLow, startedAt)
+	if err != nil {
+		t.Fatalf("OpenSiteEvent(seems_down) error = %v", err)
+	}
+	if !insertedSeemsDown {
+		t.Fatal("OpenSiteEvent(seems_down) inserted = false, want true")
+	}
+
+	insertedConfirmedDown, err := OpenSiteEvent(ctx, siteID, endpointID, CheckTypeHTTP, EventTypeConfirmedDown, EventSeverityHigh, startedAt)
+	if err != nil {
+		t.Fatalf("OpenSiteEvent(confirmed_down) error = %v", err)
+	}
+	if !insertedConfirmedDown {
+		t.Fatal("OpenSiteEvent(confirmed_down) inserted = false, want true")
+	}
+
+	insertedAgain, err := OpenSiteEvent(ctx, siteID, endpointID, CheckTypeHTTP, EventTypeSeemsDown, EventSeverityLow, startedAt)
+	if err != nil {
+		t.Fatalf("OpenSiteEvent(seems_down duplicate) error = %v", err)
+	}
+	if insertedAgain {
+		t.Fatal("OpenSiteEvent(seems_down duplicate) inserted = true, want false")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestConfirmDownTxCarriesStartedAtFromOpenSeemsDown(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	oldDB := db
+	db = mockDB
+	t.Cleanup(func() {
+		db = oldDB
+		_ = mockDB.Close()
+	})
+
+	siteID := int64(77)
+	blogID := int64(123)
+	var endpointID *int64
+	changedAt := time.Date(2026, time.April, 24, 11, 0, 0, 0, time.UTC)
+	originalStartedAt := time.Date(2026, time.April, 24, 10, 15, 0, 0, time.UTC)
+
+	selectQuery := regexp.QuoteMeta(`SELECT started_at
+		 FROM jetmon_site_events
+		 WHERE jetpack_monitor_site_id = ?
+		   AND endpoint_id <=> ?
+		   AND check_type = ?
+		   AND event_type = ?
+		   AND ended_at IS NULL
+		 ORDER BY started_at ASC
+		 LIMIT 1
+		 FOR UPDATE`)
+	closeQuery := regexp.QuoteMeta(`UPDATE jetmon_site_events
+		 SET ended_at = ?, resolution_reason = ?
+		 WHERE jetpack_monitor_site_id = ?
+		   AND endpoint_id <=> ?
+		   AND check_type = ?
+		   AND event_type = ?
+		   AND ended_at IS NULL`)
+	insertQuery := regexp.QuoteMeta(`INSERT INTO jetmon_site_events
+			(jetpack_monitor_site_id, endpoint_id, check_type, event_type, severity, started_at)
+		 SELECT ?, ?, ?, ?, ?, ?
+		 WHERE NOT EXISTS (
+			SELECT 1
+			FROM jetmon_site_events
+			WHERE jetpack_monitor_site_id = ?
+			  AND endpoint_id <=> ?
+			  AND check_type = ?
+			  AND event_type = ?
+			  AND ended_at IS NULL
+		 )`)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(selectQuery).
+		WithArgs(siteID, endpointID, CheckTypeHTTP, EventTypeSeemsDown).
+		WillReturnRows(sqlmock.NewRows([]string{"started_at"}).AddRow(originalStartedAt))
+	mock.ExpectExec(closeQuery).
+		WithArgs(changedAt.UTC(), ResolutionReasonPromotedToConfirmedDown, siteID, endpointID, CheckTypeHTTP, EventTypeSeemsDown).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(insertQuery).
+		WithArgs(siteID, endpointID, CheckTypeHTTP, EventTypeConfirmedDown, EventSeverityHigh, originalStartedAt.UTC(), siteID, endpointID, CheckTypeHTTP, EventTypeConfirmedDown).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE jetpack_monitor_sites SET site_status = ?, last_status_change = ? WHERE blog_id = ?`)).
+		WithArgs(statusConfirmedDown, changedAt.UTC(), blogID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	err = ConfirmDownTx(context.Background(), siteID, blogID, endpointID, CheckTypeHTTP, EventTypeConfirmedDown, EventSeverityHigh, changedAt, true)
+	if err != nil {
+		t.Fatalf("ConfirmDownTx() error = %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestCloseOpenSiteEventTypeClosesOnlyMatchingEventType(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	oldDB := db
+	db = mockDB
+	t.Cleanup(func() {
+		db = oldDB
+		_ = mockDB.Close()
+	})
+
+	endedAt := time.Date(2026, time.April, 24, 12, 0, 0, 0, time.UTC)
+	siteID := int64(901)
+	var endpointID *int64
+
+	query := regexp.QuoteMeta(`UPDATE jetmon_site_events
+		 SET ended_at = ?, resolution_reason = ?
+		 WHERE jetpack_monitor_site_id = ?
+		   AND endpoint_id <=> ?
+		   AND check_type = ?
+		   AND event_type = ?
+		   AND ended_at IS NULL`)
+	mock.ExpectExec(query).
+		WithArgs(endedAt.UTC(), ResolutionReasonFalseAlarm, siteID, endpointID, CheckTypeHTTP, EventTypeSeemsDown).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	closed, err := CloseOpenSiteEventType(context.Background(), siteID, endpointID, CheckTypeHTTP, EventTypeSeemsDown, endedAt, ResolutionReasonFalseAlarm)
+	if err != nil {
+		t.Fatalf("CloseOpenSiteEventType() error = %v", err)
+	}
+	if !closed {
+		t.Fatal("CloseOpenSiteEventType() closed = false, want true")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
 	}
 }

--- a/internal/db/site_events.go
+++ b/internal/db/site_events.go
@@ -1,9 +1,61 @@
 package db
 
-const (
-	EventTypeSeemsDown     = 1
-	EventTypeConfirmedDown = 2
+type EventType uint8
+type EventSeverity uint8
+type ResolutionReason uint8
+type CheckType uint8
 
-	EventSeverityLow  = 1
-	EventSeverityHigh = 2
+const (
+	EventTypeSeemsDown     EventType = 1
+	EventTypeConfirmedDown EventType = 2
+
+	EventSeverityLow  EventSeverity = 1
+	EventSeverityHigh EventSeverity = 2
+
+	ResolutionReasonVerifierCleared ResolutionReason = 1
+	ResolutionReasonFalseAlarm      ResolutionReason = 2
+
+	CheckTypeHTTP CheckType = 1
 )
+
+func EventTypeLabel(t EventType) string {
+	switch t {
+	case EventTypeSeemsDown:
+		return "seems_down"
+	case EventTypeConfirmedDown:
+		return "confirmed_down"
+	default:
+		return "unknown"
+	}
+}
+
+func EventSeverityLabel(s EventSeverity) string {
+	switch s {
+	case EventSeverityLow:
+		return "low"
+	case EventSeverityHigh:
+		return "high"
+	default:
+		return "unknown"
+	}
+}
+
+func ResolutionReasonLabel(r ResolutionReason) string {
+	switch r {
+	case ResolutionReasonVerifierCleared:
+		return "verifier_cleared"
+	case ResolutionReasonFalseAlarm:
+		return "false_alarm"
+	default:
+		return "unknown"
+	}
+}
+
+func CheckTypeLabel(c CheckType) string {
+	switch c {
+	case CheckTypeHTTP:
+		return "http"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/db/site_events.go
+++ b/internal/db/site_events.go
@@ -1,0 +1,9 @@
+package db
+
+const (
+	EventTypeSeemsDown     = 1
+	EventTypeConfirmedDown = 2
+
+	EventSeverityLow  = 1
+	EventSeverityHigh = 2
+)

--- a/internal/db/site_events.go
+++ b/internal/db/site_events.go
@@ -12,8 +12,9 @@ const (
 	EventSeverityLow  EventSeverity = 1
 	EventSeverityHigh EventSeverity = 2
 
-	ResolutionReasonVerifierCleared ResolutionReason = 1
-	ResolutionReasonFalseAlarm      ResolutionReason = 2
+	ResolutionReasonVerifierCleared         ResolutionReason = 1
+	ResolutionReasonFalseAlarm              ResolutionReason = 2
+	ResolutionReasonPromotedToConfirmedDown ResolutionReason = 3
 
 	CheckTypeHTTP CheckType = 1
 )
@@ -46,6 +47,8 @@ func ResolutionReasonLabel(r ResolutionReason) string {
 		return "verifier_cleared"
 	case ResolutionReasonFalseAlarm:
 		return "false_alarm"
+	case ResolutionReasonPromotedToConfirmedDown:
+		return "promoted_to_confirmed_down"
 	default:
 		return "unknown"
 	}

--- a/internal/db/site_events_test.go
+++ b/internal/db/site_events_test.go
@@ -1,0 +1,29 @@
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestSiteEventLabels(t *testing.T) {
+	if got := EventTypeLabel(EventTypeSeemsDown); got != "seems_down" {
+		t.Fatalf("EventTypeLabel(seems_down) = %q, want seems_down", got)
+	}
+	if got := EventSeverityLabel(EventSeverityHigh); got != "high" {
+		t.Fatalf("EventSeverityLabel(high) = %q, want high", got)
+	}
+	if got := ResolutionReasonLabel(ResolutionReasonFalseAlarm); got != "false_alarm" {
+		t.Fatalf("ResolutionReasonLabel(false_alarm) = %q, want false_alarm", got)
+	}
+	if got := CheckTypeLabel(CheckTypeHTTP); got != "http" {
+		t.Fatalf("CheckTypeLabel(http) = %q, want http", got)
+	}
+}
+
+func TestSiteEventFunctionSignaturesCompile(t *testing.T) {
+	var _ func(context.Context, int64, *int64, CheckType, EventType, EventSeverity, time.Time) (bool, error) = OpenSiteEvent
+	var _ func(context.Context, int64, *int64, CheckType, EventType, EventSeverity) (bool, error) = UpgradeOpenSiteEvent
+	var _ func(context.Context, int64, *int64, CheckType, time.Time, ResolutionReason) (bool, error) = CloseOpenSiteEvent
+	var _ func(context.Context, int64, int64, *int64, CheckType, EventType, EventSeverity, time.Time, bool) error = ConfirmDownTx
+}

--- a/internal/db/site_events_test.go
+++ b/internal/db/site_events_test.go
@@ -16,6 +16,9 @@ func TestSiteEventLabels(t *testing.T) {
 	if got := ResolutionReasonLabel(ResolutionReasonFalseAlarm); got != "false_alarm" {
 		t.Fatalf("ResolutionReasonLabel(false_alarm) = %q, want false_alarm", got)
 	}
+	if got := ResolutionReasonLabel(ResolutionReasonPromotedToConfirmedDown); got != "promoted_to_confirmed_down" {
+		t.Fatalf("ResolutionReasonLabel(promoted_to_confirmed_down) = %q, want promoted_to_confirmed_down", got)
+	}
 	if got := CheckTypeLabel(CheckTypeHTTP); got != "http" {
 		t.Fatalf("CheckTypeLabel(http) = %q, want http", got)
 	}
@@ -23,7 +26,7 @@ func TestSiteEventLabels(t *testing.T) {
 
 func TestSiteEventFunctionSignaturesCompile(t *testing.T) {
 	var _ func(context.Context, int64, *int64, CheckType, EventType, EventSeverity, time.Time) (bool, error) = OpenSiteEvent
-	var _ func(context.Context, int64, *int64, CheckType, EventType, EventSeverity) (bool, error) = UpgradeOpenSiteEvent
+	var _ func(context.Context, int64, *int64, CheckType, EventType, time.Time, ResolutionReason) (bool, error) = CloseOpenSiteEventType
 	var _ func(context.Context, int64, *int64, CheckType, time.Time, ResolutionReason) (bool, error) = CloseOpenSiteEvent
 	var _ func(context.Context, int64, int64, *int64, CheckType, EventType, EventSeverity, time.Time, bool) error = ConfirmDownTx
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -38,6 +38,7 @@ var (
 	dbOpenSiteEvent        = db.OpenSiteEvent
 	dbUpgradeOpenSiteEvent = db.UpgradeOpenSiteEvent
 	dbCloseOpenSiteEvent   = db.CloseOpenSiteEvent
+	dbConfirmDownTx        = db.ConfirmDownTx
 	veriflierCheckFunc     = func(c *veriflier.VeriflierClient, ctx stdctx.Context, req veriflier.CheckRequest) (*veriflier.CheckResult, error) {
 		return c.Check(ctx, req)
 	}
@@ -300,7 +301,9 @@ func (o *Orchestrator) handleRecovery(site db.Site, res checker.Result) {
 
 	o.retries.clear(site.BlogID)
 	recoveryTime := nowFunc().UTC()
-	o.closeOpenSiteEvent(site, recoveryTime)
+	if !inMaintenance(site) {
+		o.closeOpenSiteEvent(site, nil, db.CheckTypeHTTP, recoveryTime, db.ResolutionReasonVerifierCleared)
+	}
 
 	if site.SiteStatus != statusRunning {
 		changeTime := recoveryTime
@@ -321,8 +324,8 @@ func (o *Orchestrator) handleRecovery(site db.Site, res checker.Result) {
 
 func (o *Orchestrator) handleFailure(site db.Site, res checker.Result) {
 	entry := o.retries.record(res)
-	if entry.failCount == 1 {
-		o.openSiteEvent(site, db.EventTypeSeemsDown, db.EventSeverityLow, entry.firstFailAt)
+	if entry.failCount == 1 && !inMaintenance(site) {
+		o.openSiteEvent(site, nil, db.CheckTypeHTTP, db.EventTypeSeemsDown, db.EventSeverityLow, entry.firstFailAt)
 	}
 
 	if entry.failCount < config.Get().NumOfChecks {
@@ -405,7 +408,9 @@ func (o *Orchestrator) escalateToVerifliers(site db.Site, entry *retryEntry) {
 		log.Printf("orchestrator: blog_id=%d verifliers did not confirm down (%d/%d)", site.BlogID, confirmations, quorum)
 		_ = dbRecordFalsePositive(site.BlogID, entry.lastResult.HTTPCode, entry.lastResult.ErrorCode,
 			entry.lastResult.RTT.Milliseconds())
-		o.closeOpenSiteEvent(site, nowFunc().UTC())
+		if !inMaintenance(site) {
+			o.closeOpenSiteEvent(site, nil, db.CheckTypeHTTP, nowFunc().UTC(), db.ResolutionReasonFalseAlarm)
+		}
 		o.retries.clear(site.BlogID)
 	}
 }
@@ -416,15 +421,38 @@ func (o *Orchestrator) confirmDown(site db.Site, entry *retryEntry, vResults []v
 
 	log.Printf("orchestrator: blog_id=%d confirmed down", site.BlogID)
 	o.auditTransition(site.BlogID, site.SiteStatus, newStatus, "confirmed down")
-	o.upgradeOpenSiteEvent(site, db.EventTypeConfirmedDown, db.EventSeverityHigh)
-
-	if config.Get().DBUpdatesEnable {
-		_ = dbUpdateSiteStatus(o.ctx, site.BlogID, newStatus, changeTime)
-	}
 
 	if inMaintenance(site) {
+		if config.Get().DBUpdatesEnable {
+			_ = dbUpdateSiteStatus(o.ctx, site.BlogID, newStatus, changeTime)
+		}
 		o.auditLog(site.BlogID, audit.EventMaintenanceActive, "local", 0, 0, 0, "downtime suppressed during maintenance")
-	} else if !o.isAlertSuppressed(site) {
+		o.retries.clear(site.BlogID)
+		return
+	}
+
+	if site.ID <= 0 {
+		log.Printf("orchestrator: warning: blog_id=%d missing site ID, skipping upgrade site-event write", site.BlogID)
+		if config.Get().DBUpdatesEnable {
+			_ = dbUpdateSiteStatus(o.ctx, site.BlogID, newStatus, changeTime)
+		}
+	} else {
+		if err := dbConfirmDownTx(
+			o.ctx,
+			site.ID,
+			site.BlogID,
+			nil,
+			db.CheckTypeHTTP,
+			db.EventTypeConfirmedDown,
+			db.EventSeverityHigh,
+			changeTime,
+			config.Get().DBUpdatesEnable,
+		); err != nil {
+			log.Printf("orchestrator: confirm-down tx site_id=%d blog_id=%d: %v", site.ID, site.BlogID, err)
+		}
+	}
+
+	if !o.isAlertSuppressed(site) {
 		o.sendNotification(site, entry.lastResult, newStatus, changeTime, vResults)
 	} else {
 		o.auditLog(site.BlogID, audit.EventAlertSuppressed, "local", 0, 0, 0, "cooldown active")
@@ -433,32 +461,32 @@ func (o *Orchestrator) confirmDown(site db.Site, entry *retryEntry, vResults []v
 	o.retries.clear(site.BlogID)
 }
 
-func (o *Orchestrator) openSiteEvent(site db.Site, eventType, severity uint8, startedAt time.Time) {
+func (o *Orchestrator) openSiteEvent(site db.Site, endpointID *int64, checkType db.CheckType, eventType db.EventType, severity db.EventSeverity, startedAt time.Time) {
 	if site.ID <= 0 {
 		log.Printf("orchestrator: warning: blog_id=%d missing site ID, skipping open site-event write", site.BlogID)
 		return
 	}
-	if err := dbOpenSiteEvent(o.ctx, site.ID, eventType, severity, startedAt); err != nil {
+	if _, err := dbOpenSiteEvent(o.ctx, site.ID, endpointID, checkType, eventType, severity, startedAt); err != nil {
 		log.Printf("orchestrator: open site event site_id=%d blog_id=%d: %v", site.ID, site.BlogID, err)
 	}
 }
 
-func (o *Orchestrator) upgradeOpenSiteEvent(site db.Site, eventType, severity uint8) {
+func (o *Orchestrator) upgradeOpenSiteEvent(site db.Site, endpointID *int64, checkType db.CheckType, eventType db.EventType, severity db.EventSeverity) {
 	if site.ID <= 0 {
 		log.Printf("orchestrator: warning: blog_id=%d missing site ID, skipping upgrade site-event write", site.BlogID)
 		return
 	}
-	if err := dbUpgradeOpenSiteEvent(o.ctx, site.ID, eventType, severity); err != nil {
+	if _, err := dbUpgradeOpenSiteEvent(o.ctx, site.ID, endpointID, checkType, eventType, severity); err != nil {
 		log.Printf("orchestrator: upgrade site event site_id=%d blog_id=%d: %v", site.ID, site.BlogID, err)
 	}
 }
 
-func (o *Orchestrator) closeOpenSiteEvent(site db.Site, endedAt time.Time) {
+func (o *Orchestrator) closeOpenSiteEvent(site db.Site, endpointID *int64, checkType db.CheckType, endedAt time.Time, reason db.ResolutionReason) {
 	if site.ID <= 0 {
 		log.Printf("orchestrator: warning: blog_id=%d missing site ID, skipping close site-event write", site.BlogID)
 		return
 	}
-	if err := dbCloseOpenSiteEvent(o.ctx, site.ID, endedAt); err != nil {
+	if _, err := dbCloseOpenSiteEvent(o.ctx, site.ID, endpointID, checkType, endedAt, reason); err != nil {
 		log.Printf("orchestrator: close site event site_id=%d blog_id=%d: %v", site.ID, site.BlogID, err)
 	}
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -23,23 +23,23 @@ const (
 )
 
 var (
-	nowFunc                = time.Now
-	dbClaimBuckets         = db.ClaimBuckets
-	dbHeartbeat            = db.Heartbeat
-	dbReleaseHost          = db.ReleaseHost
-	dbMarkHostDraining     = db.MarkHostDraining
-	dbGetSitesForBucket    = db.GetSitesForBucket
-	dbMarkSiteChecked      = db.MarkSiteChecked
-	dbRecordCheckHistory   = db.RecordCheckHistory
-	dbUpdateSSLExpiry      = db.UpdateSSLExpiry
-	dbUpdateSiteStatus     = db.UpdateSiteStatus
-	dbRecordFalsePositive  = db.RecordFalsePositive
-	dbUpdateLastAlertSent  = db.UpdateLastAlertSent
-	dbOpenSiteEvent        = db.OpenSiteEvent
-	dbUpgradeOpenSiteEvent = db.UpgradeOpenSiteEvent
-	dbCloseOpenSiteEvent   = db.CloseOpenSiteEvent
-	dbConfirmDownTx        = db.ConfirmDownTx
-	veriflierCheckFunc     = func(c *veriflier.VeriflierClient, ctx stdctx.Context, req veriflier.CheckRequest) (*veriflier.CheckResult, error) {
+	nowFunc                  = time.Now
+	dbClaimBuckets           = db.ClaimBuckets
+	dbHeartbeat              = db.Heartbeat
+	dbReleaseHost            = db.ReleaseHost
+	dbMarkHostDraining       = db.MarkHostDraining
+	dbGetSitesForBucket      = db.GetSitesForBucket
+	dbMarkSiteChecked        = db.MarkSiteChecked
+	dbRecordCheckHistory     = db.RecordCheckHistory
+	dbUpdateSSLExpiry        = db.UpdateSSLExpiry
+	dbUpdateSiteStatus       = db.UpdateSiteStatus
+	dbRecordFalsePositive    = db.RecordFalsePositive
+	dbUpdateLastAlertSent    = db.UpdateLastAlertSent
+	dbOpenSiteEvent          = db.OpenSiteEvent
+	dbCloseOpenSiteEvent     = db.CloseOpenSiteEvent
+	dbCloseOpenSiteEventType = db.CloseOpenSiteEventType
+	dbConfirmDownTx          = db.ConfirmDownTx
+	veriflierCheckFunc       = func(c *veriflier.VeriflierClient, ctx stdctx.Context, req veriflier.CheckRequest) (*veriflier.CheckResult, error) {
 		return c.Check(ctx, req)
 	}
 	wpcomNotifyFunc     = func(c *wpcom.Client, n wpcom.Notification) error { return c.Notify(n) }
@@ -302,7 +302,7 @@ func (o *Orchestrator) handleRecovery(site db.Site, res checker.Result) {
 	o.retries.clear(site.BlogID)
 	recoveryTime := nowFunc().UTC()
 	if !inMaintenance(site) {
-		o.closeOpenSiteEvent(site, nil, db.CheckTypeHTTP, recoveryTime, db.ResolutionReasonVerifierCleared)
+		o.closeOpenSiteEventType(site, nil, db.CheckTypeHTTP, db.EventTypeConfirmedDown, recoveryTime, db.ResolutionReasonVerifierCleared)
 	}
 
 	if site.SiteStatus != statusRunning {
@@ -409,7 +409,7 @@ func (o *Orchestrator) escalateToVerifliers(site db.Site, entry *retryEntry) {
 		_ = dbRecordFalsePositive(site.BlogID, entry.lastResult.HTTPCode, entry.lastResult.ErrorCode,
 			entry.lastResult.RTT.Milliseconds())
 		if !inMaintenance(site) {
-			o.closeOpenSiteEvent(site, nil, db.CheckTypeHTTP, nowFunc().UTC(), db.ResolutionReasonFalseAlarm)
+			o.closeOpenSiteEventType(site, nil, db.CheckTypeHTTP, db.EventTypeSeemsDown, nowFunc().UTC(), db.ResolutionReasonFalseAlarm)
 		}
 		o.retries.clear(site.BlogID)
 	}
@@ -471,22 +471,22 @@ func (o *Orchestrator) openSiteEvent(site db.Site, endpointID *int64, checkType 
 	}
 }
 
-func (o *Orchestrator) upgradeOpenSiteEvent(site db.Site, endpointID *int64, checkType db.CheckType, eventType db.EventType, severity db.EventSeverity) {
-	if site.ID <= 0 {
-		log.Printf("orchestrator: warning: blog_id=%d missing site ID, skipping upgrade site-event write", site.BlogID)
-		return
-	}
-	if _, err := dbUpgradeOpenSiteEvent(o.ctx, site.ID, endpointID, checkType, eventType, severity); err != nil {
-		log.Printf("orchestrator: upgrade site event site_id=%d blog_id=%d: %v", site.ID, site.BlogID, err)
-	}
-}
-
 func (o *Orchestrator) closeOpenSiteEvent(site db.Site, endpointID *int64, checkType db.CheckType, endedAt time.Time, reason db.ResolutionReason) {
 	if site.ID <= 0 {
 		log.Printf("orchestrator: warning: blog_id=%d missing site ID, skipping close site-event write", site.BlogID)
 		return
 	}
 	if _, err := dbCloseOpenSiteEvent(o.ctx, site.ID, endpointID, checkType, endedAt, reason); err != nil {
+		log.Printf("orchestrator: close site event site_id=%d blog_id=%d: %v", site.ID, site.BlogID, err)
+	}
+}
+
+func (o *Orchestrator) closeOpenSiteEventType(site db.Site, endpointID *int64, checkType db.CheckType, eventType db.EventType, endedAt time.Time, reason db.ResolutionReason) {
+	if site.ID <= 0 {
+		log.Printf("orchestrator: warning: blog_id=%d missing site ID, skipping close site-event write", site.BlogID)
+		return
+	}
+	if _, err := dbCloseOpenSiteEventType(o.ctx, site.ID, endpointID, checkType, eventType, endedAt, reason); err != nil {
 		log.Printf("orchestrator: close site event site_id=%d blog_id=%d: %v", site.ID, site.BlogID, err)
 	}
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -23,19 +23,22 @@ const (
 )
 
 var (
-	nowFunc               = time.Now
-	dbClaimBuckets        = db.ClaimBuckets
-	dbHeartbeat           = db.Heartbeat
-	dbReleaseHost         = db.ReleaseHost
-	dbMarkHostDraining    = db.MarkHostDraining
-	dbGetSitesForBucket   = db.GetSitesForBucket
-	dbMarkSiteChecked     = db.MarkSiteChecked
-	dbRecordCheckHistory  = db.RecordCheckHistory
-	dbUpdateSSLExpiry     = db.UpdateSSLExpiry
-	dbUpdateSiteStatus    = db.UpdateSiteStatus
-	dbRecordFalsePositive = db.RecordFalsePositive
-	dbUpdateLastAlertSent = db.UpdateLastAlertSent
-	veriflierCheckFunc    = func(c *veriflier.VeriflierClient, ctx stdctx.Context, req veriflier.CheckRequest) (*veriflier.CheckResult, error) {
+	nowFunc                = time.Now
+	dbClaimBuckets         = db.ClaimBuckets
+	dbHeartbeat            = db.Heartbeat
+	dbReleaseHost          = db.ReleaseHost
+	dbMarkHostDraining     = db.MarkHostDraining
+	dbGetSitesForBucket    = db.GetSitesForBucket
+	dbMarkSiteChecked      = db.MarkSiteChecked
+	dbRecordCheckHistory   = db.RecordCheckHistory
+	dbUpdateSSLExpiry      = db.UpdateSSLExpiry
+	dbUpdateSiteStatus     = db.UpdateSiteStatus
+	dbRecordFalsePositive  = db.RecordFalsePositive
+	dbUpdateLastAlertSent  = db.UpdateLastAlertSent
+	dbOpenSiteEvent        = db.OpenSiteEvent
+	dbUpgradeOpenSiteEvent = db.UpgradeOpenSiteEvent
+	dbCloseOpenSiteEvent   = db.CloseOpenSiteEvent
+	veriflierCheckFunc     = func(c *veriflier.VeriflierClient, ctx stdctx.Context, req veriflier.CheckRequest) (*veriflier.CheckResult, error) {
 		return c.Check(ctx, req)
 	}
 	wpcomNotifyFunc     = func(c *wpcom.Client, n wpcom.Notification) error { return c.Notify(n) }
@@ -296,9 +299,11 @@ func (o *Orchestrator) handleRecovery(site db.Site, res checker.Result) {
 	}
 
 	o.retries.clear(site.BlogID)
+	recoveryTime := nowFunc().UTC()
+	o.closeOpenSiteEvent(site, recoveryTime)
 
 	if site.SiteStatus != statusRunning {
-		changeTime := nowFunc().UTC()
+		changeTime := recoveryTime
 		log.Printf("orchestrator: blog_id=%d recovered", site.BlogID)
 		o.auditTransition(site.BlogID, site.SiteStatus, statusRunning, "site recovered")
 
@@ -316,6 +321,9 @@ func (o *Orchestrator) handleRecovery(site db.Site, res checker.Result) {
 
 func (o *Orchestrator) handleFailure(site db.Site, res checker.Result) {
 	entry := o.retries.record(res)
+	if entry.failCount == 1 {
+		o.openSiteEvent(site, db.EventTypeSeemsDown, db.EventSeverityLow, entry.firstFailAt)
+	}
 
 	if entry.failCount < config.Get().NumOfChecks {
 		o.auditLog(site.BlogID, audit.EventRetryDispatched, o.hostname,
@@ -397,6 +405,7 @@ func (o *Orchestrator) escalateToVerifliers(site db.Site, entry *retryEntry) {
 		log.Printf("orchestrator: blog_id=%d verifliers did not confirm down (%d/%d)", site.BlogID, confirmations, quorum)
 		_ = dbRecordFalsePositive(site.BlogID, entry.lastResult.HTTPCode, entry.lastResult.ErrorCode,
 			entry.lastResult.RTT.Milliseconds())
+		o.closeOpenSiteEvent(site, nowFunc().UTC())
 		o.retries.clear(site.BlogID)
 	}
 }
@@ -407,6 +416,7 @@ func (o *Orchestrator) confirmDown(site db.Site, entry *retryEntry, vResults []v
 
 	log.Printf("orchestrator: blog_id=%d confirmed down", site.BlogID)
 	o.auditTransition(site.BlogID, site.SiteStatus, newStatus, "confirmed down")
+	o.upgradeOpenSiteEvent(site, db.EventTypeConfirmedDown, db.EventSeverityHigh)
 
 	if config.Get().DBUpdatesEnable {
 		_ = dbUpdateSiteStatus(o.ctx, site.BlogID, newStatus, changeTime)
@@ -421,6 +431,36 @@ func (o *Orchestrator) confirmDown(site db.Site, entry *retryEntry, vResults []v
 	}
 
 	o.retries.clear(site.BlogID)
+}
+
+func (o *Orchestrator) openSiteEvent(site db.Site, eventType, severity uint8, startedAt time.Time) {
+	if site.ID <= 0 {
+		log.Printf("orchestrator: warning: blog_id=%d missing site ID, skipping open site-event write", site.BlogID)
+		return
+	}
+	if err := dbOpenSiteEvent(o.ctx, site.ID, eventType, severity, startedAt); err != nil {
+		log.Printf("orchestrator: open site event site_id=%d blog_id=%d: %v", site.ID, site.BlogID, err)
+	}
+}
+
+func (o *Orchestrator) upgradeOpenSiteEvent(site db.Site, eventType, severity uint8) {
+	if site.ID <= 0 {
+		log.Printf("orchestrator: warning: blog_id=%d missing site ID, skipping upgrade site-event write", site.BlogID)
+		return
+	}
+	if err := dbUpgradeOpenSiteEvent(o.ctx, site.ID, eventType, severity); err != nil {
+		log.Printf("orchestrator: upgrade site event site_id=%d blog_id=%d: %v", site.ID, site.BlogID, err)
+	}
+}
+
+func (o *Orchestrator) closeOpenSiteEvent(site db.Site, endedAt time.Time) {
+	if site.ID <= 0 {
+		log.Printf("orchestrator: warning: blog_id=%d missing site ID, skipping close site-event write", site.BlogID)
+		return
+	}
+	if err := dbCloseOpenSiteEvent(o.ctx, site.ID, endedAt); err != nil {
+		log.Printf("orchestrator: close site event site_id=%d blog_id=%d: %v", site.ID, site.BlogID, err)
+	}
 }
 
 func (o *Orchestrator) sendNotification(site db.Site, res checker.Result, status int, changeTime time.Time, vResults []veriflier.CheckResult) {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -314,8 +314,8 @@ func stubOrchestratorDeps() func() {
 	origDBRecordCheckHistory := dbRecordCheckHistory
 	origDBUpdateSSLExpiry := dbUpdateSSLExpiry
 	origDBOpenSiteEvent := dbOpenSiteEvent
-	origDBUpgradeOpenSiteEvent := dbUpgradeOpenSiteEvent
 	origDBCloseOpenSiteEvent := dbCloseOpenSiteEvent
+	origDBCloseOpenSiteEventType := dbCloseOpenSiteEventType
 	origDBConfirmDownTx := dbConfirmDownTx
 	origNotify := wpcomNotifyFunc
 	origVeriflierCheck := veriflierCheckFunc
@@ -330,10 +330,10 @@ func stubOrchestratorDeps() func() {
 	dbOpenSiteEvent = func(context.Context, int64, *int64, db.CheckType, db.EventType, db.EventSeverity, time.Time) (bool, error) {
 		return true, nil
 	}
-	dbUpgradeOpenSiteEvent = func(context.Context, int64, *int64, db.CheckType, db.EventType, db.EventSeverity) (bool, error) {
+	dbCloseOpenSiteEvent = func(context.Context, int64, *int64, db.CheckType, time.Time, db.ResolutionReason) (bool, error) {
 		return true, nil
 	}
-	dbCloseOpenSiteEvent = func(context.Context, int64, *int64, db.CheckType, time.Time, db.ResolutionReason) (bool, error) {
+	dbCloseOpenSiteEventType = func(context.Context, int64, *int64, db.CheckType, db.EventType, time.Time, db.ResolutionReason) (bool, error) {
 		return true, nil
 	}
 	dbConfirmDownTx = func(context.Context, int64, int64, *int64, db.CheckType, db.EventType, db.EventSeverity, time.Time, bool) error {
@@ -353,8 +353,8 @@ func stubOrchestratorDeps() func() {
 		dbRecordCheckHistory = origDBRecordCheckHistory
 		dbUpdateSSLExpiry = origDBUpdateSSLExpiry
 		dbOpenSiteEvent = origDBOpenSiteEvent
-		dbUpgradeOpenSiteEvent = origDBUpgradeOpenSiteEvent
 		dbCloseOpenSiteEvent = origDBCloseOpenSiteEvent
+		dbCloseOpenSiteEventType = origDBCloseOpenSiteEventType
 		dbConfirmDownTx = origDBConfirmDownTx
 		wpcomNotifyFunc = origNotify
 		veriflierCheckFunc = origVeriflierCheck
@@ -677,13 +677,15 @@ func TestEscalateToVerifliersFalsePositiveClosesOpenEvent(t *testing.T) {
 
 	var gotSiteID int64
 	var gotCheckType db.CheckType
+	var gotEventType db.EventType
 	var gotReason db.ResolutionReason
 	var gotEndedAt time.Time
 	var closeCalls int
-	dbCloseOpenSiteEvent = func(_ context.Context, siteID int64, _ *int64, checkType db.CheckType, endedAt time.Time, reason db.ResolutionReason) (bool, error) {
+	dbCloseOpenSiteEventType = func(_ context.Context, siteID int64, _ *int64, checkType db.CheckType, eventType db.EventType, endedAt time.Time, reason db.ResolutionReason) (bool, error) {
 		closeCalls++
 		gotSiteID = siteID
 		gotCheckType = checkType
+		gotEventType = eventType
 		gotReason = reason
 		gotEndedAt = endedAt
 		return true, nil
@@ -728,6 +730,9 @@ func TestEscalateToVerifliersFalsePositiveClosesOpenEvent(t *testing.T) {
 	if gotCheckType != db.CheckTypeHTTP {
 		t.Fatalf("CloseOpenSiteEvent check_type = %d, want %d", gotCheckType, db.CheckTypeHTTP)
 	}
+	if gotEventType != db.EventTypeSeemsDown {
+		t.Fatalf("CloseOpenSiteEvent event_type = %d, want %d", gotEventType, db.EventTypeSeemsDown)
+	}
 	if gotReason != db.ResolutionReasonFalseAlarm {
 		t.Fatalf("CloseOpenSiteEvent reason = %d, want %d", gotReason, db.ResolutionReasonFalseAlarm)
 	}
@@ -741,7 +746,7 @@ func TestEscalateToVerifliersFalsePositiveInMaintenanceDoesNotCloseOpenEvent(t *
 	cfg.PeerOfflineLimit = 2
 
 	var closeCalls int
-	dbCloseOpenSiteEvent = func(context.Context, int64, *int64, db.CheckType, time.Time, db.ResolutionReason) (bool, error) {
+	dbCloseOpenSiteEventType = func(context.Context, int64, *int64, db.CheckType, db.EventType, time.Time, db.ResolutionReason) (bool, error) {
 		closeCalls++
 		return true, nil
 	}
@@ -799,13 +804,15 @@ func TestHandleRecoveryClosesOpenEvent(t *testing.T) {
 
 	var gotSiteID int64
 	var gotCheckType db.CheckType
+	var gotEventType db.EventType
 	var gotReason db.ResolutionReason
 	var gotEndedAt time.Time
 	var closeCalls int
-	dbCloseOpenSiteEvent = func(_ context.Context, siteID int64, _ *int64, checkType db.CheckType, endedAt time.Time, reason db.ResolutionReason) (bool, error) {
+	dbCloseOpenSiteEventType = func(_ context.Context, siteID int64, _ *int64, checkType db.CheckType, eventType db.EventType, endedAt time.Time, reason db.ResolutionReason) (bool, error) {
 		closeCalls++
 		gotSiteID = siteID
 		gotCheckType = checkType
+		gotEventType = eventType
 		gotReason = reason
 		gotEndedAt = endedAt
 		return true, nil
@@ -831,6 +838,9 @@ func TestHandleRecoveryClosesOpenEvent(t *testing.T) {
 	}
 	if gotCheckType != db.CheckTypeHTTP {
 		t.Fatalf("CloseOpenSiteEvent check_type = %d, want %d", gotCheckType, db.CheckTypeHTTP)
+	}
+	if gotEventType != db.EventTypeConfirmedDown {
+		t.Fatalf("CloseOpenSiteEvent event_type = %d, want %d", gotEventType, db.EventTypeConfirmedDown)
 	}
 	if gotReason != db.ResolutionReasonVerifierCleared {
 		t.Fatalf("CloseOpenSiteEvent reason = %d, want %d", gotReason, db.ResolutionReasonVerifierCleared)
@@ -1199,7 +1209,7 @@ func TestHandleRecoveryInMaintenance(t *testing.T) {
 	setTestConfig(t)
 
 	var closeCalls int
-	dbCloseOpenSiteEvent = func(context.Context, int64, *int64, db.CheckType, time.Time, db.ResolutionReason) (bool, error) {
+	dbCloseOpenSiteEventType = func(context.Context, int64, *int64, db.CheckType, db.EventType, time.Time, db.ResolutionReason) (bool, error) {
 		closeCalls++
 		return true, nil
 	}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -316,6 +316,7 @@ func stubOrchestratorDeps() func() {
 	origDBOpenSiteEvent := dbOpenSiteEvent
 	origDBUpgradeOpenSiteEvent := dbUpgradeOpenSiteEvent
 	origDBCloseOpenSiteEvent := dbCloseOpenSiteEvent
+	origDBConfirmDownTx := dbConfirmDownTx
 	origNotify := wpcomNotifyFunc
 	origVeriflierCheck := veriflierCheckFunc
 
@@ -326,9 +327,18 @@ func stubOrchestratorDeps() func() {
 	dbMarkSiteChecked = func(context.Context, int64, time.Time) error { return nil }
 	dbRecordCheckHistory = func(int64, int, int, int64, int64, int64, int64, int64) error { return nil }
 	dbUpdateSSLExpiry = func(context.Context, int64, time.Time) error { return nil }
-	dbOpenSiteEvent = func(context.Context, int64, uint8, uint8, time.Time) error { return nil }
-	dbUpgradeOpenSiteEvent = func(context.Context, int64, uint8, uint8) error { return nil }
-	dbCloseOpenSiteEvent = func(context.Context, int64, time.Time) error { return nil }
+	dbOpenSiteEvent = func(context.Context, int64, *int64, db.CheckType, db.EventType, db.EventSeverity, time.Time) (bool, error) {
+		return true, nil
+	}
+	dbUpgradeOpenSiteEvent = func(context.Context, int64, *int64, db.CheckType, db.EventType, db.EventSeverity) (bool, error) {
+		return true, nil
+	}
+	dbCloseOpenSiteEvent = func(context.Context, int64, *int64, db.CheckType, time.Time, db.ResolutionReason) (bool, error) {
+		return true, nil
+	}
+	dbConfirmDownTx = func(context.Context, int64, int64, *int64, db.CheckType, db.EventType, db.EventSeverity, time.Time, bool) error {
+		return nil
+	}
 	wpcomNotifyFunc = func(_ *wpcom.Client, _ wpcom.Notification) error { return nil }
 	veriflierCheckFunc = func(c *veriflier.VeriflierClient, ctx context.Context, req veriflier.CheckRequest) (*veriflier.CheckResult, error) {
 		return c.Check(ctx, req)
@@ -345,6 +355,7 @@ func stubOrchestratorDeps() func() {
 		dbOpenSiteEvent = origDBOpenSiteEvent
 		dbUpgradeOpenSiteEvent = origDBUpgradeOpenSiteEvent
 		dbCloseOpenSiteEvent = origDBCloseOpenSiteEvent
+		dbConfirmDownTx = origDBConfirmDownTx
 		wpcomNotifyFunc = origNotify
 		veriflierCheckFunc = origVeriflierCheck
 	}
@@ -503,17 +514,21 @@ func TestHandleFailureFirstFailureOpensSeemsDownEvent(t *testing.T) {
 	failAt := time.Date(2026, time.April, 23, 12, 0, 0, 0, time.UTC)
 
 	var gotSiteID int64
-	var gotEventType uint8
-	var gotSeverity uint8
+	var gotEventType db.EventType
+	var gotSeverity db.EventSeverity
+	var gotCheckType db.CheckType
+	var gotEndpointID *int64
 	var gotStartedAt time.Time
 	var openCalls int
-	dbOpenSiteEvent = func(_ context.Context, siteID int64, eventType, severity uint8, startedAt time.Time) error {
+	dbOpenSiteEvent = func(_ context.Context, siteID int64, endpointID *int64, checkType db.CheckType, eventType db.EventType, severity db.EventSeverity, startedAt time.Time) (bool, error) {
 		openCalls++
 		gotSiteID = siteID
+		gotEndpointID = endpointID
+		gotCheckType = checkType
 		gotEventType = eventType
 		gotSeverity = severity
 		gotStartedAt = startedAt
-		return nil
+		return true, nil
 	}
 
 	o := &Orchestrator{
@@ -544,25 +559,71 @@ func TestHandleFailureFirstFailureOpensSeemsDownEvent(t *testing.T) {
 	if gotSeverity != db.EventSeverityLow {
 		t.Fatalf("OpenSiteEvent severity = %d, want %d", gotSeverity, db.EventSeverityLow)
 	}
+	if gotCheckType != db.CheckTypeHTTP {
+		t.Fatalf("OpenSiteEvent check_type = %d, want %d", gotCheckType, db.CheckTypeHTTP)
+	}
+	if gotEndpointID != nil {
+		t.Fatal("OpenSiteEvent endpoint_id should be nil for site-level checks")
+	}
 	if !gotStartedAt.Equal(failAt) {
 		t.Fatalf("OpenSiteEvent started_at = %v, want %v", gotStartedAt, failAt)
 	}
 }
 
-func TestConfirmDownUpgradesOpenEvent(t *testing.T) {
+func TestHandleFailureInMaintenanceDoesNotOpenSeemsDownEvent(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	setTestConfig(t)
+	config.Get().NumOfChecks = 3
+
+	var openCalls int
+	dbOpenSiteEvent = func(context.Context, int64, *int64, db.CheckType, db.EventType, db.EventSeverity, time.Time) (bool, error) {
+		openCalls++
+		return true, nil
+	}
+
+	now := time.Now()
+	past := now.Add(-1 * time.Hour)
+	future := now.Add(1 * time.Hour)
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		hostname: "local",
+		ctx:      context.Background(),
+	}
+
+	o.handleFailure(db.Site{ID: 99, BlogID: 1, MaintenanceStart: &past, MaintenanceEnd: &future}, checkerResultFailure(1))
+
+	if openCalls != 0 {
+		t.Fatalf("OpenSiteEvent calls during maintenance = %d, want 0", openCalls)
+	}
+}
+
+func TestConfirmDownUsesConfirmDownTx(t *testing.T) {
 	restore := stubOrchestratorDeps()
 	defer restore()
 	setTestConfig(t)
 
 	var gotSiteID int64
-	var gotEventType uint8
-	var gotSeverity uint8
-	var upgradeCalls int
-	dbUpgradeOpenSiteEvent = func(_ context.Context, siteID int64, eventType, severity uint8) error {
-		upgradeCalls++
+	var gotBlogID int64
+	var gotEndpointID *int64
+	var gotCheckType db.CheckType
+	var gotEventType db.EventType
+	var gotSeverity db.EventSeverity
+	var gotChangedAt time.Time
+	var gotDBUpdatesEnabled bool
+	var txCalls int
+	dbConfirmDownTx = func(_ context.Context, siteID, blogID int64, endpointID *int64, checkType db.CheckType, eventType db.EventType, severity db.EventSeverity, changedAt time.Time, dbUpdatesEnabled bool) error {
+		txCalls++
 		gotSiteID = siteID
+		gotBlogID = blogID
+		gotEndpointID = endpointID
+		gotCheckType = checkType
 		gotEventType = eventType
 		gotSeverity = severity
+		gotChangedAt = changedAt
+		gotDBUpdatesEnabled = dbUpdatesEnabled
 		return nil
 	}
 
@@ -578,17 +639,29 @@ func TestConfirmDownUpgradesOpenEvent(t *testing.T) {
 
 	o.confirmDown(db.Site{ID: 77, BlogID: 123, SiteStatus: statusRunning}, entry, nil)
 
-	if upgradeCalls != 1 {
-		t.Fatalf("UpgradeOpenSiteEvent calls = %d, want 1", upgradeCalls)
+	if txCalls != 1 {
+		t.Fatalf("ConfirmDownTx calls = %d, want 1", txCalls)
 	}
-	if gotSiteID != 77 {
-		t.Fatalf("UpgradeOpenSiteEvent site_id = %d, want 77", gotSiteID)
+	if gotSiteID != 77 || gotBlogID != 123 {
+		t.Fatalf("ConfirmDownTx site_id/blog_id = %d/%d, want 77/123", gotSiteID, gotBlogID)
+	}
+	if gotEndpointID != nil {
+		t.Fatal("ConfirmDownTx endpoint_id should be nil for site-level checks")
+	}
+	if gotCheckType != db.CheckTypeHTTP {
+		t.Fatalf("ConfirmDownTx check_type = %d, want %d", gotCheckType, db.CheckTypeHTTP)
 	}
 	if gotEventType != db.EventTypeConfirmedDown {
-		t.Fatalf("UpgradeOpenSiteEvent event_type = %d, want %d", gotEventType, db.EventTypeConfirmedDown)
+		t.Fatalf("ConfirmDownTx event_type = %d, want %d", gotEventType, db.EventTypeConfirmedDown)
 	}
 	if gotSeverity != db.EventSeverityHigh {
-		t.Fatalf("UpgradeOpenSiteEvent severity = %d, want %d", gotSeverity, db.EventSeverityHigh)
+		t.Fatalf("ConfirmDownTx severity = %d, want %d", gotSeverity, db.EventSeverityHigh)
+	}
+	if gotChangedAt.IsZero() {
+		t.Fatal("ConfirmDownTx changedAt should be set")
+	}
+	if gotDBUpdatesEnabled {
+		t.Fatal("ConfirmDownTx dbUpdatesEnabled should be false in test config")
 	}
 }
 
@@ -603,13 +676,17 @@ func TestEscalateToVerifliersFalsePositiveClosesOpenEvent(t *testing.T) {
 	nowFunc = func() time.Time { return fixedNow }
 
 	var gotSiteID int64
+	var gotCheckType db.CheckType
+	var gotReason db.ResolutionReason
 	var gotEndedAt time.Time
 	var closeCalls int
-	dbCloseOpenSiteEvent = func(_ context.Context, siteID int64, endedAt time.Time) error {
+	dbCloseOpenSiteEvent = func(_ context.Context, siteID int64, _ *int64, checkType db.CheckType, endedAt time.Time, reason db.ResolutionReason) (bool, error) {
 		closeCalls++
 		gotSiteID = siteID
+		gotCheckType = checkType
+		gotReason = reason
 		gotEndedAt = endedAt
-		return nil
+		return true, nil
 	}
 
 	call := 0
@@ -648,6 +725,68 @@ func TestEscalateToVerifliersFalsePositiveClosesOpenEvent(t *testing.T) {
 	if !gotEndedAt.Equal(fixedNow) {
 		t.Fatalf("CloseOpenSiteEvent ended_at = %v, want %v", gotEndedAt, fixedNow)
 	}
+	if gotCheckType != db.CheckTypeHTTP {
+		t.Fatalf("CloseOpenSiteEvent check_type = %d, want %d", gotCheckType, db.CheckTypeHTTP)
+	}
+	if gotReason != db.ResolutionReasonFalseAlarm {
+		t.Fatalf("CloseOpenSiteEvent reason = %d, want %d", gotReason, db.ResolutionReasonFalseAlarm)
+	}
+}
+
+func TestEscalateToVerifliersFalsePositiveInMaintenanceDoesNotCloseOpenEvent(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+
+	cfg := setTestConfig(t)
+	cfg.PeerOfflineLimit = 2
+
+	var closeCalls int
+	dbCloseOpenSiteEvent = func(context.Context, int64, *int64, db.CheckType, time.Time, db.ResolutionReason) (bool, error) {
+		closeCalls++
+		return true, nil
+	}
+
+	call := 0
+	veriflierCheckFunc = func(c *veriflier.VeriflierClient, _ context.Context, req veriflier.CheckRequest) (*veriflier.CheckResult, error) {
+		call++
+		return &veriflier.CheckResult{
+			BlogID:   req.BlogID,
+			Host:     c.Addr(),
+			Success:  call != 1,
+			HTTPCode: 200,
+		}, nil
+	}
+
+	now := time.Now()
+	past := now.Add(-1 * time.Hour)
+	future := now.Add(1 * time.Hour)
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		ctx:      context.Background(),
+		hostname: "local-host",
+		veriflierClients: []*veriflier.VeriflierClient{
+			veriflier.NewVeriflierClient("v1", ""),
+			veriflier.NewVeriflierClient("v2", ""),
+		},
+	}
+
+	fail := checkerResultFailure(654)
+	o.retries.record(fail)
+	entry := o.retries.get(654)
+	o.escalateToVerifliers(db.Site{
+		ID:               44,
+		BlogID:           654,
+		MonitorURL:       "https://example.com",
+		SiteStatus:       statusRunning,
+		MaintenanceStart: &past,
+		MaintenanceEnd:   &future,
+	}, entry)
+
+	if closeCalls != 0 {
+		t.Fatalf("CloseOpenSiteEvent calls during maintenance false-positive = %d, want 0", closeCalls)
+	}
 }
 
 func TestHandleRecoveryClosesOpenEvent(t *testing.T) {
@@ -659,13 +798,17 @@ func TestHandleRecoveryClosesOpenEvent(t *testing.T) {
 	nowFunc = func() time.Time { return fixedNow }
 
 	var gotSiteID int64
+	var gotCheckType db.CheckType
+	var gotReason db.ResolutionReason
 	var gotEndedAt time.Time
 	var closeCalls int
-	dbCloseOpenSiteEvent = func(_ context.Context, siteID int64, endedAt time.Time) error {
+	dbCloseOpenSiteEvent = func(_ context.Context, siteID int64, _ *int64, checkType db.CheckType, endedAt time.Time, reason db.ResolutionReason) (bool, error) {
 		closeCalls++
 		gotSiteID = siteID
+		gotCheckType = checkType
+		gotReason = reason
 		gotEndedAt = endedAt
-		return nil
+		return true, nil
 	}
 
 	o := &Orchestrator{
@@ -685,6 +828,12 @@ func TestHandleRecoveryClosesOpenEvent(t *testing.T) {
 	}
 	if !gotEndedAt.Equal(fixedNow) {
 		t.Fatalf("CloseOpenSiteEvent ended_at = %v, want %v", gotEndedAt, fixedNow)
+	}
+	if gotCheckType != db.CheckTypeHTTP {
+		t.Fatalf("CloseOpenSiteEvent check_type = %d, want %d", gotCheckType, db.CheckTypeHTTP)
+	}
+	if gotReason != db.ResolutionReasonVerifierCleared {
+		t.Fatalf("CloseOpenSiteEvent reason = %d, want %d", gotReason, db.ResolutionReasonVerifierCleared)
 	}
 }
 
@@ -1004,6 +1153,12 @@ func TestConfirmDownInMaintenance(t *testing.T) {
 	defer restore()
 	setTestConfig(t)
 
+	var txCalls int
+	dbConfirmDownTx = func(context.Context, int64, int64, *int64, db.CheckType, db.EventType, db.EventSeverity, time.Time, bool) error {
+		txCalls++
+		return nil
+	}
+
 	wpcomNotifyFunc = func(_ *wpcom.Client, _ wpcom.Notification) error {
 		t.Fatal("notification should not be sent during maintenance")
 		return nil
@@ -1033,12 +1188,21 @@ func TestConfirmDownInMaintenance(t *testing.T) {
 	if o.retries.get(77) != nil {
 		t.Fatal("retry entry should be cleared after confirmDown in maintenance")
 	}
+	if txCalls != 0 {
+		t.Fatalf("ConfirmDownTx calls during maintenance = %d, want 0", txCalls)
+	}
 }
 
 func TestHandleRecoveryInMaintenance(t *testing.T) {
 	restore := stubOrchestratorDeps()
 	defer restore()
 	setTestConfig(t)
+
+	var closeCalls int
+	dbCloseOpenSiteEvent = func(context.Context, int64, *int64, db.CheckType, time.Time, db.ResolutionReason) (bool, error) {
+		closeCalls++
+		return true, nil
+	}
 
 	wpcomNotifyFunc = func(_ *wpcom.Client, _ wpcom.Notification) error {
 		t.Fatal("notification should not be sent during maintenance")
@@ -1062,6 +1226,10 @@ func TestHandleRecoveryInMaintenance(t *testing.T) {
 		MaintenanceStart: &past,
 		MaintenanceEnd:   &future,
 	}, checkerResultSuccess(1))
+
+	if closeCalls != 0 {
+		t.Fatalf("CloseOpenSiteEvent calls during maintenance = %d, want 0", closeCalls)
+	}
 }
 
 func TestProcessResultsLogsErrorsFromDB(t *testing.T) {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -313,6 +313,9 @@ func stubOrchestratorDeps() func() {
 	origDBMarkSiteChecked := dbMarkSiteChecked
 	origDBRecordCheckHistory := dbRecordCheckHistory
 	origDBUpdateSSLExpiry := dbUpdateSSLExpiry
+	origDBOpenSiteEvent := dbOpenSiteEvent
+	origDBUpgradeOpenSiteEvent := dbUpgradeOpenSiteEvent
+	origDBCloseOpenSiteEvent := dbCloseOpenSiteEvent
 	origNotify := wpcomNotifyFunc
 	origVeriflierCheck := veriflierCheckFunc
 
@@ -323,6 +326,9 @@ func stubOrchestratorDeps() func() {
 	dbMarkSiteChecked = func(context.Context, int64, time.Time) error { return nil }
 	dbRecordCheckHistory = func(int64, int, int, int64, int64, int64, int64, int64) error { return nil }
 	dbUpdateSSLExpiry = func(context.Context, int64, time.Time) error { return nil }
+	dbOpenSiteEvent = func(context.Context, int64, uint8, uint8, time.Time) error { return nil }
+	dbUpgradeOpenSiteEvent = func(context.Context, int64, uint8, uint8) error { return nil }
+	dbCloseOpenSiteEvent = func(context.Context, int64, time.Time) error { return nil }
 	wpcomNotifyFunc = func(_ *wpcom.Client, _ wpcom.Notification) error { return nil }
 	veriflierCheckFunc = func(c *veriflier.VeriflierClient, ctx context.Context, req veriflier.CheckRequest) (*veriflier.CheckResult, error) {
 		return c.Check(ctx, req)
@@ -336,6 +342,9 @@ func stubOrchestratorDeps() func() {
 		dbMarkSiteChecked = origDBMarkSiteChecked
 		dbRecordCheckHistory = origDBRecordCheckHistory
 		dbUpdateSSLExpiry = origDBUpdateSSLExpiry
+		dbOpenSiteEvent = origDBOpenSiteEvent
+		dbUpgradeOpenSiteEvent = origDBUpgradeOpenSiteEvent
+		dbCloseOpenSiteEvent = origDBCloseOpenSiteEvent
 		wpcomNotifyFunc = origNotify
 		veriflierCheckFunc = origVeriflierCheck
 	}
@@ -482,6 +491,200 @@ func TestHandleFailureBelowThresholdDoesNotEscalate(t *testing.T) {
 	}
 	if o.retries.get(1) == nil {
 		t.Fatal("retry entry should exist after first failure")
+	}
+}
+
+func TestHandleFailureFirstFailureOpensSeemsDownEvent(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	setTestConfig(t)
+	config.Get().NumOfChecks = 3
+
+	failAt := time.Date(2026, time.April, 23, 12, 0, 0, 0, time.UTC)
+
+	var gotSiteID int64
+	var gotEventType uint8
+	var gotSeverity uint8
+	var gotStartedAt time.Time
+	var openCalls int
+	dbOpenSiteEvent = func(_ context.Context, siteID int64, eventType, severity uint8, startedAt time.Time) error {
+		openCalls++
+		gotSiteID = siteID
+		gotEventType = eventType
+		gotSeverity = severity
+		gotStartedAt = startedAt
+		return nil
+	}
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		hostname: "local",
+		ctx:      context.Background(),
+	}
+
+	o.handleFailure(db.Site{ID: 99, BlogID: 1}, checker.Result{
+		BlogID:    1,
+		Success:   false,
+		HTTPCode:  500,
+		ErrorCode: checker.ErrorConnect,
+		RTT:       100 * time.Millisecond,
+		Timestamp: failAt,
+	})
+
+	if openCalls != 1 {
+		t.Fatalf("OpenSiteEvent calls = %d, want 1", openCalls)
+	}
+	if gotSiteID != 99 {
+		t.Fatalf("OpenSiteEvent site_id = %d, want 99", gotSiteID)
+	}
+	if gotEventType != db.EventTypeSeemsDown {
+		t.Fatalf("OpenSiteEvent event_type = %d, want %d", gotEventType, db.EventTypeSeemsDown)
+	}
+	if gotSeverity != db.EventSeverityLow {
+		t.Fatalf("OpenSiteEvent severity = %d, want %d", gotSeverity, db.EventSeverityLow)
+	}
+	if !gotStartedAt.Equal(failAt) {
+		t.Fatalf("OpenSiteEvent started_at = %v, want %v", gotStartedAt, failAt)
+	}
+}
+
+func TestConfirmDownUpgradesOpenEvent(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	setTestConfig(t)
+
+	var gotSiteID int64
+	var gotEventType uint8
+	var gotSeverity uint8
+	var upgradeCalls int
+	dbUpgradeOpenSiteEvent = func(_ context.Context, siteID int64, eventType, severity uint8) error {
+		upgradeCalls++
+		gotSiteID = siteID
+		gotEventType = eventType
+		gotSeverity = severity
+		return nil
+	}
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		hostname: "local",
+		ctx:      context.Background(),
+	}
+	fail := checkerResultFailure(123)
+	o.retries.record(fail)
+	entry := o.retries.get(123)
+
+	o.confirmDown(db.Site{ID: 77, BlogID: 123, SiteStatus: statusRunning}, entry, nil)
+
+	if upgradeCalls != 1 {
+		t.Fatalf("UpgradeOpenSiteEvent calls = %d, want 1", upgradeCalls)
+	}
+	if gotSiteID != 77 {
+		t.Fatalf("UpgradeOpenSiteEvent site_id = %d, want 77", gotSiteID)
+	}
+	if gotEventType != db.EventTypeConfirmedDown {
+		t.Fatalf("UpgradeOpenSiteEvent event_type = %d, want %d", gotEventType, db.EventTypeConfirmedDown)
+	}
+	if gotSeverity != db.EventSeverityHigh {
+		t.Fatalf("UpgradeOpenSiteEvent severity = %d, want %d", gotSeverity, db.EventSeverityHigh)
+	}
+}
+
+func TestEscalateToVerifliersFalsePositiveClosesOpenEvent(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+
+	cfg := setTestConfig(t)
+	cfg.PeerOfflineLimit = 2
+
+	fixedNow := time.Date(2026, time.April, 23, 12, 34, 56, 0, time.UTC)
+	nowFunc = func() time.Time { return fixedNow }
+
+	var gotSiteID int64
+	var gotEndedAt time.Time
+	var closeCalls int
+	dbCloseOpenSiteEvent = func(_ context.Context, siteID int64, endedAt time.Time) error {
+		closeCalls++
+		gotSiteID = siteID
+		gotEndedAt = endedAt
+		return nil
+	}
+
+	call := 0
+	veriflierCheckFunc = func(c *veriflier.VeriflierClient, _ context.Context, req veriflier.CheckRequest) (*veriflier.CheckResult, error) {
+		call++
+		return &veriflier.CheckResult{
+			BlogID:   req.BlogID,
+			Host:     c.Addr(),
+			Success:  call != 1,
+			HTTPCode: 200,
+		}, nil
+	}
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		ctx:      context.Background(),
+		hostname: "local-host",
+		veriflierClients: []*veriflier.VeriflierClient{
+			veriflier.NewVeriflierClient("v1", ""),
+			veriflier.NewVeriflierClient("v2", ""),
+		},
+	}
+
+	fail := checkerResultFailure(654)
+	o.retries.record(fail)
+	entry := o.retries.get(654)
+	o.escalateToVerifliers(db.Site{ID: 44, BlogID: 654, MonitorURL: "https://example.com", SiteStatus: statusRunning}, entry)
+
+	if closeCalls != 1 {
+		t.Fatalf("CloseOpenSiteEvent calls = %d, want 1", closeCalls)
+	}
+	if gotSiteID != 44 {
+		t.Fatalf("CloseOpenSiteEvent site_id = %d, want 44", gotSiteID)
+	}
+	if !gotEndedAt.Equal(fixedNow) {
+		t.Fatalf("CloseOpenSiteEvent ended_at = %v, want %v", gotEndedAt, fixedNow)
+	}
+}
+
+func TestHandleRecoveryClosesOpenEvent(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	setTestConfig(t)
+
+	fixedNow := time.Date(2026, time.April, 23, 14, 0, 0, 0, time.UTC)
+	nowFunc = func() time.Time { return fixedNow }
+
+	var gotSiteID int64
+	var gotEndedAt time.Time
+	var closeCalls int
+	dbCloseOpenSiteEvent = func(_ context.Context, siteID int64, endedAt time.Time) error {
+		closeCalls++
+		gotSiteID = siteID
+		gotEndedAt = endedAt
+		return nil
+	}
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		hostname: "local",
+		ctx:      context.Background(),
+	}
+
+	o.handleRecovery(db.Site{ID: 12, BlogID: 1, SiteStatus: statusConfirmedDown}, checkerResultSuccess(1))
+
+	if closeCalls != 1 {
+		t.Fatalf("CloseOpenSiteEvent calls = %d, want 1", closeCalls)
+	}
+	if gotSiteID != 12 {
+		t.Fatalf("CloseOpenSiteEvent site_id = %d, want 12", gotSiteID)
+	}
+	if !gotEndedAt.Equal(fixedNow) {
+		t.Fatalf("CloseOpenSiteEvent ended_at = %v, want %v", gotEndedAt, fixedNow)
 	}
 }
 


### PR DESCRIPTION
## Summary
This branch layers a first-class site event lifecycle onto Jetmon 2 and wires it into the monitor flow, while also tightening migration behavior and expanding project docs/API planning relative to `master`.

## Changes vs `master`
- Added a dedicated `jetmon_site_events` table (migration 9) and introduced explicit event lifecycle/severity constants in `internal/db/site_events.go`:
  - lifecycle/event types: `SeemsDown` and `ConfirmedDown`
  - severities: `Low` and `High`
- Integrated event lifecycle transitions into the orchestrator:
  - open on first local failure (`openSiteEvent`)
  - upgrade on verifier-confirmed downtime (`upgradeOpenSiteEvent`)
  - close on recovery or false-positive clear (`closeOpenSiteEvent`)
- Added DB query helpers for event lifecycle operations (`OpenSiteEvent`, `UpgradeOpenSiteEvent`, `CloseOpenSiteEvent`) with tests.
- Added/expanded API surface documentation for the planned authenticated `/api/v1/*` endpoints in `ROADMAP.md`, including:
  - state/event/history/uptime/read APIs
  - manage/trigger write APIs
  - auth model (`Authorization: Bearer <token>`, scoped API keys)
  - per-key rate limiting behavior and returned rate-limit headers
- Included migration resilience improvements around migration application ordering/idempotency and migration 8 (`last_checked_at`, `last_alert_sent_at`, supporting index) so schema upgrades are safer on partially migrated environments.
- Added major documentation updates (`ARCHITECTURE.md`, `PROJECT.md`, `EVENTS.md`, `TAXONOMY.md`, `ROADMAP.md`, and README updates), including clearer getting-started/onboarding references from the main docs.

## Testing performed
- `go test ./...`
- Added and exercised targeted tests around:
  - orchestrator event open/upgrade/close flow
  - DB event query helpers
  - broader checker/config/dashboard/veriflier/wpcom/orchestrator paths included in this branch