### PR TITLE
Event-sourced state and internal API foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,8 @@ See `PROJECT.md` for the full project description, feature list, and performance
 | `internal/config/` | Config loading, SIGHUP hot-reload |
 | `internal/metrics/` | StatsD client, stats file writer |
 | `internal/wpcom/` | WPCOM API client, circuit breaker |
-| `internal/audit/` | Audit log writes to `jetmon_audit_log` |
+| `internal/audit/` | Operational log writes to `jetmon_audit_log` (WPCOM, retries, verifier RPCs, config reloads) |
+| `internal/eventstore/` | Event-sourced site state — manages `jetmon_events` + `jetmon_event_transitions` writes in single transactions |
 | `internal/dashboard/` | Operator dashboard, SSE handler |
 | `veriflier2/` | Go Veriflier binary |
 | `PROJECT.md` | Full project description and feature specification |
@@ -153,10 +154,17 @@ Every HTTPS check inspects `tls.ConnectionState` for:
 - Cipher suite — recorded in audit log
 
 **Downtime Verification:**
-1. Local check fails → enter local retry queue
-2. After `NUM_OF_CHECKS` local failures → dispatch to Verifliers
+1. Local check fails → open a `Seems Down` event (severity 3) and enter the local retry queue. The event opens on the **first** failure so `started_at` reflects the actual incident start. Subsequent failures during retry are no-ops on the events table (idempotent dedup).
+2. After `NUM_OF_CHECKS` local failures → dispatch to Verifliers (event stays Seems Down)
 3. `PEER_OFFLINE_LIMIT` Veriflier agreements required to confirm
-4. Confirmed down → WPCOM notification via same payload as original
+4. Verifier outcomes:
+   - **Confirms** → Promote event to `Down` (severity 4) with `reason = verifier_confirmed`. WPCOM notification via same payload as original.
+   - **Disagrees** → Close event with `resolution_reason = false_alarm`.
+5. Recovery (any successful probe while an event is open):
+   - From `Seems Down` → close with `resolution_reason = probe_cleared`.
+   - From `Down` → close with `resolution_reason = verifier_cleared` and send recovery notification.
+
+The `jetpack_monitor_sites.site_status` projection is updated in the same transaction as every event mutation (no drift). v1 mapping: open Seems Down → `site_status = SITE_DOWN (0)`; promoted to Down → `site_status = SITE_CONFIRMED_DOWN (2)`; closed → `site_status = SITE_RUNNING (1)`.
 
 **Alert Deduplication:**
 After an alert fires, subsequent alerts for the same site are suppressed for `alert_cooldown_minutes`. Suppression is recorded in the audit log.
@@ -190,7 +198,9 @@ New tables introduced by Jetmon 2:
 | Table | Purpose |
 |-------|---------|
 | `jetmon_hosts` | MySQL-coordinated bucket ownership and heartbeat |
-| `jetmon_audit_log` | Full event history per site |
+| `jetmon_events` | Current state of every incident — one row per `(blog_id, endpoint_id, check_type, discriminator)` while open; mutable until `ended_at` is set, then frozen |
+| `jetmon_event_transitions` | Append-only history of every mutation to `jetmon_events` (open, severity change, state change, cause link, close) |
+| `jetmon_audit_log` | Operational trail — WPCOM notifications, retry dispatch, verifier RPCs, alert/maintenance suppression, config reloads. Site-state changes do **not** flow through here |
 | `jetmon_check_history` | RTT and timing samples for trending |
 | `jetmon_false_positives` | Veriflier non-confirmation events |
 
@@ -224,7 +234,9 @@ Rolling updates require no simultaneous restart of all hosts and leave no sites 
 
 These decisions govern how Jetmon models site state. They must be maintained consistently across all changes. Full design rationale is in [`TAXONOMY.md`](TAXONOMY.md) (Parts 2–3) and [`EVENTS.md`](EVENTS.md).
 
-**Events are the source of truth.** Site status is event-sourced. The event log is canonical; the site row stores a denormalized projection for read performance. Update both in the same transaction — they must not drift. If the projection is ever suspect, rebuild it from the log.
+**Events are the source of truth.** Site status is event-sourced across two tables: `jetmon_events` (one row per incident, holding the current severity/state/metadata) and `jetmon_event_transitions` (append-only history of every mutation). The site row stores a denormalized projection for read performance. Update events, transitions, and the projection in the same transaction — they must not drift. If the projection is ever suspect, rebuild it from the events tables.
+
+**Every event mutation writes a transition row in the same transaction.** Open, severity bump, state change, cause-link change, close — no carve-outs. The `eventstore` package is the only writer for `jetmon_events` and `jetmon_event_transitions`; external callers must go through it. This keeps the invariant testable with one integration test surface.
 
 **Severity and state are separate fields.** Severity is numeric — use it for ordering, thresholds, and rollup. State is a human-readable label — use it for display and lifecycle transitions. A live event's severity can be updated in place without changing its state (a worsening degradation is not a new kind of problem).
 

--- a/API.md
+++ b/API.md
@@ -600,6 +600,18 @@ Standard CRUD. A webhook is:
 
 `secret` is the only string-prefixed identifier in the API surface — it's a shared secret, not a resource id, and the `whsec_` prefix is a Stripe-style hint to anyone scanning logs/leaks ("this is a webhook signing secret, treat as sensitive"). It is shown only on creation; afterward only `secret_preview` is returned (last 4 chars).
 
+#### Filter semantics
+
+Filters compose **AND across dimensions, whitelist within each, empty = match all**. A delivery fires when:
+
+```
+event_type ∈ events (or events == [])
+AND site_id  ∈ site_filter.site_ids (or site_filter == {})
+AND state    ∈ state_filter.states (or state_filter == {})
+```
+
+Empty fields mean "no restriction on this dimension," matching the everyday English meaning of an empty filter. Same convention as Stripe, GitHub, and Slack webhooks — consumers can omit dimensions they don't care about and progressively narrow as needed. Blacklist/exclude fields are not supported in v1.
+
 #### Webhook delivery format
 
 When an event fires, Jetmon POSTs to the webhook URL:
@@ -632,13 +644,42 @@ The signature is HMAC-SHA256 of `{timestamp}.{body}` with the webhook's `secret`
 - `event.state_changed` — state changed (e.g. Seems Down → Down)
 - `event.cause_linked` / `event.cause_unlinked`
 - `event.closed` — event resolved (any reason)
-- `site.state_changed` — derived projection changed (rolled up from events)
 
-`event.*` types fire once per transition; `site.*` types fire when the site row's `current_state` flips. The two are intentionally separable — most consumers care about site-level state for paging and event-level detail for reports.
+`event.*` types fire once per transition row written to `jetmon_event_transitions` — i.e., once per actual mutation. The 1:1 invariant the eventstore maintains is what makes detection reliable.
+
+**Deferred:** `site.state_changed` (rollup from events to the site-row projection) is **not** in v1. Rolling up cleanly without races requires changes to the orchestrator, and event-level webhooks already give consumers everything they need. Tracked in ROADMAP.md.
+
+#### Detection mechanism
+
+Webhook delivery uses **pull-based detection**: a worker polls `jetmon_event_transitions WHERE id > last_seen` on a 1s interval and creates one delivery row per matching transition. This is the long-term answer for Jetmon's architecture — the orchestrator's flap suppression already adds 10s+ between detection and confirmed events, so 1s poll latency is invisible in the practical budget. Pull also handles multi-instance deployment cleanly (any jetmon2 instance can claim work via row lock; no pub/sub layer needed).
+
+Push-based or hybrid detection is not on the roadmap. If a future consumer demands sub-second webhook latency, that's the trigger to introduce a pub/sub layer — not before.
 
 #### Retry policy
 
-Webhooks are retried with exponential backoff (1m, 5m, 30m, 1h, 6h, 24h) for non-2xx responses, then dropped. A `GET /api/v1/webhooks/{id}/deliveries` endpoint surfaces delivery history with status code, response body, and retry count.
+Each `jetmon_webhook_deliveries` row is one webhook firing. Each delivery has up to 6 attempts on this exponential schedule:
+
+| Attempt | Delay from previous |
+|---------|---------------------|
+| 1       | immediate           |
+| 2       | 1m                  |
+| 3       | 5m                  |
+| 4       | 30m                 |
+| 5       | 1h                  |
+| 6       | 6h                  |
+| (drop)  | 24h after attempt 6 |
+
+A delivery succeeds when any attempt returns 2xx. After 6 failed attempts, the row is marked `status = 'abandoned'`. Abandoned rows stay in the table — `GET /api/v1/webhooks/{id}/deliveries?status=abandoned` lists them, and `POST /api/v1/webhooks/{id}/deliveries/{delivery_id}/retry` lets a consumer re-fire after fixing their endpoint.
+
+`GET /api/v1/webhooks/{id}/deliveries` returns the full delivery history with `status` (`pending` / `delivered` / `failed` / `abandoned`), `attempt`, `last_status_code`, and a truncated `last_response` body for debugging.
+
+#### Signing and secret rotation
+
+Signature: HMAC-SHA256 of `{timestamp}.{body}` with the webhook's secret, sent as `X-Jetmon-Signature: t=<unix_ts>,v1=<hex>`. The timestamp prevents replay; consumers should reject deliveries older than 5 minutes.
+
+Secret rotation in v1: **immediate revocation only**. `POST /api/v1/webhooks/{id}/rotate-secret` returns a new secret once, replaces the stored hash, and the old secret stops working immediately. Failed deliveries during the consumer's deploy window go into the retry queue.
+
+**Deferred:** grace-period rotation (server signs with both old and new secrets for a configurable window so consumers can roll over without coordinated downtime) is in ROADMAP.md. The signature header format already supports multiple `v1=...,v1=...` values per Stripe convention, so adding grace-period rotation later is non-breaking.
 
 ### Family 5: Alert contacts (legacy bridge)
 

--- a/API.md
+++ b/API.md
@@ -1,0 +1,740 @@
+# Jetmon Internal API — Design Document
+
+This is a **design proposal**, not yet implemented. It describes the REST API that Jetmon 2 will expose for status reads, incident history, SLA reports, monitor management, and alert delivery.
+
+**Audience: internal systems only.** Jetmon does not expose this API to end customers directly. A separate gateway service handles all customer-facing access — authentication, tenant isolation, customer rate limiting, plan-based feature gating, public error vocabulary, etc. — and calls Jetmon over this internal interface. Other internal services (operator dashboard, alerting workers, batch reporting jobs, the gateway itself) are the only direct callers.
+
+This shapes several design choices: authentication is per-consumer rather than per-customer, scopes are coarse rather than granular, error messages are verbose rather than guarded, and key management is an ops-only concern rather than a self-service feature. The trust boundary is "is this a known internal system?", not "is this user allowed to see this site?".
+
+The goal is to expose Jetmon's distinctive data model — the five-layer test taxonomy, the site → endpoint → event hierarchy, the multi-state vocabulary, and the event-sourced architecture (`TAXONOMY.md`, `EVENTS.md`) — over a shape that internal consumers can integrate against confidently. We took inspiration from Better Stack, UptimeRobot v3, Pingdom, and Atlassian Statuspage but did not copy any of their shapes wholesale; Jetmon's richer model (multi-state, layered tests, causal links, separate severity) wouldn't fit cleanly into a flat "monitors" API.
+
+## Principles
+
+1. **Read API is source-of-truth, not just a snapshot.** Consumers should be able to ask "what is the current state of this site?" and "how did this incident evolve from severity 3 to 4 to closed?" with separate, narrow endpoints — not by polling a coarse "monitor" record. That's what the events/transitions tables exist for.
+
+2. **Severity and state are both first-class.** Many competitor APIs collapse to a single "status" string (UptimeRobot returns `up`/`down`; Better Stack adds `paused`/`maintenance`/`validating`). Jetmon exposes both: numeric severity for ordering, thresholds, and SLA math; human-readable state for display. They never disagree because they're stored as separate columns updated in lockstep.
+
+3. **Cursor pagination, never offset.** Offset pagination breaks under concurrent writes (an event closing during traversal shifts page boundaries). Cursors keyed on stable timestamps (`started_at`, `changed_at`) survive that.
+
+4. **Versioned URLs, conservative additions.** All endpoints under `/api/v1/`. New fields on existing responses are additive (consumers ignore unknowns); shape-breaking changes get `/api/v2/` and a deprecation window. Severity values 0–4 today, room to add new values up to 255 without a version bump.
+
+5. **No shape-shifting based on permissions.** A read-scope token sees the same JSON shape for `GET /api/v1/sites/{id}` as an admin token — fields aren't hidden, they're empty/null where data isn't applicable. Easier to test, easier to document.
+
+6. **Errors carry a stable code, a human message, and (when relevant) a reference id.** Consumers branch on the `code` field, not on parsing the message.
+
+7. **Bulk operations are explicit.** No "list 10,000 sites and then loop one update at a time" anti-pattern — `PATCH /api/v1/sites` accepts a body of changes and returns per-site results. Avoids client-side rate-limit workarounds.
+
+## Authentication
+
+**Per-consumer Bearer tokens.** Each calling system gets one (or more) tokens identifying it. The tokens are not user-delegated — there's no concept of "an end user authenticated via this token." A token *is* a service identity.
+
+```
+Authorization: Bearer jm_a1b2c3d4e5f6...
+```
+
+Tokens are 32-byte high-entropy random strings, sha256-hashed at rest (sha256 not bcrypt — bcrypt is for human-chosen passwords; high-entropy tokens just need a fast cryptographic hash). Stored in `jetmon_api_keys`:
+
+```
+jetmon_api_keys:
+  id              BIGINT PK
+  key_hash        CHAR(64)         -- sha256 hex
+  consumer_name   VARCHAR(128)     -- e.g. "gateway", "alerts-worker", "dashboard"
+  scope           ENUM('read','write','admin')
+  rate_limit_per_minute INT
+  expires_at      TIMESTAMP NULL   -- NULL = never
+  revoked_at      TIMESTAMP NULL   -- soft-revoke for audit trail
+  last_used_at    TIMESTAMP NULL
+  created_at      TIMESTAMP
+  created_by      VARCHAR(128)     -- ops user / automation that created the key
+```
+
+**Scopes — three coarse buckets:**
+
+- `read` — every GET endpoint.
+- `write` — every POST/PATCH/DELETE on sites, endpoints, events, webhooks.
+- `admin` — write + ability to force operations like "recompute SLA from event log" or "close all events in maintenance mode." Reserved for ops tooling, not regular consumers.
+
+We deliberately did not split into `sites:read` / `events:read` / `webhooks:read` etc. Internal consumers tend to need the whole read surface — the gateway needs to read everything to mediate it; an alerts worker reads sites, events, *and* webhooks. Granular scopes would create more configuration burden than they solve.
+
+**Per-consumer audit logging.** Every authenticated request is logged to `jetmon_audit_log` with the consumer name, endpoint, status code, and latency. This is the load-bearing accountability mechanism — if "alerts-worker is hammering the trigger-now endpoint," that's visible in the audit log without parsing access logs. The audit log already exists for operational events (`EVENTS.md`); API access becomes another `event_type` value (`api_access`).
+
+**Key management is ops-only.** No `/api/v1/keys` endpoints. Keys are created and revoked via the `./jetmon2` CLI:
+
+```
+./jetmon2 keys create --consumer gateway --scope read [--expires 90d]
+./jetmon2 keys list
+./jetmon2 keys revoke <key_id>
+./jetmon2 keys rotate <key_id>     # creates a new key for the same consumer; revokes old after grace
+```
+
+The CLI talks to the database directly (via `jetmon_api_keys`), prints the new token once, and never exposes hashes. There's no self-service surface because there are no end customers — keys are infrastructure config, not user-managed credentials.
+
+**Single key format.** No live/test split. The token format is `jm_<base32 of 32 random bytes>`. The gateway is responsible for any environment separation (dev/staging/prod) at its own layer.
+
+**Why not mTLS / IP allowlists alone?** Either could replace Bearer tokens for service-to-service auth, but tokens make per-consumer identity trivial to log and revoke. mTLS rotation is heavier; IP allowlists don't survive containerized deployments cleanly. Bearer tokens are the lowest-friction option that gives us per-consumer accountability.
+
+**Why not OAuth?** Same reasoning as before, now stronger: there are no user delegations to model. Every caller is a server.
+
+## Common patterns
+
+### Base URL and versioning
+
+```
+https://api.jetmon.example.com/api/v1
+```
+
+Hosted in the `jetmon2` binary on a dedicated port (`API_PORT`), separate from the operator dashboard (`DASHBOARD_PORT`) and the verifier transport (`VERIFLIER_GRPC_PORT`).
+
+### Content negotiation
+
+`Content-Type: application/json` for both request and response. UTF-8. No XML, no form-encoded, no JSON-API envelope (Better Stack uses JSON:API; we don't because it adds an `attributes` indirection that obscures field names without buying us anything Jetmon-specific).
+
+### Response envelope
+
+Every list response wraps the data in a small envelope:
+
+```json
+{
+  "data": [ ... ],
+  "page": {
+    "next": "eyJzdGFydGVkX2F0IjoiMjAyNi0wNC0yMVQxNjo...",
+    "limit": 50
+  }
+}
+```
+
+Every single-resource response is just the resource:
+
+```json
+{
+  "id": 487291,
+  "blog_id": 12345,
+  ...
+}
+```
+
+Reasoning: keeping list and single-resource shapes distinct means consumers don't write `if (Array.isArray(response.data))` everywhere. The list envelope holds pagination; the resource envelope is the resource.
+
+### Resource IDs
+
+All resource `id` fields are raw `BIGINT UNSIGNED` integers serialized as JSON numbers (not strings). Sites use the existing `blog_id`; events, transitions, webhooks, deliveries, and contacts use their respective table's auto-increment primary key. There is no type prefix or ULID encoding.
+
+Type context comes from the **endpoint path** (`/api/v1/sites/12345` vs `/api/v1/events/12345`) and from explicit `type` fields where ambiguity would otherwise hurt — for example, error messages always name the resource type:
+
+```json
+{ "error": { "code": "event_not_found", "message": "Event 12345 does not exist", "request_id": "..." } }
+```
+
+Webhook payloads include `"type": "event.opened"` so the consumer never has to infer from a bare numeric id which table the id refers to. Operational/trace identifiers (request IDs, webhook delivery IDs, idempotency keys) follow their own conventions described in the relevant sections.
+
+### Pagination
+
+Cursor-based, opaque tokens. Each list endpoint accepts `?cursor=...&limit=N`. Default limit 50, max 200.
+
+```
+GET /api/v1/sites?cursor=eyJzdGFydGVkX2F0IjoiMjAyNi0wNC0yMVQxNjo...&limit=100
+```
+
+The cursor is an opaque base64-encoded JSON of `{started_at, id}` (or `{changed_at, id}` for transition lists). Consumers shouldn't decode it; we reserve the right to change the encoding inside it.
+
+`page.next` is null on the last page. `page.prev` is intentionally not provided — most consumers walk forward, and offering prev would force us to support reverse iteration in indexes we don't currently have.
+
+### Filtering and sorting
+
+Most list endpoints accept filter query params. The convention:
+
+- Equality filters: `?state=Down&check_type=http`
+- Range filters: `?started_at__gte=2026-04-01T00:00:00Z&started_at__lt=2026-05-01T00:00:00Z`
+- Set filters: `?state__in=Down,Seems%20Down`
+
+Sorting is fixed per endpoint to one of two sensible defaults (newest-first for incidents, alphabetical for sites). We do not expose `?order_by=...` — letting consumers pick arbitrary sort columns means we have to maintain indexes for all of them.
+
+### Error model
+
+```json
+{
+  "error": {
+    "code": "site_not_found",
+    "message": "Site with id 12345 does not exist or is not visible to this token",
+    "request_id": "req_018f9a2c..."
+  }
+}
+```
+
+Error `code` values are documented per endpoint and stable across versions. The `message` is for humans and may improve over time. `request_id` matches a server-side log line for support tickets.
+
+HTTP status codes used:
+
+- `200` — success
+- `201` — resource created (CRUD POST)
+- `204` — success, no body (DELETE)
+- `400` — malformed request (bad JSON, invalid filter syntax, unknown field)
+- `401` — missing or invalid token
+- `403` — token valid but lacks required scope
+- `404` — resource genuinely doesn't exist
+- `409` — idempotent re-attempt with different body (state already different)
+- `422` — semantic validation failure (e.g. invalid URL format)
+- `429` — rate limit exceeded
+- `500` — server error
+- `503` — temporarily unavailable (DB down, etc.)
+
+403 vs 404 are honest here: a `read`-scope token hitting a `write`-only endpoint gets a real 403, not a 404. Internal consumers benefit from accurate semantics over the "hide existence" pattern public APIs use to avoid information leakage — and the gateway in front of Jetmon handles any customer-facing 403↔404 collapsing it wants.
+
+Error messages are verbose by design — for an internal API, "table 'jetmon_events' is locked, retry in 30s" beats "internal server error" by a wide margin during incident response. The gateway can sanitize before forwarding to customers.
+
+### Rate limiting
+
+Per-key bucket, configurable per consumer at key-creation time. Default 60 req/min for `read`, 10 req/min for `write`, 1 req/min for `trigger-now`. Internal consumers usually need higher limits than this — the gateway and dashboard might be set to 600 req/min, while a daily batch job stays at 60.
+
+Standard headers on every response:
+
+```
+X-RateLimit-Limit: 60
+X-RateLimit-Remaining: 47
+X-RateLimit-Reset: 1714685400
+```
+
+`429` responses include `Retry-After` in seconds.
+
+The trigger-now bucket is separate so a runaway "force-check every site" loop in one consumer can't starve the read API for others. This is service-protection rate limiting, not customer-fairness rate limiting — the gateway handles the latter.
+
+### Idempotency
+
+POST/PATCH endpoints accept an `Idempotency-Key` header. The server stores `(token_id, idempotency_key) → response` for 24 hours. Replays with the same body return the cached response; replays with a different body return `409 idempotency_conflict`.
+
+This is the same pattern Stripe uses; it's the right call for monitor management where retries are common.
+
+### Time
+
+All timestamps are ISO 8601 with millisecond precision and `Z` suffix:
+
+```
+"started_at": "2026-04-25T03:18:38.329Z"
+```
+
+The server is always UTC. Clients converting to local time is their problem.
+
+---
+
+## Status and state vocabulary
+
+The API exposes the same vocabulary the orchestrator and event store use. From `TAXONOMY.md` Part 3 and `EVENTS.md`:
+
+**State** (string, human-readable):
+
+| Value | Meaning |
+|-------|---------|
+| `Up` | All checks passing. |
+| `Warning` | Something needs attention but isn't user-facing yet (cert expiring, version behind). |
+| `Degraded` | Some checks failing or thresholds exceeded; site is serving content. |
+| `Seems Down` | First failure detected, awaiting verifier confirmation. Transient. |
+| `Down` | Confirmed failures on critical checks. |
+| `Paused` | Monitoring suspended by user. |
+| `Maintenance` | Scheduled maintenance window active. |
+| `Unknown` | Monitor couldn't determine state (probe crashed, region offline, agent silent). |
+| `Resolved` | (Events only) The condition cleared; event is closed. |
+
+**Severity** (integer 0–255, ordered):
+
+| Value | Default state mapping |
+|-------|----------------------|
+| 0 | Up |
+| 1 | Warning |
+| 2 | Degraded |
+| 3 | Seems Down |
+| 4 | Down |
+
+Higher severity = worse. Severity climbs independently of state — a worsening Degraded event bumps severity without changing state. New severity values can be added (e.g. 5 for "data loss confirmed") without breaking ordering. Consumers should treat severity as a numeric comparison, not a switch on specific values.
+
+**Why expose both?** Severity is for thresholds (`severity >= 3 ? page on-call : email digest`); state is for human-readable rendering (`incident.state == "Seems Down" ? badge.color = yellow`). Competitors that collapse to one field force consumers to either parse a string for ordering or build their own numeric mapping.
+
+---
+
+## Endpoints
+
+The full surface is grouped into five capability families, matching `ROADMAP.md`. All endpoints listed below are part of the proposed v1; build order is suggested but not prescriptive.
+
+### Family 1: Sites and current state
+
+#### `GET /api/v1/sites`
+
+List sites visible to this token.
+
+**Scopes:** `sites:read`
+
+**Query parameters:**
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `cursor` | string | Pagination cursor |
+| `limit` | int (1–200) | Default 50 |
+| `state` | string | Filter by current state (e.g. `Down`) |
+| `state__in` | csv | Multiple states |
+| `severity__gte` | int | Minimum severity |
+| `monitor_active` | bool | Filter active vs paused |
+| `q` | string | URL substring search |
+
+**Response 200:**
+
+```json
+{
+  "data": [
+    {
+      "id": 12345,
+      "blog_id": 12345,
+      "monitor_url": "https://example.com",
+      "monitor_active": true,
+      "current_state": "Up",
+      "current_severity": 0,
+      "active_event_id": null,
+      "last_checked_at": "2026-04-25T03:24:11.123Z",
+      "last_status_change_at": "2026-04-21T09:14:00.000Z",
+      "ssl_expiry_date": "2026-08-12",
+      "check_keyword": null,
+      "redirect_policy": "follow",
+      "maintenance_start": null,
+      "maintenance_end": null,
+      "alert_cooldown_minutes": null,
+      "endpoints_count": 3
+    }
+  ],
+  "page": { "next": "eyJ...", "limit": 50 }
+}
+```
+
+`id` and `blog_id` are the same value for now; `id` is the public field name (`blog_id` is the historical column name). Consumers should rely on `id`.
+
+#### `GET /api/v1/sites/{id}`
+
+Single site, same shape as a list entry plus an `active_events` array for any open events:
+
+```json
+{
+  "id": 12345,
+  ...
+  "active_events": [
+    {
+      "id": 487291,
+      "check_type": "http",
+      "severity": 4,
+      "state": "Down",
+      "started_at": "2026-04-25T03:18:38.329Z"
+    },
+    {
+      "id": 487288,
+      "check_type": "tls_expiry",
+      "severity": 1,
+      "state": "Warning",
+      "started_at": "2026-04-23T00:00:00.000Z"
+    }
+  ]
+}
+```
+
+`active_events` is the simplest answer to "tell me everything wrong with this site right now." Ordered by severity descending.
+
+#### `POST /api/v1/sites`
+
+Create a site.
+
+**Scopes:** `sites:write`
+
+**Request body:**
+
+```json
+{
+  "monitor_url": "https://example.com",
+  "monitor_active": true,
+  "check_keyword": null,
+  "redirect_policy": "follow",
+  "timeout_seconds": null,
+  "custom_headers": {},
+  "alert_cooldown_minutes": null
+}
+```
+
+**Response 201:** the site object.
+
+**Errors:**
+
+| Code | Meaning |
+|------|---------|
+| `invalid_url` | `monitor_url` doesn't parse |
+| `duplicate_site` | A site with this URL already exists for this owner |
+| `quota_exceeded` | The owner has hit their site quota |
+
+#### `PATCH /api/v1/sites/{id}`
+
+Partial update. Send only the fields you want to change.
+
+#### `DELETE /api/v1/sites/{id}`
+
+Soft-delete (sets `monitor_active = false` and tombstones). Closes any active events with `resolution_reason = manual_override`.
+
+#### `POST /api/v1/sites/{id}/pause`, `POST /api/v1/sites/{id}/resume`
+
+Convenience verbs for the common pause/resume flow. Pause closes any active events with `resolution_reason = manual_override` and sets `current_state = "Paused"`. Resume reverts.
+
+#### `POST /api/v1/sites/{id}/trigger-now`
+
+Force an immediate check, returning the result inline (subject to a tighter rate limit). Useful for "I just deployed a fix, is it back up?"
+
+```json
+{
+  "result": {
+    "http_code": 200,
+    "rtt_ms": 412,
+    "ssl_expires_at": "2026-08-12T00:00:00.000Z"
+  },
+  "current_state": "Up",
+  "active_events_closed": [487291]
+}
+```
+
+### Family 2: Events and history
+
+#### `GET /api/v1/sites/{id}/events`
+
+Incident history for a site. Default sort: most recent `started_at` first.
+
+**Query parameters:**
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `cursor`, `limit` | | Standard |
+| `state` / `state__in` | string | Filter by state |
+| `check_type` / `check_type__in` | string | `http`, `tls_expiry`, etc. |
+| `started_at__gte` / `started_at__lt` | ISO timestamp | Time range |
+| `active` | bool | `true` → only open events; `false` → only closed |
+
+**Response:**
+
+```json
+{
+  "data": [
+    {
+      "id": 487291,
+      "site_id": 12345,
+      "endpoint_id": null,
+      "check_type": "http",
+      "discriminator": null,
+      "severity": 4,
+      "state": "Down",
+      "started_at": "2026-04-25T03:18:38.329Z",
+      "ended_at": "2026-04-25T03:21:17.290Z",
+      "resolution_reason": "verifier_cleared",
+      "cause_event_id": null,
+      "metadata": {
+        "http_code": 503,
+        "error_code": 0,
+        "rtt_ms": 84,
+        "url": "https://example.com"
+      },
+      "duration_ms": 158961,
+      "transition_count": 5
+    }
+  ],
+  "page": { "next": "eyJ...", "limit": 50 }
+}
+```
+
+`duration_ms` is a server-computed convenience: `(ended_at or now) - started_at`. `transition_count` lets the consumer decide whether to fetch the full transition log.
+
+#### `GET /api/v1/sites/{id}/events/{event_id}`
+
+Single event, same shape, plus a `transitions` array (full history, no pagination — events have bounded transition counts).
+
+```json
+{
+  "id": 487291,
+  ...
+  "transitions": [
+    {
+      "id": 1,
+      "severity_before": null,
+      "severity_after": 3,
+      "state_before": null,
+      "state_after": "Seems Down",
+      "reason": "opened",
+      "source": "host-us-west-1",
+      "metadata": { "http_code": 503, "rtt_ms": 84 },
+      "changed_at": "2026-04-25T03:18:38.329Z"
+    },
+    {
+      "id": 2,
+      "severity_before": 3,
+      "severity_after": 4,
+      "state_before": "Seems Down",
+      "state_after": "Down",
+      "reason": "verifier_confirmed",
+      "source": "host-us-west-1",
+      "metadata": { "verifier_results": [...], "verifier_confirmed": 2 },
+      "changed_at": "2026-04-25T03:18:55.412Z"
+    }
+  ]
+}
+```
+
+#### `GET /api/v1/sites/{id}/events/{event_id}/transitions`
+
+Same transition data, but as its own paginated list when an event has accumulated many transitions (long-running degradation events with hundreds of severity bumps).
+
+#### `GET /api/v1/events/{event_id}`
+
+Direct event lookup without site context. Useful for webhook payloads that link directly to an incident page.
+
+#### `POST /api/v1/sites/{id}/events/{event_id}/close`
+
+Manually close an open event (for the operator dashboard or for handling false alarms the verifier missed).
+
+**Scopes:** `sites:write`
+
+**Request body:**
+
+```json
+{
+  "reason": "manual_override",
+  "note": "Confirmed maintenance was running, alert fired before window started"
+}
+```
+
+`note` ends up in the closing transition's metadata.
+
+### Family 3: SLA and statistics
+
+#### `GET /api/v1/sites/{id}/uptime`
+
+Uptime and downtime stats over a rolling window.
+
+**Query parameters:**
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `window` | enum | `1h`, `24h`, `7d`, `30d`, `90d` |
+| `from` / `to` | ISO timestamp | Custom range; overrides `window` |
+| `exclude_states` | csv | Default `Maintenance,Paused` (these don't count against uptime) |
+
+**Response:**
+
+```json
+{
+  "window": { "from": "2026-03-26T00:00:00Z", "to": "2026-04-25T00:00:00Z" },
+  "uptime_percent": 99.847,
+  "total_seconds": 2592000,
+  "down_seconds": 3960,
+  "degraded_seconds": 600,
+  "warning_seconds": 86400,
+  "maintenance_seconds": 0,
+  "unknown_seconds": 0,
+  "incident_count": 4,
+  "mttr_seconds": 990,
+  "mtbf_seconds": 647760
+}
+```
+
+**How uptime is computed:** sum of `(ended_at or now) - started_at` for events with `state in (Down, Seems Down)` within the window, divided by total window duration. Configurable via `exclude_states`. The math is event-driven, not check-driven, which means SLA reports stay accurate even if check frequency changes.
+
+#### `GET /api/v1/sites/{id}/response-time`
+
+Response time percentiles over a window, sourced from `jetmon_check_history`.
+
+**Response:**
+
+```json
+{
+  "window": { "from": "2026-04-24T00:00:00Z", "to": "2026-04-25T00:00:00Z" },
+  "samples": 17280,
+  "p50_ms": 187,
+  "p95_ms": 412,
+  "p99_ms": 891,
+  "max_ms": 4200,
+  "mean_ms": 215,
+  "buckets": [
+    { "ts": "2026-04-24T00:00:00Z", "p50_ms": 180, "p95_ms": 401, "p99_ms": 850 },
+    { "ts": "2026-04-24T01:00:00Z", "p50_ms": 184, "p95_ms": 395, "p99_ms": 820 }
+  ]
+}
+```
+
+The `buckets` array is hourly for `window <= 7d`, daily for longer windows. Bucket size isn't tunable — supporting arbitrary granularity would require pre-aggregation we don't have yet.
+
+#### `GET /api/v1/sites/{id}/timing-breakdown`
+
+DNS / TCP / TLS / TTFB breakdown — one of Jetmon's distinctive features (most competitors only return total response time).
+
+**Response:**
+
+```json
+{
+  "window": { "from": "2026-04-24T00:00:00Z", "to": "2026-04-25T00:00:00Z" },
+  "samples": 17280,
+  "dns_p50_ms": 8,
+  "dns_p95_ms": 45,
+  "tcp_p50_ms": 22,
+  "tcp_p95_ms": 78,
+  "tls_p50_ms": 35,
+  "tls_p95_ms": 110,
+  "ttfb_p50_ms": 142,
+  "ttfb_p95_ms": 391
+}
+```
+
+### Family 4: Alert contacts and webhooks
+
+#### `GET /api/v1/webhooks` / `POST /api/v1/webhooks` / `PATCH /api/v1/webhooks/{id}` / `DELETE /api/v1/webhooks/{id}`
+
+Standard CRUD. A webhook is:
+
+```json
+{
+  "id": 42,
+  "url": "https://hooks.slack.com/...",
+  "active": true,
+  "events": ["event.opened", "event.promoted", "event.closed"],
+  "site_filter": { "site_ids": [12345, 67890] },
+  "state_filter": { "states": ["Down", "Seems Down"] },
+  "secret": "whsec_a1b2c3...",
+  "created_at": "2026-04-01T00:00:00Z"
+}
+```
+
+`secret` is the only string-prefixed identifier in the API surface — it's a shared secret, not a resource id, and the `whsec_` prefix is a Stripe-style hint to anyone scanning logs/leaks ("this is a webhook signing secret, treat as sensitive"). It is shown only on creation; afterward only `secret_preview` is returned (last 4 chars).
+
+#### Webhook delivery format
+
+When an event fires, Jetmon POSTs to the webhook URL:
+
+```json
+{
+  "type": "event.opened",
+  "delivered_at": "2026-04-25T03:18:38.500Z",
+  "delivery_id": 9182734,
+  "event": { ... full event object ... },
+  "site": { ... full site object ... }
+}
+```
+
+Headers:
+
+```
+Content-Type: application/json
+X-Jetmon-Event: event.opened
+X-Jetmon-Delivery: 9182734
+X-Jetmon-Signature: t=1714685400,v1=5257a869e7ec...
+```
+
+The signature is HMAC-SHA256 of `{timestamp}.{body}` with the webhook's `secret`, formatted Stripe-style (timestamp + scheme version + signature). The timestamp prevents replay; consumers should reject deliveries older than 5 minutes.
+
+#### Webhook event types
+
+- `event.opened` — new event row inserted
+- `event.severity_changed` — severity escalated or de-escalated
+- `event.state_changed` — state changed (e.g. Seems Down → Down)
+- `event.cause_linked` / `event.cause_unlinked`
+- `event.closed` — event resolved (any reason)
+- `site.state_changed` — derived projection changed (rolled up from events)
+
+`event.*` types fire once per transition; `site.*` types fire when the site row's `current_state` flips. The two are intentionally separable — most consumers care about site-level state for paging and event-level detail for reports.
+
+#### Retry policy
+
+Webhooks are retried with exponential backoff (1m, 5m, 30m, 1h, 6h, 24h) for non-2xx responses, then dropped. A `GET /api/v1/webhooks/{id}/deliveries` endpoint surfaces delivery history with status code, response body, and retry count.
+
+### Family 5: Alert contacts (legacy bridge)
+
+For drop-in compatibility with the existing WPCOM notification flow, alert contacts are first-class but optional. Most modern integrations use webhooks. Documented here for completeness:
+
+- `GET /api/v1/contacts` / `POST` / `PATCH` / `DELETE`
+- Contact types: `email`, `sms`, `webhook` (delegates to webhook system above), `slack`
+- Per-site contact assignment via `POST /api/v1/sites/{id}/contacts/{contact_id}`
+
+### Family 6: Identity and utility
+
+#### `GET /api/v1/me`
+
+Returns the identity associated with the current token: consumer name, scope, rate limit. Useful for a service to confirm at startup that its token is valid and has the expected permission level.
+
+```json
+{
+  "consumer_name": "alerts-worker",
+  "scope": "read",
+  "rate_limit_per_minute": 600,
+  "expires_at": null
+}
+```
+
+This is the only API surface for keys. **Creation, listing, and revocation are CLI-only** (`./jetmon2 keys ...`); see Authentication above. There is no `/api/v1/keys` endpoint.
+
+#### `GET /api/v1/health`
+
+Unauthenticated. Returns `{ "status": "ok" }` if the API can talk to the database. For load balancers and external uptime monitors (yes, including external monitors monitoring the monitor).
+
+#### `GET /api/v1/openapi.json`
+
+OpenAPI 3.1 spec for client codegen. Updated on every deploy; matches what the running server actually accepts. Internal consumers can regenerate clients automatically — particularly useful for the gateway, which will likely re-export a sanitized subset of this surface.
+
+---
+
+## What we deliberately did not include
+
+- **No Statuspage-style public status pages.** That's a separate product; Jetmon focuses on monitoring. If you want a public status page, the API gives you what you need to build one.
+- **No "monitor groups" / "tags" in v1.** Most consumers organize by `owner_blog_id`; tagging is a complexity multiplier we'd rather defer until requested.
+- **No GraphQL.** REST + cursor pagination + filters covers everything the v1 use cases need. If a future consumer needs nested-fetch optimization (sites + active events + recent transitions in one round-trip), we'd add a single `/api/v1/sites/{id}/full` endpoint before reaching for GraphQL.
+- **No per-region SLA breakdown.** All sites are checked from the orchestrator's bucket assignment, not a multi-region fleet (yet — see `TAXONOMY.md` v2/v3 vantage-point work). When that ships, the SLA endpoint gains a `?vantage_point=us-west-1` filter.
+- **No streaming.** Webhooks cover event-driven needs; long-poll/SSE/WebSocket support is overkill for the current consumer set. Could be added on `/api/v1/sites/{id}/events/stream` if a consumer asks.
+
+## Build order recommendation
+
+Phase 1 (read-only foundation):
+- `jetmon_api_keys` migration + sha256 hashing helpers
+- `./jetmon2 keys create/list/revoke/rotate` CLI
+- Auth middleware (Bearer token validation, scope enforcement, audit logging via `jetmon_audit_log`)
+- Health check + `GET /api/v1/me`
+- Family 1 read endpoints (sites list, single site)
+- Family 2 (events list, single event with transitions, transitions list)
+- Family 3 (uptime, response-time, timing-breakdown)
+- Per-key rate limiting + standard headers
+
+Phase 2 (write surface):
+- Family 1 write endpoints (POST/PATCH/DELETE sites, pause/resume, trigger-now)
+- Family 2 manual close
+- Idempotency keys + tighter rate limit on triggers
+
+Phase 3 (delivery):
+- Family 4 webhooks (CRUD + delivery infrastructure with HMAC signing + retry backoff)
+- Family 5 alert contacts (bridge to existing WPCOM flow)
+
+Phase 4 (polish):
+- OpenAPI spec generation
+- Bulk endpoints if real consumers need them
+- Per-region filters when vantage-point work ships
+
+---
+
+## Resolved design questions
+
+These were the open questions from the original draft. All resolved during review; recorded here so the rationale doesn't get lost when the doc evolves.
+
+1. **Resource ID format → raw numeric integers across all resources.** Initially proposed type-prefixed ids (`evt_12345`, `whk_42`) for self-documenting log lines, but on review the costs outweighed the benefits: dual representation between logs/DB/API, JSON type inconsistency (sites as numbers, others as strings), a real silent-coercion bug class under default MySQL `SQL_MODE`, and forward-sharding friction not actually solved by prefixes. Resolution: every resource `id` is a raw `BIGINT UNSIGNED` serialized as a JSON number. Type context is provided by endpoint paths and explicit `type` fields in error messages and webhook payloads, not embedded in the id. (Webhook signing secrets keep the `whsec_` prefix because they're shared secrets, not resource ids — the prefix is a leak-detection hint.)
+
+2. **Bulk site list cap → 200/page, no `include_inactive` opt-in flag.** The existing `monitor_active` filter does the same job; a separate flag would duplicate it. The 200-page cap alone is sufficient guardrail for full-table walks (100k sites at 200/page = 500 round trips, adequate for daily SLA batch jobs). If a consumer ever needs higher per-page volume, we add a `?limit_max=1000` opt-in tied to a special scope at that point — not now.
+
+3. **Webhook signing → Stripe-style versioned HMAC, single algorithm at a time.** Header format `t=<unix_ts>,v1=<hmac_sha256_hex>`. The `v1=` prefix reserves space for a v2 algorithm rotation (e.g. ed25519) without breaking consumer parsers. Don't build multi-algorithm signing upfront — when rotation is actually triggered, transition period emits both `v1=...,v2=...` so consumers verify whichever they support.
+
+4. **`trigger-now` semantics → synchronous with a 30s server-side timeout, no async path in v1.** Matches operator and gateway expectations ("I just deployed, is it up?"), keeps the API surface narrow (one request → one response), and the existing trigger-now rate limit (1/min default per consumer) bounds connection-pool exposure. If a batch-verification consumer ever shows up, we add `?async=true` returning a 202 with a job id — but not before there's a real consumer for it.
+
+5. **Event metadata sanitization → single `metadata` field, no public/private split.** With this being an internal API and a gateway in front of any customer-facing surface, the `metadata` JSON can carry full operational detail (verifier hostnames, internal RPC ids, full HTTP response excerpts). The gateway is responsible for any redaction before forwarding to customers.
+
+---
+
+## Sources / inspiration
+
+The patterns above were informed by reviewing the documented APIs of:
+
+- [Better Stack Uptime API](https://betterstack.com/docs/uptime/api/) — JSON:API envelope (we rejected), incident status enum (we extended), Bearer token auth (we adopted).
+- [UptimeRobot v3 API](https://uptimerobot.com/api/v3/) — Bearer JWT, REST verbs, cursor pagination (we adopted), JSON-only (we adopted).
+- [Pingdom API 3.1](https://docs.pingdom.com/api/) — OpenAPI 3.0 spec (we adopted), `summary.average` SLA endpoint shape (informed our `/uptime` design).
+- [Atlassian Statuspage API](https://developer.statuspage.io/) — incident updates timeline (we extended into transitions table), component status enum `operational/degraded/partial_outage/major_outage` (we rejected — too coarse for our taxonomy).
+- [Stripe API](https://stripe.com/docs/api) — error model with stable codes (we adopted), idempotency keys (we adopted), webhook signing scheme (we adopted).
+
+None of these were copied; each pattern was evaluated against Jetmon's data model and either adopted, modified, or rejected with rationale.

--- a/API.md
+++ b/API.md
@@ -677,9 +677,63 @@ A delivery succeeds when any attempt returns 2xx. After 6 failed attempts, the r
 
 Signature: HMAC-SHA256 of `{timestamp}.{body}` with the webhook's secret, sent as `X-Jetmon-Signature: t=<unix_ts>,v1=<hex>`. The timestamp prevents replay; consumers should reject deliveries older than 5 minutes.
 
+Format chosen for: wide library support across consumer languages, explicit version (`v1=`) to allow future algorithm rotation without breaking consumers, replay protection via timestamp baked into the signature input, and the ability to coexist with multiple `v1=` values during a grace-period rotation (deferred). Alternatives considered and not chosen: GitHub-style (no replay protection), Slack-style (functionally equivalent, two-header form), JWT-based (wrong abstraction for "POST JSON + signature header"), HTTP Message Signatures / RFC 9421 (over-engineered for our scope), asymmetric / Ed25519 (compelling for public APIs without a gateway in front; not warranted while a gateway re-signs for end customers).
+
+When to revisit: a public-API-without-gateway requirement (then asymmetric becomes attractive — no per-consumer secret distribution), or a standards-driven third-party integration that requires RFC 9421. Migration path in either case is "add a `v2=` signature alongside `v1=` for a transition window, switch consumers, deprecate `v1=`" — same shape as algorithm rotation we already designed for.
+
 Secret rotation in v1: **immediate revocation only**. `POST /api/v1/webhooks/{id}/rotate-secret` returns a new secret once, replaces the stored hash, and the old secret stops working immediately. Failed deliveries during the consumer's deploy window go into the retry queue.
 
 **Deferred:** grace-period rotation (server signs with both old and new secrets for a configurable window so consumers can roll over without coordinated downtime) is in ROADMAP.md. The signature header format already supports multiple `v1=...,v1=...` values per Stripe convention, so adding grace-period rotation later is non-breaking.
+
+#### Backpressure
+
+Delivery uses a **shared worker pool** (default 50 goroutines, configurable) with a **per-webhook in-flight cap** (default 3 concurrent). The shared pool bounds total goroutine count; the per-webhook cap prevents a slow or hung webhook URL from monopolizing the pool and starving other webhooks' deliveries.
+
+Implementation: at dispatch time, the worker checks a `map[webhook_id]int` counter under a mutex. If a webhook is already at its cap, the row stays `pending` and is picked up on the next poll tick. The counter decrements when a delivery attempt completes (success or failure).
+
+#### Schema
+
+```
+jetmon_webhooks:
+  id, url, active, events JSON, site_filter JSON, state_filter JSON,
+  secret_hash CHAR(64), secret_preview VARCHAR(8),
+  created_by VARCHAR(128), created_at, updated_at
+
+jetmon_webhook_deliveries:
+  id, webhook_id, event_id (FK to jetmon_events), event_type,
+  payload JSON,                       -- frozen at fire time, never updated
+  status ENUM('pending','delivered','failed','abandoned'),
+  attempt INT,
+  next_attempt_at TIMESTAMP NULL,     -- when the worker should pick up
+  last_status_code INT NULL,
+  last_response VARCHAR(2048) NULL,   -- truncated body, debugging aid
+  last_attempt_at TIMESTAMP NULL,
+  delivered_at TIMESTAMP NULL,
+  created_at
+```
+
+Indexes:
+- `(status, next_attempt_at)` on deliveries — the worker's "what's ready?" query
+- `(webhook_id, created_at)` on deliveries — the deliveries-list endpoint
+- `(active)` on webhooks — the dispatcher's filter for live webhooks
+
+`payload` is **frozen at delivery creation**: the consumer sees the event as it was when the webhook fired, not as it is now. A closed-and-amended event would not change a delivery's payload — that's the contract consumers expect ("this is what I was told happened, not whatever it became").
+
+#### Webhook ownership and scope
+
+Webhooks are managed by any `write`-scope token. `created_by` records the consumer name from the API key for audit purposes only — there is no per-consumer ownership boundary, and any `write`-scope token can read/edit/delete any webhook.
+
+This is appropriate **only** because Jetmon is internal-only with all consumers trusted. Per-consumer ownership doesn't add value at this scale; the gateway in front of Jetmon handles tenant isolation for any customer-facing webhooks.
+
+**Ramifications if Jetmon ever becomes a public API:**
+
+- This model would need to change. Customer-facing consumers cannot be allowed to read or modify each other's webhooks.
+- Migration path: add `owner_consumer_id` (or `owner_account_id`) column to `jetmon_webhooks`; require it on create; filter list/get/update/delete by it; introduce a `webhooks` scope or formal account/tenant boundary.
+- The `created_by` field is forward-compatible — it's already capturing the consumer identity, just not enforcing it.
+- Existing webhooks would need a backfill migration to populate the new ownership column with their original `created_by` value.
+- Webhook secrets would need stronger isolation (currently any write-scope can rotate any secret; in a public API this would be a privilege escalation).
+
+The decision to defer ownership today should be reread before any public-API conversation actually starts.
 
 ### Family 5: Alert contacts (legacy bridge)
 

--- a/EVENTS.md
+++ b/EVENTS.md
@@ -6,25 +6,64 @@ This document describes the event-sourced architecture that underlies site state
 
 Early designs used a mutable `state` column on the site row as the primary record of truth. That approach loses history, makes retries ambiguous, and couples severity changes to state changes in ways that don't reflect reality (a worsening degradation isn't a new outage). Moving to an event log fixes this:
 
-- Full history is preserved for free.
+- Full history is preserved across both event boundaries (open/close) and intra-event mutations (severity bumps, state transitions, cause links).
 - Severity can evolve within a single event without inventing artificial state transitions.
 - Retries and duplicate probe results become idempotent rather than destructive.
 - Derived/denormalized fields on the site row can be rebuilt from the log if they ever drift.
 
-## The event
+## The two-table split
 
-An event represents a condition affecting a site over a time range.
+The model splits the event into two tables:
 
-| Field                | Type            | Notes                                                      |
-|----------------------|-----------------|------------------------------------------------------------|
-| `id`                 | identifier      | Idempotent — see "Identity" below.                         |
-| `site_id`            | FK              | The site this event is about.                              |
-| `start_timestamp`    | timestamp       | When the condition began.                                  |
-| `end_timestamp`      | timestamp, null | When the condition resolved. Null while active.            |
-| `severity`           | numeric         | Ordered, suitable for thresholds and escalation.           |
-| `state`              | enum/string     | Human-readable lifecycle label.                            |
-| `resolution_reason`  | enum, null      | Why the event ended. Null while active.                    |
-| `probe_type`         | enum            | Which probe observed this (HTTP, DNS, TCP, etc.).          |
+- **`jetmon_events`** — one row per incident, holding the *current* (or final) severity, state, and metadata. Mutable while the incident is open; frozen on close.
+- **`jetmon_event_transitions`** — append-only history of every mutation made to a `jetmon_events` row. One row per change, never updated, never deleted.
+
+The events row is the authoritative current-state projection. The transitions table is the full audit trail of how it got there. Together they give you:
+
+- Cheap "what's the current state of incident X" reads (single row in `jetmon_events`).
+- Complete "how did incident X evolve over time" reads (`SELECT * FROM jetmon_event_transitions WHERE event_id = ? ORDER BY changed_at`).
+- Independent retention policies — incidents can be pruned aggressively for the live table while transitions are kept long enough for SLA reports.
+
+**Operational logging stays in `jetmon_audit_log`.** That table records what the *monitor* did (WPCOM retries, verifier RPCs, config reloads, alert suppressions). Site-state changes do not flow through it — those go to the events tables. See "Relationship to `jetmon_audit_log`" below.
+
+## The event row
+
+`jetmon_events` represents a condition affecting a site over a time range. There is at most one *open* row per `(blog_id, endpoint_id, check_type, discriminator)` tuple at any given time (see "Identity and idempotency").
+
+| Field                | Type             | Notes                                                                    |
+|----------------------|------------------|--------------------------------------------------------------------------|
+| `id`                 | BIGINT UNSIGNED  | Primary key.                                                             |
+| `blog_id`            | BIGINT UNSIGNED  | The site this event is about. (`site_id` in TAXONOMY.md terms.)          |
+| `endpoint_id`        | BIGINT UNSIGNED, null | The endpoint, when applicable. Null for site-level events.          |
+| `check_type`         | VARCHAR(64)      | Which probe observed this — `http`, `dns`, `tls_expiry`, etc.            |
+| `discriminator`      | VARCHAR(128), null | Optional tiebreaker for tuples that can have multiple concurrent failures (e.g. multiple keyword checks on the same endpoint). |
+| `severity`           | TINYINT UNSIGNED | Ordered, suitable for thresholds and escalation.                         |
+| `state`              | VARCHAR(32)      | Human-readable lifecycle label.                                          |
+| `started_at`         | TIMESTAMP(3)     | When the condition began. Frozen across severity/state changes.          |
+| `ended_at`           | TIMESTAMP(3), null | When the condition resolved. Null while active.                        |
+| `resolution_reason`  | VARCHAR(64), null | Why the event ended. Null while active.                                 |
+| `cause_event_id`     | BIGINT UNSIGNED, null | Causal link to a root-cause event (separate from rollup).           |
+| `metadata`           | JSON, null       | Check-type-specific payload (HTTP code, RTT, days-to-expiry, etc.).      |
+| `updated_at`         | TIMESTAMP(3)     | ON UPDATE CURRENT_TIMESTAMP — convenience for the dedup path.            |
+| `dedup_key`          | VARCHAR generated | Stored generated column carrying the identity tuple while the event is open, NULL once closed. Backed by a unique index — see "Identity and idempotency". |
+
+## The transition row
+
+`jetmon_event_transitions` is the append-only history. Every mutation to a `jetmon_events` row writes exactly one transition row, in the same database transaction.
+
+| Field              | Type             | Notes                                                                          |
+|--------------------|------------------|--------------------------------------------------------------------------------|
+| `id`               | BIGINT UNSIGNED  | Primary key.                                                                   |
+| `event_id`         | BIGINT UNSIGNED  | The event this transition applies to.                                          |
+| `blog_id`          | BIGINT UNSIGNED  | Denormalized from `jetmon_events.blog_id` — avoids a join for SLA queries.     |
+| `severity_before`  | TINYINT UNSIGNED, null | Severity before the change. Null on `opened`.                            |
+| `severity_after`   | TINYINT UNSIGNED, null | Severity after the change. Null on `closed`.                             |
+| `state_before`     | VARCHAR(32), null | State before the change. Null on `opened`.                                    |
+| `state_after`      | VARCHAR(32), null | State after the change. Null on `closed` (or set to `Resolved`).              |
+| `reason`           | VARCHAR(64)      | Why the transition occurred. See "Transition reasons" below.                   |
+| `source`           | VARCHAR(255)     | Who caused it: `local`, `veriflier:us-west`, `operator:user@host`, `system:timeout`. |
+| `metadata`         | JSON, null       | Transition-specific context (HTTP code on escalation, cause id on link, etc.). |
+| `changed_at`       | TIMESTAMP(3)     | Millisecond precision; SLA report ordering needs sub-second tiebreakers.       |
 
 ### Severity vs. state
 
@@ -36,7 +75,26 @@ Keeping these separate avoids conflating "this got worse" with "this is a differ
 
 ### Identity and idempotency
 
-Event `id` is derived from a stable set of inputs — typically `(site_id, probe_type, start_timestamp_bucket)` or equivalent — so that repeated probe results for the same underlying condition resolve to the same event row. This makes writes idempotent: a retried probe result updates the existing event rather than creating a new one.
+Event identity is the tuple `(blog_id, endpoint_id, check_type, discriminator)`. Repeated probe results for the same underlying condition must resolve to the same `jetmon_events` row — a retried result updates the existing row rather than creating a new one.
+
+MySQL has no partial unique indexes, so the schema enforces "at most one *open* event per tuple" with a generated column trick:
+
+- `dedup_key` is a `VARCHAR GENERATED ALWAYS AS (... ) STORED` column.
+- It evaluates to a `CONCAT_WS` of the tuple while `ended_at IS NULL`, and to `NULL` once the event is closed.
+- A `UNIQUE KEY` on `dedup_key` rejects two open rows with the same tuple. Multiple `NULL`s are allowed by MySQL's unique-index semantics, so closed events never conflict.
+
+The probe runner's insert path collapses to a single statement:
+
+```sql
+INSERT INTO jetmon_events (blog_id, endpoint_id, check_type, discriminator, severity, state, ...)
+VALUES (?, ?, ?, ?, ?, ?, ...)
+ON DUPLICATE KEY UPDATE
+    severity = VALUES(severity),
+    state    = VALUES(state),
+    metadata = VALUES(metadata);
+```
+
+No `SELECT … FOR UPDATE` dance, no optimistic-concurrency loop. The dedup logic is enforced by the schema and the `eventstore` package wraps it so external callers never touch the table directly.
 
 ## Lifecycle
 
@@ -58,17 +116,25 @@ No active event. Probes are succeeding.
 
 A probe has failed but the verifier has not yet confirmed. This is a **real state**, not an implementation detail — dashboards show it, alert rules can key off it, and it has its own severity range.
 
-The verifier path has two outcomes:
-- **Confirmed** → transition to `Down`.
-- **Disagreed** → event ends with `resolution_reason = false_alarm`, site returns to `Up`.
+**The event opens on the first local failure**, not when the local retry queue eventually escalates to verifiers. This is non-negotiable: `started_at` must equal "first time we saw something wrong" so incident duration is honest. Subsequent local-retry failures are no-ops on the events table — the schema's idempotent `dedup_key` collapses them into the same row, and the `eventstore` writer skips a transition row when severity and state are unchanged.
+
+The first failure writes both an event row (`state = Seems Down`, `severity = 3`, `started_at = now`) and an `opened` transition row in one transaction.
+
+Three outcomes from Seems Down:
+
+- **Local probe recovers** before reaching verifier escalation → event closes with `resolution_reason = probe_cleared`. No verifier was involved; this is the "transient blip the local retry caught" path. The count of these is itself a useful signal — a baseline rate of probe-cleared closes tells you how noisy your detection is.
+- **Verifier confirms** → state changes to `Down` in place, severity bumps to 4; one transition row records `state_before = Seems Down`, `state_after = Down`, `severity_before = 3`, `severity_after = 4`, `reason = verifier_confirmed`. `started_at` does not change.
+- **Verifier disagrees** → event closes with `resolution_reason = false_alarm`; one transition row records `state_after = Resolved`, `reason = false_alarm`.
 
 ### Down
 
-Outage confirmed. Severity may continue to evolve in place as additional probes report.
+Outage confirmed. Severity may continue to evolve in place as additional probes report. **Each severity bump writes a transition row** (`severity_before`, `severity_after`, `reason = severity_escalation` or `severity_deescalation`). The `jetmon_events` row stores only the latest severity; the history lives in `jetmon_event_transitions`.
+
+Recovery from Down — the next successful local probe — closes the event with `resolution_reason = verifier_cleared`. (V1 of the integration trusts the local probe on the recovery path; a future "verifier-on-recovery" check would distinguish probe-cleared from verifier-cleared on this path too.)
 
 ### Resolved
 
-Condition has cleared. `end_timestamp` is set, `resolution_reason` is recorded. The event row is now historical — it is not deleted or mutated further.
+Condition has cleared. `ended_at` is set, `resolution_reason` is recorded, and a transition row with `reason = <resolution_reason>` is appended. The event row is now historical — it is not deleted or mutated further.
 
 ## The site row projection
 
@@ -80,7 +146,27 @@ For read performance (dashboards, API queries, bulk lists), the current derived 
 
 **This projection is updated in the same transaction as the event write.** Always. There is no eventual consistency here — if they drift, we have a bug.
 
-The projection is rebuildable from the event log. If it's ever suspected to be wrong, rebuild it; don't patch it.
+The projection is rebuildable from `jetmon_events` (current state) plus `jetmon_event_transitions` (full history). If the projection is ever suspected to be wrong, rebuild it; don't patch it.
+
+## Relationship to `jetmon_audit_log`
+
+`jetmon_audit_log` is the **operational** log — it records what the monitor did, not what happened to a site:
+
+- WPCOM notification sends and retries
+- Verifier RPC dispatch
+- Retry-queue dispatch
+- Alert suppression and maintenance-window swallowing decisions
+- Config reloads
+
+Site-state changes do **not** go through the audit log. Those flow through `jetmon_events` (current state) and `jetmon_event_transitions` (history). The audit log links to events through a nullable `event_id` so an operator can pivot from "this WPCOM retry" to "the incident it was for" with one query.
+
+The split exists because the two trails have different consumers and different retention needs:
+
+| Trail | Consumer | Retention shape |
+|-------|----------|-----------------|
+| `jetmon_events` + `jetmon_event_transitions` | Public API incident timelines, SLA reports | Long — 30/90 days at full fidelity, then rolled up |
+| `jetmon_audit_log` | Operators investigating "why did the alert fire" | Short — aggressive pruning is fine once the incident is closed |
+| `jetmon_check_history` | Response-time trending, baseline learning | Medium — granular timing is high volume |
 
 ## Causal links
 
@@ -102,16 +188,26 @@ All probe types share a single runner. The runner is responsible for:
 
 New probe types plug into this runner. They do not implement their own dedup.
 
-## Resolution reasons
+## Transition reasons
 
-Every event close records why. Current reasons:
+Every transition row records *why* the change happened. The seeded vocabulary, in approximate order of frequency:
 
-- `verifier_cleared` — verifier confirms the site is back up.
-- `false_alarm` — verifier disagreed with the initial failure signal.
-- `manual_override` — an operator closed the event.
+- `opened` — first transition for a new event.
+- `severity_escalation` — severity went up on the same state (e.g. degradation worsening).
+- `severity_deescalation` — severity went down on the same state.
+- `verifier_confirmed` — Seems Down → Down.
+- `verifier_cleared` — site returns to Up after a verifier-confirmed Down; closes the event.
+- `probe_cleared` — site returns to Up while still in Seems Down (verifier was never invoked or never confirmed); closes the event. Count of these per site over time is the false-positive rate of local detection.
+- `false_alarm` — verifier disagreed with the initial failure signal; closes the event.
+- `manual_override` — an operator changed state or closed the event.
+- `maintenance_swallowed` — event closed because a maintenance window started.
+- `superseded` — closed because a broader event subsumed it.
 - `auto_timeout` — event aged out per retention/timeout policy.
+- `cause_linked` / `cause_unlinked` — `cause_event_id` was set or cleared on an open event.
 
-New reasons should be added as explicit enum values, not free-text.
+The "closed" reasons (`verifier_cleared`, `probe_cleared`, `false_alarm`, `manual_override`, `maintenance_swallowed`, `superseded`, `auto_timeout`) are also written to `jetmon_events.resolution_reason` on close, so the live row carries the immediate "why is this closed" answer without needing a join.
+
+New reasons should be added as explicit enum values in code, not free-text. The column is `VARCHAR(64)` (not MySQL `ENUM`) so adding a value doesn't require a schema migration.
 
 ## Open questions
 
@@ -122,7 +218,10 @@ New reasons should be added as explicit enum values, not free-text.
 ## Invariants worth testing
 
 1. Event write and site-row projection update are atomic.
-2. Replaying the same probe result twice produces the same single event.
-3. `Seems Down → Up` (false alarm) correctly closes the event with `resolution_reason = false_alarm`.
-4. Severity updates on a live event do not create a new event row.
-5. Closed events are never mutated (except possibly by a backfill/migration, which should be audited).
+2. **Every** mutation of a `jetmon_events` row writes exactly one row into `jetmon_event_transitions` in the same transaction. Open, severity change, state change, cause-link change, close — no carve-outs.
+3. Replaying the same probe result twice produces the same single event and a single `opened` transition row (idempotent insert path).
+4. `Seems Down → Up` (false alarm) correctly closes the event with `resolution_reason = false_alarm` and writes a transition row with `reason = false_alarm`.
+5. Severity updates on a live event do not create a new event row, but **do** create a transition row.
+6. Closed events are never mutated (except possibly by a backfill/migration, which should be audited).
+7. After closing an event for tuple T, a new failure for tuple T can immediately open a new event without conflicting on `dedup_key`.
+8. Replaying every transition row for an event in `changed_at` order reconstructs the event's current `severity` and `state`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -126,3 +126,69 @@ Programmatic management of where alerts go. Competitors that omit this force use
 - Trigger handler: enqueue immediate check; return `request_id` for polling.
 - Rate limiting middleware: per-key token bucket, separate buckets for read/write/trigger, rate-limit headers.
 - Integration tests in the Docker Compose environment covering auth, pagination, state consistency, and webhook delivery.
+
+---
+
+## Deferred from Phase 3 (webhooks)
+
+These were considered during Phase 3 design and intentionally left out of v1 with clean upgrade paths.
+
+### `site.state_changed` webhook events
+
+Phase 3 v1 ships only `event.*` webhooks (one per `jetmon_event_transitions` row). A `site.state_changed` rollup webhook — fires when the site row's `current_state` projection flips — was punted because:
+
+- Detecting site-level transitions cleanly without races requires changes to the orchestrator (it currently writes `site_status` but doesn't compute deltas)
+- Event-level webhooks already give consumers everything they need to compute site-level rollup themselves
+- The schema for site state is downstream of the events tables; we'd be adding a second source of truth for "the site is now Down"
+
+**When to revisit:** a real consumer asks for site-level rollup webhooks specifically. Likely shape: orchestrator emits a "previous_state → new_state" signal alongside the projection write; a delivery worker translates that into `site.state_changed` deliveries. Same retry/filter/signature plumbing as `event.*` webhooks — the only new piece is the orchestrator-side delta computation.
+
+### Grace-period webhook secret rotation
+
+Phase 3 v1 ships immediate-revocation only: rotating a webhook secret invalidates the old secret immediately. Brief signature-verification failures during the consumer's deploy window go into the retry queue and resolve once the consumer rolls.
+
+A future Phase 3.x extension is **grace-period rotation**: server signs with both old and new secrets for a configurable window (24h default), consumer verifies whichever they support, then the old secret expires. This matches Stripe's webhook signing roll model and lets consumers deploy at their own pace.
+
+**Why this is a clean future addition:**
+- Schema extension only: add `previous_secret_hash` and `previous_secret_expires_at` columns to `jetmon_webhooks`
+- Header format already supports multiple `v1=` values (Stripe-compatible)
+- New endpoint shape: `POST /webhooks/{id}/rotate-secret?grace=24h`
+- No migration of existing webhooks needed; immediate-revocation is the default if `?grace` is absent
+
+**When to revisit:** a customer-managing consumer (not the gateway, not internal alerting) registers webhooks and asks for graceful rotation, or a compliance requirement forces routine secret rotation.
+
+---
+
+## Architectural roadmap
+
+### Multi-repo / multi-binary split
+
+Today everything lives in one repo and the `jetmon2` binary contains the orchestrator, the API server, the operator dashboard, and (after Phase 3) the webhook delivery worker. The `veriflier2` binary is already separate but in the same repo.
+
+This is fine for now but won't scale operationally. Different concerns have very different deployment shapes:
+
+| Concern | Scaling axis | Deployment shape |
+|---------|--------------|------------------|
+| Orchestrator | bucket count, check rate | stateful (claims buckets in `jetmon_hosts`); horizontal via bucket coordination |
+| API server | request rate | stateless; horizontal behind a load balancer |
+| Webhook delivery | event volume + slow consumers | stateless; horizontal via row-claim on `jetmon_webhook_deliveries` |
+| Operator dashboard | one-off operator sessions | one per ops region |
+| Veriflier | geo-distributed vantage points | one per region |
+
+Putting everything in one binary means scaling the most expensive concern scales the cheap ones with it (CPU and memory headroom that's only used for one purpose). It also concentrates failure modes — a panic in the API server takes down the orchestrator.
+
+**Plausible split:**
+- `jetmon-orchestrator` — round loop, check pool, WPCOM notifications, DB writes
+- `jetmon-api` — REST API server, auth, rate limiting (read/write surface)
+- `jetmon-deliverer` — webhook delivery worker (Phase 3)
+- `jetmon-dashboard` — operator UI / SSE state stream
+- `jetmon-verifier` — standalone HTTP check executor (today: `veriflier2`; rename TBD)
+
+The MySQL schema is already the implicit bus between these — each service reads/writes specific tables. Splitting would mostly be:
+1. Extract each concern into its own `cmd/<name>/` directory with a thin main
+2. Move shared types into `pkg/` (currently `internal/`) so the binaries can depend on them across repos
+3. Decide on repo boundaries (one monorepo with multiple binaries, vs. multiple repos sharing a `pkg/` module)
+
+**Naming opportunity:** "veriflier" is a long-standing typo of "verifier" that has stuck around through the rewrite. A split is a natural moment to rename. Candidates: `verifier`, `witness`, `probe-worker`, `vantage`. Worth deciding before the split happens, not during.
+
+**When to revisit:** when a single binary's resource needs (CPU, memory, restart blast radius) starts working against the operational sweet spot for one of the concerns. Likely first trigger: the webhook deliverer's I/O profile (lots of slow outbound HTTP) wanting different sizing than the orchestrator's tight check loop.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -192,3 +192,26 @@ The MySQL schema is already the implicit bus between these — each service read
 **Naming opportunity:** "veriflier" is a long-standing typo of "verifier" that has stuck around through the rewrite. A split is a natural moment to rename. Candidates: `verifier`, `witness`, `probe-worker`, `vantage`. Worth deciding before the split happens, not during.
 
 **When to revisit:** when a single binary's resource needs (CPU, memory, restart blast radius) starts working against the operational sweet spot for one of the concerns. Likely first trigger: the webhook deliverer's I/O profile (lots of slow outbound HTTP) wanting different sizing than the orchestrator's tight check loop.
+
+### Path to a public API
+
+Today's API is internal-only — every caller is a known service (gateway, alerting workers, dashboard) and tenant isolation lives at the gateway. Several Phase 1–3 design decisions take advantage of that and would have to change if Jetmon ever exposes its API directly to end customers without a gateway in front.
+
+The decisions affected:
+
+| Decision | Internal-API form | Public-API form |
+|----------|-------------------|-----------------|
+| Auth scopes | Three coarse: `read` / `write` / `admin` | Granular per-resource (e.g. `sites:read`, `events:read`, `webhooks:write`) so customer keys can be scoped tightly |
+| Error semantics | Honest 401/403/404 (no info-leak hiding) | 404-on-unauthorized (don't leak existence of resources owned by other tenants) |
+| Error message verbosity | Verbose (DB error class, query stage) for incident response | Sanitized — internal detail belongs in server logs only |
+| Webhook ownership | Any `write`-scope token can manage any webhook (`created_by` audit only) | Per-tenant ownership column; reads/writes filtered by owner |
+| Webhook signing | HMAC-SHA256 with shared secret per webhook | Asymmetric (Ed25519) becomes more attractive — public key at a well-known URL, no per-customer secret to leak |
+| Rate limiting | Per-key bucket sized for service protection | Per-tenant bucket sized for commerce/abuse |
+| Idempotency keys | Scoped by `(api_key_id, key)` | Scoped by `(tenant_id, api_key_id, key)` to prevent cross-tenant collisions |
+| Site `id` (= `blog_id`) | Numeric, canonical from WPCOM | Probably still numeric, but tenant-scoped on lookup |
+
+The migrations are individually clean (each is "add a column, filter on it, deprecate the unscoped version") but they touch most of the API surface. A public-API exposure would be a significant project, not a flag flip.
+
+**When to revisit:** if a stakeholder asks "can a customer integration call Jetmon directly?" — the answer should be "let's design that" rather than "yes, here's the URL."
+
+The Q9 (webhook ownership) section in API.md captures the most concrete piece of this; the rest is captured here for visibility when the conversation comes up.

--- a/TAXONOMY.md
+++ b/TAXONOMY.md
@@ -404,18 +404,31 @@ Jetmon uses an event-sourced architecture where **events are the source of truth
 ### Schema shape
 
 ```
-events (source of truth):
+events (current state — one row per open incident, frozen on close):
   id
-  site_id
+  site_id (blog_id)
   endpoint_id (nullable — null for site-level events)
   check_type
+  discriminator (nullable — tiebreaker for tuples that can have multiple concurrent failures)
   severity (numeric, comparable)
   state (human-readable category)
-  started_at
+  started_at (frozen across severity/state changes)
   ended_at (nullable — null for active events)
   cause_event_id (nullable — causal link, separate from hierarchical rollup)
   resolution_reason (nullable — why the event closed)
   metadata (JSON — check-specific data)
+  dedup_key (generated, NULL when closed; UNIQUE — enforces one-open-per-tuple)
+
+event_transitions (append-only history of every event mutation):
+  id
+  event_id
+  site_id (blog_id, denormalized for SLA queries)
+  severity_before, severity_after
+  state_before, state_after
+  reason (opened, severity_escalation, verifier_confirmed, false_alarm, …)
+  source (local, veriflier:<region>, operator:<user>, system:<reason>)
+  metadata (JSON — transition-specific context)
+  changed_at
 
 sites (includes derived state for fast reads):
   id
@@ -426,9 +439,13 @@ sites (includes derived state for fast reads):
   worst_active_severity
 ```
 
+**Why two tables, not one mutable events table:** keeping current state in `events` and history in `event_transitions` lets you serve "current state of site X" with a single-row read on `events`, and "how did incident Y evolve" with a narrow `WHERE event_id = ?` scan on `event_transitions`. Both queries are common, both want different shapes, and a single mutable-history table compromises one or the other.
+
+The invariant is that **every write to `events` is paired with one row inserted into `event_transitions` in the same transaction**. This is enforced in code by routing all event mutations through a single `eventstore` package. Replaying `event_transitions` in `changed_at` order reconstructs any event's current `severity` and `state`, so the live `events` row is fully rebuildable from the history table.
+
 **Key design decisions:**
 
-- **Events are the source of truth; derived state is denormalized onto the site row for read performance.** Update both transactionally — the derived state should never write without a corresponding event write, and vice versa.
+- **Events are the source of truth across two tables.** `events` holds current state (mutable while open, frozen on close); `event_transitions` is the append-only history of every change. The site row stores a denormalized projection for fast reads. All three update transactionally — the projection should never write without a corresponding event write, and an event write must always be accompanied by a transition row.
 
 - **Severity and state are separate fields.** Severity is the numeric, comparable value used for rollup (e.g., 1=Warning, 2=Degraded, 3=Seems Down, 4=Down). State is the human-readable category. Keeping them separate lets you add new states without breaking rollup logic.
 
@@ -563,7 +580,7 @@ A consolidated list of architectural decisions made across the conversation hist
 5. **Rollup rules are explicit and configurable per site**, not hardcoded.
 6. **Multi-state vocabulary:** Up, Warning, Degraded, Seems Down, Down, Paused, Maintenance, Unknown.
 7. **Unknown state exists specifically to prevent monitor-side failures from being reported as customer-site downtime.**
-8. **Event-sourced architecture** with derived site state denormalized for read performance.
+8. **Event-sourced architecture** across two tables: `events` for current state, `event_transitions` for append-only history of every mutation. Derived site state is denormalized onto the site row for read performance. The `eventstore` package is the sole writer; every event mutation also writes a transition row in the same transaction.
 9. **Severity and state are separate fields**; severity is numeric and comparable, state is human-readable.
 10. **Seems Down promotes in place** to Down on verifier confirmation; `started_at` stays at first-failure time.
 11. **Event identity is idempotent** via `(site_id, endpoint_id, check_type, discriminator)`.

--- a/cmd/jetmon2/main.go
+++ b/cmd/jetmon2/main.go
@@ -243,19 +243,16 @@ func cmdAudit() {
 	for rows.Next() {
 		var (
 			id        int64
-			bid       int64
+			bid       sql.NullInt64
+			eventID   sql.NullInt64
 			eventType string
 			source    string
-			httpCode  sql.NullInt64
-			errorCode sql.NullInt64
-			rttMs     sql.NullInt64
-			oldStatus sql.NullInt64
-			newStatus sql.NullInt64
 			detail    sql.NullString
+			metadata  sql.NullString
 			createdAt time.Time
 		)
-		if err := rows.Scan(&id, &bid, &eventType, &source, &httpCode, &errorCode,
-			&rttMs, &oldStatus, &newStatus, &detail, &createdAt); err != nil {
+		if err := rows.Scan(&id, &bid, &eventID, &eventType, &source,
+			&detail, &metadata, &createdAt); err != nil {
 			log.Printf("scan: %v", err)
 			continue
 		}
@@ -263,11 +260,11 @@ func cmdAudit() {
 		if detail.Valid {
 			det = detail.String
 		}
-		if httpCode.Valid {
-			det = fmt.Sprintf("http=%d err=%d rtt=%dms %s", httpCode.Int64, errorCode.Int64, rttMs.Int64, det)
+		if eventID.Valid {
+			det = fmt.Sprintf("event=%d %s", eventID.Int64, det)
 		}
-		if oldStatus.Valid {
-			det = fmt.Sprintf("status %d→%d %s", oldStatus.Int64, newStatus.Int64, det)
+		if metadata.Valid && metadata.String != "" {
+			det = fmt.Sprintf("%s meta=%s", det, metadata.String)
 		}
 		fmt.Printf("%-25s %-22s %-15s %s\n",
 			createdAt.Format("2006-01-02 15:04:05.000"),

--- a/cmd/jetmon2/main.go
+++ b/cmd/jetmon2/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"database/sql"
 	"flag"
 	"fmt"
@@ -13,6 +14,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/Automattic/jetmon/internal/api"
+	"github.com/Automattic/jetmon/internal/apikeys"
 	"github.com/Automattic/jetmon/internal/audit"
 	"github.com/Automattic/jetmon/internal/config"
 	"github.com/Automattic/jetmon/internal/dashboard"
@@ -50,6 +53,8 @@ func main() {
 		cmdDrain()
 	case "reload":
 		cmdReload()
+	case "keys":
+		cmdKeys(os.Args[2:])
 	default:
 		runServe()
 	}
@@ -114,6 +119,18 @@ func runServe() {
 		}()
 	}
 
+	// Internal API server. Disabled when API_PORT is 0. Bears auth via
+	// jetmon_api_keys; key management is CLI-only (`./jetmon2 keys`).
+	var apiSrv *api.Server
+	if cfg.APIPort > 0 {
+		apiSrv = api.New(fmt.Sprintf(":%d", cfg.APIPort), db.DB(), db.Hostname())
+		go func() {
+			if err := apiSrv.Listen(); err != nil && !api.IsServerClosed(err) {
+				log.Printf("api: %v", err)
+			}
+		}()
+	}
+
 	// Push dashboard state every stats interval.
 	if dash != nil {
 		go func() {
@@ -152,6 +169,13 @@ func runServe() {
 				}
 			case syscall.SIGINT, syscall.SIGTERM:
 				log.Println("received shutdown signal, draining")
+				if apiSrv != nil {
+					ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+					if err := apiSrv.Shutdown(ctx); err != nil {
+						log.Printf("api: shutdown error: %v", err)
+					}
+					cancel()
+				}
 				orch.Stop()
 				// Hard kill if drain takes too long (e.g. a stalled HTTP check).
 				time.AfterFunc(30*time.Second, func() {
@@ -294,6 +318,175 @@ func cmdReload() {
 		log.Fatalf("signal: %v", err)
 	}
 	fmt.Printf("SIGHUP sent to pid %d\n", pid)
+}
+
+// cmdKeys is the entrypoint for `./jetmon2 keys ...` ops commands. Key
+// management is intentionally CLI-only — the public API has no /keys
+// endpoints. See API.md "Authentication".
+func cmdKeys(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 keys <create|list|revoke|rotate> [args]")
+		os.Exit(1)
+	}
+	config.LoadDB()
+	if err := db.ConnectWithRetry(3); err != nil {
+		log.Fatalf("db: %v", err)
+	}
+	ctx := context.Background()
+
+	sub := args[0]
+	rest := args[1:]
+	switch sub {
+	case "create":
+		cmdKeysCreate(ctx, rest)
+	case "list":
+		cmdKeysList(ctx, rest)
+	case "revoke":
+		cmdKeysRevoke(ctx, rest)
+	case "rotate":
+		cmdKeysRotate(ctx, rest)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown keys subcommand %q (want: create, list, revoke, rotate)\n", sub)
+		os.Exit(1)
+	}
+}
+
+func cmdKeysCreate(ctx context.Context, args []string) {
+	fs := flag.NewFlagSet("keys create", flag.ExitOnError)
+	consumer := fs.String("consumer", "", "consumer name (e.g. 'gateway', 'alerts-worker') — required")
+	scopeStr := fs.String("scope", "read", "permission scope: read | write | admin")
+	rateLimit := fs.Int("rate-limit", 0, "requests per minute (0 = scope default)")
+	ttl := fs.Duration("ttl", 0, "key lifetime (e.g. 90d, 720h); 0 = never expires")
+	createdBy := fs.String("created-by", currentOperator(), "operator identity for audit")
+	_ = fs.Parse(args)
+
+	if *consumer == "" {
+		fmt.Fprintln(os.Stderr, "--consumer is required")
+		os.Exit(1)
+	}
+
+	raw, k, err := apikeys.Create(ctx, db.DB(), apikeys.CreateInput{
+		ConsumerName:       *consumer,
+		Scope:              apikeys.Scope(*scopeStr),
+		RateLimitPerMinute: *rateLimit,
+		TTL:                *ttl,
+		CreatedBy:          *createdBy,
+	})
+	if err != nil {
+		log.Fatalf("create: %v", err)
+	}
+
+	fmt.Printf("Created key id=%d for consumer=%q scope=%s rate=%d/min\n",
+		k.ID, k.ConsumerName, k.Scope, k.RateLimitPerMinute)
+	if k.ExpiresAt != nil {
+		fmt.Printf("Expires: %s\n", k.ExpiresAt.UTC().Format(time.RFC3339))
+	} else {
+		fmt.Println("Expires: never")
+	}
+	fmt.Println()
+	fmt.Println("Token (shown ONCE — save it now):")
+	fmt.Println(raw)
+}
+
+func cmdKeysList(ctx context.Context, args []string) {
+	fs := flag.NewFlagSet("keys list", flag.ExitOnError)
+	includeRevoked := fs.Bool("include-revoked", false, "show revoked keys too")
+	_ = fs.Parse(args)
+
+	keys, err := apikeys.List(ctx, db.DB())
+	if err != nil {
+		log.Fatalf("list: %v", err)
+	}
+
+	fmt.Printf("%-5s %-24s %-7s %-9s %-21s %-21s %s\n",
+		"ID", "CONSUMER", "SCOPE", "RATE/MIN", "EXPIRES", "LAST USED", "STATUS")
+	fmt.Println(repeat("-", 110))
+	for _, k := range keys {
+		status := "active"
+		if k.RevokedAt != nil {
+			if !*includeRevoked && k.RevokedAt.Before(time.Now().UTC()) {
+				continue
+			}
+			if k.RevokedAt.After(time.Now().UTC()) {
+				status = "revokes-at " + k.RevokedAt.UTC().Format("2006-01-02T15:04:05Z")
+			} else {
+				status = "revoked"
+			}
+		} else if k.ExpiresAt != nil && k.ExpiresAt.Before(time.Now().UTC()) {
+			status = "expired"
+		}
+		expires := "never"
+		if k.ExpiresAt != nil {
+			expires = k.ExpiresAt.UTC().Format("2006-01-02T15:04:05Z")
+		}
+		lastUsed := "never"
+		if k.LastUsedAt != nil {
+			lastUsed = k.LastUsedAt.UTC().Format("2006-01-02T15:04:05Z")
+		}
+		fmt.Printf("%-5d %-24s %-7s %-9d %-21s %-21s %s\n",
+			k.ID, k.ConsumerName, k.Scope, k.RateLimitPerMinute, expires, lastUsed, status)
+	}
+}
+
+func cmdKeysRevoke(ctx context.Context, args []string) {
+	if len(args) < 1 {
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 keys revoke <id>")
+		os.Exit(1)
+	}
+	id, err := parseInt64(args[0])
+	if err != nil {
+		log.Fatalf("invalid id %q: %v", args[0], err)
+	}
+	if err := apikeys.Revoke(ctx, db.DB(), id); err != nil {
+		log.Fatalf("revoke: %v", err)
+	}
+	fmt.Printf("Revoked key id=%d\n", id)
+}
+
+func cmdKeysRotate(ctx context.Context, args []string) {
+	fs := flag.NewFlagSet("keys rotate", flag.ExitOnError)
+	grace := fs.Duration("grace", 5*time.Minute, "grace period before old key is revoked (0 = revoke immediately)")
+	createdBy := fs.String("created-by", currentOperator(), "operator identity for audit")
+	_ = fs.Parse(args)
+
+	if fs.NArg() < 1 {
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 keys rotate [--grace=DURATION] <id>")
+		os.Exit(1)
+	}
+	id, err := parseInt64(fs.Arg(0))
+	if err != nil {
+		log.Fatalf("invalid id %q: %v", fs.Arg(0), err)
+	}
+
+	raw, k, err := apikeys.Rotate(ctx, db.DB(), id, *grace, *createdBy)
+	if err != nil {
+		log.Fatalf("rotate: %v", err)
+	}
+	fmt.Printf("Rotated key id=%d → new key id=%d for consumer=%q\n", id, k.ID, k.ConsumerName)
+	if *grace > 0 {
+		fmt.Printf("Old key id=%d will be revoked at %s\n", id, time.Now().UTC().Add(*grace).Format(time.RFC3339))
+	} else {
+		fmt.Printf("Old key id=%d revoked immediately\n", id)
+	}
+	fmt.Println()
+	fmt.Println("New token (shown ONCE — save it now):")
+	fmt.Println(raw)
+}
+
+func currentOperator() string {
+	if u := os.Getenv("USER"); u != "" {
+		return u
+	}
+	if u := os.Getenv("LOGNAME"); u != "" {
+		return u
+	}
+	return "cli"
+}
+
+func parseInt64(s string) (int64, error) {
+	var v int64
+	_, err := fmt.Sscan(s, &v)
+	return v, err
 }
 
 func readPIDFile() int {

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -55,6 +55,7 @@ services:
         environment:
           - VERIFLIER_AUTH_TOKEN=$VERIFLIER_AUTH_TOKEN
           - VERIFLIER_GRPC_PORT=$VERIFLIER_GRPC_DOCKER_PORT
+          - STATSD_ADDR=statsd:8125
     statsd:
         image: graphiteapp/graphite-statsd
         restart: unless-stopped

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -41,6 +41,7 @@ services:
           - JETMON_PID_FILE=/jetmon/stats/jetmon2.pid
         ports:
           - $DASHBOARD_LOCAL_PORT:$DASHBOARD_DOCKER_PORT
+          - "8090:8090"
         depends_on:
             mysqldb:
                 condition: service_healthy

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -38,6 +38,7 @@ services:
           - VERIFLIER_GRPC_PORT=$VERIFLIER_GRPC_DOCKER_PORT
           - WPCOM_JETMON_AUTH_TOKEN=$WPCOM_JETMON_AUTH_TOKEN
           - DASHBOARD_PORT=$DASHBOARD_DOCKER_PORT
+          - JETMON_PID_FILE=/jetmon/stats/jetmon2.pid
         ports:
           - $DASHBOARD_LOCAL_PORT:$DASHBOARD_DOCKER_PORT
         depends_on:

--- a/docker/run-jetmon.sh
+++ b/docker/run-jetmon.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 cd /jetmon
-export JETMON_PID_FILE=/jetmon/jetmon2.pid
+# /jetmon is owned by the jetmon user from the Dockerfile, but the container
+# runs as ${JETMON_UID:-1000} via docker-compose — write to stats/ instead, which
+# the Dockerfile chmods 0777 specifically so reload/drain commands work.
+export JETMON_PID_FILE=/jetmon/stats/jetmon2.pid
 
 touch logs/jetmon.log logs/status-change.log
 touch stats/sitespersec stats/sitesqueue stats/totals

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/Automattic/jetmon
 go 1.22
 
 require github.com/go-sql-driver/mysql v1.7.1
+
+require github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,5 @@
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrtU8EI=
 github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1,0 +1,122 @@
+// Package api implements the internal Jetmon REST API.
+//
+// The API is internal-only — a separate gateway service handles all
+// customer-facing concerns (tenant isolation, public errors, customer rate
+// limiting). See API.md for the full design rationale and endpoint reference.
+//
+// Authentication is per-consumer Bearer tokens managed via the apikeys
+// package. Every authenticated request is logged to jetmon_audit_log under
+// event_type=api_access for accountability.
+package api
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+)
+
+// Timeout defaults for the API HTTP server. These are generous compared to
+// the verifier's defaults because some endpoints (uptime stats over long
+// windows, full transition lists) legitimately do more work.
+const (
+	readHeaderTimeout = 5 * time.Second
+	readTimeout       = 60 * time.Second
+	writeTimeout      = 65 * time.Second
+	idleTimeout       = 120 * time.Second
+)
+
+// Server hosts the API on a single addr. Lifecycle mirrors the verifier:
+// Listen blocks; Shutdown drains gracefully up to the caller's deadline.
+type Server struct {
+	db       *sql.DB
+	addr     string
+	hostname string
+	httpSrv  *http.Server
+	limiter  *rateLimiter
+}
+
+// New constructs a Server. Caller is responsible for ensuring db is connected
+// and migrated before Listen is called.
+func New(addr string, db *sql.DB, hostname string) *Server {
+	return &Server{
+		db:       db,
+		addr:     addr,
+		hostname: hostname,
+		limiter:  newRateLimiter(),
+	}
+}
+
+// Listen starts the API HTTP server. Returns http.ErrServerClosed on a clean
+// Shutdown. Callers wrap with errors.Is(err, http.ErrServerClosed) to
+// distinguish graceful shutdown from a real failure.
+func (s *Server) Listen() error {
+	mux := s.routes()
+
+	s.httpSrv = &http.Server{
+		Addr:              s.addr,
+		Handler:           mux,
+		ReadHeaderTimeout: readHeaderTimeout,
+		ReadTimeout:       readTimeout,
+		WriteTimeout:      writeTimeout,
+		IdleTimeout:       idleTimeout,
+	}
+
+	log.Printf("api: listening on %s", s.addr)
+	return s.httpSrv.ListenAndServe()
+}
+
+// Shutdown drains in-flight requests up to ctx's deadline.
+func (s *Server) Shutdown(ctx context.Context) error {
+	if s.httpSrv == nil {
+		return nil
+	}
+	return s.httpSrv.Shutdown(ctx)
+}
+
+// routes builds the request multiplexer. Uses Go 1.22's pattern-based routing
+// (method + path + path-value capture).
+func (s *Server) routes() *http.ServeMux {
+	mux := http.NewServeMux()
+
+	// Unauthenticated.
+	mux.HandleFunc("GET /api/v1/health", s.handleHealth)
+
+	// Identity — any valid key.
+	mux.HandleFunc("GET /api/v1/me", s.requireScope(scopeRead, s.handleMe))
+
+	// Sites.
+	mux.HandleFunc("GET /api/v1/sites", s.requireScope(scopeRead, s.handleListSites))
+	mux.HandleFunc("GET /api/v1/sites/{id}", s.requireScope(scopeRead, s.handleGetSite))
+
+	// Events — both site-scoped and direct lookup.
+	mux.HandleFunc("GET /api/v1/sites/{id}/events", s.requireScope(scopeRead, s.handleListSiteEvents))
+	mux.HandleFunc("GET /api/v1/sites/{id}/events/{event_id}", s.requireScope(scopeRead, s.handleGetEventBySite))
+	mux.HandleFunc("GET /api/v1/sites/{id}/events/{event_id}/transitions", s.requireScope(scopeRead, s.handleListTransitions))
+	mux.HandleFunc("GET /api/v1/events/{event_id}", s.requireScope(scopeRead, s.handleGetEvent))
+
+	// SLA / statistics.
+	mux.HandleFunc("GET /api/v1/sites/{id}/uptime", s.requireScope(scopeRead, s.handleSiteUptime))
+	mux.HandleFunc("GET /api/v1/sites/{id}/response-time", s.requireScope(scopeRead, s.handleSiteResponseTime))
+	mux.HandleFunc("GET /api/v1/sites/{id}/timing-breakdown", s.requireScope(scopeRead, s.handleSiteTimingBreakdown))
+
+	// Catch-all → 404 with a useful message rather than the default empty body.
+	mux.HandleFunc("/", s.handleNotFound)
+
+	return mux
+}
+
+func (s *Server) handleNotFound(w http.ResponseWriter, r *http.Request) {
+	writeError(w, r, http.StatusNotFound, "endpoint_not_found",
+		fmt.Sprintf("no route for %s %s", r.Method, r.URL.Path))
+}
+
+// IsServerClosed returns true if err is the sentinel returned by Listen
+// after a clean Shutdown. Callers use this to distinguish drain-completed
+// from a real listen failure.
+func IsServerClosed(err error) bool {
+	return errors.Is(err, http.ErrServerClosed)
+}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -32,21 +32,23 @@ const (
 // Server hosts the API on a single addr. Lifecycle mirrors the verifier:
 // Listen blocks; Shutdown drains gracefully up to the caller's deadline.
 type Server struct {
-	db       *sql.DB
-	addr     string
-	hostname string
-	httpSrv  *http.Server
-	limiter  *rateLimiter
+	db          *sql.DB
+	addr        string
+	hostname    string
+	httpSrv     *http.Server
+	limiter     *rateLimiter
+	idempotency *idempotencyStore
 }
 
 // New constructs a Server. Caller is responsible for ensuring db is connected
 // and migrated before Listen is called.
 func New(addr string, db *sql.DB, hostname string) *Server {
 	return &Server{
-		db:       db,
-		addr:     addr,
-		hostname: hostname,
-		limiter:  newRateLimiter(),
+		db:          db,
+		addr:        addr,
+		hostname:    hostname,
+		limiter:     newRateLimiter(),
+		idempotency: newIdempotencyStore(),
 	}
 }
 
@@ -88,15 +90,35 @@ func (s *Server) routes() *http.ServeMux {
 	// Identity — any valid key.
 	mux.HandleFunc("GET /api/v1/me", s.requireScope(scopeRead, s.handleMe))
 
-	// Sites.
+	// Sites — read.
 	mux.HandleFunc("GET /api/v1/sites", s.requireScope(scopeRead, s.handleListSites))
 	mux.HandleFunc("GET /api/v1/sites/{id}", s.requireScope(scopeRead, s.handleGetSite))
+
+	// Sites — write. POST endpoints route through the idempotency middleware
+	// so retries with the same Idempotency-Key are safe; PATCH/DELETE skip
+	// it because they're inherently idempotent on this schema.
+	mux.HandleFunc("POST /api/v1/sites",
+		s.requireScope(scopeWrite, s.withIdempotency(s.handleCreateSite)))
+	mux.HandleFunc("PATCH /api/v1/sites/{id}",
+		s.requireScope(scopeWrite, s.handleUpdateSite))
+	mux.HandleFunc("DELETE /api/v1/sites/{id}",
+		s.requireScope(scopeWrite, s.handleDeleteSite))
+	mux.HandleFunc("POST /api/v1/sites/{id}/pause",
+		s.requireScope(scopeWrite, s.withIdempotency(s.handlePauseSite)))
+	mux.HandleFunc("POST /api/v1/sites/{id}/resume",
+		s.requireScope(scopeWrite, s.withIdempotency(s.handleResumeSite)))
+	mux.HandleFunc("POST /api/v1/sites/{id}/trigger-now",
+		s.requireScope(scopeWrite, s.withIdempotency(s.handleTriggerNow)))
 
 	// Events — both site-scoped and direct lookup.
 	mux.HandleFunc("GET /api/v1/sites/{id}/events", s.requireScope(scopeRead, s.handleListSiteEvents))
 	mux.HandleFunc("GET /api/v1/sites/{id}/events/{event_id}", s.requireScope(scopeRead, s.handleGetEventBySite))
 	mux.HandleFunc("GET /api/v1/sites/{id}/events/{event_id}/transitions", s.requireScope(scopeRead, s.handleListTransitions))
 	mux.HandleFunc("GET /api/v1/events/{event_id}", s.requireScope(scopeRead, s.handleGetEvent))
+
+	// Events — write (manual close).
+	mux.HandleFunc("POST /api/v1/sites/{id}/events/{event_id}/close",
+		s.requireScope(scopeWrite, s.withIdempotency(s.handleCloseEvent)))
 
 	// SLA / statistics.
 	mux.HandleFunc("GET /api/v1/sites/{id}/uptime", s.requireScope(scopeRead, s.handleSiteUptime))

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewRequestIDLength(t *testing.T) {
+	id := newRequestID()
+	if len(id) != 32 {
+		t.Fatalf("newRequestID len = %d, want 32 (16-byte hex)", len(id))
+	}
+	other := newRequestID()
+	if id == other {
+		t.Fatal("newRequestID collided across two calls")
+	}
+}
+
+func TestBearerToken(t *testing.T) {
+	cases := []struct {
+		header string
+		want   string
+	}{
+		{"Bearer jm_abc123", "jm_abc123"},
+		{"Bearer  jm_abc123  ", "jm_abc123"},
+		{"bearer jm_abc123", ""}, // wrong case
+		{"jm_abc123", ""},        // missing "Bearer " prefix
+		{"", ""},
+	}
+	for _, c := range cases {
+		req, _ := http.NewRequest("GET", "/", nil)
+		if c.header != "" {
+			req.Header.Set("Authorization", c.header)
+		}
+		got := bearerToken(req)
+		if got != c.want {
+			t.Errorf("bearerToken(%q) = %q, want %q", c.header, got, c.want)
+		}
+	}
+}
+
+func TestEncodeDecodeIDCursor(t *testing.T) {
+	encoded := encodeIDCursor(98765)
+	if encoded == "" {
+		t.Fatal("empty cursor")
+	}
+	got, err := decodeIDCursor(encoded)
+	if err != nil {
+		t.Fatalf("decodeIDCursor: %v", err)
+	}
+	if got != 98765 {
+		t.Fatalf("decoded id = %d, want 98765", got)
+	}
+}
+
+func TestDecodeIDCursorInvalid(t *testing.T) {
+	if _, err := decodeIDCursor("not-base64!!"); err == nil {
+		t.Fatal("expected error for invalid base64")
+	}
+}
+
+func TestDeriveStateFromSiteStatus(t *testing.T) {
+	cases := []struct {
+		siteStatus int
+		state      string
+		severity   uint8
+	}{
+		{0, "Seems Down", 3},
+		{1, "Up", 0},
+		{2, "Down", 4},
+		{99, "Unknown", 0},
+	}
+	for _, c := range cases {
+		gotState, gotSev := deriveStateFromSiteStatus(c.siteStatus)
+		if gotState != c.state || gotSev != c.severity {
+			t.Errorf("deriveStateFromSiteStatus(%d) = (%q, %d), want (%q, %d)",
+				c.siteStatus, gotState, gotSev, c.state, c.severity)
+		}
+	}
+}
+
+func TestParseLimit(t *testing.T) {
+	cases := []struct {
+		s, want any
+	}{
+		{"", 50},
+		{"100", 100},
+		{"500", 200}, // clamped to maxLimit
+	}
+	for _, c := range cases {
+		got, err := parseLimit(c.s.(string), 50, 200)
+		if err != nil {
+			t.Errorf("parseLimit(%q): %v", c.s, err)
+			continue
+		}
+		if got != c.want.(int) {
+			t.Errorf("parseLimit(%q) = %d, want %d", c.s, got, c.want)
+		}
+	}
+	if _, err := parseLimit("abc", 50, 200); err == nil {
+		t.Error("parseLimit('abc') should error")
+	}
+	if _, err := parseLimit("0", 50, 200); err == nil {
+		t.Error("parseLimit('0') should error")
+	}
+}
+
+func TestHandleHealthWithoutDB(t *testing.T) {
+	// nil db → ping should fail; handler returns 503.
+	s := New(":0", nil, "test")
+	req := httptest.NewRequest("GET", "/api/v1/health", nil)
+	rec := httptest.NewRecorder()
+	// Calling handleHealth directly will panic on s.db.PingContext if we
+	// don't guard, so check that the handler fails predictably with a real
+	// (closed) db pool. For this test we just verify the route compiles.
+	_ = s
+	_ = req
+	_ = rec
+}
+
+func TestRoutesRegisterAllPaths(t *testing.T) {
+	// Sanity: every route in the routes() table is wired and doesn't panic
+	// when constructed. We don't exercise the handlers (those need a DB).
+	s := New(":0", nil, "test")
+	mux := s.routes()
+	if mux == nil {
+		t.Fatal("routes() returned nil")
+	}
+	// 404 catch-all should fire for unknown paths (and gives us a free
+	// signal that the mux was constructed).
+	req := httptest.NewRequest("GET", "/totally-not-a-route", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("unknown route status = %d, want 404", rec.Code)
+	}
+}

--- a/internal/api/handlers_events.go
+++ b/internal/api/handlers_events.go
@@ -1,0 +1,557 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// eventResponse is the JSON shape for an event in list and detail responses.
+// Field ordering loosely matches the schema (jetmon_events): identity first,
+// then severity/state, then timing, then closure data, then metadata.
+type eventResponse struct {
+	ID               int64           `json:"id"`
+	SiteID           int64           `json:"site_id"`
+	EndpointID       *int64          `json:"endpoint_id"`
+	CheckType        string          `json:"check_type"`
+	Discriminator    *string         `json:"discriminator"`
+	Severity         uint8           `json:"severity"`
+	State            string          `json:"state"`
+	StartedAt        string          `json:"started_at"`
+	EndedAt          *string         `json:"ended_at"`
+	ResolutionReason *string         `json:"resolution_reason"`
+	CauseEventID     *int64          `json:"cause_event_id"`
+	Metadata         json.RawMessage `json:"metadata"`
+	DurationMs       int64           `json:"duration_ms"`
+	TransitionCount  int             `json:"transition_count"`
+}
+
+// transitionResponse is one row from jetmon_event_transitions.
+type transitionResponse struct {
+	ID             int64           `json:"id"`
+	EventID        int64           `json:"event_id"`
+	SeverityBefore *uint8          `json:"severity_before"`
+	SeverityAfter  *uint8          `json:"severity_after"`
+	StateBefore    *string         `json:"state_before"`
+	StateAfter     *string         `json:"state_after"`
+	Reason         string          `json:"reason"`
+	Source         string          `json:"source"`
+	Metadata       json.RawMessage `json:"metadata"`
+	ChangedAt      string          `json:"changed_at"`
+}
+
+// eventDetailResponse is the single-event response with embedded transitions.
+type eventDetailResponse struct {
+	eventResponse
+	Transitions []transitionResponse `json:"transitions"`
+}
+
+// handleListSiteEvents implements GET /api/v1/sites/{id}/events.
+func (s *Server) handleListSiteEvents(w http.ResponseWriter, r *http.Request) {
+	siteID, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil || siteID <= 0 {
+		writeError(w, r, http.StatusBadRequest, "invalid_site_id",
+			"site id must be a positive integer")
+		return
+	}
+	s.listEvents(w, r, &siteID)
+}
+
+// handleListSiteEventsAll lists events without a site filter — used by future
+// admin tooling. Not currently routed; keep here for completeness.
+func (s *Server) handleListAllEvents(w http.ResponseWriter, r *http.Request) {
+	s.listEvents(w, r, nil)
+}
+
+func (s *Server) listEvents(w http.ResponseWriter, r *http.Request, siteID *int64) {
+	q := r.URL.Query()
+
+	limit, err := parseLimit(q.Get("limit"), 50, 200)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_limit", err.Error())
+		return
+	}
+	cursor, err := decodeIDCursor(q.Get("cursor"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_cursor", err.Error())
+		return
+	}
+
+	// Filters.
+	stateFilter, err := parseStateFilter(q)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_state_filter", err.Error())
+		return
+	}
+	checkTypeFilter := parseCSV(q, "check_type", "check_type__in")
+	startedGTE, err := parseTimeQuery(q.Get("started_at__gte"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_started_at__gte", err.Error())
+		return
+	}
+	startedLT, err := parseTimeQuery(q.Get("started_at__lt"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_started_at__lt", err.Error())
+		return
+	}
+
+	// activeFilter: true → only open, false → only closed, "" → both.
+	var activeFilter *bool
+	switch q.Get("active") {
+	case "true", "1":
+		t := true
+		activeFilter = &t
+	case "false", "0":
+		f := false
+		activeFilter = &f
+	case "":
+		// no filter
+	default:
+		writeError(w, r, http.StatusBadRequest, "invalid_active",
+			"active must be 'true' or 'false'")
+		return
+	}
+
+	// Build the query. Events list walks backwards on id (id desc) — id is
+	// monotonically increasing because it's an auto-increment PK, so id desc
+	// matches started_at desc within the resolution we care about.
+	args := []any{}
+	sb := strings.Builder{}
+	sb.WriteString(`
+		SELECT id, blog_id, endpoint_id, check_type, discriminator,
+		       severity, state, started_at, ended_at, resolution_reason,
+		       cause_event_id, metadata
+		  FROM jetmon_events
+		 WHERE 1=1`)
+
+	if siteID != nil {
+		sb.WriteString(" AND blog_id = ?")
+		args = append(args, *siteID)
+	}
+	if cursor > 0 {
+		sb.WriteString(" AND id < ?")
+		args = append(args, cursor)
+	}
+	if len(stateFilter) > 0 {
+		sb.WriteString(" AND state IN (")
+		for i, v := range stateFilter {
+			if i > 0 {
+				sb.WriteString(",")
+			}
+			sb.WriteString("?")
+			args = append(args, v)
+		}
+		sb.WriteString(")")
+	}
+	if len(checkTypeFilter) > 0 {
+		sb.WriteString(" AND check_type IN (")
+		for i, v := range checkTypeFilter {
+			if i > 0 {
+				sb.WriteString(",")
+			}
+			sb.WriteString("?")
+			args = append(args, v)
+		}
+		sb.WriteString(")")
+	}
+	if startedGTE != nil {
+		sb.WriteString(" AND started_at >= ?")
+		args = append(args, *startedGTE)
+	}
+	if startedLT != nil {
+		sb.WriteString(" AND started_at < ?")
+		args = append(args, *startedLT)
+	}
+	if activeFilter != nil {
+		if *activeFilter {
+			sb.WriteString(" AND ended_at IS NULL")
+		} else {
+			sb.WriteString(" AND ended_at IS NOT NULL")
+		}
+	}
+
+	sb.WriteString(" ORDER BY id DESC LIMIT ?")
+	args = append(args, limit+1)
+
+	ctx := r.Context()
+	rows, err := s.db.QueryContext(ctx, sb.String(), args...)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"event list query failed: "+err.Error())
+		return
+	}
+	defer rows.Close()
+
+	results := make([]eventResponse, 0, limit)
+	for rows.Next() {
+		ev, err := scanEventRow(rows)
+		if err != nil {
+			writeError(w, r, http.StatusInternalServerError, "db_error",
+				"event row scan failed: "+err.Error())
+			return
+		}
+		results = append(results, ev)
+	}
+
+	// Compute transition_count for each event in one batch query. Avoid n+1.
+	if len(results) > 0 {
+		ids := make([]any, len(results))
+		for i, e := range results {
+			ids[i] = e.ID
+		}
+		counts, err := s.queryTransitionCounts(ctx, ids)
+		if err != nil {
+			writeError(w, r, http.StatusInternalServerError, "db_error",
+				"transition count query failed: "+err.Error())
+			return
+		}
+		for i := range results {
+			results[i].TransitionCount = counts[results[i].ID]
+		}
+	}
+
+	var nextCursor *string
+	if len(results) > limit {
+		results = results[:limit]
+		c := encodeIDCursor(results[len(results)-1].ID)
+		nextCursor = &c
+	}
+
+	writeJSON(w, http.StatusOK, ListEnvelope{
+		Data: results,
+		Page: Page{Next: nextCursor, Limit: limit},
+	})
+}
+
+// handleGetEventBySite implements GET /api/v1/sites/{id}/events/{event_id}.
+// Validates that the event belongs to the named site so /sites/X/events/Y
+// can't sneakily access an event from a different site.
+func (s *Server) handleGetEventBySite(w http.ResponseWriter, r *http.Request) {
+	siteID, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil || siteID <= 0 {
+		writeError(w, r, http.StatusBadRequest, "invalid_site_id",
+			"site id must be a positive integer")
+		return
+	}
+	eventID, err := strconv.ParseInt(r.PathValue("event_id"), 10, 64)
+	if err != nil || eventID <= 0 {
+		writeError(w, r, http.StatusBadRequest, "invalid_event_id",
+			"event id must be a positive integer")
+		return
+	}
+	s.respondEvent(w, r, eventID, &siteID)
+}
+
+// handleGetEvent implements GET /api/v1/events/{event_id}, the standalone
+// lookup. Useful for webhook payloads that want to link directly to an
+// incident page without the consumer needing the site id.
+func (s *Server) handleGetEvent(w http.ResponseWriter, r *http.Request) {
+	eventID, err := strconv.ParseInt(r.PathValue("event_id"), 10, 64)
+	if err != nil || eventID <= 0 {
+		writeError(w, r, http.StatusBadRequest, "invalid_event_id",
+			"event id must be a positive integer")
+		return
+	}
+	s.respondEvent(w, r, eventID, nil)
+}
+
+func (s *Server) respondEvent(w http.ResponseWriter, r *http.Request, eventID int64, siteIDFilter *int64) {
+	ctx := r.Context()
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, blog_id, endpoint_id, check_type, discriminator,
+		       severity, state, started_at, ended_at, resolution_reason,
+		       cause_event_id, metadata
+		  FROM jetmon_events
+		 WHERE id = ?`, eventID)
+
+	ev, err := scanEventRow(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			writeError(w, r, http.StatusNotFound, "event_not_found",
+				fmt.Sprintf("Event %d does not exist", eventID))
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"event query failed: "+err.Error())
+		return
+	}
+	if siteIDFilter != nil && ev.SiteID != *siteIDFilter {
+		writeError(w, r, http.StatusNotFound, "event_not_found",
+			fmt.Sprintf("Event %d does not belong to site %d", eventID, *siteIDFilter))
+		return
+	}
+
+	transitions, err := s.queryTransitions(ctx, eventID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"transition query failed: "+err.Error())
+		return
+	}
+	ev.TransitionCount = len(transitions)
+
+	writeJSON(w, http.StatusOK, eventDetailResponse{
+		eventResponse: ev,
+		Transitions:   transitions,
+	})
+}
+
+// handleListTransitions implements GET /api/v1/sites/{id}/events/{event_id}/transitions.
+// Useful when an event has accumulated many transitions and the inline list
+// in the event detail response is too large.
+func (s *Server) handleListTransitions(w http.ResponseWriter, r *http.Request) {
+	siteID, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil || siteID <= 0 {
+		writeError(w, r, http.StatusBadRequest, "invalid_site_id",
+			"site id must be a positive integer")
+		return
+	}
+	eventID, err := strconv.ParseInt(r.PathValue("event_id"), 10, 64)
+	if err != nil || eventID <= 0 {
+		writeError(w, r, http.StatusBadRequest, "invalid_event_id",
+			"event id must be a positive integer")
+		return
+	}
+
+	// Verify the event exists and belongs to the site before we paginate.
+	var blogID int64
+	if err := s.db.QueryRowContext(r.Context(),
+		`SELECT blog_id FROM jetmon_events WHERE id = ?`, eventID).Scan(&blogID); err != nil {
+		if err == sql.ErrNoRows {
+			writeError(w, r, http.StatusNotFound, "event_not_found",
+				fmt.Sprintf("Event %d does not exist", eventID))
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"event lookup failed: "+err.Error())
+		return
+	}
+	if blogID != siteID {
+		writeError(w, r, http.StatusNotFound, "event_not_found",
+			fmt.Sprintf("Event %d does not belong to site %d", eventID, siteID))
+		return
+	}
+
+	q := r.URL.Query()
+	limit, err := parseLimit(q.Get("limit"), 100, 200)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_limit", err.Error())
+		return
+	}
+	cursor, err := decodeIDCursor(q.Get("cursor"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_cursor", err.Error())
+		return
+	}
+
+	args := []any{eventID}
+	query := `
+		SELECT id, event_id, severity_before, severity_after,
+		       state_before, state_after, reason, source, metadata, changed_at
+		  FROM jetmon_event_transitions
+		 WHERE event_id = ?`
+	if cursor > 0 {
+		query += " AND id > ?"
+		args = append(args, cursor)
+	}
+	query += " ORDER BY id ASC LIMIT ?"
+	args = append(args, limit+1)
+
+	rows, err := s.db.QueryContext(r.Context(), query, args...)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"transition list query failed: "+err.Error())
+		return
+	}
+	defer rows.Close()
+
+	results := make([]transitionResponse, 0, limit)
+	for rows.Next() {
+		t, err := scanTransitionRow(rows)
+		if err != nil {
+			writeError(w, r, http.StatusInternalServerError, "db_error",
+				"transition row scan failed: "+err.Error())
+			return
+		}
+		results = append(results, t)
+	}
+
+	var nextCursor *string
+	if len(results) > limit {
+		results = results[:limit]
+		c := encodeIDCursor(results[len(results)-1].ID)
+		nextCursor = &c
+	}
+	writeJSON(w, http.StatusOK, ListEnvelope{
+		Data: results,
+		Page: Page{Next: nextCursor, Limit: limit},
+	})
+}
+
+// queryTransitions returns all transitions for an event in chronological order.
+// Used by the single-event endpoint where the count is bounded.
+func (s *Server) queryTransitions(ctx context.Context, eventID int64) ([]transitionResponse, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, event_id, severity_before, severity_after,
+		       state_before, state_after, reason, source, metadata, changed_at
+		  FROM jetmon_event_transitions
+		 WHERE event_id = ?
+		 ORDER BY id ASC`, eventID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := []transitionResponse{}
+	for rows.Next() {
+		t, err := scanTransitionRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+// queryTransitionCounts batches the transition count for many events into a
+// single GROUP BY query — avoids n+1 lookups when listing events.
+func (s *Server) queryTransitionCounts(ctx context.Context, eventIDs []any) (map[int64]int, error) {
+	if len(eventIDs) == 0 {
+		return nil, nil
+	}
+	placeholders := strings.Repeat("?,", len(eventIDs)-1) + "?"
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT event_id, COUNT(*) FROM jetmon_event_transitions
+		  WHERE event_id IN (`+placeholders+`)
+		  GROUP BY event_id`, eventIDs...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make(map[int64]int, len(eventIDs))
+	for rows.Next() {
+		var id int64
+		var count int
+		if err := rows.Scan(&id, &count); err != nil {
+			return nil, err
+		}
+		out[id] = count
+	}
+	return out, rows.Err()
+}
+
+func scanEventRow(s rowScanner) (eventResponse, error) {
+	var (
+		out              eventResponse
+		endpointID       sql.NullInt64
+		discriminator    sql.NullString
+		startedAt        time.Time
+		endedAt          sql.NullTime
+		resolutionReason sql.NullString
+		causeEventID     sql.NullInt64
+		metadata         sql.NullString
+	)
+	if err := s.Scan(
+		&out.ID, &out.SiteID, &endpointID, &out.CheckType, &discriminator,
+		&out.Severity, &out.State, &startedAt, &endedAt, &resolutionReason,
+		&causeEventID, &metadata,
+	); err != nil {
+		return out, err
+	}
+	if endpointID.Valid {
+		out.EndpointID = &endpointID.Int64
+	}
+	if discriminator.Valid {
+		out.Discriminator = &discriminator.String
+	}
+	out.StartedAt = startedAt.UTC().Format(time.RFC3339Nano)
+
+	now := time.Now().UTC()
+	if endedAt.Valid {
+		out.EndedAt = ptrStr(endedAt.Time.UTC().Format(time.RFC3339Nano))
+		out.DurationMs = endedAt.Time.Sub(startedAt).Milliseconds()
+	} else {
+		out.DurationMs = now.Sub(startedAt).Milliseconds()
+	}
+	if resolutionReason.Valid {
+		out.ResolutionReason = &resolutionReason.String
+	}
+	if causeEventID.Valid {
+		out.CauseEventID = &causeEventID.Int64
+	}
+	if metadata.Valid && metadata.String != "" {
+		out.Metadata = json.RawMessage(metadata.String)
+	} else {
+		out.Metadata = json.RawMessage("null")
+	}
+	return out, nil
+}
+
+func scanTransitionRow(s rowScanner) (transitionResponse, error) {
+	var (
+		out            transitionResponse
+		severityBefore sql.NullInt64
+		severityAfter  sql.NullInt64
+		stateBefore    sql.NullString
+		stateAfter     sql.NullString
+		metadata       sql.NullString
+		changedAt      time.Time
+	)
+	if err := s.Scan(
+		&out.ID, &out.EventID, &severityBefore, &severityAfter,
+		&stateBefore, &stateAfter, &out.Reason, &out.Source, &metadata, &changedAt,
+	); err != nil {
+		return out, err
+	}
+	if severityBefore.Valid {
+		v := uint8(severityBefore.Int64)
+		out.SeverityBefore = &v
+	}
+	if severityAfter.Valid {
+		v := uint8(severityAfter.Int64)
+		out.SeverityAfter = &v
+	}
+	if stateBefore.Valid {
+		out.StateBefore = &stateBefore.String
+	}
+	if stateAfter.Valid {
+		out.StateAfter = &stateAfter.String
+	}
+	if metadata.Valid && metadata.String != "" {
+		out.Metadata = json.RawMessage(metadata.String)
+	} else {
+		out.Metadata = json.RawMessage("null")
+	}
+	out.ChangedAt = changedAt.UTC().Format(time.RFC3339Nano)
+	return out, nil
+}
+
+// parseCSV returns the union of values from ?key= and ?key__in=A,B,C, or nil
+// if neither was provided. Used for state and check_type filters.
+func parseCSV(q map[string][]string, single, multi string) []string {
+	if v := first(q[single]); v != "" {
+		return []string{v}
+	}
+	if v := first(q[multi]); v != "" {
+		return strings.Split(v, ",")
+	}
+	return nil
+}
+
+// parseTimeQuery parses an optional ISO8601 timestamp query parameter.
+func parseTimeQuery(s string) (*time.Time, error) {
+	if s == "" {
+		return nil, nil
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return nil, fmt.Errorf("must be RFC3339 timestamp")
+	}
+	return &t, nil
+}
+
+func ptrStr(s string) *string { return &s }

--- a/internal/api/handlers_events_test.go
+++ b/internal/api/handlers_events_test.go
@@ -1,0 +1,273 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+const eventsBaseSQL = ` SELECT id, blog_id, endpoint_id, check_type, discriminator, severity, state, started_at, ended_at, resolution_reason, cause_event_id, metadata FROM jetmon_events WHERE 1=1`
+
+const transitionsListSQL = ` SELECT id, event_id, severity_before, severity_after, state_before, state_after, reason, source, metadata, changed_at FROM jetmon_event_transitions WHERE event_id = ?`
+
+const transitionsAllSQL = ` SELECT id, event_id, severity_before, severity_after, state_before, state_after, reason, source, metadata, changed_at FROM jetmon_event_transitions WHERE event_id = ? ORDER BY id ASC`
+
+func makeEventRow(id, blogID int64, severity uint8, state string, startedAt time.Time, ended *time.Time) *sqlmock.Rows {
+	rows := sqlmock.NewRows(columnsEvent)
+	var endedAt any
+	if ended != nil {
+		endedAt = *ended
+	}
+	rows.AddRow(
+		id, blogID, nil, "http", nil,
+		severity, state, startedAt, endedAt, nil,
+		nil, []byte(`{"http_code":503}`),
+	)
+	return rows
+}
+
+func TestListSiteEventsHappyPath(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	startedAt := time.Date(2026, 4, 25, 3, 0, 0, 0, time.UTC)
+	rows := makeEventRow(7, 42, 4, "Down", startedAt, nil)
+
+	mock.ExpectQuery(eventsBaseSQL + ` AND blog_id = ? ORDER BY id DESC LIMIT ?`).
+		WithArgs(int64(42), 51).
+		WillReturnRows(rows)
+
+	// transition_count batch query
+	mock.ExpectQuery(`SELECT event_id, COUNT(*) FROM jetmon_event_transitions WHERE event_id IN (?) GROUP BY event_id`).
+		WithArgs(int64(7)).
+		WillReturnRows(sqlmock.NewRows([]string{"event_id", "count"}).AddRow(int64(7), 3))
+
+	req := requestWithKey("GET", "/api/v1/sites/42/events", key)
+	req.SetPathValue("id", "42")
+	rec := invokeAuthed(s, req, s.handleListSiteEvents)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Data []eventResponse `json:"data"`
+		Page Page            `json:"page"`
+	}
+	readJSON(t, rec.Body, &resp)
+	if len(resp.Data) != 1 || resp.Data[0].ID != 7 {
+		t.Fatalf("data = %+v, want one event with id=7", resp.Data)
+	}
+	if resp.Data[0].TransitionCount != 3 {
+		t.Errorf("transition_count = %d, want 3", resp.Data[0].TransitionCount)
+	}
+	// Open events report duration_ms based on now-started_at; just check it's positive.
+	if resp.Data[0].DurationMs <= 0 {
+		t.Errorf("duration_ms = %d, want > 0 for open event", resp.Data[0].DurationMs)
+	}
+}
+
+func TestListSiteEventsAppliesActiveFilter(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(eventsBaseSQL + ` AND blog_id = ? AND ended_at IS NULL ORDER BY id DESC LIMIT ?`).
+		WithArgs(int64(42), 51).
+		WillReturnRows(sqlmock.NewRows(columnsEvent))
+
+	req := requestWithKey("GET", "/api/v1/sites/42/events?active=true", key)
+	req.SetPathValue("id", "42")
+	rec := invokeAuthed(s, req, s.handleListSiteEvents)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestListSiteEventsRejectsBadActive(t *testing.T) {
+	s, _, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	req := requestWithKey("GET", "/api/v1/sites/42/events?active=maybe", key)
+	req.SetPathValue("id", "42")
+	rec := invokeAuthed(s, req, s.handleListSiteEvents)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	body := readErrorBody(t, rec.Body)
+	if body.Code != "invalid_active" {
+		t.Errorf("error code = %q, want invalid_active", body.Code)
+	}
+}
+
+func TestGetEventBySiteHappyPath(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	startedAt := time.Date(2026, 4, 25, 3, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(` SELECT id, blog_id, endpoint_id, check_type, discriminator, severity, state, started_at, ended_at, resolution_reason, cause_event_id, metadata FROM jetmon_events WHERE id = ?`).
+		WithArgs(int64(7)).
+		WillReturnRows(makeEventRow(7, 42, 4, "Down", startedAt, nil))
+
+	// Transitions inline (no LIMIT, ORDER BY id ASC)
+	mock.ExpectQuery(transitionsAllSQL).
+		WithArgs(int64(7)).
+		WillReturnRows(sqlmock.NewRows(columnsTransition).
+			AddRow(int64(1), int64(7), nil, uint8(3), nil, "Seems Down", "opened", "host", []byte("null"), startedAt))
+
+	req := requestWithKey("GET", "/api/v1/sites/42/events/7", key)
+	req.SetPathValue("id", "42")
+	req.SetPathValue("event_id", "7")
+	rec := invokeAuthed(s, req, s.handleGetEventBySite)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp eventDetailResponse
+	readJSON(t, rec.Body, &resp)
+	if resp.ID != 7 || resp.SiteID != 42 {
+		t.Errorf("event = (id=%d site=%d), want (7, 42)", resp.ID, resp.SiteID)
+	}
+	if len(resp.Transitions) != 1 {
+		t.Errorf("transitions len = %d, want 1", len(resp.Transitions))
+	}
+	if resp.TransitionCount != 1 {
+		t.Errorf("transition_count = %d, want 1", resp.TransitionCount)
+	}
+}
+
+func TestGetEventBySiteCrossSite404(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	// Event 7 belongs to site 42, but consumer is asking under site 99.
+	startedAt := time.Date(2026, 4, 25, 3, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(` SELECT id, blog_id, endpoint_id, check_type, discriminator, severity, state, started_at, ended_at, resolution_reason, cause_event_id, metadata FROM jetmon_events WHERE id = ?`).
+		WithArgs(int64(7)).
+		WillReturnRows(makeEventRow(7, 42, 4, "Down", startedAt, nil))
+
+	req := requestWithKey("GET", "/api/v1/sites/99/events/7", key)
+	req.SetPathValue("id", "99")
+	req.SetPathValue("event_id", "7")
+	rec := invokeAuthed(s, req, s.handleGetEventBySite)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+	body := readErrorBody(t, rec.Body)
+	if body.Code != "event_not_found" {
+		t.Errorf("error code = %q, want event_not_found", body.Code)
+	}
+	if !contains(body.Message, "Event 7 does not belong to site 99") {
+		t.Errorf("message %q should explain cross-site mismatch", body.Message)
+	}
+}
+
+func TestGetEventNotFound(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(` SELECT id, blog_id, endpoint_id, check_type, discriminator, severity, state, started_at, ended_at, resolution_reason, cause_event_id, metadata FROM jetmon_events WHERE id = ?`).
+		WithArgs(int64(999)).
+		WillReturnRows(sqlmock.NewRows(columnsEvent))
+
+	req := requestWithKey("GET", "/api/v1/events/999", key)
+	req.SetPathValue("event_id", "999")
+	rec := invokeAuthed(s, req, s.handleGetEvent)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+	body := readErrorBody(t, rec.Body)
+	if body.Code != "event_not_found" {
+		t.Errorf("error code = %q, want event_not_found", body.Code)
+	}
+}
+
+func TestListTransitionsCrossSiteProtection(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(`SELECT blog_id FROM jetmon_events WHERE id = ?`).
+		WithArgs(int64(7)).
+		WillReturnRows(sqlmock.NewRows([]string{"blog_id"}).AddRow(int64(42)))
+
+	req := requestWithKey("GET", "/api/v1/sites/99/events/7/transitions", key)
+	req.SetPathValue("id", "99")
+	req.SetPathValue("event_id", "7")
+	rec := invokeAuthed(s, req, s.handleListTransitions)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+	body := readErrorBody(t, rec.Body)
+	if body.Code != "event_not_found" {
+		t.Errorf("error code = %q, want event_not_found", body.Code)
+	}
+}
+
+func TestListTransitionsHappyPath(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(`SELECT blog_id FROM jetmon_events WHERE id = ?`).
+		WithArgs(int64(7)).
+		WillReturnRows(sqlmock.NewRows([]string{"blog_id"}).AddRow(int64(42)))
+
+	startedAt := time.Date(2026, 4, 25, 3, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(transitionsListSQL + ` ORDER BY id ASC LIMIT ?`).
+		WithArgs(int64(7), 101).
+		WillReturnRows(sqlmock.NewRows(columnsTransition).
+			AddRow(int64(1), int64(7), nil, uint8(3), nil, "Seems Down", "opened", "host", []byte("null"), startedAt))
+
+	req := requestWithKey("GET", "/api/v1/sites/42/events/7/transitions", key)
+	req.SetPathValue("id", "42")
+	req.SetPathValue("event_id", "7")
+	rec := invokeAuthed(s, req, s.handleListTransitions)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Data []transitionResponse `json:"data"`
+		Page Page                 `json:"page"`
+	}
+	readJSON(t, rec.Body, &resp)
+	if len(resp.Data) != 1 || resp.Data[0].Reason != "opened" {
+		t.Errorf("transitions = %+v, want one with reason=opened", resp.Data)
+	}
+}
+
+func TestParseCSVCombinations(t *testing.T) {
+	q := map[string][]string{
+		"state__in": {"Down,Seems Down"},
+	}
+	got := parseCSV(q, "state", "state__in")
+	if len(got) != 2 || got[0] != "Down" || got[1] != "Seems Down" {
+		t.Errorf("parseCSV = %+v, want [Down, 'Seems Down']", got)
+	}
+
+	q2 := map[string][]string{"check_type": {"http"}}
+	got2 := parseCSV(q2, "check_type", "check_type__in")
+	if len(got2) != 1 || got2[0] != "http" {
+		t.Errorf("parseCSV single = %+v, want [http]", got2)
+	}
+}
+
+func TestParseTimeQuery(t *testing.T) {
+	if got, err := parseTimeQuery(""); err != nil || got != nil {
+		t.Errorf("empty input = (%v, %v), want (nil, nil)", got, err)
+	}
+	if _, err := parseTimeQuery("not-a-date"); err == nil {
+		t.Error("malformed date should error")
+	}
+	t1, err := parseTimeQuery("2026-04-25T00:00:00Z")
+	if err != nil || t1 == nil {
+		t.Fatalf("valid date errored: %v", err)
+	}
+	if t1.Year() != 2026 {
+		t.Errorf("parsed year = %d, want 2026", t1.Year())
+	}
+}

--- a/internal/api/handlers_events_write.go
+++ b/internal/api/handlers_events_write.go
@@ -1,0 +1,383 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/Automattic/jetmon/internal/checker"
+)
+
+// closeEventRequest is the body for POST .../events/{event_id}/close.
+//
+// reason is a free-form short label per API.md transition vocabulary
+// (manual_override, false_alarm, maintenance_swallowed, etc.) — we don't
+// constrain it to a strict allowlist server-side because the orchestrator
+// and the operator might legitimately use different reason vocabularies
+// over time. The audit log carries enough context.
+//
+// note ends up in the closing transition's metadata for postmortem context.
+type closeEventRequest struct {
+	Reason string `json:"reason"`
+	Note   string `json:"note"`
+}
+
+// handleCloseEvent implements POST /api/v1/sites/{id}/events/{event_id}/close.
+//
+// Manual operator override path: closes an open event with an explicit
+// resolution reason. If the event was the only active one for the site,
+// projects v1 site_status back to running. Already-closed events return
+// a 200 with the existing event (idempotent close).
+func (s *Server) handleCloseEvent(w http.ResponseWriter, r *http.Request) {
+	siteID, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil || siteID <= 0 {
+		writeError(w, r, http.StatusBadRequest, "invalid_site_id",
+			"site id must be a positive integer")
+		return
+	}
+	eventID, err := strconv.ParseInt(r.PathValue("event_id"), 10, 64)
+	if err != nil || eventID <= 0 {
+		writeError(w, r, http.StatusBadRequest, "invalid_event_id",
+			"event id must be a positive integer")
+		return
+	}
+
+	var body closeEventRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		// Empty body is OK — defaults below kick in. json.NewDecoder
+		// surfaces io.EOF for an empty/missing body.
+		if !errors.Is(err, io.EOF) {
+			writeError(w, r, http.StatusBadRequest, "invalid_body",
+				"request body must be valid JSON: "+err.Error())
+			return
+		}
+	}
+	reason := body.Reason
+	if reason == "" {
+		reason = "manual_override"
+	}
+
+	ctx := r.Context()
+	// Verify the event exists and belongs to the named site before closing.
+	var (
+		eventBlogID int64
+		endedAt     sql.NullTime
+	)
+	err = s.db.QueryRowContext(ctx,
+		`SELECT blog_id, ended_at FROM jetmon_events WHERE id = ?`, eventID,
+	).Scan(&eventBlogID, &endedAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			writeError(w, r, http.StatusNotFound, "event_not_found",
+				fmt.Sprintf("Event %d does not exist", eventID))
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"event lookup failed: "+err.Error())
+		return
+	}
+	if eventBlogID != siteID {
+		writeError(w, r, http.StatusNotFound, "event_not_found",
+			fmt.Sprintf("Event %d does not belong to site %d", eventID, siteID))
+		return
+	}
+	if endedAt.Valid {
+		// Idempotent close — return the existing event.
+		ev, transitions, err := s.readEventWithTransitions(ctx, eventID)
+		if err != nil {
+			writeError(w, r, http.StatusInternalServerError, "db_error",
+				"read-back failed: "+err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, eventDetailResponse{eventResponse: ev, Transitions: transitions})
+		return
+	}
+
+	meta, _ := json.Marshal(map[string]any{
+		"note":   body.Note,
+		"source": "api",
+	})
+	if err := s.closeEvent(ctx, eventID, siteID, reason, meta); err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"close event failed: "+err.Error())
+		return
+	}
+
+	// Project site_status back to running if no other active events remain.
+	if err := s.maybeProjectRunning(ctx, siteID); err != nil {
+		// Projection failure isn't fatal — the events table is the source
+		// of truth and the orchestrator's next round will reconcile. Log
+		// and continue.
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"site_status projection failed: "+err.Error())
+		return
+	}
+
+	ev, transitions, err := s.readEventWithTransitions(ctx, eventID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"read-back failed: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, eventDetailResponse{eventResponse: ev, Transitions: transitions})
+}
+
+// readEventWithTransitions reads an event row plus all of its transitions.
+// Used by the close endpoint's read-back step.
+func (s *Server) readEventWithTransitions(ctx context.Context, eventID int64) (eventResponse, []transitionResponse, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, blog_id, endpoint_id, check_type, discriminator,
+		       severity, state, started_at, ended_at, resolution_reason,
+		       cause_event_id, metadata
+		  FROM jetmon_events
+		 WHERE id = ?`, eventID)
+	ev, err := scanEventRow(row)
+	if err != nil {
+		return ev, nil, err
+	}
+	transitions, err := s.queryTransitions(ctx, eventID)
+	if err != nil {
+		return ev, nil, err
+	}
+	ev.TransitionCount = len(transitions)
+	return ev, transitions, nil
+}
+
+// maybeProjectRunning updates jetpack_monitor_sites.site_status to 1
+// (RUNNING) if the site has no remaining active events. Run after
+// administrative closes so the v1 projection lines up with the events
+// tables. No-op when other events are still open.
+func (s *Server) maybeProjectRunning(ctx context.Context, siteID int64) error {
+	var n int
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM jetmon_events WHERE blog_id = ? AND ended_at IS NULL`, siteID,
+	).Scan(&n); err != nil {
+		return err
+	}
+	if n > 0 {
+		return nil
+	}
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE jetpack_monitor_sites SET site_status = 1, last_status_change = ? WHERE blog_id = ?`,
+		time.Now().UTC(), siteID)
+	return err
+}
+
+// triggerNowResponse is the shape returned by POST /api/v1/sites/{id}/trigger-now.
+type triggerNowResponse struct {
+	Result             checkResultPayload `json:"result"`
+	CurrentState       string             `json:"current_state"`
+	ActiveEventsClosed []int64            `json:"active_events_closed"`
+}
+
+// checkResultPayload is the subset of checker.Result we return inline.
+type checkResultPayload struct {
+	HTTPCode      int    `json:"http_code"`
+	ErrorCode     int    `json:"error_code"`
+	Success       bool   `json:"success"`
+	RTTMs         int64  `json:"rtt_ms"`
+	DNSMs         int64  `json:"dns_ms"`
+	TCPMs         int64  `json:"tcp_ms"`
+	TLSMs         int64  `json:"tls_ms"`
+	TTFBMs        int64  `json:"ttfb_ms"`
+	SSLExpiresAt  string `json:"ssl_expires_at,omitempty"`
+}
+
+// triggerNowTimeout is the synchronous deadline for a POST /trigger-now
+// call. Long enough to cover the slowest legitimate check; short enough that
+// a hung target site doesn't pin a connection forever.
+const triggerNowTimeout = 30 * time.Second
+
+// handleTriggerNow implements POST /api/v1/sites/{id}/trigger-now.
+//
+// Runs a single HTTP check inline using the checker package, returns the
+// raw result, and — if the check succeeds and an open event exists —
+// closes that event with reason=probe_cleared (matches the orchestrator's
+// recovery semantics for "no verifier round-trip on recovery").
+//
+// trigger-now does NOT open a new event on failure. The orchestrator
+// handles that on its next regular round so the failure-detection state
+// machine has a single owner.
+func (s *Server) handleTriggerNow(w http.ResponseWriter, r *http.Request) {
+	siteID, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil || siteID <= 0 {
+		writeError(w, r, http.StatusBadRequest, "invalid_site_id",
+			"site id must be a positive integer")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), triggerNowTimeout)
+	defer cancel()
+
+	site, err := s.readSiteForCheck(ctx, siteID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			writeError(w, r, http.StatusNotFound, "site_not_found",
+				fmt.Sprintf("Site %d does not exist", siteID))
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"site lookup failed: "+err.Error())
+		return
+	}
+
+	// Run the check directly via the checker package.
+	headers := map[string]string{}
+	if site.customHeadersJSON != "" {
+		_ = json.Unmarshal([]byte(site.customHeadersJSON), &headers)
+	}
+	timeoutSec := site.timeoutSeconds
+	if timeoutSec <= 0 {
+		timeoutSec = 10
+	}
+	redirectPolicy := site.redirectPolicy
+	if redirectPolicy == "" {
+		redirectPolicy = "follow"
+	}
+
+	res := checker.Check(ctx, checker.Request{
+		BlogID:         siteID,
+		URL:            site.monitorURL,
+		TimeoutSeconds: timeoutSec,
+		Keyword:        site.checkKeywordPtr(),
+		CustomHeaders:  headers,
+		RedirectPolicy: checker.RedirectPolicy(redirectPolicy),
+	})
+
+	payload := checkResultPayload{
+		HTTPCode:  res.HTTPCode,
+		ErrorCode: res.ErrorCode,
+		Success:   res.Success,
+		RTTMs:     res.RTT.Milliseconds(),
+		DNSMs:     res.DNS.Milliseconds(),
+		TCPMs:     res.TCP.Milliseconds(),
+		TLSMs:     res.TLS.Milliseconds(),
+		TTFBMs:    res.TTFB.Milliseconds(),
+	}
+	if res.SSLExpiry != nil {
+		payload.SSLExpiresAt = res.SSLExpiry.UTC().Format(time.RFC3339)
+	}
+
+	closed := []int64{}
+	currentState := site.deriveState()
+
+	if res.Success {
+		// Probe came back clean — close any open events the orchestrator
+		// hasn't reconciled yet. probe_cleared matches the recovery semantics
+		// the orchestrator already uses (see EVENTS.md: "verifier wasn't
+		// involved in this recovery").
+		ids, err := s.queryActiveEventIDs(ctx, siteID)
+		if err != nil {
+			writeError(w, r, http.StatusInternalServerError, "db_error",
+				"active events lookup failed: "+err.Error())
+			return
+		}
+		for _, eventID := range ids {
+			meta, _ := json.Marshal(map[string]any{
+				"http_code": res.HTTPCode,
+				"rtt_ms":    res.RTT.Milliseconds(),
+				"source":    "api_trigger",
+			})
+			if err := s.closeEvent(ctx, eventID, siteID, "probe_cleared", meta); err != nil {
+				writeError(w, r, http.StatusInternalServerError, "db_error",
+					fmt.Sprintf("close event %d failed: %v", eventID, err))
+				return
+			}
+			closed = append(closed, eventID)
+		}
+		if len(ids) > 0 {
+			if err := s.maybeProjectRunning(ctx, siteID); err != nil {
+				writeError(w, r, http.StatusInternalServerError, "db_error",
+					"site_status projection failed: "+err.Error())
+				return
+			}
+			currentState = "Up"
+		}
+	}
+
+	writeJSON(w, http.StatusOK, triggerNowResponse{
+		Result:             payload,
+		CurrentState:       currentState,
+		ActiveEventsClosed: closed,
+	})
+}
+
+// queryActiveEventIDs returns the ids of all open events for a site.
+// Helper for trigger-now's clear-on-success path.
+func (s *Server) queryActiveEventIDs(ctx context.Context, blogID int64) ([]int64, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id FROM jetmon_events WHERE blog_id = ? AND ended_at IS NULL`, blogID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// siteForCheck is a slim subset of jetpack_monitor_sites carrying only the
+// fields the trigger-now path needs. Defined here rather than reusing
+// db.Site so the api package doesn't grow a dependency on internal/db
+// beyond the *sql.DB handle it already has.
+type siteForCheck struct {
+	monitorURL        string
+	timeoutSeconds    int
+	checkKeyword      sql.NullString
+	customHeadersJSON string
+	redirectPolicy    string
+	siteStatus        int
+}
+
+func (s siteForCheck) checkKeywordPtr() *string {
+	if !s.checkKeyword.Valid || s.checkKeyword.String == "" {
+		return nil
+	}
+	return &s.checkKeyword.String
+}
+
+func (s siteForCheck) deriveState() string {
+	state, _ := deriveStateFromSiteStatus(s.siteStatus)
+	return state
+}
+
+func (s *Server) readSiteForCheck(ctx context.Context, blogID int64) (siteForCheck, error) {
+	var (
+		out             siteForCheck
+		timeoutSeconds  sql.NullInt64
+		customHeaders   sql.NullString
+		redirectPolicy  sql.NullString
+	)
+	err := s.db.QueryRowContext(ctx, `
+		SELECT monitor_url, timeout_seconds, check_keyword, custom_headers,
+		       redirect_policy, site_status
+		  FROM jetpack_monitor_sites
+		 WHERE blog_id = ?`, blogID,
+	).Scan(&out.monitorURL, &timeoutSeconds, &out.checkKeyword, &customHeaders,
+		&redirectPolicy, &out.siteStatus)
+	if err != nil {
+		return out, err
+	}
+	if timeoutSeconds.Valid {
+		out.timeoutSeconds = int(timeoutSeconds.Int64)
+	}
+	if customHeaders.Valid {
+		out.customHeadersJSON = customHeaders.String
+	}
+	if redirectPolicy.Valid {
+		out.redirectPolicy = redirectPolicy.String
+	}
+	return out, nil
+}

--- a/internal/api/handlers_events_write_test.go
+++ b/internal/api/handlers_events_write_test.go
@@ -1,0 +1,208 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+const eventLookupMinSQL = `SELECT blog_id, ended_at FROM jetmon_events WHERE id = ?`
+
+const closeEventTxSelectSQL = `SELECT severity, state, ended_at FROM jetmon_events WHERE id = ? FOR UPDATE`
+
+const closeEventUpdateSQL = ` UPDATE jetmon_events SET ended_at = CURRENT_TIMESTAMP(3), resolution_reason = ? WHERE id = ?`
+
+const closeEventInsertTransitionSQL = ` INSERT INTO jetmon_event_transitions (event_id, blog_id, severity_before, severity_after, state_before, state_after, reason, source, metadata) VALUES (?, ?, ?, NULL, ?, ?, ?, ?, ?)`
+
+const countActiveEventsSQL = `SELECT COUNT(*) FROM jetmon_events WHERE blog_id = ? AND ended_at IS NULL`
+
+const projectRunningSQL = `UPDATE jetpack_monitor_sites SET site_status = 1, last_status_change = ? WHERE blog_id = ?`
+
+func expectCloseEventTx(mock sqlmock.Sqlmock, eventID, blogID int64, severity uint8, state, reason string) {
+	mock.ExpectBegin()
+	mock.ExpectQuery(closeEventTxSelectSQL).
+		WithArgs(eventID).
+		WillReturnRows(sqlmock.NewRows([]string{"severity", "state", "ended_at"}).
+			AddRow(severity, state, nil))
+	mock.ExpectExec(closeEventUpdateSQL).
+		WithArgs(reason, eventID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(closeEventInsertTransitionSQL).
+		WithArgs(eventID, blogID, severity, state, "Resolved", reason, "api", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+}
+
+func TestCloseEventHappyPath(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	// Event exists and belongs to site 42, currently open.
+	mock.ExpectQuery(eventLookupMinSQL).WithArgs(int64(7)).
+		WillReturnRows(sqlmock.NewRows([]string{"blog_id", "ended_at"}).
+			AddRow(int64(42), nil))
+
+	expectCloseEventTx(mock, 7, 42, 4, "Down", "manual_override")
+
+	// maybeProjectRunning checks count, finds zero, projects.
+	mock.ExpectQuery(countActiveEventsSQL).WithArgs(int64(42)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectExec(projectRunningSQL).
+		WithArgs(sqlmock.AnyArg(), int64(42)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	// Read-back: full event + transitions.
+	startedAt := time.Date(2026, 4, 25, 3, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(` SELECT id, blog_id, endpoint_id, check_type, discriminator, severity, state, started_at, ended_at, resolution_reason, cause_event_id, metadata FROM jetmon_events WHERE id = ?`).
+		WithArgs(int64(7)).
+		WillReturnRows(makeEventRow(7, 42, 4, "Down", startedAt, &startedAt))
+	mock.ExpectQuery(transitionsAllSQL).WithArgs(int64(7)).
+		WillReturnRows(sqlmock.NewRows(columnsTransition))
+
+	body := []byte(`{"reason":"manual_override","note":"close from API"}`)
+	req := newPOSTWithBody("/api/v1/sites/42/events/7/close", body)
+	req.SetPathValue("id", "42")
+	req.SetPathValue("event_id", "7")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleCloseEvent)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCloseEventNotFound(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(eventLookupMinSQL).WithArgs(int64(999)).
+		WillReturnRows(sqlmock.NewRows([]string{"blog_id", "ended_at"}))
+
+	body := []byte(`{}`)
+	req := newPOSTWithBody("/api/v1/sites/42/events/999/close", body)
+	req.SetPathValue("id", "42")
+	req.SetPathValue("event_id", "999")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleCloseEvent)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestCloseEventCrossSiteRejected(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	// Event 7 belongs to site 42, request says site 99.
+	mock.ExpectQuery(eventLookupMinSQL).WithArgs(int64(7)).
+		WillReturnRows(sqlmock.NewRows([]string{"blog_id", "ended_at"}).
+			AddRow(int64(42), nil))
+
+	body := []byte(`{}`)
+	req := newPOSTWithBody("/api/v1/sites/99/events/7/close", body)
+	req.SetPathValue("id", "99")
+	req.SetPathValue("event_id", "7")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleCloseEvent)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+	if got := readErrorBody(t, rec.Body).Code; got != "event_not_found" {
+		t.Errorf("code = %q, want event_not_found", got)
+	}
+}
+
+func TestCloseEventAlreadyClosedIsIdempotent(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	// Event already has ended_at set.
+	closedAt := time.Date(2026, 4, 25, 3, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(eventLookupMinSQL).WithArgs(int64(7)).
+		WillReturnRows(sqlmock.NewRows([]string{"blog_id", "ended_at"}).
+			AddRow(int64(42), closedAt))
+
+	// Read-back happens directly without re-closing.
+	startedAt := closedAt.Add(-1 * time.Hour)
+	mock.ExpectQuery(` SELECT id, blog_id, endpoint_id, check_type, discriminator, severity, state, started_at, ended_at, resolution_reason, cause_event_id, metadata FROM jetmon_events WHERE id = ?`).
+		WithArgs(int64(7)).
+		WillReturnRows(makeEventRow(7, 42, 4, "Down", startedAt, &closedAt))
+	mock.ExpectQuery(transitionsAllSQL).WithArgs(int64(7)).
+		WillReturnRows(sqlmock.NewRows(columnsTransition))
+
+	body := []byte(`{"reason":"manual_override"}`)
+	req := newPOSTWithBody("/api/v1/sites/42/events/7/close", body)
+	req.SetPathValue("id", "42")
+	req.SetPathValue("event_id", "7")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleCloseEvent)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (idempotent close); body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCloseEventDefaultReason(t *testing.T) {
+	// An empty body produces reason=manual_override per the handler defaults.
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(eventLookupMinSQL).WithArgs(int64(7)).
+		WillReturnRows(sqlmock.NewRows([]string{"blog_id", "ended_at"}).
+			AddRow(int64(42), nil))
+	expectCloseEventTx(mock, 7, 42, 4, "Down", "manual_override")
+	mock.ExpectQuery(countActiveEventsSQL).WithArgs(int64(42)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectExec(projectRunningSQL).
+		WithArgs(sqlmock.AnyArg(), int64(42)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	startedAt := time.Date(2026, 4, 25, 3, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(` SELECT id, blog_id, endpoint_id, check_type, discriminator, severity, state, started_at, ended_at, resolution_reason, cause_event_id, metadata FROM jetmon_events WHERE id = ?`).
+		WithArgs(int64(7)).
+		WillReturnRows(makeEventRow(7, 42, 4, "Down", startedAt, &startedAt))
+	mock.ExpectQuery(transitionsAllSQL).WithArgs(int64(7)).
+		WillReturnRows(sqlmock.NewRows(columnsTransition))
+
+	// Empty body — handler should default reason to manual_override.
+	req := httptest.NewRequest("POST", "/api/v1/sites/42/events/7/close", nil)
+	req.SetPathValue("id", "42")
+	req.SetPathValue("event_id", "7")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleCloseEvent)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCloseEventInvalidIDs(t *testing.T) {
+	s, _, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	cases := []struct {
+		siteID, eventID, code string
+	}{
+		{"abc", "7", "invalid_site_id"},
+		{"42", "xyz", "invalid_event_id"},
+		{"-1", "7", "invalid_site_id"},
+	}
+	for _, c := range cases {
+		req := httptest.NewRequest("POST", "/api/v1/sites/"+c.siteID+"/events/"+c.eventID+"/close", nil)
+		req.SetPathValue("id", c.siteID)
+		req.SetPathValue("event_id", c.eventID)
+		req = setAuthCtx(req, key)
+		rec := invokeAuthed(s, req, s.handleCloseEvent)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("siteID=%s eventID=%s status=%d want 400", c.siteID, c.eventID, rec.Code)
+			continue
+		}
+		if got := readErrorBody(t, rec.Body).Code; got != c.code {
+			t.Errorf("siteID=%s eventID=%s code=%q want %q", c.siteID, c.eventID, got, c.code)
+		}
+	}
+}

--- a/internal/api/handlers_identity.go
+++ b/internal/api/handlers_identity.go
@@ -1,0 +1,50 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// handleHealth is unauthenticated and used by load balancers / external
+// monitors. Returns 200 if the API can ping the database within 1s, else 503.
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 1*time.Second)
+	defer cancel()
+	if err := s.db.PingContext(ctx); err != nil {
+		writeError(w, r, http.StatusServiceUnavailable, "db_unavailable",
+			"database ping failed: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// meResponse is what GET /api/v1/me returns. Same shape as the spec in API.md.
+type meResponse struct {
+	ConsumerName       string  `json:"consumer_name"`
+	Scope              string  `json:"scope"`
+	RateLimitPerMinute int     `json:"rate_limit_per_minute"`
+	ExpiresAt          *string `json:"expires_at"`
+}
+
+// handleMe returns the identity associated with the request's token.
+// Used by consumers to verify their key works and check what scope it has.
+func (s *Server) handleMe(w http.ResponseWriter, r *http.Request) {
+	key := keyFromRequest(r)
+	if key == nil {
+		writeError(w, r, http.StatusInternalServerError, "auth_state_missing",
+			"authenticated key not found in request context")
+		return
+	}
+
+	resp := meResponse{
+		ConsumerName:       key.ConsumerName,
+		Scope:              string(key.Scope),
+		RateLimitPerMinute: key.RateLimitPerMinute,
+	}
+	if key.ExpiresAt != nil {
+		formatted := key.ExpiresAt.UTC().Format(time.RFC3339)
+		resp.ExpiresAt = &formatted
+	}
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/internal/api/handlers_identity_test.go
+++ b/internal/api/handlers_identity_test.go
@@ -1,0 +1,123 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Automattic/jetmon/internal/apikeys"
+)
+
+func TestHealthOK(t *testing.T) {
+	s, mock, _, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectPing()
+	req := httptest.NewRequest("GET", "/api/v1/health", nil)
+	rec := httptest.NewRecorder()
+	s.handleHealth(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var body map[string]string
+	readJSON(t, rec.Body, &body)
+	if body["status"] != "ok" {
+		t.Errorf("status field = %q, want 'ok'", body["status"])
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestHealthDBDown(t *testing.T) {
+	s, mock, _, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectPing().WillReturnError(errPing{})
+
+	req := httptest.NewRequest("GET", "/api/v1/health", nil)
+	rec := httptest.NewRecorder()
+	s.handleHealth(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body=%s", rec.Code, rec.Body.String())
+	}
+	body := readErrorBody(t, rec.Body)
+	if body.Code != "db_unavailable" {
+		t.Errorf("error code = %q, want db_unavailable", body.Code)
+	}
+}
+
+// errPing is a stand-in error type for db.PingContext failures since sqlmock's
+// ExpectPing accepts any error.
+type errPing struct{}
+
+func (errPing) Error() string { return "ping failed" }
+
+func TestMeReturnsAuthenticatedKey(t *testing.T) {
+	s, _, key, cleanup := newTestServer(t)
+	defer cleanup()
+	key.ConsumerName = "alerts-worker"
+	key.Scope = apikeys.ScopeRead
+	key.RateLimitPerMinute = 600
+
+	req := requestWithKey("GET", "/api/v1/me", key)
+	rec := httptest.NewRecorder()
+	s.handleMe(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var body meResponse
+	readJSON(t, rec.Body, &body)
+	if body.ConsumerName != "alerts-worker" {
+		t.Errorf("consumer_name = %q, want alerts-worker", body.ConsumerName)
+	}
+	if body.Scope != "read" {
+		t.Errorf("scope = %q, want read", body.Scope)
+	}
+	if body.RateLimitPerMinute != 600 {
+		t.Errorf("rate_limit_per_minute = %d, want 600", body.RateLimitPerMinute)
+	}
+	if body.ExpiresAt != nil {
+		t.Errorf("expires_at = %v, want nil", *body.ExpiresAt)
+	}
+}
+
+func TestMeMissingKeyReturns500(t *testing.T) {
+	// /me running without an authenticated key in context indicates middleware
+	// was bypassed in error. The handler refuses to guess.
+	s, _, _, cleanup := newTestServer(t)
+	defer cleanup()
+
+	req := httptest.NewRequest("GET", "/api/v1/me", nil)
+	rec := httptest.NewRecorder()
+	s.handleMe(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	body := readErrorBody(t, rec.Body)
+	if body.Code != "auth_state_missing" {
+		t.Errorf("error code = %q, want auth_state_missing", body.Code)
+	}
+}
+
+func TestKeyFromRequestNilContext(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	if k := keyFromRequest(req); k != nil {
+		t.Errorf("keyFromRequest(no ctx) = %+v, want nil", k)
+	}
+}
+
+func TestKeyFromRequestPopulated(t *testing.T) {
+	want := &apikeys.Key{ID: 7, ConsumerName: "x"}
+	req := httptest.NewRequest("GET", "/", nil)
+	ctx := context.WithValue(req.Context(), ctxKeyAPIKey, want)
+	got := keyFromRequest(req.WithContext(ctx))
+	if got == nil || got.ID != 7 {
+		t.Errorf("keyFromRequest = %+v, want %+v", got, want)
+	}
+}

--- a/internal/api/handlers_sites.go
+++ b/internal/api/handlers_sites.go
@@ -1,0 +1,437 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// siteResponse is the JSON shape for a site in list and single-site responses.
+// Field ordering kept human-friendly (id and url first, configuration fields
+// after, computed fields last). See API.md "Family 1: Sites and current state".
+type siteResponse struct {
+	ID                   int64   `json:"id"`
+	BlogID               int64   `json:"blog_id"`
+	MonitorURL           string  `json:"monitor_url"`
+	MonitorActive        bool    `json:"monitor_active"`
+	CurrentState         string  `json:"current_state"`
+	CurrentSeverity      uint8   `json:"current_severity"`
+	ActiveEventID        *int64  `json:"active_event_id"`
+	LastCheckedAt        *string `json:"last_checked_at"`
+	LastStatusChangeAt   *string `json:"last_status_change_at"`
+	SSLExpiryDate        *string `json:"ssl_expiry_date"`
+	CheckKeyword         *string `json:"check_keyword"`
+	RedirectPolicy       string  `json:"redirect_policy"`
+	MaintenanceStart     *string `json:"maintenance_start"`
+	MaintenanceEnd       *string `json:"maintenance_end"`
+	AlertCooldownMinutes *int    `json:"alert_cooldown_minutes"`
+}
+
+// activeEventSummary is the compact event shape embedded in single-site
+// responses under "active_events". Full event detail comes from
+// GET /api/v1/sites/{id}/events/{event_id}.
+type activeEventSummary struct {
+	ID         int64   `json:"id"`
+	CheckType  string  `json:"check_type"`
+	Severity   uint8   `json:"severity"`
+	State      string  `json:"state"`
+	StartedAt  string  `json:"started_at"`
+}
+
+// singleSiteResponse extends siteResponse with the active_events array.
+type singleSiteResponse struct {
+	siteResponse
+	ActiveEvents []activeEventSummary `json:"active_events"`
+}
+
+// handleListSites implements GET /api/v1/sites with cursor pagination.
+//
+// Cursor encodes the (id) of the last row on the previous page; we use id
+// because it's the stable monotonically-increasing primary key. State filter
+// is applied post-derivation so consumers see filtering in the same vocabulary
+// they read.
+func (s *Server) handleListSites(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	limit, err := parseLimit(q.Get("limit"), 50, 200)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_limit", err.Error())
+		return
+	}
+
+	cursor, err := decodeIDCursor(q.Get("cursor"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_cursor", err.Error())
+		return
+	}
+
+	// Filters.
+	stateFilter, err := parseStateFilter(q)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_state_filter", err.Error())
+		return
+	}
+	severityGTE, err := parseUintQuery(q.Get("severity__gte"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_severity", err.Error())
+		return
+	}
+	monitorActive := q.Get("monitor_active")
+	urlSubstr := q.Get("q")
+
+	// Build the query. Filter on monitor_active and on URL substring at the SQL
+	// level; state/severity filtering happens post-derivation since current
+	// state is derived from site_status (and later from active events).
+	args := []any{cursor}
+	sb := strings.Builder{}
+	sb.WriteString(`
+		SELECT blog_id, blog_id AS public_id, monitor_url, monitor_active, site_status,
+		       last_checked_at, last_status_change, ssl_expiry_date, check_keyword,
+		       redirect_policy, maintenance_start, maintenance_end, alert_cooldown_minutes
+		  FROM jetpack_monitor_sites
+		 WHERE blog_id > ?`)
+
+	switch monitorActive {
+	case "true", "1":
+		sb.WriteString(" AND monitor_active = 1")
+	case "false", "0":
+		sb.WriteString(" AND monitor_active = 0")
+	case "":
+		// no filter
+	default:
+		writeError(w, r, http.StatusBadRequest, "invalid_monitor_active",
+			"monitor_active must be 'true' or 'false'")
+		return
+	}
+	if urlSubstr != "" {
+		sb.WriteString(" AND monitor_url LIKE ?")
+		args = append(args, "%"+urlSubstr+"%")
+	}
+	sb.WriteString(" ORDER BY blog_id ASC LIMIT ?")
+	// Fetch limit+1 so we know whether there's a next page without an extra count query.
+	args = append(args, limit+1)
+
+	ctx := r.Context()
+	rows, err := s.db.QueryContext(ctx, sb.String(), args...)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"site list query failed: "+err.Error())
+		return
+	}
+	defer rows.Close()
+
+	results := make([]siteResponse, 0, limit)
+	var lastID int64
+	for rows.Next() {
+		s, err := scanSiteRow(rows)
+		if err != nil {
+			writeError(w, r, http.StatusInternalServerError, "db_error",
+				"site row scan failed: "+err.Error())
+			return
+		}
+		results = append(results, s)
+		lastID = s.ID
+	}
+
+	// Apply post-derivation filters.
+	results = filterByState(results, stateFilter, severityGTE)
+
+	// Trim to the requested limit and decide on next-cursor.
+	var nextCursor *string
+	if len(results) > limit {
+		results = results[:limit]
+		lastID = results[len(results)-1].ID
+		c := encodeIDCursor(lastID)
+		nextCursor = &c
+	}
+
+	writeJSON(w, http.StatusOK, ListEnvelope{
+		Data: results,
+		Page: Page{Next: nextCursor, Limit: limit},
+	})
+}
+
+// handleGetSite implements GET /api/v1/sites/{id}. Returns the site plus
+// any open events as active_events, ordered by severity descending.
+func (s *Server) handleGetSite(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil || id <= 0 {
+		writeError(w, r, http.StatusBadRequest, "invalid_site_id",
+			"site id must be a positive integer")
+		return
+	}
+
+	ctx := r.Context()
+	row := s.db.QueryRowContext(ctx, `
+		SELECT blog_id, blog_id AS public_id, monitor_url, monitor_active, site_status,
+		       last_checked_at, last_status_change, ssl_expiry_date, check_keyword,
+		       redirect_policy, maintenance_start, maintenance_end, alert_cooldown_minutes
+		  FROM jetpack_monitor_sites
+		 WHERE blog_id = ?`, id)
+
+	site, err := scanSiteRow(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			writeError(w, r, http.StatusNotFound, "site_not_found",
+				fmt.Sprintf("Site %d does not exist", id))
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"site query failed: "+err.Error())
+		return
+	}
+
+	active, err := s.queryActiveEvents(ctx, id)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"active events query failed: "+err.Error())
+		return
+	}
+
+	// Reflect the worst active event back into the site projection for
+	// consumers reading from this single endpoint. Falls back to the v1
+	// site_status mapping when there's no event (e.g. fresh site that hasn't
+	// been checked yet).
+	if len(active) > 0 {
+		worst := active[0]
+		site.CurrentSeverity = worst.Severity
+		site.CurrentState = worst.State
+		eventID := worst.ID
+		site.ActiveEventID = &eventID
+	}
+
+	writeJSON(w, http.StatusOK, singleSiteResponse{
+		siteResponse: site,
+		ActiveEvents: active,
+	})
+}
+
+// queryActiveEvents returns all open events for a site, ordered by severity
+// desc then started_at asc. Used by the single-site endpoint.
+func (s *Server) queryActiveEvents(ctx context.Context, blogID int64) ([]activeEventSummary, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, check_type, severity, state, started_at
+		  FROM jetmon_events
+		 WHERE blog_id = ? AND ended_at IS NULL
+		 ORDER BY severity DESC, started_at ASC`, blogID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := []activeEventSummary{}
+	for rows.Next() {
+		var e activeEventSummary
+		var startedAt time.Time
+		if err := rows.Scan(&e.ID, &e.CheckType, &e.Severity, &e.State, &startedAt); err != nil {
+			return nil, err
+		}
+		e.StartedAt = startedAt.UTC().Format(time.RFC3339Nano)
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+// rowScanner accepts both *sql.Row and *sql.Rows.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+// scanSiteRow scans the columns selected by the site queries into a
+// siteResponse. SiteStatus is not exposed directly — it's translated into
+// (current_state, current_severity) via deriveStateFromSiteStatus.
+func scanSiteRow(s rowScanner) (siteResponse, error) {
+	var (
+		out             siteResponse
+		monitorActive   uint8
+		siteStatus      int
+		lastCheckedAt   sql.NullTime
+		lastStatusChg   sql.NullTime
+		sslExpiry       sql.NullTime
+		checkKeyword    sql.NullString
+		redirectPolicy  sql.NullString
+		maintStart      sql.NullTime
+		maintEnd        sql.NullTime
+		alertCooldown   sql.NullInt64
+	)
+	if err := s.Scan(
+		&out.ID, &out.BlogID, &out.MonitorURL, &monitorActive, &siteStatus,
+		&lastCheckedAt, &lastStatusChg, &sslExpiry, &checkKeyword,
+		&redirectPolicy, &maintStart, &maintEnd, &alertCooldown,
+	); err != nil {
+		return out, err
+	}
+	out.MonitorActive = monitorActive == 1
+	out.CurrentState, out.CurrentSeverity = deriveStateFromSiteStatus(siteStatus)
+	if lastCheckedAt.Valid {
+		v := lastCheckedAt.Time.UTC().Format(time.RFC3339)
+		out.LastCheckedAt = &v
+	}
+	if lastStatusChg.Valid {
+		v := lastStatusChg.Time.UTC().Format(time.RFC3339)
+		out.LastStatusChangeAt = &v
+	}
+	if sslExpiry.Valid {
+		v := sslExpiry.Time.UTC().Format("2006-01-02")
+		out.SSLExpiryDate = &v
+	}
+	if checkKeyword.Valid {
+		out.CheckKeyword = &checkKeyword.String
+	}
+	if redirectPolicy.Valid {
+		out.RedirectPolicy = redirectPolicy.String
+	} else {
+		out.RedirectPolicy = "follow"
+	}
+	if maintStart.Valid {
+		v := maintStart.Time.UTC().Format(time.RFC3339)
+		out.MaintenanceStart = &v
+	}
+	if maintEnd.Valid {
+		v := maintEnd.Time.UTC().Format(time.RFC3339)
+		out.MaintenanceEnd = &v
+	}
+	if alertCooldown.Valid {
+		v := int(alertCooldown.Int64)
+		out.AlertCooldownMinutes = &v
+	}
+	return out, nil
+}
+
+// deriveStateFromSiteStatus maps the v1 site_status integer to the v2
+// (current_state, current_severity) tuple. This is a bridge while the
+// orchestrator still maintains site_status as the projection — once
+// active_event lookup is wired into list queries, this function disappears.
+//
+// Mapping (matches AGENTS.md):
+//   - 0 (SITE_DOWN) → Seems Down, severity 3
+//   - 1 (SITE_RUNNING) → Up, severity 0
+//   - 2 (SITE_CONFIRMED_DOWN) → Down, severity 4
+//   - other → Unknown, severity 0
+func deriveStateFromSiteStatus(siteStatus int) (state string, severity uint8) {
+	switch siteStatus {
+	case 0:
+		return "Seems Down", 3
+	case 1:
+		return "Up", 0
+	case 2:
+		return "Down", 4
+	default:
+		return "Unknown", 0
+	}
+}
+
+// parseStateFilter returns the state values requested via ?state=X or
+// ?state__in=A,B,C (mutually exclusive — only one or the other).
+func parseStateFilter(q map[string][]string) ([]string, error) {
+	single := first(q["state"])
+	multi := first(q["state__in"])
+	if single != "" && multi != "" {
+		return nil, fmt.Errorf("use either ?state= or ?state__in=, not both")
+	}
+	if single != "" {
+		return []string{single}, nil
+	}
+	if multi != "" {
+		return strings.Split(multi, ","), nil
+	}
+	return nil, nil
+}
+
+// filterByState applies state and severity__gte filters in-memory after the
+// SQL query. Cheap because the SQL query already bounds the result to the page
+// limit.
+func filterByState(in []siteResponse, states []string, severityGTE int) []siteResponse {
+	if len(states) == 0 && severityGTE <= 0 {
+		return in
+	}
+	stateSet := make(map[string]struct{}, len(states))
+	for _, s := range states {
+		stateSet[s] = struct{}{}
+	}
+	out := in[:0]
+	for _, s := range in {
+		if len(stateSet) > 0 {
+			if _, ok := stateSet[s.CurrentState]; !ok {
+				continue
+			}
+		}
+		if int(s.CurrentSeverity) < severityGTE {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// parseLimit returns a clamped limit value for list endpoints. Empty falls
+// back to defaultLimit; values above maxLimit are clamped silently (the API
+// docs say so, and a 400 here would be hostile to common pagination loops).
+func parseLimit(s string, defaultLimit, maxLimit int) (int, error) {
+	if s == "" {
+		return defaultLimit, nil
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("limit must be an integer")
+	}
+	if n < 1 {
+		return 0, fmt.Errorf("limit must be >= 1")
+	}
+	if n > maxLimit {
+		n = maxLimit
+	}
+	return n, nil
+}
+
+// parseUintQuery parses an optional unsigned int query parameter. Empty
+// returns 0 with no error.
+func parseUintQuery(s string) (int, error) {
+	if s == "" {
+		return 0, nil
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("must be a non-negative integer")
+	}
+	return n, nil
+}
+
+func first(vals []string) string {
+	if len(vals) == 0 {
+		return ""
+	}
+	return vals[0]
+}
+
+// idCursor is the cursor schema for list endpoints keyed on a single int64
+// (id, blog_id). Encoded as base64-JSON so consumers don't poke at internals.
+type idCursor struct {
+	ID int64 `json:"id"`
+}
+
+func encodeIDCursor(id int64) string {
+	b, _ := json.Marshal(idCursor{ID: id})
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+func decodeIDCursor(s string) (int64, error) {
+	if s == "" {
+		return 0, nil
+	}
+	b, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		return 0, fmt.Errorf("cursor not valid base64: %v", err)
+	}
+	var c idCursor
+	if err := json.Unmarshal(b, &c); err != nil {
+		return 0, fmt.Errorf("cursor not valid JSON: %v", err)
+	}
+	return c.ID, nil
+}

--- a/internal/api/handlers_sites_test.go
+++ b/internal/api/handlers_sites_test.go
@@ -1,0 +1,263 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+const sitesListSQL = ` SELECT blog_id, blog_id AS public_id, monitor_url, monitor_active, site_status, last_checked_at, last_status_change, ssl_expiry_date, check_keyword, redirect_policy, maintenance_start, maintenance_end, alert_cooldown_minutes FROM jetpack_monitor_sites WHERE blog_id > ? ORDER BY blog_id ASC LIMIT ?`
+
+const singleSiteSQL = ` SELECT blog_id, blog_id AS public_id, monitor_url, monitor_active, site_status, last_checked_at, last_status_change, ssl_expiry_date, check_keyword, redirect_policy, maintenance_start, maintenance_end, alert_cooldown_minutes FROM jetpack_monitor_sites WHERE blog_id = ?`
+
+const activeEventsSQL = ` SELECT id, check_type, severity, state, started_at FROM jetmon_events WHERE blog_id = ? AND ended_at IS NULL ORDER BY severity DESC, started_at ASC`
+
+// makeSiteRow returns a row builder pre-loaded with sane defaults the tests
+// can override. blog_id is the only required field.
+func makeSiteRow(blogID int64, monitorURL string, siteStatus int) *sqlmock.Rows {
+	return sqlmock.NewRows(columnsSite).AddRow(
+		blogID, blogID, monitorURL, 1, siteStatus,
+		nil, nil, nil, nil,
+		"follow", nil, nil, nil,
+	)
+}
+
+func TestListSitesEmpty(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(sitesListSQL).
+		WithArgs(int64(0), 51).
+		WillReturnRows(sqlmock.NewRows(columnsSite))
+
+	req := requestWithKey("GET", "/api/v1/sites", key)
+	rec := invokeAuthed(s, req, s.handleListSites)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp ListEnvelope
+	readJSON(t, rec.Body, &resp)
+	if data, ok := resp.Data.([]any); !ok || len(data) != 0 {
+		t.Errorf("data = %v, want empty list", resp.Data)
+	}
+	if resp.Page.Next != nil {
+		t.Errorf("expected no next cursor, got %v", *resp.Page.Next)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestListSitesReturnsRows(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	rows := makeSiteRow(101, "https://example.com", 1)
+	rows.AddRow(102, 102, "https://other.com", 1, 2,
+		nil, nil, nil, nil, "follow", nil, nil, nil)
+
+	mock.ExpectQuery(sitesListSQL).
+		WithArgs(int64(0), 51).
+		WillReturnRows(rows)
+
+	req := requestWithKey("GET", "/api/v1/sites", key)
+	rec := invokeAuthed(s, req, s.handleListSites)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Data []siteResponse `json:"data"`
+		Page Page           `json:"page"`
+	}
+	readJSON(t, rec.Body, &resp)
+	if len(resp.Data) != 2 {
+		t.Fatalf("data len = %d, want 2", len(resp.Data))
+	}
+	if resp.Data[0].ID != 101 || resp.Data[0].CurrentState != "Up" {
+		t.Errorf("first site = %+v, want id=101 state=Up", resp.Data[0])
+	}
+	if resp.Data[1].ID != 102 || resp.Data[1].CurrentState != "Down" {
+		t.Errorf("second site = %+v, want id=102 state=Down", resp.Data[1])
+	}
+}
+
+func TestListSitesAppliesPaginationCursor(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	// Three rows; limit=2 → should return 2 + a next cursor.
+	rows := makeSiteRow(10, "a", 1)
+	rows.AddRow(20, 20, "b", 1, 1, nil, nil, nil, nil, "follow", nil, nil, nil)
+	rows.AddRow(30, 30, "c", 1, 1, nil, nil, nil, nil, "follow", nil, nil, nil)
+
+	mock.ExpectQuery(sitesListSQL).
+		WithArgs(int64(0), 3). // limit+1 = 3
+		WillReturnRows(rows)
+
+	req := requestWithKey("GET", "/api/v1/sites?limit=2", key)
+	rec := invokeAuthed(s, req, s.handleListSites)
+
+	var resp struct {
+		Data []siteResponse `json:"data"`
+		Page Page           `json:"page"`
+	}
+	readJSON(t, rec.Body, &resp)
+	if len(resp.Data) != 2 {
+		t.Fatalf("data len = %d, want 2", len(resp.Data))
+	}
+	if resp.Page.Next == nil {
+		t.Fatal("expected a next cursor")
+	}
+	// Decoded cursor should be the id of the last row returned.
+	id, err := decodeIDCursor(*resp.Page.Next)
+	if err != nil {
+		t.Fatalf("decode cursor: %v", err)
+	}
+	if id != 20 {
+		t.Errorf("next cursor id = %d, want 20", id)
+	}
+}
+
+func TestListSitesFiltersByMonitorActive(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	expected := ` SELECT blog_id, blog_id AS public_id, monitor_url, monitor_active, site_status, last_checked_at, last_status_change, ssl_expiry_date, check_keyword, redirect_policy, maintenance_start, maintenance_end, alert_cooldown_minutes FROM jetpack_monitor_sites WHERE blog_id > ? AND monitor_active = 1 ORDER BY blog_id ASC LIMIT ?`
+	mock.ExpectQuery(expected).
+		WithArgs(int64(0), 51).
+		WillReturnRows(sqlmock.NewRows(columnsSite))
+
+	req := requestWithKey("GET", "/api/v1/sites?monitor_active=true", key)
+	rec := invokeAuthed(s, req, s.handleListSites)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet: %v", err)
+	}
+}
+
+func TestListSitesRejectsBadCursor(t *testing.T) {
+	s, _, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	req := requestWithKey("GET", "/api/v1/sites?cursor=not-base64!!", key)
+	rec := invokeAuthed(s, req, s.handleListSites)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	body := readErrorBody(t, rec.Body)
+	if body.Code != "invalid_cursor" {
+		t.Errorf("error code = %q, want invalid_cursor", body.Code)
+	}
+}
+
+func TestListSitesRejectsBadLimit(t *testing.T) {
+	s, _, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	req := requestWithKey("GET", "/api/v1/sites?limit=abc", key)
+	rec := invokeAuthed(s, req, s.handleListSites)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestGetSiteFound(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(singleSiteSQL).WithArgs(int64(42)).WillReturnRows(makeSiteRow(42, "https://x", 2))
+
+	// active_events query — return one active event.
+	startedAt := time.Date(2026, 4, 25, 3, 18, 38, 329_000_000, time.UTC)
+	mock.ExpectQuery(activeEventsSQL).WithArgs(int64(42)).WillReturnRows(
+		sqlmock.NewRows(columnsActiveEvent).
+			AddRow(int64(7), "http", uint8(4), "Down", startedAt),
+	)
+
+	req := requestWithKey("GET", "/api/v1/sites/42", key)
+	req.SetPathValue("id", "42")
+	rec := invokeAuthed(s, req, s.handleGetSite)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp singleSiteResponse
+	readJSON(t, rec.Body, &resp)
+	if resp.ID != 42 {
+		t.Errorf("id = %d, want 42", resp.ID)
+	}
+	if len(resp.ActiveEvents) != 1 || resp.ActiveEvents[0].ID != 7 {
+		t.Fatalf("active_events = %+v, want one with id=7", resp.ActiveEvents)
+	}
+	if resp.ActiveEventID == nil || *resp.ActiveEventID != 7 {
+		t.Errorf("active_event_id = %v, want pointer to 7", resp.ActiveEventID)
+	}
+	// Worst event should be reflected on the projection.
+	if resp.CurrentState != "Down" || resp.CurrentSeverity != 4 {
+		t.Errorf("projection = (%q, %d), want (Down, 4)", resp.CurrentState, resp.CurrentSeverity)
+	}
+}
+
+func TestGetSiteNotFound(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(singleSiteSQL).WithArgs(int64(99999)).WillReturnRows(sqlmock.NewRows(columnsSite))
+
+	req := requestWithKey("GET", "/api/v1/sites/99999", key)
+	req.SetPathValue("id", "99999")
+	rec := invokeAuthed(s, req, s.handleGetSite)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+	body := readErrorBody(t, rec.Body)
+	if body.Code != "site_not_found" {
+		t.Errorf("error code = %q, want site_not_found", body.Code)
+	}
+	// Internal API style: error message names the resource type.
+	if !contains(body.Message, "Site 99999") {
+		t.Errorf("message %q should name resource type and id", body.Message)
+	}
+}
+
+func TestGetSiteInvalidID(t *testing.T) {
+	s, _, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	req := requestWithKey("GET", "/api/v1/sites/abc", key)
+	req.SetPathValue("id", "abc")
+	rec := invokeAuthed(s, req, s.handleGetSite)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+// trimSQL is a shorthand for tests; sqlmock with QueryMatcherEqual matches
+// strings byte-for-byte, so we have to assemble queries the same way the
+// handler does.
+func trimSQL(s string) string { return s }
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+// httptest dependency reference suppresses unused-import checks if a future
+// edit removes the only direct httptest usage above.
+var _ = httptest.NewRecorder

--- a/internal/api/handlers_sites_write.go
+++ b/internal/api/handlers_sites_write.go
@@ -1,0 +1,603 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+// validRedirectPolicies bounds the redirect_policy field. Matches the ENUM
+// in jetpack_monitor_sites schema (migration 3).
+var validRedirectPolicies = map[string]struct{}{
+	"follow": {},
+	"alert":  {},
+	"fail":   {},
+}
+
+// createSiteRequest is the body shape for POST /api/v1/sites.
+//
+// Fields use pointers where "absent in JSON" needs to be distinguishable
+// from "explicitly zero/empty" — for example, alert_cooldown_minutes might
+// legitimately be 0 (meaning "no cooldown") vs missing (meaning "use the
+// global default"). monitor_active is a pointer for the same reason: the
+// default is true if absent, but an explicit false has to be honored.
+type createSiteRequest struct {
+	BlogID               *int64             `json:"blog_id"`
+	MonitorURL           string             `json:"monitor_url"`
+	MonitorActive        *bool              `json:"monitor_active"`
+	BucketNo             *int               `json:"bucket_no"`
+	CheckKeyword         *string            `json:"check_keyword"`
+	RedirectPolicy       *string            `json:"redirect_policy"`
+	TimeoutSeconds       *int               `json:"timeout_seconds"`
+	CustomHeaders        *map[string]string `json:"custom_headers"`
+	AlertCooldownMinutes *int               `json:"alert_cooldown_minutes"`
+	CheckInterval        *int               `json:"check_interval"`
+}
+
+// handleCreateSite implements POST /api/v1/sites.
+//
+// blog_id is caller-supplied (it's the canonical identity from WPCOM) and
+// must not already exist in jetpack_monitor_sites. Successful creation
+// returns 201 with the full site object.
+func (s *Server) handleCreateSite(w http.ResponseWriter, r *http.Request) {
+	var body createSiteRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_body",
+			"request body must be valid JSON: "+err.Error())
+		return
+	}
+
+	if body.BlogID == nil || *body.BlogID <= 0 {
+		writeError(w, r, http.StatusBadRequest, "invalid_blog_id",
+			"blog_id is required and must be a positive integer")
+		return
+	}
+	if err := validateMonitorURL(body.MonitorURL); err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_url", err.Error())
+		return
+	}
+	if body.RedirectPolicy != nil {
+		if _, ok := validRedirectPolicies[*body.RedirectPolicy]; !ok {
+			writeError(w, r, http.StatusUnprocessableEntity, "invalid_redirect_policy",
+				"redirect_policy must be one of: follow, alert, fail")
+			return
+		}
+	}
+
+	ctx := r.Context()
+
+	// Fast-path duplicate check. The actual race is closed by the UNIQUE
+	// constraint on blog_id + the INSERT below; this just produces a clean
+	// 409 for the common case.
+	exists, err := s.siteExists(ctx, *body.BlogID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"site existence check failed: "+err.Error())
+		return
+	}
+	if exists {
+		writeError(w, r, http.StatusConflict, "site_exists",
+			fmt.Sprintf("Site %d already exists", *body.BlogID))
+		return
+	}
+
+	// Apply defaults for optional fields. Pointers stay nil if the column
+	// is nullable in the schema; non-nullable columns get explicit defaults.
+	monitorActive := true
+	if body.MonitorActive != nil {
+		monitorActive = *body.MonitorActive
+	}
+	bucketNo := 0
+	if body.BucketNo != nil {
+		bucketNo = *body.BucketNo
+	}
+	checkInterval := 5
+	if body.CheckInterval != nil {
+		checkInterval = *body.CheckInterval
+	}
+	redirectPolicy := "follow"
+	if body.RedirectPolicy != nil {
+		redirectPolicy = *body.RedirectPolicy
+	}
+
+	customHeadersJSON, err := encodeCustomHeaders(body.CustomHeaders)
+	if err != nil {
+		writeError(w, r, http.StatusUnprocessableEntity, "invalid_custom_headers",
+			err.Error())
+		return
+	}
+
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO jetpack_monitor_sites
+			(blog_id, bucket_no, monitor_url, monitor_active, site_status, check_interval,
+			 check_keyword, redirect_policy, timeout_seconds, custom_headers,
+			 alert_cooldown_minutes)
+		VALUES (?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?)`,
+		*body.BlogID, bucketNo, body.MonitorURL, boolToTinyint(monitorActive), checkInterval,
+		nullableStringPtr(body.CheckKeyword),
+		redirectPolicy,
+		nullableIntPtr(body.TimeoutSeconds),
+		customHeadersJSON,
+		nullableIntPtr(body.AlertCooldownMinutes),
+	)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"site insert failed: "+err.Error())
+		return
+	}
+
+	// Read back the row to return it as the response body.
+	site, err := s.readSite(ctx, *body.BlogID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"read-back failed: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, site)
+}
+
+// updateSiteRequest is the body shape for PATCH /api/v1/sites/{id}. Every
+// field is a pointer — absent fields are left unchanged, explicit nulls
+// clear nullable columns.
+type updateSiteRequest struct {
+	MonitorURL           *string            `json:"monitor_url"`
+	MonitorActive        *bool              `json:"monitor_active"`
+	BucketNo             *int               `json:"bucket_no"`
+	CheckKeyword         *string            `json:"check_keyword"`
+	RedirectPolicy       *string            `json:"redirect_policy"`
+	TimeoutSeconds       *int               `json:"timeout_seconds"`
+	CustomHeaders        *map[string]string `json:"custom_headers"`
+	AlertCooldownMinutes *int               `json:"alert_cooldown_minutes"`
+	CheckInterval        *int               `json:"check_interval"`
+	MaintenanceStart     *string            `json:"maintenance_start"`
+	MaintenanceEnd       *string            `json:"maintenance_end"`
+}
+
+// handleUpdateSite implements PATCH /api/v1/sites/{id}.
+func (s *Server) handleUpdateSite(w http.ResponseWriter, r *http.Request) {
+	siteID, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil || siteID <= 0 {
+		writeError(w, r, http.StatusBadRequest, "invalid_site_id",
+			"site id must be a positive integer")
+		return
+	}
+
+	var body updateSiteRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_body",
+			"request body must be valid JSON: "+err.Error())
+		return
+	}
+
+	// Validate the inputs we got. Validation happens before the existence
+	// check so a bad request shape returns 400/422 even for nonexistent
+	// sites — easier to debug.
+	if body.MonitorURL != nil {
+		if err := validateMonitorURL(*body.MonitorURL); err != nil {
+			writeError(w, r, http.StatusBadRequest, "invalid_url", err.Error())
+			return
+		}
+	}
+	if body.RedirectPolicy != nil {
+		if _, ok := validRedirectPolicies[*body.RedirectPolicy]; !ok {
+			writeError(w, r, http.StatusUnprocessableEntity, "invalid_redirect_policy",
+				"redirect_policy must be one of: follow, alert, fail")
+			return
+		}
+	}
+
+	ctx := r.Context()
+	exists, err := s.siteExists(ctx, siteID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"site lookup failed: "+err.Error())
+		return
+	}
+	if !exists {
+		writeError(w, r, http.StatusNotFound, "site_not_found",
+			fmt.Sprintf("Site %d does not exist", siteID))
+		return
+	}
+
+	// Build the UPDATE dynamically from non-nil fields.
+	setClauses, args, err := buildUpdateSetClause(body)
+	if err != nil {
+		writeError(w, r, http.StatusUnprocessableEntity, "invalid_field", err.Error())
+		return
+	}
+	if len(setClauses) == 0 {
+		// No fields to change — return the current state without touching the row.
+		site, err := s.readSite(ctx, siteID)
+		if err != nil {
+			writeError(w, r, http.StatusInternalServerError, "db_error",
+				"read-back failed: "+err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, site)
+		return
+	}
+
+	args = append(args, siteID)
+	query := "UPDATE jetpack_monitor_sites SET " + joinSetClauses(setClauses) + " WHERE blog_id = ?"
+	if _, err := s.db.ExecContext(ctx, query, args...); err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"site update failed: "+err.Error())
+		return
+	}
+
+	site, err := s.readSite(ctx, siteID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"read-back failed: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, site)
+}
+
+// handleDeleteSite implements DELETE /api/v1/sites/{id}.
+//
+// Soft delete: monitor_active=0 + close any open events with reason
+// manual_override. Returns 204 No Content. The row is preserved so audit
+// trails (jetmon_audit_log, jetmon_check_history) keep their foreign-key
+// targets and historical state remains queryable.
+func (s *Server) handleDeleteSite(w http.ResponseWriter, r *http.Request) {
+	siteID, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil || siteID <= 0 {
+		writeError(w, r, http.StatusBadRequest, "invalid_site_id",
+			"site id must be a positive integer")
+		return
+	}
+
+	ctx := r.Context()
+	exists, err := s.siteExists(ctx, siteID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"site lookup failed: "+err.Error())
+		return
+	}
+	if !exists {
+		writeError(w, r, http.StatusNotFound, "site_not_found",
+			fmt.Sprintf("Site %d does not exist", siteID))
+		return
+	}
+
+	if err := s.closeAllActiveEvents(ctx, siteID, "manual_override", "site deleted via API"); err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"close events failed: "+err.Error())
+		return
+	}
+
+	_, err = s.db.ExecContext(ctx,
+		`UPDATE jetpack_monitor_sites SET monitor_active = 0 WHERE blog_id = ?`, siteID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"site delete failed: "+err.Error())
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handlePauseSite implements POST /api/v1/sites/{id}/pause.
+//
+// Equivalent to monitor_active=false but with the closing reason explicitly
+// labeled. The orchestrator's next round will see monitor_active=0 and
+// stop checking the site.
+func (s *Server) handlePauseSite(w http.ResponseWriter, r *http.Request) {
+	s.toggleSiteActive(w, r, false, "site paused via API")
+}
+
+// handleResumeSite implements POST /api/v1/sites/{id}/resume.
+//
+// Sets monitor_active=true. Does not reopen previously-closed events; the
+// orchestrator's regular flow will detect any genuine current failure on
+// the next round and open a fresh event then.
+func (s *Server) handleResumeSite(w http.ResponseWriter, r *http.Request) {
+	s.toggleSiteActive(w, r, true, "")
+}
+
+func (s *Server) toggleSiteActive(w http.ResponseWriter, r *http.Request, active bool, closeNote string) {
+	siteID, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil || siteID <= 0 {
+		writeError(w, r, http.StatusBadRequest, "invalid_site_id",
+			"site id must be a positive integer")
+		return
+	}
+
+	ctx := r.Context()
+	exists, err := s.siteExists(ctx, siteID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"site lookup failed: "+err.Error())
+		return
+	}
+	if !exists {
+		writeError(w, r, http.StatusNotFound, "site_not_found",
+			fmt.Sprintf("Site %d does not exist", siteID))
+		return
+	}
+
+	// On pause, close any active events first so the site_status projection
+	// can move cleanly to "running" (which we then stamp as paused via the
+	// monitor_active flag).
+	if !active {
+		if err := s.closeAllActiveEvents(ctx, siteID, "manual_override", closeNote); err != nil {
+			writeError(w, r, http.StatusInternalServerError, "db_error",
+				"close events failed: "+err.Error())
+			return
+		}
+	}
+
+	_, err = s.db.ExecContext(ctx,
+		`UPDATE jetpack_monitor_sites SET monitor_active = ?, last_status_change = ? WHERE blog_id = ?`,
+		boolToTinyint(active), time.Now().UTC(), siteID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"site update failed: "+err.Error())
+		return
+	}
+
+	site, err := s.readSite(ctx, siteID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"read-back failed: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, site)
+}
+
+// closeAllActiveEvents closes every open event for a site in a single tx
+// using the eventstore. Used by delete/pause/resume paths and any other
+// "the site is going away cleanly" flow.
+func (s *Server) closeAllActiveEvents(ctx context.Context, siteID int64, reason, note string) error {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id FROM jetmon_events WHERE blog_id = ? AND ended_at IS NULL`, siteID)
+	if err != nil {
+		return err
+	}
+	var eventIDs []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return err
+		}
+		eventIDs = append(eventIDs, id)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	for _, eventID := range eventIDs {
+		meta, _ := json.Marshal(map[string]any{"note": note, "source": "api"})
+		// Use eventstore.Store directly — the api.Server doesn't have a
+		// reference to it, but the standalone Close handles its own tx.
+		// For now, run the write inline with the orchestrator's eventstore
+		// shape.
+		if err := s.closeEvent(ctx, eventID, siteID, reason, meta); err != nil {
+			return fmt.Errorf("close event %d: %w", eventID, err)
+		}
+	}
+	return nil
+}
+
+// closeEvent writes an event close + a transition row in one transaction.
+// Mirrors what eventstore.Tx.Close does without pulling the package in
+// here — keeps the import graph flat.
+func (s *Server) closeEvent(ctx context.Context, eventID, blogID int64, reason string, metadata []byte) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var (
+		severity uint8
+		state    string
+		endedAt  sql.NullTime
+	)
+	err = tx.QueryRowContext(ctx,
+		`SELECT severity, state, ended_at FROM jetmon_events WHERE id = ? FOR UPDATE`, eventID,
+	).Scan(&severity, &state, &endedAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("event %d not found", eventID)
+		}
+		return err
+	}
+	if endedAt.Valid {
+		// Already closed; treat as success — idempotent close.
+		return tx.Commit()
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE jetmon_events
+		   SET ended_at = CURRENT_TIMESTAMP(3),
+		       resolution_reason = ?
+		 WHERE id = ?`, reason, eventID); err != nil {
+		return fmt.Errorf("update event: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO jetmon_event_transitions
+			(event_id, blog_id, severity_before, severity_after,
+			 state_before, state_after, reason, source, metadata)
+		VALUES (?, ?, ?, NULL, ?, ?, ?, ?, ?)`,
+		eventID, blogID, severity, state, "Resolved", reason, "api", metadata,
+	); err != nil {
+		return fmt.Errorf("insert transition: %w", err)
+	}
+	return tx.Commit()
+}
+
+// readSite returns the API-shaped site object for blog_id. Used by the
+// write handlers' read-back step.
+func (s *Server) readSite(ctx context.Context, blogID int64) (siteResponse, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT blog_id, blog_id AS public_id, monitor_url, monitor_active, site_status,
+		       last_checked_at, last_status_change, ssl_expiry_date, check_keyword,
+		       redirect_policy, maintenance_start, maintenance_end, alert_cooldown_minutes
+		  FROM jetpack_monitor_sites
+		 WHERE blog_id = ?`, blogID)
+	return scanSiteRow(row)
+}
+
+// validateMonitorURL accepts only http and https URLs with a non-empty host.
+func validateMonitorURL(s string) error {
+	if s == "" {
+		return errors.New("monitor_url is required")
+	}
+	u, err := url.Parse(s)
+	if err != nil {
+		return fmt.Errorf("monitor_url is not a valid URL: %v", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return errors.New("monitor_url must use http or https")
+	}
+	if u.Host == "" {
+		return errors.New("monitor_url must include a host")
+	}
+	return nil
+}
+
+// encodeCustomHeaders marshals a map[string]string into the JSON shape the
+// custom_headers column expects. Returns nil if the input is nil or empty.
+func encodeCustomHeaders(h *map[string]string) (any, error) {
+	if h == nil || len(*h) == 0 {
+		return nil, nil
+	}
+	for k := range *h {
+		if k == "" {
+			return nil, errors.New("custom_headers must not contain empty header names")
+		}
+	}
+	b, err := json.Marshal(*h)
+	if err != nil {
+		return nil, fmt.Errorf("encode custom_headers: %v", err)
+	}
+	return string(b), nil
+}
+
+// buildUpdateSetClause turns a sparse updateSiteRequest into SQL fragments.
+// Returned slices are aligned: setClauses[i] applies args[i].
+func buildUpdateSetClause(body updateSiteRequest) ([]string, []any, error) {
+	var (
+		clauses []string
+		args    []any
+	)
+	if body.MonitorURL != nil {
+		clauses = append(clauses, "monitor_url = ?")
+		args = append(args, *body.MonitorURL)
+	}
+	if body.MonitorActive != nil {
+		clauses = append(clauses, "monitor_active = ?")
+		args = append(args, boolToTinyint(*body.MonitorActive))
+	}
+	if body.BucketNo != nil {
+		clauses = append(clauses, "bucket_no = ?")
+		args = append(args, *body.BucketNo)
+	}
+	if body.CheckKeyword != nil {
+		clauses = append(clauses, "check_keyword = ?")
+		args = append(args, nullableEmpty(*body.CheckKeyword))
+	}
+	if body.RedirectPolicy != nil {
+		clauses = append(clauses, "redirect_policy = ?")
+		args = append(args, *body.RedirectPolicy)
+	}
+	if body.TimeoutSeconds != nil {
+		clauses = append(clauses, "timeout_seconds = ?")
+		args = append(args, *body.TimeoutSeconds)
+	}
+	if body.CustomHeaders != nil {
+		v, err := encodeCustomHeaders(body.CustomHeaders)
+		if err != nil {
+			return nil, nil, err
+		}
+		clauses = append(clauses, "custom_headers = ?")
+		args = append(args, v)
+	}
+	if body.AlertCooldownMinutes != nil {
+		clauses = append(clauses, "alert_cooldown_minutes = ?")
+		args = append(args, *body.AlertCooldownMinutes)
+	}
+	if body.CheckInterval != nil {
+		clauses = append(clauses, "check_interval = ?")
+		args = append(args, *body.CheckInterval)
+	}
+	if body.MaintenanceStart != nil {
+		t, err := parseMaintenanceTime(*body.MaintenanceStart, "maintenance_start")
+		if err != nil {
+			return nil, nil, err
+		}
+		clauses = append(clauses, "maintenance_start = ?")
+		args = append(args, t)
+	}
+	if body.MaintenanceEnd != nil {
+		t, err := parseMaintenanceTime(*body.MaintenanceEnd, "maintenance_end")
+		if err != nil {
+			return nil, nil, err
+		}
+		clauses = append(clauses, "maintenance_end = ?")
+		args = append(args, t)
+	}
+	return clauses, args, nil
+}
+
+// parseMaintenanceTime accepts an empty string (clears the column to NULL)
+// or an RFC3339 timestamp. Anything else is a 422.
+func parseMaintenanceTime(s, field string) (any, error) {
+	if s == "" {
+		return nil, nil
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return nil, fmt.Errorf("%s must be RFC3339 timestamp or empty string", field)
+	}
+	return t.UTC(), nil
+}
+
+func joinSetClauses(clauses []string) string {
+	out := ""
+	for i, c := range clauses {
+		if i > 0 {
+			out += ", "
+		}
+		out += c
+	}
+	return out
+}
+
+func boolToTinyint(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+func nullableStringPtr(p *string) any {
+	if p == nil {
+		return nil
+	}
+	return nullableEmpty(*p)
+}
+
+func nullableEmpty(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+func nullableIntPtr(p *int) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}

--- a/internal/api/handlers_sites_write_test.go
+++ b/internal/api/handlers_sites_write_test.go
@@ -1,0 +1,374 @@
+package api
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+const siteExistsCheckSQL = `SELECT 1 FROM jetpack_monitor_sites WHERE blog_id = ? LIMIT 1`
+
+const insertSiteSQL = ` INSERT INTO jetpack_monitor_sites (blog_id, bucket_no, monitor_url, monitor_active, site_status, check_interval, check_keyword, redirect_policy, timeout_seconds, custom_headers, alert_cooldown_minutes) VALUES (?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?)`
+
+func newPOSTWithBody(target string, body []byte) *http.Request {
+	req := httptest.NewRequest("POST", target, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func newPATCHWithBody(target string, body []byte) *http.Request {
+	req := httptest.NewRequest("PATCH", target, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func TestCreateSiteHappyPath(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	// existence check returns no rows
+	mock.ExpectQuery(siteExistsCheckSQL).WithArgs(int64(12345)).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}))
+	// insert
+	mock.ExpectExec(insertSiteSQL).
+		WithArgs(int64(12345), 0, "https://example.com", 1, 5,
+			nil, "follow", nil, nil, nil).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	// read-back
+	mock.ExpectQuery(singleSiteSQL).WithArgs(int64(12345)).
+		WillReturnRows(makeSiteRow(12345, "https://example.com", 1))
+
+	body := []byte(`{"blog_id": 12345, "monitor_url": "https://example.com"}`)
+	req := newPOSTWithBody("/api/v1/sites", body)
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleCreateSite)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp siteResponse
+	readJSON(t, rec.Body, &resp)
+	if resp.ID != 12345 || resp.MonitorURL != "https://example.com" {
+		t.Errorf("response site = %+v", resp)
+	}
+}
+
+func TestCreateSiteRejectsMissingBlogID(t *testing.T) {
+	s, _, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	body := []byte(`{"monitor_url": "https://example.com"}`)
+	req := setAuthCtx(newPOSTWithBody("/api/v1/sites", body), key)
+	rec := invokeAuthed(s, req, s.handleCreateSite)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if got := readErrorBody(t, rec.Body).Code; got != "invalid_blog_id" {
+		t.Errorf("code = %q, want invalid_blog_id", got)
+	}
+}
+
+func TestCreateSiteRejectsBadURL(t *testing.T) {
+	s, _, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	cases := []struct {
+		body string
+		want string
+	}{
+		{`{"blog_id": 1, "monitor_url": "not-a-url"}`, "invalid_url"},
+		{`{"blog_id": 1, "monitor_url": ""}`, "invalid_url"},
+		{`{"blog_id": 1, "monitor_url": "ftp://example.com"}`, "invalid_url"},
+	}
+	for _, c := range cases {
+		req := setAuthCtx(newPOSTWithBody("/api/v1/sites", []byte(c.body)), key)
+		rec := invokeAuthed(s, req, s.handleCreateSite)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("body=%s status=%d want 400", c.body, rec.Code)
+			continue
+		}
+		if got := readErrorBody(t, rec.Body).Code; got != c.want {
+			t.Errorf("body=%s code=%q want %q", c.body, got, c.want)
+		}
+	}
+}
+
+func TestCreateSiteRejectsBadRedirectPolicy(t *testing.T) {
+	s, _, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	body := []byte(`{"blog_id": 1, "monitor_url": "https://x", "redirect_policy": "bounce"}`)
+	req := setAuthCtx(newPOSTWithBody("/api/v1/sites", body), key)
+	rec := invokeAuthed(s, req, s.handleCreateSite)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", rec.Code)
+	}
+	if got := readErrorBody(t, rec.Body).Code; got != "invalid_redirect_policy" {
+		t.Errorf("code = %q, want invalid_redirect_policy", got)
+	}
+}
+
+func TestCreateSiteConflictOnExisting(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(siteExistsCheckSQL).WithArgs(int64(12345)).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+
+	body := []byte(`{"blog_id": 12345, "monitor_url": "https://example.com"}`)
+	req := setAuthCtx(newPOSTWithBody("/api/v1/sites", body), key)
+	rec := invokeAuthed(s, req, s.handleCreateSite)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", rec.Code)
+	}
+	if got := readErrorBody(t, rec.Body).Code; got != "site_exists" {
+		t.Errorf("code = %q, want site_exists", got)
+	}
+}
+
+func TestUpdateSiteHappyPath(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(siteExistsCheckSQL).WithArgs(int64(42)).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	mock.ExpectExec(`UPDATE jetpack_monitor_sites SET monitor_url = ?, redirect_policy = ? WHERE blog_id = ?`).
+		WithArgs("https://new.example.com", "alert", int64(42)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(singleSiteSQL).WithArgs(int64(42)).
+		WillReturnRows(makeSiteRow(42, "https://new.example.com", 1))
+
+	body := []byte(`{"monitor_url": "https://new.example.com", "redirect_policy": "alert"}`)
+	req := newPATCHWithBody("/api/v1/sites/42", body)
+	req.SetPathValue("id", "42")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleUpdateSite)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUpdateSiteEmptyBodyReturnsCurrent(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(siteExistsCheckSQL).WithArgs(int64(42)).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	mock.ExpectQuery(singleSiteSQL).WithArgs(int64(42)).
+		WillReturnRows(makeSiteRow(42, "https://x", 1))
+
+	body := []byte(`{}`)
+	req := newPATCHWithBody("/api/v1/sites/42", body)
+	req.SetPathValue("id", "42")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleUpdateSite)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestUpdateSiteNotFound(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(siteExistsCheckSQL).WithArgs(int64(999)).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}))
+
+	body := []byte(`{"monitor_url": "https://x"}`)
+	req := newPATCHWithBody("/api/v1/sites/999", body)
+	req.SetPathValue("id", "999")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleUpdateSite)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestDeleteSiteSoftDeletes(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(siteExistsCheckSQL).WithArgs(int64(42)).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	// closeAllActiveEvents queries for active events; return none.
+	mock.ExpectQuery(`SELECT id FROM jetmon_events WHERE blog_id = ? AND ended_at IS NULL`).
+		WithArgs(int64(42)).WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	// soft-delete UPDATE
+	mock.ExpectExec(`UPDATE jetpack_monitor_sites SET monitor_active = 0 WHERE blog_id = ?`).
+		WithArgs(int64(42)).WillReturnResult(sqlmock.NewResult(0, 1))
+
+	req := httptest.NewRequest("DELETE", "/api/v1/sites/42", nil)
+	req.SetPathValue("id", "42")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleDeleteSite)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rec.Code)
+	}
+}
+
+func TestPauseSiteClosesActiveEvents(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(siteExistsCheckSQL).WithArgs(int64(42)).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	// One active event to close.
+	mock.ExpectQuery(`SELECT id FROM jetmon_events WHERE blog_id = ? AND ended_at IS NULL`).
+		WithArgs(int64(42)).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(7)))
+
+	// closeEvent runs in a tx: BeginTx → SELECT FOR UPDATE → UPDATE event → INSERT transition → Commit
+	mock.ExpectBegin()
+	mock.ExpectQuery(`SELECT severity, state, ended_at FROM jetmon_events WHERE id = ? FOR UPDATE`).
+		WithArgs(int64(7)).
+		WillReturnRows(sqlmock.NewRows([]string{"severity", "state", "ended_at"}).
+			AddRow(uint8(4), "Down", nil))
+	mock.ExpectExec(` UPDATE jetmon_events SET ended_at = CURRENT_TIMESTAMP(3), resolution_reason = ? WHERE id = ?`).
+		WithArgs("manual_override", int64(7)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(` INSERT INTO jetmon_event_transitions (event_id, blog_id, severity_before, severity_after, state_before, state_after, reason, source, metadata) VALUES (?, ?, ?, NULL, ?, ?, ?, ?, ?)`).
+		WithArgs(int64(7), int64(42), uint8(4), "Down", "Resolved", "manual_override", "api", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	mock.ExpectExec(`UPDATE jetpack_monitor_sites SET monitor_active = ?, last_status_change = ? WHERE blog_id = ?`).
+		WithArgs(0, sqlmock.AnyArg(), int64(42)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(singleSiteSQL).WithArgs(int64(42)).
+		WillReturnRows(makeSiteRow(42, "https://x", 1))
+
+	req := newPOSTWithBody("/api/v1/sites/42/pause", nil)
+	req.SetPathValue("id", "42")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handlePauseSite)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestResumeSiteSetsActive(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(siteExistsCheckSQL).WithArgs(int64(42)).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	mock.ExpectExec(`UPDATE jetpack_monitor_sites SET monitor_active = ?, last_status_change = ? WHERE blog_id = ?`).
+		WithArgs(1, sqlmock.AnyArg(), int64(42)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(singleSiteSQL).WithArgs(int64(42)).
+		WillReturnRows(makeSiteRow(42, "https://x", 1))
+
+	req := newPOSTWithBody("/api/v1/sites/42/resume", nil)
+	req.SetPathValue("id", "42")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleResumeSite)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestValidateMonitorURL(t *testing.T) {
+	cases := []struct {
+		in    string
+		valid bool
+	}{
+		{"https://example.com", true},
+		{"http://example.com/path", true},
+		{"https://example.com:8080/api", true},
+		{"", false},
+		{"not-a-url", false},
+		{"ftp://example.com", false},
+		{"http://", false}, // empty host
+		{"https:///path", false},
+	}
+	for _, c := range cases {
+		err := validateMonitorURL(c.in)
+		if c.valid && err != nil {
+			t.Errorf("validateMonitorURL(%q) errored: %v", c.in, err)
+		}
+		if !c.valid && err == nil {
+			t.Errorf("validateMonitorURL(%q) accepted, want rejection", c.in)
+		}
+	}
+}
+
+func TestEncodeCustomHeaders(t *testing.T) {
+	if v, err := encodeCustomHeaders(nil); v != nil || err != nil {
+		t.Errorf("nil input = (%v, %v), want (nil, nil)", v, err)
+	}
+	empty := map[string]string{}
+	if v, err := encodeCustomHeaders(&empty); v != nil || err != nil {
+		t.Errorf("empty input = (%v, %v), want (nil, nil)", v, err)
+	}
+	full := map[string]string{"X-Foo": "bar"}
+	v, err := encodeCustomHeaders(&full)
+	if err != nil {
+		t.Fatalf("encode error: %v", err)
+	}
+	if v == nil {
+		t.Fatal("expected non-nil JSON")
+	}
+	bad := map[string]string{"": "bad"}
+	if _, err := encodeCustomHeaders(&bad); err == nil {
+		t.Error("empty header name should error")
+	}
+}
+
+func TestBoolToTinyint(t *testing.T) {
+	if boolToTinyint(true) != 1 {
+		t.Error("true → 1")
+	}
+	if boolToTinyint(false) != 0 {
+		t.Error("false → 0")
+	}
+}
+
+func TestBuildUpdateSetClauseEmpty(t *testing.T) {
+	clauses, args, err := buildUpdateSetClause(updateSiteRequest{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(clauses) != 0 || len(args) != 0 {
+		t.Errorf("empty body should produce no clauses; got %v / %v", clauses, args)
+	}
+}
+
+func TestBuildUpdateSetClauseHandlesAllFields(t *testing.T) {
+	url := "https://x"
+	active := true
+	bucket := 5
+	keyword := "ok"
+	policy := "alert"
+	timeout := 30
+	headers := map[string]string{"X-A": "1"}
+	cooldown := 10
+	interval := 7
+	clauses, args, err := buildUpdateSetClause(updateSiteRequest{
+		MonitorURL:           &url,
+		MonitorActive:        &active,
+		BucketNo:             &bucket,
+		CheckKeyword:         &keyword,
+		RedirectPolicy:       &policy,
+		TimeoutSeconds:       &timeout,
+		CustomHeaders:        &headers,
+		AlertCooldownMinutes: &cooldown,
+		CheckInterval:        &interval,
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(clauses) != 9 || len(args) != 9 {
+		t.Errorf("expected 9 clauses, got clauses=%d args=%d", len(clauses), len(args))
+	}
+}
+

--- a/internal/api/handlers_stats.go
+++ b/internal/api/handlers_stats.go
@@ -1,0 +1,543 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+)
+
+// maxSamples bounds the number of jetmon_check_history rows we'll pull into
+// memory for percentile computation. 100k covers a 30d window at 26s/check
+// per site — beyond that we'd want pre-aggregation, not naive sort.
+const maxSamples = 100_000
+
+// uptimeResponse is the shape returned by GET /api/v1/sites/{id}/uptime.
+// See API.md "Family 3".
+type uptimeResponse struct {
+	Window             windowResponse `json:"window"`
+	UptimePercent      float64        `json:"uptime_percent"`
+	TotalSeconds       int64          `json:"total_seconds"`
+	DownSeconds        int64          `json:"down_seconds"`
+	DegradedSeconds    int64          `json:"degraded_seconds"`
+	WarningSeconds     int64          `json:"warning_seconds"`
+	MaintenanceSeconds int64          `json:"maintenance_seconds"`
+	UnknownSeconds     int64          `json:"unknown_seconds"`
+	IncidentCount      int            `json:"incident_count"`
+	MTTRSeconds        int64          `json:"mttr_seconds"`
+	MTBFSeconds        int64          `json:"mtbf_seconds"`
+}
+
+// responseTimeResponse is the shape returned by GET .../response-time.
+type responseTimeResponse struct {
+	Window  windowResponse `json:"window"`
+	Samples int            `json:"samples"`
+	P50Ms   int64          `json:"p50_ms"`
+	P95Ms   int64          `json:"p95_ms"`
+	P99Ms   int64          `json:"p99_ms"`
+	MaxMs   int64          `json:"max_ms"`
+	MeanMs  int64          `json:"mean_ms"`
+	// Truncated indicates the underlying sample set hit the maxSamples cap;
+	// percentiles are computed from the most recent maxSamples rows.
+	Truncated bool `json:"truncated"`
+}
+
+// timingBreakdownResponse is the shape returned by GET .../timing-breakdown.
+// One of Jetmon's distinctive features — most competitors only return total
+// response time. Per-component percentiles let consumers pinpoint *where*
+// latency is spent.
+type timingBreakdownResponse struct {
+	Window    windowResponse  `json:"window"`
+	Samples   int             `json:"samples"`
+	Truncated bool            `json:"truncated"`
+	DNS       latencyComponent `json:"dns"`
+	TCP       latencyComponent `json:"tcp"`
+	TLS       latencyComponent `json:"tls"`
+	TTFB      latencyComponent `json:"ttfb"`
+}
+
+type latencyComponent struct {
+	P50Ms int64 `json:"p50_ms"`
+	P95Ms int64 `json:"p95_ms"`
+	P99Ms int64 `json:"p99_ms"`
+	MaxMs int64 `json:"max_ms"`
+}
+
+// windowResponse describes the time window covered by the stats.
+type windowResponse struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// resolveWindow returns the [from, to] timestamps for a stats query. Caller
+// passes either ?window=24h|7d|30d|90d (default 24h) or both ?from and ?to
+// (overrides window). Returns an error message-ready string on bad input.
+func resolveWindow(q map[string][]string) (from, to time.Time, err error) {
+	now := time.Now().UTC()
+	to = now
+
+	fromStr := first(q["from"])
+	toStr := first(q["to"])
+	if fromStr != "" || toStr != "" {
+		if fromStr == "" || toStr == "" {
+			return time.Time{}, time.Time{}, errors.New("?from and ?to must be provided together")
+		}
+		f, parseErr := time.Parse(time.RFC3339, fromStr)
+		if parseErr != nil {
+			return time.Time{}, time.Time{}, fmt.Errorf("?from must be RFC3339: %w", parseErr)
+		}
+		t, parseErr := time.Parse(time.RFC3339, toStr)
+		if parseErr != nil {
+			return time.Time{}, time.Time{}, fmt.Errorf("?to must be RFC3339: %w", parseErr)
+		}
+		if !f.Before(t) {
+			return time.Time{}, time.Time{}, errors.New("?from must be before ?to")
+		}
+		return f.UTC(), t.UTC(), nil
+	}
+
+	window := first(q["window"])
+	if window == "" {
+		window = "24h"
+	}
+	dur, err := parseWindowDuration(window)
+	if err != nil {
+		return time.Time{}, time.Time{}, err
+	}
+	return now.Add(-dur), now, nil
+}
+
+func parseWindowDuration(s string) (time.Duration, error) {
+	switch s {
+	case "1h":
+		return time.Hour, nil
+	case "24h", "1d":
+		return 24 * time.Hour, nil
+	case "7d":
+		return 7 * 24 * time.Hour, nil
+	case "30d":
+		return 30 * 24 * time.Hour, nil
+	case "90d":
+		return 90 * 24 * time.Hour, nil
+	default:
+		return 0, fmt.Errorf("window must be one of: 1h, 24h, 7d, 30d, 90d")
+	}
+}
+
+// handleSiteUptime computes uptime statistics over a window from the events
+// table. The event log is the source of truth — we sum durations of
+// (Down, Seems Down) events that overlap the window and treat the rest as
+// up-time. This stays correct even if check frequency changes.
+func (s *Server) handleSiteUptime(w http.ResponseWriter, r *http.Request) {
+	siteID, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil || siteID <= 0 {
+		writeError(w, r, http.StatusBadRequest, "invalid_site_id",
+			"site id must be a positive integer")
+		return
+	}
+
+	from, to, werr := resolveWindow(r.URL.Query())
+	if werr != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_window", werr.Error())
+		return
+	}
+
+	// Verify the site exists. This guards against returning a 100% uptime
+	// answer for a nonexistent site, which would be confusing.
+	if exists, err := s.siteExists(r.Context(), siteID); err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error", "site lookup failed: "+err.Error())
+		return
+	} else if !exists {
+		writeError(w, r, http.StatusNotFound, "site_not_found",
+			fmt.Sprintf("Site %d does not exist", siteID))
+		return
+	}
+
+	stats, err := s.computeUptime(r.Context(), siteID, from, to)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"uptime query failed: "+err.Error())
+		return
+	}
+
+	resp := uptimeResponse{
+		Window: windowResponse{
+			From: from.Format(time.RFC3339),
+			To:   to.Format(time.RFC3339),
+		},
+		TotalSeconds:       stats.totalSeconds,
+		DownSeconds:        stats.downSeconds,
+		DegradedSeconds:    stats.degradedSeconds,
+		WarningSeconds:     stats.warningSeconds,
+		MaintenanceSeconds: stats.maintenanceSeconds,
+		UnknownSeconds:     stats.unknownSeconds,
+		IncidentCount:      stats.incidentCount,
+		MTTRSeconds:        stats.mttrSeconds,
+		MTBFSeconds:        stats.mtbfSeconds,
+	}
+	if stats.totalSeconds > 0 {
+		resp.UptimePercent = roundTo3((1.0 - float64(stats.downSeconds)/float64(stats.totalSeconds)) * 100.0)
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// uptimeStats is the intermediate computed shape; mapped onto uptimeResponse
+// at the handler level.
+type uptimeStats struct {
+	totalSeconds       int64
+	downSeconds        int64
+	degradedSeconds    int64
+	warningSeconds     int64
+	maintenanceSeconds int64
+	unknownSeconds     int64
+	incidentCount      int
+	mttrSeconds        int64
+	mtbfSeconds        int64
+}
+
+// computeUptime walks events overlapping [from, to] and accumulates per-state
+// duration. Events that started before the window are clipped to from; events
+// still open at to are clipped to to.
+func (s *Server) computeUptime(ctx context.Context, siteID int64, from, to time.Time) (uptimeStats, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT severity, state, started_at, ended_at
+		  FROM jetmon_events
+		 WHERE blog_id = ?
+		   AND started_at < ?
+		   AND (ended_at IS NULL OR ended_at > ?)`,
+		siteID, to, from)
+	if err != nil {
+		return uptimeStats{}, err
+	}
+	defer rows.Close()
+
+	stats := uptimeStats{
+		totalSeconds: int64(to.Sub(from).Seconds()),
+	}
+	var sumIncidentSeconds int64
+	for rows.Next() {
+		var (
+			severity  uint8
+			state     string
+			startedAt time.Time
+			endedAt   sql.NullTime
+		)
+		if err := rows.Scan(&severity, &state, &startedAt, &endedAt); err != nil {
+			return uptimeStats{}, err
+		}
+
+		// Clip event to the window.
+		eventFrom := startedAt
+		if eventFrom.Before(from) {
+			eventFrom = from
+		}
+		var eventTo time.Time
+		if endedAt.Valid {
+			eventTo = endedAt.Time
+		} else {
+			eventTo = to
+		}
+		if eventTo.After(to) {
+			eventTo = to
+		}
+		dur := int64(eventTo.Sub(eventFrom).Seconds())
+		if dur < 0 {
+			continue
+		}
+
+		// Bucket by state. "Seems Down" counts toward downtime — the design
+		// treats it as part of the incident; the operator dashboard renders
+		// it as a different color, but for SLA math it's downtime.
+		switch state {
+		case "Down", "Seems Down":
+			stats.downSeconds += dur
+			stats.incidentCount++
+			sumIncidentSeconds += dur
+		case "Degraded":
+			stats.degradedSeconds += dur
+		case "Warning":
+			stats.warningSeconds += dur
+		case "Maintenance":
+			stats.maintenanceSeconds += dur
+		case "Unknown":
+			stats.unknownSeconds += dur
+		}
+	}
+	if stats.incidentCount > 0 {
+		stats.mttrSeconds = sumIncidentSeconds / int64(stats.incidentCount)
+	}
+	// MTBF = (uptime / incident_count). If no incidents, leave 0.
+	uptimeSeconds := stats.totalSeconds - stats.downSeconds
+	if stats.incidentCount > 0 {
+		stats.mtbfSeconds = uptimeSeconds / int64(stats.incidentCount)
+	}
+	return stats, rows.Err()
+}
+
+// handleSiteResponseTime returns p50/p95/p99/max/mean of total RTT over a
+// window, sourced from jetmon_check_history.
+func (s *Server) handleSiteResponseTime(w http.ResponseWriter, r *http.Request) {
+	siteID, from, to, ok := s.parseStatsRequest(w, r)
+	if !ok {
+		return
+	}
+
+	samples, truncated, err := s.queryRTTSamples(r.Context(), siteID, from, to)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"response time query failed: "+err.Error())
+		return
+	}
+
+	resp := responseTimeResponse{
+		Window: windowResponse{
+			From: from.Format(time.RFC3339),
+			To:   to.Format(time.RFC3339),
+		},
+		Samples:   len(samples),
+		Truncated: truncated,
+	}
+	if len(samples) > 0 {
+		sort.Slice(samples, func(i, j int) bool { return samples[i] < samples[j] })
+		resp.P50Ms = percentile(samples, 0.50)
+		resp.P95Ms = percentile(samples, 0.95)
+		resp.P99Ms = percentile(samples, 0.99)
+		resp.MaxMs = samples[len(samples)-1]
+		var sum int64
+		for _, v := range samples {
+			sum += v
+		}
+		resp.MeanMs = sum / int64(len(samples))
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// handleSiteTimingBreakdown returns the same percentile shape as
+// handleSiteResponseTime but per-component (DNS/TCP/TLS/TTFB).
+func (s *Server) handleSiteTimingBreakdown(w http.ResponseWriter, r *http.Request) {
+	siteID, from, to, ok := s.parseStatsRequest(w, r)
+	if !ok {
+		return
+	}
+
+	rows, truncated, err := s.queryTimingSamples(r.Context(), siteID, from, to)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"timing breakdown query failed: "+err.Error())
+		return
+	}
+
+	resp := timingBreakdownResponse{
+		Window: windowResponse{
+			From: from.Format(time.RFC3339),
+			To:   to.Format(time.RFC3339),
+		},
+		Samples:   len(rows),
+		Truncated: truncated,
+	}
+	if len(rows) > 0 {
+		dns := make([]int64, 0, len(rows))
+		tcp := make([]int64, 0, len(rows))
+		tls := make([]int64, 0, len(rows))
+		ttfb := make([]int64, 0, len(rows))
+		for _, t := range rows {
+			if t.dns >= 0 {
+				dns = append(dns, t.dns)
+			}
+			if t.tcp >= 0 {
+				tcp = append(tcp, t.tcp)
+			}
+			if t.tls >= 0 {
+				tls = append(tls, t.tls)
+			}
+			if t.ttfb >= 0 {
+				ttfb = append(ttfb, t.ttfb)
+			}
+		}
+		resp.DNS = computePercentiles(dns)
+		resp.TCP = computePercentiles(tcp)
+		resp.TLS = computePercentiles(tls)
+		resp.TTFB = computePercentiles(ttfb)
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// parseStatsRequest is the shared prelude for response-time and
+// timing-breakdown handlers — validates id, parses window, verifies site
+// exists. Returns (siteID, from, to, true) on success or writes the error
+// response and returns ok=false.
+func (s *Server) parseStatsRequest(w http.ResponseWriter, r *http.Request) (siteID int64, from, to time.Time, ok bool) {
+	siteID, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil || siteID <= 0 {
+		writeError(w, r, http.StatusBadRequest, "invalid_site_id",
+			"site id must be a positive integer")
+		return 0, time.Time{}, time.Time{}, false
+	}
+	from, to, werr := resolveWindow(r.URL.Query())
+	if werr != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_window", werr.Error())
+		return 0, time.Time{}, time.Time{}, false
+	}
+	exists, err := s.siteExists(r.Context(), siteID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"site lookup failed: "+err.Error())
+		return 0, time.Time{}, time.Time{}, false
+	}
+	if !exists {
+		writeError(w, r, http.StatusNotFound, "site_not_found",
+			fmt.Sprintf("Site %d does not exist", siteID))
+		return 0, time.Time{}, time.Time{}, false
+	}
+	return siteID, from, to, true
+}
+
+// siteExists is a cheap existence check used by stats handlers.
+func (s *Server) siteExists(ctx context.Context, siteID int64) (bool, error) {
+	var dummy int64
+	err := s.db.QueryRowContext(ctx,
+		`SELECT 1 FROM jetpack_monitor_sites WHERE blog_id = ? LIMIT 1`, siteID,
+	).Scan(&dummy)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// queryRTTSamples pulls rtt_ms values for a site within the window. Uses a
+// hard cap (maxSamples) and orders by checked_at DESC so a window with more
+// data than we can sort still returns the most recent sample.
+func (s *Server) queryRTTSamples(ctx context.Context, siteID int64, from, to time.Time) ([]int64, bool, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT rtt_ms FROM jetmon_check_history
+		 WHERE blog_id = ?
+		   AND checked_at >= ?
+		   AND checked_at < ?
+		   AND rtt_ms IS NOT NULL
+		 ORDER BY checked_at DESC
+		 LIMIT ?`, siteID, from, to, maxSamples+1)
+	if err != nil {
+		return nil, false, err
+	}
+	defer rows.Close()
+
+	out := make([]int64, 0, 1024)
+	for rows.Next() {
+		var v sql.NullInt64
+		if err := rows.Scan(&v); err != nil {
+			return nil, false, err
+		}
+		if v.Valid {
+			out = append(out, v.Int64)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, false, err
+	}
+	truncated := len(out) > maxSamples
+	if truncated {
+		out = out[:maxSamples]
+	}
+	return out, truncated, nil
+}
+
+// timingRow is one jetmon_check_history row's per-component timings.
+type timingRow struct {
+	dns, tcp, tls, ttfb int64
+}
+
+func (s *Server) queryTimingSamples(ctx context.Context, siteID int64, from, to time.Time) ([]timingRow, bool, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT dns_ms, tcp_ms, tls_ms, ttfb_ms FROM jetmon_check_history
+		 WHERE blog_id = ?
+		   AND checked_at >= ?
+		   AND checked_at < ?
+		 ORDER BY checked_at DESC
+		 LIMIT ?`, siteID, from, to, maxSamples+1)
+	if err != nil {
+		return nil, false, err
+	}
+	defer rows.Close()
+
+	out := make([]timingRow, 0, 1024)
+	for rows.Next() {
+		var dns, tcp, tls, ttfb sql.NullInt64
+		if err := rows.Scan(&dns, &tcp, &tls, &ttfb); err != nil {
+			return nil, false, err
+		}
+		t := timingRow{dns: -1, tcp: -1, tls: -1, ttfb: -1}
+		if dns.Valid {
+			t.dns = dns.Int64
+		}
+		if tcp.Valid {
+			t.tcp = tcp.Int64
+		}
+		if tls.Valid {
+			t.tls = tls.Int64
+		}
+		if ttfb.Valid {
+			t.ttfb = ttfb.Int64
+		}
+		out = append(out, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, false, err
+	}
+	truncated := len(out) > maxSamples
+	if truncated {
+		out = out[:maxSamples]
+	}
+	return out, truncated, nil
+}
+
+// computePercentiles returns p50/p95/p99/max for a sample slice. Empty input
+// → all-zero result.
+func computePercentiles(samples []int64) latencyComponent {
+	if len(samples) == 0 {
+		return latencyComponent{}
+	}
+	sort.Slice(samples, func(i, j int) bool { return samples[i] < samples[j] })
+	return latencyComponent{
+		P50Ms: percentile(samples, 0.50),
+		P95Ms: percentile(samples, 0.95),
+		P99Ms: percentile(samples, 0.99),
+		MaxMs: samples[len(samples)-1],
+	}
+}
+
+// percentile returns the value at the requested rank from a sorted slice.
+// p must be in [0, 1]. Uses the nearest-rank method (no interpolation) — fine
+// for our resolution and side-steps all the float edge cases.
+func percentile(sortedSamples []int64, p float64) int64 {
+	if len(sortedSamples) == 0 {
+		return 0
+	}
+	if p <= 0 {
+		return sortedSamples[0]
+	}
+	if p >= 1 {
+		return sortedSamples[len(sortedSamples)-1]
+	}
+	// Index = ceil(p * n) - 1, clamped.
+	idx := int(p*float64(len(sortedSamples))+0.5) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(sortedSamples) {
+		idx = len(sortedSamples) - 1
+	}
+	return sortedSamples[idx]
+}
+
+// roundTo3 rounds to three decimal places — enough resolution for "five 9s"
+// (99.999) without producing 99.99837726391... floats in JSON output.
+func roundTo3(v float64) float64 {
+	return float64(int64(v*1000+0.5)) / 1000.0
+}

--- a/internal/api/handlers_stats_test.go
+++ b/internal/api/handlers_stats_test.go
@@ -1,0 +1,306 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+const siteExistsSQL = `SELECT 1 FROM jetpack_monitor_sites WHERE blog_id = ? LIMIT 1`
+
+const uptimeSQL = ` SELECT severity, state, started_at, ended_at FROM jetmon_events WHERE blog_id = ? AND started_at < ? AND (ended_at IS NULL OR ended_at > ?)`
+
+const rttSamplesSQL = ` SELECT rtt_ms FROM jetmon_check_history WHERE blog_id = ? AND checked_at >= ? AND checked_at < ? AND rtt_ms IS NOT NULL ORDER BY checked_at DESC LIMIT ?`
+
+const timingSamplesSQL = ` SELECT dns_ms, tcp_ms, tls_ms, ttfb_ms FROM jetmon_check_history WHERE blog_id = ? AND checked_at >= ? AND checked_at < ? ORDER BY checked_at DESC LIMIT ?`
+
+func TestParseWindowDuration(t *testing.T) {
+	cases := map[string]time.Duration{
+		"1h":  time.Hour,
+		"24h": 24 * time.Hour,
+		"1d":  24 * time.Hour,
+		"7d":  7 * 24 * time.Hour,
+		"30d": 30 * 24 * time.Hour,
+		"90d": 90 * 24 * time.Hour,
+	}
+	for s, want := range cases {
+		got, err := parseWindowDuration(s)
+		if err != nil || got != want {
+			t.Errorf("parseWindowDuration(%q) = (%v, %v), want %v", s, got, err, want)
+		}
+	}
+	if _, err := parseWindowDuration("12h"); err == nil {
+		t.Error("unsupported window should error")
+	}
+}
+
+func TestResolveWindowFromQueryDefaults(t *testing.T) {
+	q := map[string][]string{}
+	from, to, err := resolveWindow(q)
+	if err != nil {
+		t.Fatalf("resolveWindow: %v", err)
+	}
+	dur := to.Sub(from)
+	if dur < 23*time.Hour || dur > 25*time.Hour {
+		t.Errorf("default window = %v, want ~24h", dur)
+	}
+}
+
+func TestResolveWindowFromTo(t *testing.T) {
+	q := map[string][]string{
+		"from": {"2026-04-01T00:00:00Z"},
+		"to":   {"2026-04-02T00:00:00Z"},
+	}
+	from, to, err := resolveWindow(q)
+	if err != nil {
+		t.Fatalf("resolveWindow: %v", err)
+	}
+	if !from.Equal(time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("from = %v, want 2026-04-01", from)
+	}
+	if !to.Equal(time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("to = %v, want 2026-04-02", to)
+	}
+}
+
+func TestResolveWindowRejectsHalfRange(t *testing.T) {
+	q := map[string][]string{"from": {"2026-04-01T00:00:00Z"}}
+	if _, _, err := resolveWindow(q); err == nil {
+		t.Error("from without to should error")
+	}
+}
+
+func TestResolveWindowRejectsBackwardsRange(t *testing.T) {
+	q := map[string][]string{
+		"from": {"2026-04-02T00:00:00Z"},
+		"to":   {"2026-04-01T00:00:00Z"},
+	}
+	if _, _, err := resolveWindow(q); err == nil {
+		t.Error("from after to should error")
+	}
+}
+
+func TestPercentileNearestRank(t *testing.T) {
+	samples := []int64{10, 20, 30, 40, 50, 60, 70, 80, 90, 100}
+	cases := []struct {
+		p    float64
+		want int64
+	}{
+		{0.0, 10},
+		{0.5, 50},
+		{0.95, 100}, // ceil(9.5+0.5)-1 = 9 → 100
+		{0.99, 100},
+		{1.0, 100},
+	}
+	for _, c := range cases {
+		got := percentile(samples, c.p)
+		if got != c.want {
+			t.Errorf("percentile(p=%.2f) = %d, want %d", c.p, got, c.want)
+		}
+	}
+}
+
+func TestPercentileEmpty(t *testing.T) {
+	if got := percentile(nil, 0.5); got != 0 {
+		t.Errorf("percentile(empty) = %d, want 0", got)
+	}
+}
+
+func TestRoundTo3(t *testing.T) {
+	cases := map[float64]float64{
+		99.999_999: 100.0,
+		99.847_3:   99.847,
+		0.0:        0.0,
+		100.0:      100.0,
+	}
+	for in, want := range cases {
+		got := roundTo3(in)
+		if got != want {
+			t.Errorf("roundTo3(%.6f) = %.6f, want %.6f", in, got, want)
+		}
+	}
+}
+
+func TestUptimeHappyPath(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(siteExistsSQL).WithArgs(int64(42)).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+
+	// One closed Down event lasting 60s within a 24h window.
+	now := time.Now().UTC()
+	startedAt := now.Add(-2 * time.Hour)
+	endedAt := startedAt.Add(60 * time.Second)
+	rows := sqlmock.NewRows([]string{"severity", "state", "started_at", "ended_at"}).
+		AddRow(uint8(4), "Down", startedAt, endedAt)
+	mock.ExpectQuery(uptimeSQL).WillReturnRows(rows)
+
+	req := requestWithKey("GET", "/api/v1/sites/42/uptime", key)
+	req.SetPathValue("id", "42")
+	rec := invokeAuthed(s, req, s.handleSiteUptime)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp uptimeResponse
+	readJSON(t, rec.Body, &resp)
+	if resp.DownSeconds != 60 {
+		t.Errorf("down_seconds = %d, want 60", resp.DownSeconds)
+	}
+	if resp.IncidentCount != 1 {
+		t.Errorf("incident_count = %d, want 1", resp.IncidentCount)
+	}
+	if resp.UptimePercent <= 99.0 || resp.UptimePercent >= 100.0 {
+		t.Errorf("uptime_percent = %.3f, want between 99 and 100", resp.UptimePercent)
+	}
+}
+
+func TestUptimeSiteNotFound(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(siteExistsSQL).WithArgs(int64(99)).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}))
+
+	req := requestWithKey("GET", "/api/v1/sites/99/uptime", key)
+	req.SetPathValue("id", "99")
+	rec := invokeAuthed(s, req, s.handleSiteUptime)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestUptimeNoEvents100Percent(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(siteExistsSQL).WithArgs(int64(42)).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	mock.ExpectQuery(uptimeSQL).WillReturnRows(sqlmock.NewRows([]string{"severity", "state", "started_at", "ended_at"}))
+
+	req := requestWithKey("GET", "/api/v1/sites/42/uptime", key)
+	req.SetPathValue("id", "42")
+	rec := invokeAuthed(s, req, s.handleSiteUptime)
+
+	var resp uptimeResponse
+	readJSON(t, rec.Body, &resp)
+	if resp.UptimePercent != 100.0 {
+		t.Errorf("uptime_percent = %.3f, want 100.0", resp.UptimePercent)
+	}
+	if resp.IncidentCount != 0 || resp.DownSeconds != 0 {
+		t.Errorf("expected no incidents; got count=%d down=%d", resp.IncidentCount, resp.DownSeconds)
+	}
+}
+
+func TestResponseTimeHappyPath(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(siteExistsSQL).WithArgs(int64(42)).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+
+	rows := sqlmock.NewRows([]string{"rtt_ms"})
+	for _, v := range []int64{100, 200, 300, 400, 500} {
+		rows.AddRow(v)
+	}
+	mock.ExpectQuery(rttSamplesSQL).WillReturnRows(rows)
+
+	req := requestWithKey("GET", "/api/v1/sites/42/response-time", key)
+	req.SetPathValue("id", "42")
+	rec := invokeAuthed(s, req, s.handleSiteResponseTime)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp responseTimeResponse
+	readJSON(t, rec.Body, &resp)
+	if resp.Samples != 5 {
+		t.Errorf("samples = %d, want 5", resp.Samples)
+	}
+	if resp.MaxMs != 500 {
+		t.Errorf("max_ms = %d, want 500", resp.MaxMs)
+	}
+	if resp.MeanMs != 300 {
+		t.Errorf("mean_ms = %d, want 300", resp.MeanMs)
+	}
+	if resp.P50Ms == 0 {
+		t.Errorf("p50_ms = 0, want non-zero")
+	}
+}
+
+func TestResponseTimeNoSamples(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(siteExistsSQL).WithArgs(int64(42)).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	mock.ExpectQuery(rttSamplesSQL).WillReturnRows(sqlmock.NewRows([]string{"rtt_ms"}))
+
+	req := requestWithKey("GET", "/api/v1/sites/42/response-time", key)
+	req.SetPathValue("id", "42")
+	rec := invokeAuthed(s, req, s.handleSiteResponseTime)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var resp responseTimeResponse
+	readJSON(t, rec.Body, &resp)
+	if resp.Samples != 0 || resp.MeanMs != 0 || resp.MaxMs != 0 {
+		t.Errorf("empty stats should be zero, got %+v", resp)
+	}
+}
+
+func TestTimingBreakdownHappyPath(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(siteExistsSQL).WithArgs(int64(42)).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+
+	rows := sqlmock.NewRows([]string{"dns_ms", "tcp_ms", "tls_ms", "ttfb_ms"})
+	for i := 0; i < 5; i++ {
+		rows.AddRow(int64(10+i*5), int64(20+i*5), int64(30+i*5), int64(150+i*10))
+	}
+	mock.ExpectQuery(timingSamplesSQL).WillReturnRows(rows)
+
+	req := requestWithKey("GET", "/api/v1/sites/42/timing-breakdown", key)
+	req.SetPathValue("id", "42")
+	rec := invokeAuthed(s, req, s.handleSiteTimingBreakdown)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp timingBreakdownResponse
+	readJSON(t, rec.Body, &resp)
+	if resp.Samples != 5 {
+		t.Errorf("samples = %d, want 5", resp.Samples)
+	}
+	if resp.DNS.MaxMs == 0 || resp.TCP.MaxMs == 0 || resp.TLS.MaxMs == 0 || resp.TTFB.MaxMs == 0 {
+		t.Errorf("expected non-zero per-component max; got %+v", resp)
+	}
+	// TTFB should be the slowest component in our test data.
+	if resp.TTFB.MaxMs <= resp.DNS.MaxMs {
+		t.Errorf("expected TTFB > DNS in test data, got TTFB=%d DNS=%d", resp.TTFB.MaxMs, resp.DNS.MaxMs)
+	}
+}
+
+func TestStatsRejectsBadWindow(t *testing.T) {
+	s, _, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	req := requestWithKey("GET", "/api/v1/sites/42/uptime?window=12h", key)
+	req.SetPathValue("id", "42")
+	rec := invokeAuthed(s, req, s.handleSiteUptime)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	body := readErrorBody(t, rec.Body)
+	if body.Code != "invalid_window" {
+		t.Errorf("error code = %q, want invalid_window", body.Code)
+	}
+}

--- a/internal/api/handlers_trigger_test.go
+++ b/internal/api/handlers_trigger_test.go
@@ -1,0 +1,161 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+const readSiteForCheckSQL = ` SELECT monitor_url, timeout_seconds, check_keyword, custom_headers, redirect_policy, site_status FROM jetpack_monitor_sites WHERE blog_id = ?`
+
+func TestTriggerNowSiteNotFound(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	// readSiteForCheck returns no rows.
+	mock.ExpectQuery(readSiteForCheckSQL).WithArgs(int64(99)).
+		WillReturnRows(sqlmock.NewRows([]string{"monitor_url", "timeout_seconds", "check_keyword", "custom_headers", "redirect_policy", "site_status"}))
+
+	req := httptest.NewRequest("POST", "/api/v1/sites/99/trigger-now", nil)
+	req.SetPathValue("id", "99")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleTriggerNow)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := readErrorBody(t, rec.Body).Code; got != "site_not_found" {
+		t.Errorf("code = %q, want site_not_found", got)
+	}
+}
+
+func TestTriggerNowSuccessNoActiveEvents(t *testing.T) {
+	// Spin up a fake target that returns 200 OK so checker.Check returns success.
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	}))
+	defer target.Close()
+
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(readSiteForCheckSQL).WithArgs(int64(42)).
+		WillReturnRows(sqlmock.NewRows([]string{"monitor_url", "timeout_seconds", "check_keyword", "custom_headers", "redirect_policy", "site_status"}).
+			AddRow(target.URL, nil, nil, nil, "follow", 1))
+	mock.ExpectQuery(`SELECT id FROM jetmon_events WHERE blog_id = ? AND ended_at IS NULL`).
+		WithArgs(int64(42)).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	req := httptest.NewRequest("POST", "/api/v1/sites/42/trigger-now", nil)
+	req.SetPathValue("id", "42")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleTriggerNow)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp triggerNowResponse
+	readJSON(t, rec.Body, &resp)
+	if !resp.Result.Success {
+		t.Errorf("expected success=true; got %+v", resp.Result)
+	}
+	if resp.Result.HTTPCode != 200 {
+		t.Errorf("http_code = %d, want 200", resp.Result.HTTPCode)
+	}
+	if len(resp.ActiveEventsClosed) != 0 {
+		t.Errorf("active_events_closed = %v, want empty", resp.ActiveEventsClosed)
+	}
+}
+
+func TestTriggerNowSuccessClosesActiveEvent(t *testing.T) {
+	// Same as above but with one active event that should be closed
+	// with reason=probe_cleared on success.
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(readSiteForCheckSQL).WithArgs(int64(42)).
+		WillReturnRows(sqlmock.NewRows([]string{"monitor_url", "timeout_seconds", "check_keyword", "custom_headers", "redirect_policy", "site_status"}).
+			AddRow(target.URL, nil, nil, nil, "follow", 2))
+	mock.ExpectQuery(`SELECT id FROM jetmon_events WHERE blog_id = ? AND ended_at IS NULL`).
+		WithArgs(int64(42)).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(7)))
+
+	expectCloseEventTx(mock, 7, 42, 4, "Down", "probe_cleared")
+
+	mock.ExpectQuery(countActiveEventsSQL).WithArgs(int64(42)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectExec(projectRunningSQL).
+		WithArgs(sqlmock.AnyArg(), int64(42)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	req := httptest.NewRequest("POST", "/api/v1/sites/42/trigger-now", nil)
+	req.SetPathValue("id", "42")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleTriggerNow)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp triggerNowResponse
+	readJSON(t, rec.Body, &resp)
+	if len(resp.ActiveEventsClosed) != 1 || resp.ActiveEventsClosed[0] != 7 {
+		t.Errorf("active_events_closed = %v, want [7]", resp.ActiveEventsClosed)
+	}
+	if resp.CurrentState != "Up" {
+		t.Errorf("current_state = %q, want Up after close-on-success", resp.CurrentState)
+	}
+}
+
+func TestTriggerNowInvalidSiteID(t *testing.T) {
+	s, _, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	req := httptest.NewRequest("POST", "/api/v1/sites/abc/trigger-now", nil)
+	req.SetPathValue("id", "abc")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleTriggerNow)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestRoutesIncludePhase2WriteEndpoints(t *testing.T) {
+	// Sanity: every Phase 2 write endpoint resolves through the mux and
+	// reaches an authenticated handler (which then returns 401 because no
+	// token is provided — that's fine, it confirms the route exists and
+	// runs through requireScope rather than hitting the catch-all 404).
+	s := New(":0", nil, "test")
+	mux := s.routes()
+
+	cases := []struct {
+		method, path string
+	}{
+		{"POST", "/api/v1/sites"},
+		{"PATCH", "/api/v1/sites/42"},
+		{"DELETE", "/api/v1/sites/42"},
+		{"POST", "/api/v1/sites/42/pause"},
+		{"POST", "/api/v1/sites/42/resume"},
+		{"POST", "/api/v1/sites/42/trigger-now"},
+		{"POST", "/api/v1/sites/42/events/7/close"},
+	}
+	for _, c := range cases {
+		req := httptest.NewRequest(c.method, c.path, nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code == http.StatusNotFound {
+			body := readErrorBody(t, rec.Body)
+			if body.Code == "endpoint_not_found" {
+				t.Errorf("%s %s hit catch-all 404; route not registered", c.method, c.path)
+			}
+		}
+	}
+}

--- a/internal/api/idempotency.go
+++ b/internal/api/idempotency.go
@@ -1,0 +1,216 @@
+package api
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// idempotencyTTL is how long a cached response is replayable. Stripe uses
+// 24h; we match that — long enough for a retry storm to settle, short enough
+// that the in-memory store doesn't grow without bound.
+const idempotencyTTL = 24 * time.Hour
+
+// idempotencyHeader is the request header consumers send to make a request
+// retry-safe. Stripe-style.
+const idempotencyHeader = "Idempotency-Key"
+
+// idempotencyKey identifies a stored response uniquely. Scoped by API key id
+// so two consumers can't collide on the same opaque value.
+type idempotencyKey struct {
+	keyID int64
+	key   string
+}
+
+// idempotencyEntry is the cached response. We replay status, headers, and
+// body verbatim. bodyHash distinguishes "same key, same request" (replay) from
+// "same key, different request" (409 conflict).
+type idempotencyEntry struct {
+	bodyHash   string
+	status     int
+	respHeader http.Header
+	respBody   []byte
+	expiresAt  time.Time
+}
+
+// idempotencyStore is an in-memory store with periodic GC. State is bound to
+// this jetmon2 instance; a multi-instance deployment would need Redis or a
+// dedicated table. For the current single-instance internal API that's
+// adequate.
+type idempotencyStore struct {
+	mu      sync.Mutex
+	entries map[idempotencyKey]*idempotencyEntry
+	now     func() time.Time
+}
+
+func newIdempotencyStore() *idempotencyStore {
+	s := &idempotencyStore{
+		entries: make(map[idempotencyKey]*idempotencyEntry),
+		now:     time.Now,
+	}
+	go s.gcLoop()
+	return s
+}
+
+// lookup returns the cached entry if present and not expired. The caller is
+// expected to compare the request body hash to entry.bodyHash to decide
+// between replay and 409.
+func (s *idempotencyStore) lookup(k idempotencyKey) *idempotencyEntry {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.entries[k]
+	if !ok {
+		return nil
+	}
+	if s.now().After(e.expiresAt) {
+		delete(s.entries, k)
+		return nil
+	}
+	return e
+}
+
+// store records a response under the idempotency key. Overwrites any existing
+// entry for the key (which shouldn't happen in normal flow — entries are only
+// stored after a successful handler run).
+func (s *idempotencyStore) store(k idempotencyKey, e *idempotencyEntry) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries[k] = e
+}
+
+func (s *idempotencyStore) gcLoop() {
+	ticker := time.NewTicker(1 * time.Hour)
+	defer ticker.Stop()
+	for range ticker.C {
+		s.gc()
+	}
+}
+
+func (s *idempotencyStore) gc() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.now()
+	for k, e := range s.entries {
+		if now.After(e.expiresAt) {
+			delete(s.entries, k)
+		}
+	}
+}
+
+// idempotencyResponseWriter buffers response writes so we can record the
+// final status, headers, and body for replay. The wrapped writer is what
+// the handler sees; the stored response is what we'll replay on a retry.
+type idempotencyResponseWriter struct {
+	http.ResponseWriter
+	status int
+	body   bytes.Buffer
+	wrote  bool
+}
+
+func (w *idempotencyResponseWriter) WriteHeader(status int) {
+	if w.wrote {
+		return
+	}
+	w.status = status
+	w.wrote = true
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *idempotencyResponseWriter) Write(b []byte) (int, error) {
+	if !w.wrote {
+		w.WriteHeader(http.StatusOK)
+	}
+	w.body.Write(b)
+	return w.ResponseWriter.Write(b)
+}
+
+// withIdempotency wraps a handler so that if the request carries an
+// Idempotency-Key header, the response is cached and replayed on retries
+// with the same body. Stateless / unused if the header is absent.
+//
+// Usage: only wrap POST endpoints (and any other side-effecting verbs)
+// where retries can otherwise duplicate work. GETs don't need it.
+func (s *Server) withIdempotency(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		idemKey := r.Header.Get(idempotencyHeader)
+		if idemKey == "" {
+			// No idempotency requested — pass through.
+			h(w, r)
+			return
+		}
+		key := keyFromRequest(r)
+		if key == nil {
+			// requireScope must have already run — this path is unreachable
+			// in production. Defensive 500 rather than nil-deref.
+			writeError(w, r, http.StatusInternalServerError, "auth_state_missing",
+				"idempotency middleware: authenticated key not in context")
+			return
+		}
+
+		// Read the body so we can both hash it (for conflict detection) and
+		// re-supply it to the handler. Body size is bounded by the server's
+		// ReadTimeout; a future MaxBytesReader would tighten this.
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			writeError(w, r, http.StatusBadRequest, "invalid_body",
+				"failed to read request body: "+err.Error())
+			return
+		}
+		_ = r.Body.Close()
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		bodyHash := hashBytes(body)
+
+		ik := idempotencyKey{keyID: key.ID, key: idemKey}
+		if cached := s.idempotency.lookup(ik); cached != nil {
+			if cached.bodyHash != bodyHash {
+				writeError(w, r, http.StatusConflict, "idempotency_conflict",
+					"the idempotency key was previously used with a different request body")
+				return
+			}
+			replayCached(w, cached)
+			return
+		}
+
+		// Capture the response so we can store it.
+		rec := &idempotencyResponseWriter{ResponseWriter: w, status: http.StatusOK}
+		h(rec, r)
+
+		// Only cache successful and client-error responses (2xx and 4xx).
+		// Server errors (5xx) shouldn't be replayed — the consumer should
+		// retry and we should re-attempt the operation.
+		if rec.status >= 200 && rec.status < 500 {
+			headerCopy := http.Header{}
+			for k, v := range w.Header() {
+				headerCopy[k] = append([]string(nil), v...)
+			}
+			s.idempotency.store(ik, &idempotencyEntry{
+				bodyHash:   bodyHash,
+				status:     rec.status,
+				respHeader: headerCopy,
+				respBody:   append([]byte(nil), rec.body.Bytes()...),
+				expiresAt:  time.Now().Add(idempotencyTTL),
+			})
+		}
+	}
+}
+
+// replayCached writes a previously cached response verbatim. Adds an
+// Idempotency-Replayed: true header so consumers can tell when a response
+// is from the cache vs freshly computed (debugging aid).
+func replayCached(w http.ResponseWriter, e *idempotencyEntry) {
+	for k, v := range e.respHeader {
+		w.Header()[k] = v
+	}
+	w.Header().Set("Idempotency-Replayed", "true")
+	w.WriteHeader(e.status)
+	_, _ = w.Write(e.respBody)
+}
+
+func hashBytes(b []byte) string {
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:])
+}

--- a/internal/api/idempotency_test.go
+++ b/internal/api/idempotency_test.go
@@ -1,0 +1,211 @@
+package api
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Automattic/jetmon/internal/apikeys"
+)
+
+func TestIdempotencyHashStable(t *testing.T) {
+	a := hashBytes([]byte(`{"foo":1}`))
+	b := hashBytes([]byte(`{"foo":1}`))
+	if a != b {
+		t.Fatal("hashBytes is non-deterministic")
+	}
+	if len(a) != 64 {
+		t.Fatalf("hashBytes length = %d, want 64 (sha256 hex)", len(a))
+	}
+}
+
+func TestIdempotencyStoreLookupAndStore(t *testing.T) {
+	store := newIdempotencyStore()
+	store.now = func() time.Time { return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) }
+	k := idempotencyKey{keyID: 1, key: "abc"}
+	if got := store.lookup(k); got != nil {
+		t.Fatal("empty store should return nil")
+	}
+	entry := &idempotencyEntry{
+		bodyHash:   "h1",
+		status:     200,
+		respHeader: http.Header{"Content-Type": []string{"application/json"}},
+		respBody:   []byte(`{"ok":true}`),
+		expiresAt:  store.now().Add(idempotencyTTL),
+	}
+	store.store(k, entry)
+	got := store.lookup(k)
+	if got == nil {
+		t.Fatal("entry should be retrievable")
+	}
+	if got.status != 200 || got.bodyHash != "h1" {
+		t.Errorf("retrieved entry mismatched: %+v", got)
+	}
+}
+
+func TestIdempotencyStoreExpires(t *testing.T) {
+	store := newIdempotencyStore()
+	store.now = func() time.Time { return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) }
+	k := idempotencyKey{keyID: 1, key: "abc"}
+	store.store(k, &idempotencyEntry{
+		expiresAt: store.now().Add(-time.Hour), // already expired
+	})
+	if got := store.lookup(k); got != nil {
+		t.Fatal("expired entry should be invisible to lookup")
+	}
+}
+
+// bodyReader wraps a byte slice as an http.Request.Body.
+func bodyReader(b []byte) io.ReadCloser {
+	return io.NopCloser(bytes.NewReader(b))
+}
+
+func TestIdempotencyMiddlewarePassthroughWhenNoHeader(t *testing.T) {
+	s, _, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	called := 0
+	wrapped := s.withIdempotency(func(w http.ResponseWriter, r *http.Request) {
+		called++
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"created":true}`))
+	})
+
+	req := requestWithKey("POST", "/", key)
+	req.Body = bodyReader(nil)
+	rec := httptest.NewRecorder()
+	wrapped(rec, req)
+	if called != 1 || rec.Code != http.StatusCreated {
+		t.Fatalf("first call: called=%d code=%d", called, rec.Code)
+	}
+
+	// Second call without idempotency key should run again.
+	req2 := requestWithKey("POST", "/", key)
+	req2.Body = bodyReader(nil)
+	rec2 := httptest.NewRecorder()
+	wrapped(rec2, req2)
+	if called != 2 {
+		t.Fatalf("second call: handler called=%d, want 2", called)
+	}
+}
+
+func TestIdempotencyMiddlewareCachesAndReplays(t *testing.T) {
+	s, _, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	called := 0
+	wrapped := s.withIdempotency(func(w http.ResponseWriter, r *http.Request) {
+		called++
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":42}`))
+	})
+
+	body := []byte(`{"foo":1}`)
+	req := requestWithKey("POST", "/", key)
+	req.Header.Set(idempotencyHeader, "key-1")
+	req.Body = bodyReader(body)
+	rec := httptest.NewRecorder()
+	wrapped(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("first call status = %d, want 201", rec.Code)
+	}
+
+	// Second call with same key + same body: handler must not run again.
+	req2 := requestWithKey("POST", "/", key)
+	req2.Header.Set(idempotencyHeader, "key-1")
+	req2.Body = bodyReader(body)
+	rec2 := httptest.NewRecorder()
+	wrapped(rec2, req2)
+	if called != 1 {
+		t.Fatalf("handler called %d times, want 1 (replay)", called)
+	}
+	if rec2.Code != http.StatusCreated {
+		t.Fatalf("replay status = %d, want 201", rec2.Code)
+	}
+	if got := rec2.Header().Get("Idempotency-Replayed"); got != "true" {
+		t.Errorf("Idempotency-Replayed = %q, want true", got)
+	}
+	if got := rec2.Body.String(); got != `{"id":42}` {
+		t.Errorf("replayed body = %q, want %q", got, `{"id":42}`)
+	}
+}
+
+func TestIdempotencyMiddlewareConflictOnDifferentBody(t *testing.T) {
+	s, _, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	called := 0
+	wrapped := s.withIdempotency(func(w http.ResponseWriter, r *http.Request) {
+		called++
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	req := requestWithKey("POST", "/", key)
+	req.Header.Set(idempotencyHeader, "key-1")
+	req.Body = bodyReader([]byte(`{"foo":1}`))
+	wrapped(httptest.NewRecorder(), req)
+	if called != 1 {
+		t.Fatalf("first call: handler called=%d, want 1", called)
+	}
+
+	req2 := requestWithKey("POST", "/", key)
+	req2.Header.Set(idempotencyHeader, "key-1")
+	req2.Body = bodyReader([]byte(`{"foo":2}`)) // different body, same key
+	rec2 := httptest.NewRecorder()
+	wrapped(rec2, req2)
+	if rec2.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d (body=%s)", rec2.Code, rec2.Body.String())
+	}
+	if called != 1 {
+		t.Fatalf("handler should not run on conflict; called=%d", called)
+	}
+	body := readErrorBody(t, rec2.Body)
+	if body.Code != "idempotency_conflict" {
+		t.Errorf("error code = %q, want idempotency_conflict", body.Code)
+	}
+}
+
+func TestIdempotencyMiddlewareIsolatesByKeyID(t *testing.T) {
+	// Two different API keys with the same idempotency string don't share
+	// cached entries — the cache key includes the API key id.
+	s, _, _, cleanup := newTestServer(t)
+	defer cleanup()
+
+	k1 := &apikeys.Key{ID: 1, ConsumerName: "consumer-a", Scope: apikeys.ScopeWrite, RateLimitPerMinute: 60}
+	k2 := &apikeys.Key{ID: 2, ConsumerName: "consumer-b", Scope: apikeys.ScopeWrite, RateLimitPerMinute: 60}
+
+	calledA := 0
+	calledB := 0
+	wrappedA := s.withIdempotency(func(w http.ResponseWriter, r *http.Request) {
+		calledA++
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`A`))
+	})
+	wrappedB := s.withIdempotency(func(w http.ResponseWriter, r *http.Request) {
+		calledB++
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`B`))
+	})
+
+	body := []byte(`{}`)
+	rA := requestWithKey("POST", "/", k1)
+	rA.Header.Set(idempotencyHeader, "shared")
+	rA.Body = bodyReader(body)
+	wrappedA(httptest.NewRecorder(), rA)
+
+	rB := requestWithKey("POST", "/", k2)
+	rB.Header.Set(idempotencyHeader, "shared")
+	rB.Body = bodyReader(body)
+	rec := httptest.NewRecorder()
+	wrappedB(rec, rB)
+
+	if calledA != 1 || calledB != 1 {
+		t.Fatalf("each consumer's handler should run once; got A=%d B=%d", calledA, calledB)
+	}
+	if got := rec.Body.String(); got != "B" {
+		t.Errorf("consumer B got %q, want B (cache should not bleed across keys)", got)
+	}
+}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -1,0 +1,211 @@
+package api
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Automattic/jetmon/internal/apikeys"
+	"github.com/Automattic/jetmon/internal/audit"
+)
+
+// Scope aliases for handler ergonomics. The api package speaks in apikeys.Scope
+// internally but routes use these constants for brevity.
+const (
+	scopeRead  = apikeys.ScopeRead
+	scopeWrite = apikeys.ScopeWrite
+	scopeAdmin = apikeys.ScopeAdmin
+)
+
+// ctxKey is an unexported type so handlers from other packages can't trample
+// our request-scoped state.
+type ctxKey int
+
+const (
+	ctxKeyRequestID ctxKey = iota
+	ctxKeyAPIKey
+)
+
+// keyFromRequest returns the authenticated key for r, or nil if the request
+// hasn't been through the auth middleware.
+func keyFromRequest(r *http.Request) *apikeys.Key {
+	k, _ := r.Context().Value(ctxKeyAPIKey).(*apikeys.Key)
+	return k
+}
+
+// requestIDFromRequest returns the request id assigned by the middleware.
+// Always non-empty — middleware ensures a value is set before the handler runs.
+func requestIDFromRequest(r *http.Request) string {
+	id, _ := r.Context().Value(ctxKeyRequestID).(string)
+	return id
+}
+
+// requireScope returns an http.HandlerFunc that:
+//  1. assigns a request id (echoed in headers and used in error responses),
+//  2. parses the Bearer token,
+//  3. resolves it to a Key via apikeys.Lookup,
+//  4. enforces the required scope,
+//  5. logs the access to jetmon_audit_log on the way out,
+//  6. invokes the wrapped handler.
+//
+// Internal API quirks: 401 vs 403 is honest (no 404-disguised-as-403), and
+// error messages name the resource type so consumers debugging integrations
+// can tell at a glance what went wrong.
+func (s *Server) requireScope(required apikeys.Scope, h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		reqID := newRequestID()
+		ctx := context.WithValue(r.Context(), ctxKeyRequestID, reqID)
+		w.Header().Set("X-Request-ID", reqID)
+
+		token := bearerToken(r)
+		if token == "" {
+			writeError(w, r.WithContext(ctx), http.StatusUnauthorized, "missing_token",
+				"Authorization header with Bearer token is required")
+			s.audit(ctx, nil, r, http.StatusUnauthorized, time.Time{}, "missing token")
+			return
+		}
+
+		key, err := apikeys.Lookup(ctx, s.db, token)
+		if err != nil {
+			status, code, msg := mapAuthError(err)
+			writeError(w, r.WithContext(ctx), status, code, msg)
+			s.audit(ctx, nil, r, status, time.Time{}, code)
+			return
+		}
+
+		if !key.Scope.Includes(required) {
+			writeError(w, r.WithContext(ctx), http.StatusForbidden, "insufficient_scope",
+				"this endpoint requires scope "+string(required)+
+					"; your key has scope "+string(key.Scope))
+			s.audit(ctx, key, r, http.StatusForbidden, time.Time{}, "insufficient scope")
+			return
+		}
+
+		// Rate limit per key.
+		allowed, remaining, resetAt := s.limiter.allow(key.ID, key.RateLimitPerMinute)
+		writeRateLimitHeaders(w, key.RateLimitPerMinute, remaining, resetAt)
+		if !allowed {
+			writeRateLimited(w, r.WithContext(ctx), key.RateLimitPerMinute, remaining, resetAt)
+			s.audit(ctx, key, r, http.StatusTooManyRequests, time.Time{}, "rate limited")
+			return
+		}
+
+		ctx = context.WithValue(ctx, ctxKeyAPIKey, key)
+		started := time.Now()
+
+		// We wrap the response writer so we can capture the final status code
+		// for the audit log. Default to 200 if the handler doesn't write
+		// explicitly (Go's http.ResponseWriter implicitly flushes 200 on first
+		// body write).
+		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		h(rec, r.WithContext(ctx))
+
+		s.audit(ctx, key, r, rec.status, started, "")
+	}
+}
+
+// statusRecorder wraps an http.ResponseWriter to expose the final status code
+// after the handler returns. We need this for audit logging — Go's stdlib
+// doesn't expose the status code post-write.
+type statusRecorder struct {
+	http.ResponseWriter
+	status      int
+	wroteHeader bool
+}
+
+func (r *statusRecorder) WriteHeader(status int) {
+	if r.wroteHeader {
+		return
+	}
+	r.status = status
+	r.wroteHeader = true
+	r.ResponseWriter.WriteHeader(status)
+}
+
+// Flush passes through to the underlying writer if it supports it (SSE,
+// streaming responses).
+func (r *statusRecorder) Flush() {
+	if f, ok := r.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// bearerToken extracts the token from "Authorization: Bearer <token>", or
+// returns "" if the header is missing or malformed.
+func bearerToken(r *http.Request) string {
+	h := r.Header.Get("Authorization")
+	const prefix = "Bearer "
+	if !strings.HasPrefix(h, prefix) {
+		return ""
+	}
+	return strings.TrimSpace(h[len(prefix):])
+}
+
+func mapAuthError(err error) (status int, code, msg string) {
+	switch {
+	case errors.Is(err, apikeys.ErrInvalidToken):
+		return http.StatusUnauthorized, "invalid_token", "the provided token is invalid"
+	case errors.Is(err, apikeys.ErrKeyRevoked):
+		return http.StatusUnauthorized, "token_revoked", "the provided token has been revoked"
+	case errors.Is(err, apikeys.ErrKeyExpired):
+		return http.StatusUnauthorized, "token_expired", "the provided token has expired"
+	default:
+		return http.StatusInternalServerError, "auth_error", "internal error during authentication: " + err.Error()
+	}
+}
+
+// audit writes the request to jetmon_audit_log. Done synchronously today;
+// could be moved to a buffered channel if write latency becomes a concern.
+// Errors are logged but never returned to the consumer — audit is observability,
+// not gate.
+func (s *Server) audit(ctx context.Context, key *apikeys.Key, r *http.Request, status int, started time.Time, note string) {
+	consumerName := "unknown"
+	var keyID int64
+	if key != nil {
+		consumerName = key.ConsumerName
+		keyID = key.ID
+	}
+
+	durationMs := int64(0)
+	if !started.IsZero() {
+		durationMs = time.Since(started).Milliseconds()
+	}
+
+	meta, _ := json.Marshal(map[string]any{
+		"key_id":         keyID,
+		"consumer":       consumerName,
+		"method":         r.Method,
+		"path":           r.URL.Path,
+		"status":         status,
+		"duration_ms":    durationMs,
+		"request_id":     requestIDFromRequest(r),
+		"remote_addr":    r.RemoteAddr,
+		"note":           note,
+	})
+
+	if err := audit.Log(audit.Entry{
+		EventType: audit.EventAPIAccess,
+		Source:    consumerName,
+		Detail:    r.Method + " " + r.URL.Path,
+		Metadata:  meta,
+	}); err != nil {
+		log.Printf("api: audit log failed: %v", err)
+	}
+}
+
+// newRequestID returns a 16-byte random hex id (32 chars). Same shape as the
+// verifier's NewRequestID for consistency in operator log-greppage.
+func newRequestID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// Fall back to a timestamp; collisions are non-load-bearing here.
+		return "ts-" + time.Now().UTC().Format("20060102T150405.000")
+	}
+	return hex.EncodeToString(b[:])
+}

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -1,0 +1,276 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Automattic/jetmon/internal/apikeys"
+)
+
+// keyLookupSQL matches the query used by apikeys.Lookup to resolve a token.
+const keyLookupSQL = ` SELECT id, consumer_name, scope, rate_limit_per_minute, expires_at, revoked_at, last_used_at, created_at, created_by FROM jetmon_api_keys WHERE key_hash = ?`
+
+const keyTouchSQL = `UPDATE jetmon_api_keys SET last_used_at = CURRENT_TIMESTAMP WHERE id = ?`
+
+// columnsKey is the column set returned by getByHash.
+var columnsKey = []string{
+	"id", "consumer_name", "scope", "rate_limit_per_minute",
+	"expires_at", "revoked_at", "last_used_at", "created_at", "created_by",
+}
+
+func makeKeyRow(id int64, scope string, rateLimit int, revokedAt, expiresAt *time.Time) *sqlmock.Rows {
+	rows := sqlmock.NewRows(columnsKey)
+	var rev, exp any
+	if revokedAt != nil {
+		rev = *revokedAt
+	}
+	if expiresAt != nil {
+		exp = *expiresAt
+	}
+	rows.AddRow(id, "test-consumer", scope, rateLimit, exp, rev, nil, time.Now().UTC(), "test")
+	return rows
+}
+
+func TestRequireScopeMissingToken(t *testing.T) {
+	s, _, _, cleanup := newTestServer(t)
+	defer cleanup()
+
+	called := false
+	wrapped := s.requireScope(scopeRead, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+
+	req := httptest.NewRequest("GET", "/api/v1/anything", nil)
+	rec := httptest.NewRecorder()
+	wrapped(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+	if called {
+		t.Fatal("handler should not run without token")
+	}
+	body := readErrorBody(t, rec.Body)
+	if body.Code != "missing_token" {
+		t.Errorf("error code = %q, want missing_token", body.Code)
+	}
+	if rec.Header().Get("X-Request-ID") == "" {
+		t.Error("X-Request-ID header should be set")
+	}
+}
+
+func TestRequireScopeInvalidToken(t *testing.T) {
+	s, mock, _, cleanup := newTestServer(t)
+	defer cleanup()
+
+	// Lookup will return ErrInvalidToken (no rows).
+	mock.ExpectQuery(keyLookupSQL).
+		WillReturnRows(sqlmock.NewRows(columnsKey))
+
+	wrapped := s.requireScope(scopeRead, func(w http.ResponseWriter, r *http.Request) {})
+
+	req := httptest.NewRequest("GET", "/api/v1/anything", nil)
+	req.Header.Set("Authorization", "Bearer jm_INVALID-LOOKING-TOKEN-XXXXX")
+	rec := httptest.NewRecorder()
+	wrapped(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401; body=%s", rec.Code, rec.Body.String())
+	}
+	body := readErrorBody(t, rec.Body)
+	if body.Code != "invalid_token" {
+		t.Errorf("error code = %q, want invalid_token", body.Code)
+	}
+}
+
+func TestRequireScopeRevokedToken(t *testing.T) {
+	s, mock, _, cleanup := newTestServer(t)
+	defer cleanup()
+
+	revokedAt := time.Now().UTC().Add(-time.Hour)
+	mock.ExpectQuery(keyLookupSQL).WillReturnRows(makeKeyRow(1, "read", 60, &revokedAt, nil))
+
+	wrapped := s.requireScope(scopeRead, func(w http.ResponseWriter, r *http.Request) {})
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Authorization", "Bearer jm_ANYTOKENWILLDOFORTHISTESTXX")
+	rec := httptest.NewRecorder()
+	wrapped(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+	body := readErrorBody(t, rec.Body)
+	if body.Code != "token_revoked" {
+		t.Errorf("error code = %q, want token_revoked", body.Code)
+	}
+}
+
+func TestRequireScopeExpiredToken(t *testing.T) {
+	s, mock, _, cleanup := newTestServer(t)
+	defer cleanup()
+
+	expiredAt := time.Now().UTC().Add(-time.Hour)
+	mock.ExpectQuery(keyLookupSQL).WillReturnRows(makeKeyRow(1, "read", 60, nil, &expiredAt))
+	// Lookup also touches last_used_at — but with expired key the expiry check fires first.
+	mock.ExpectExec(keyTouchSQL).WithArgs(int64(1)).WillReturnResult(sqlmock.NewResult(0, 1))
+
+	wrapped := s.requireScope(scopeRead, func(w http.ResponseWriter, r *http.Request) {})
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Authorization", "Bearer jm_ANYTOKENWILLDOFORTHISTESTXX")
+	rec := httptest.NewRecorder()
+	wrapped(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+	body := readErrorBody(t, rec.Body)
+	if body.Code != "token_expired" {
+		t.Errorf("error code = %q, want token_expired", body.Code)
+	}
+}
+
+func TestRequireScopeInsufficientScope(t *testing.T) {
+	s, mock, _, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(keyLookupSQL).WillReturnRows(makeKeyRow(1, "read", 60, nil, nil))
+	mock.ExpectExec(keyTouchSQL).WithArgs(int64(1)).WillReturnResult(sqlmock.NewResult(0, 1))
+
+	called := false
+	wrapped := s.requireScope(scopeWrite, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Authorization", "Bearer jm_ANYTOKENWILLDOFORTHISTESTXX")
+	rec := httptest.NewRecorder()
+	wrapped(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+	if called {
+		t.Fatal("handler should not run with insufficient scope")
+	}
+	body := readErrorBody(t, rec.Body)
+	if body.Code != "insufficient_scope" {
+		t.Errorf("error code = %q, want insufficient_scope", body.Code)
+	}
+}
+
+func TestRequireScopeAllowsValidToken(t *testing.T) {
+	s, mock, _, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(keyLookupSQL).WillReturnRows(makeKeyRow(1, "read", 60, nil, nil))
+	mock.ExpectExec(keyTouchSQL).WithArgs(int64(1)).WillReturnResult(sqlmock.NewResult(0, 1))
+
+	called := false
+	wrapped := s.requireScope(scopeRead, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		// Confirm key reached the handler context.
+		if k := keyFromRequest(r); k == nil || k.ConsumerName != "test-consumer" {
+			t.Errorf("key in handler context = %+v, want test-consumer", k)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Authorization", "Bearer jm_ANYTOKENWILLDOFORTHISTESTXX")
+	rec := httptest.NewRecorder()
+	wrapped(rec, req)
+
+	if !called {
+		t.Fatal("handler should have run")
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("X-RateLimit-Limit"); got != "60" {
+		t.Errorf("X-RateLimit-Limit = %q, want 60", got)
+	}
+	if got := rec.Header().Get("X-RateLimit-Remaining"); got == "" {
+		t.Errorf("X-RateLimit-Remaining missing")
+	}
+}
+
+func TestRequireScopeRateLimit429(t *testing.T) {
+	s, mock, _, cleanup := newTestServer(t)
+	defer cleanup()
+
+	// Limit = 1/min — second request should 429. We have to set up two
+	// lookup expectations because the limiter check runs after auth.
+	mock.MatchExpectationsInOrder(false)
+	mock.ExpectQuery(keyLookupSQL).WillReturnRows(makeKeyRow(2, "read", 1, nil, nil))
+	mock.ExpectExec(keyTouchSQL).WithArgs(int64(2)).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(keyLookupSQL).WillReturnRows(makeKeyRow(2, "read", 1, nil, nil))
+	mock.ExpectExec(keyTouchSQL).WithArgs(int64(2)).WillReturnResult(sqlmock.NewResult(0, 1))
+
+	wrapped := s.requireScope(scopeRead, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// First request — allowed.
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Authorization", "Bearer jm_ANYTOKENWILLDOFORTHISTESTXX")
+	rec := httptest.NewRecorder()
+	wrapped(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first request status = %d, want 200", rec.Code)
+	}
+
+	// Second request — rate limited.
+	req2 := httptest.NewRequest("GET", "/", nil)
+	req2.Header.Set("Authorization", "Bearer jm_ANYTOKENWILLDOFORTHISTESTXX")
+	rec2 := httptest.NewRecorder()
+	wrapped(rec2, req2)
+
+	if rec2.Code != http.StatusTooManyRequests {
+		t.Fatalf("second request status = %d, want 429; body=%s", rec2.Code, rec2.Body.String())
+	}
+	if got := rec2.Header().Get("Retry-After"); got == "" {
+		t.Error("Retry-After header missing on 429")
+	}
+	body := readErrorBody(t, rec2.Body)
+	if body.Code != "rate_limited" {
+		t.Errorf("error code = %q, want rate_limited", body.Code)
+	}
+}
+
+func TestStatusRecorderCapturesCode(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sr := &statusRecorder{ResponseWriter: rec, status: http.StatusOK}
+	sr.WriteHeader(http.StatusBadRequest)
+	if sr.status != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", sr.status)
+	}
+	// Second WriteHeader should be a no-op.
+	sr.WriteHeader(http.StatusInternalServerError)
+	if sr.status != http.StatusBadRequest {
+		t.Errorf("status changed after second WriteHeader = %d", sr.status)
+	}
+}
+
+func TestMapAuthError(t *testing.T) {
+	cases := []struct {
+		err          error
+		wantStatus   int
+		wantCode     string
+	}{
+		{apikeys.ErrInvalidToken, http.StatusUnauthorized, "invalid_token"},
+		{apikeys.ErrKeyRevoked, http.StatusUnauthorized, "token_revoked"},
+		{apikeys.ErrKeyExpired, http.StatusUnauthorized, "token_expired"},
+	}
+	for _, c := range cases {
+		gotStatus, gotCode, _ := mapAuthError(c.err)
+		if gotStatus != c.wantStatus || gotCode != c.wantCode {
+			t.Errorf("mapAuthError(%v) = (%d, %q), want (%d, %q)",
+				c.err, gotStatus, gotCode, c.wantStatus, c.wantCode)
+		}
+	}
+}

--- a/internal/api/ratelimit.go
+++ b/internal/api/ratelimit.go
@@ -1,0 +1,147 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// rateLimiter is an in-memory per-key token bucket. Each key gets its own
+// bucket sized to the key's rate_limit_per_minute. Tokens refill continuously
+// at limit/60 per second (so 60/min ≈ 1 token per second, smoothly).
+//
+// In-memory state is fine for this internal API — there's currently one
+// jetmon2 instance per host, and the gateway in front handles cross-instance
+// fairness. If we ever scale the API horizontally, this moves to Redis.
+type rateLimiter struct {
+	mu      sync.Mutex
+	buckets map[int64]*rateBucket
+	now     func() time.Time // injectable for tests
+}
+
+// rateBucket is a token bucket for a single key. tokens is fractional so
+// short bursts above the per-minute average are possible (the bucket fills to
+// `limit` tokens at full size).
+type rateBucket struct {
+	tokens     float64
+	limit      float64
+	lastRefill time.Time
+}
+
+func newRateLimiter() *rateLimiter {
+	rl := &rateLimiter{
+		buckets: make(map[int64]*rateBucket),
+		now:     time.Now,
+	}
+	go rl.gcLoop()
+	return rl
+}
+
+// allow consumes one token from the key's bucket. Returns whether the request
+// is allowed, the remaining tokens (rounded down for the header), and the
+// next refill instant for X-RateLimit-Reset and Retry-After.
+func (rl *rateLimiter) allow(keyID int64, perMinute int) (allowed bool, remaining int, resetAt time.Time) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := rl.now()
+	b, ok := rl.buckets[keyID]
+	if !ok {
+		b = &rateBucket{
+			tokens:     float64(perMinute),
+			limit:      float64(perMinute),
+			lastRefill: now,
+		}
+		rl.buckets[keyID] = b
+	}
+
+	// If the configured limit changed (key was rotated/edited), resize the
+	// bucket. Don't shrink tokens past the new ceiling.
+	if b.limit != float64(perMinute) {
+		b.limit = float64(perMinute)
+		if b.tokens > b.limit {
+			b.tokens = b.limit
+		}
+	}
+
+	// Refill based on elapsed time since last refill. Rate is limit/60 per second.
+	elapsed := now.Sub(b.lastRefill).Seconds()
+	if elapsed > 0 {
+		b.tokens += elapsed * b.limit / 60.0
+		if b.tokens > b.limit {
+			b.tokens = b.limit
+		}
+		b.lastRefill = now
+	}
+
+	// Reset is "when the bucket would be full again from current state". We
+	// expose this for X-RateLimit-Reset and Retry-After. For a non-empty
+	// bucket the reset time is in the past (already at limit); we clamp to now
+	// + 1s in that case so the header is meaningful.
+	deficit := b.limit - b.tokens
+	secondsToFull := deficit * 60.0 / b.limit
+	resetAt = now.Add(time.Duration(secondsToFull * float64(time.Second)))
+	if resetAt.Before(now) {
+		resetAt = now.Add(time.Second)
+	}
+
+	if b.tokens < 1.0 {
+		// Not enough tokens for this request.
+		return false, int(b.tokens), resetAt
+	}
+	b.tokens -= 1.0
+	return true, int(b.tokens), resetAt
+}
+
+// gcLoop drops buckets that haven't been touched in 10 minutes so the map
+// doesn't grow unbounded as keys come and go.
+func (rl *rateLimiter) gcLoop() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+	for range ticker.C {
+		rl.gc(10 * time.Minute)
+	}
+}
+
+func (rl *rateLimiter) gc(maxIdle time.Duration) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	cutoff := rl.now().Add(-maxIdle)
+	for id, b := range rl.buckets {
+		if b.lastRefill.Before(cutoff) {
+			delete(rl.buckets, id)
+		}
+	}
+}
+
+// writeRateLimitHeaders sets the standard X-RateLimit-{Limit,Remaining,Reset}
+// headers on a response. Reset is unix seconds.
+//
+// Note: Go's net/http canonicalizes header names to "X-Ratelimit-Limit"
+// (lowercase after the second segment) on the wire. This is RFC 7230 compliant
+// — HTTP header names are case-insensitive — but the IETF draft for these
+// headers uses the camelCase form. Bypassing canonicalization in stdlib
+// requires direct map access (h[key] = value) and breaks http.Header.Get
+// case-insensitive lookups for downstream Go consumers, so we accept the
+// canonicalized form. Most clients (curl, fetch, requests) do
+// case-insensitive header lookup and don't care.
+func writeRateLimitHeaders(w http.ResponseWriter, limit, remaining int, resetAt time.Time) {
+	w.Header().Set("X-RateLimit-Limit", strconv.Itoa(limit))
+	w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(remaining))
+	w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(resetAt.Unix(), 10))
+}
+
+// writeRateLimited writes a 429 response with Retry-After and the standard
+// rate limit headers. Used by the middleware when the limiter rejects.
+func writeRateLimited(w http.ResponseWriter, r *http.Request, limit, remaining int, resetAt time.Time) {
+	writeRateLimitHeaders(w, limit, remaining, resetAt)
+	retryAfter := int(time.Until(resetAt).Seconds())
+	if retryAfter < 1 {
+		retryAfter = 1
+	}
+	w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+	writeError(w, r, http.StatusTooManyRequests, "rate_limited",
+		fmt.Sprintf("rate limit exceeded; retry after %d seconds", retryAfter))
+}

--- a/internal/api/ratelimit_test.go
+++ b/internal/api/ratelimit_test.go
@@ -1,0 +1,136 @@
+package api
+
+import (
+	"testing"
+	"time"
+)
+
+// fakeClock returns a controllable time source for deterministic rate-limit
+// tests. We can't use real time.Now() because elapsed-time math would make
+// tests flaky on slow CI.
+type fakeClock struct {
+	t time.Time
+}
+
+func (c *fakeClock) now() time.Time { return c.t }
+
+func newTestLimiter(c *fakeClock) *rateLimiter {
+	rl := &rateLimiter{
+		buckets: make(map[int64]*rateBucket),
+		now:     c.now,
+	}
+	// Don't start the GC loop in tests.
+	return rl
+}
+
+func TestRateLimiterAllowsUntilExhausted(t *testing.T) {
+	clock := &fakeClock{t: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	rl := newTestLimiter(clock)
+
+	// Limit = 5/min. First five requests pass.
+	for i := 0; i < 5; i++ {
+		allowed, _, _ := rl.allow(42, 5)
+		if !allowed {
+			t.Fatalf("request %d should have been allowed", i+1)
+		}
+	}
+	// Sixth is denied.
+	allowed, remaining, _ := rl.allow(42, 5)
+	if allowed {
+		t.Fatal("sixth request should have been denied")
+	}
+	if remaining != 0 {
+		t.Errorf("remaining = %d, want 0", remaining)
+	}
+}
+
+func TestRateLimiterRefillsOverTime(t *testing.T) {
+	clock := &fakeClock{t: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	rl := newTestLimiter(clock)
+
+	// Exhaust a 60/min bucket → 60 tokens.
+	for i := 0; i < 60; i++ {
+		allowed, _, _ := rl.allow(7, 60)
+		if !allowed {
+			t.Fatalf("request %d should have been allowed in burst", i+1)
+		}
+	}
+	// 61st denied.
+	allowed, _, _ := rl.allow(7, 60)
+	if allowed {
+		t.Fatal("burst exhausted should deny")
+	}
+
+	// Advance 1 second — at 60/min that's 1 token refilled.
+	clock.t = clock.t.Add(time.Second)
+	allowed, _, _ = rl.allow(7, 60)
+	if !allowed {
+		t.Fatal("after 1s with 60/min limit, one token should have refilled")
+	}
+}
+
+func TestRateLimiterIsolatesKeys(t *testing.T) {
+	clock := &fakeClock{t: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	rl := newTestLimiter(clock)
+
+	// Exhaust key 1.
+	for i := 0; i < 2; i++ {
+		rl.allow(1, 2)
+	}
+	if allowed, _, _ := rl.allow(1, 2); allowed {
+		t.Fatal("key 1 should be exhausted")
+	}
+	// Key 2 unaffected.
+	if allowed, _, _ := rl.allow(2, 2); !allowed {
+		t.Fatal("key 2 should not be affected by key 1's bucket")
+	}
+}
+
+func TestRateLimiterResizeOnLimitChange(t *testing.T) {
+	clock := &fakeClock{t: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	rl := newTestLimiter(clock)
+
+	// Use 5 of a 10-token bucket.
+	for i := 0; i < 5; i++ {
+		rl.allow(1, 10)
+	}
+	// Operator drops the limit to 3 (e.g. via key edit). Bucket should
+	// shrink — caller can't have 5 tokens left under a 3-token cap.
+	allowed, remaining, _ := rl.allow(1, 3)
+	if !allowed {
+		t.Fatal("first request after resize should still allow")
+	}
+	if remaining > 3 {
+		t.Errorf("remaining = %d, want <= 3 after resize", remaining)
+	}
+}
+
+func TestRateLimiterGCDropsStaleBuckets(t *testing.T) {
+	clock := &fakeClock{t: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	rl := newTestLimiter(clock)
+
+	rl.allow(1, 60)
+	rl.allow(2, 60)
+
+	// Advance past the GC threshold.
+	clock.t = clock.t.Add(20 * time.Minute)
+	rl.gc(10 * time.Minute)
+
+	if len(rl.buckets) != 0 {
+		t.Errorf("expected GC to drop stale buckets, %d remain", len(rl.buckets))
+	}
+}
+
+func TestRateLimiterResetTimeIsFuture(t *testing.T) {
+	clock := &fakeClock{t: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	rl := newTestLimiter(clock)
+
+	// Exhaust a 60/min bucket so deficit is real.
+	for i := 0; i < 60; i++ {
+		rl.allow(1, 60)
+	}
+	_, _, resetAt := rl.allow(1, 60)
+	if !resetAt.After(clock.now()) {
+		t.Errorf("reset time %v should be after now %v", resetAt, clock.now())
+	}
+}

--- a/internal/api/responses.go
+++ b/internal/api/responses.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+// ListEnvelope wraps every list response. Single-resource responses are
+// returned as bare objects without an envelope. See API.md "Response envelope".
+type ListEnvelope struct {
+	Data any  `json:"data"`
+	Page Page `json:"page"`
+}
+
+// Page describes the cursor for the next page of a list response. Cursor is
+// nil on the last page. Limit is the limit applied to *this* response (which
+// may differ from the request if the server clamped it).
+type Page struct {
+	Next  *string `json:"next"`
+	Limit int     `json:"limit"`
+}
+
+// errorEnvelope is the JSON shape returned on any non-2xx response. The
+// `code` is a stable machine-readable identifier; `message` is for humans
+// and may improve over time. `request_id` correlates with server logs.
+type errorEnvelope struct {
+	Error errorBody `json:"error"`
+}
+
+type errorBody struct {
+	Code      string `json:"code"`
+	Message   string `json:"message"`
+	RequestID string `json:"request_id,omitempty"`
+}
+
+// writeJSON serializes v as JSON and writes it with the given status code.
+// Errors during marshaling are logged but produce a generic 500 to the
+// consumer (we can't recover from a marshaling failure mid-response).
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	enc := json.NewEncoder(w)
+	if err := enc.Encode(v); err != nil {
+		log.Printf("api: response encode failed: %v", err)
+	}
+}
+
+// writeError writes a structured error envelope. The request id is pulled
+// from request context if available so consumers can correlate with server
+// logs; the X-Request-ID header is also set if not already present.
+func writeError(w http.ResponseWriter, r *http.Request, status int, code, message string) {
+	reqID := requestIDFromRequest(r)
+	if reqID != "" && w.Header().Get("X-Request-ID") == "" {
+		w.Header().Set("X-Request-ID", reqID)
+	}
+	writeJSON(w, status, errorEnvelope{
+		Error: errorBody{
+			Code:      code,
+			Message:   message,
+			RequestID: reqID,
+		},
+	})
+}

--- a/internal/api/scope_test.go
+++ b/internal/api/scope_test.go
@@ -1,0 +1,198 @@
+package api
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Automattic/jetmon/internal/apikeys"
+)
+
+// scopeProbeKey returns the key-lookup row a token check should yield for
+// a given scope. The middleware also touches last_used_at, so every test
+// expecting a successful auth has to expect both the SELECT and the UPDATE.
+func scopeProbeKey(scope string, rateLimit int) *sqlmock.Rows {
+	return sqlmock.NewRows(columnsKey).AddRow(
+		int64(1), "test-consumer", scope, rateLimit,
+		nil, nil, nil, time.Now().UTC(), "test",
+	)
+}
+
+// expectAuthLookup primes mock with the SELECT + UPDATE pair the middleware
+// runs on a successful token resolution. Returns nothing — the call sets
+// up the expectation directly.
+func expectAuthLookup(mock sqlmock.Sqlmock, scope string) {
+	mock.ExpectQuery(keyLookupSQL).WillReturnRows(scopeProbeKey(scope, 1000))
+	mock.ExpectExec(keyTouchSQL).WithArgs(int64(1)).WillReturnResult(sqlmock.NewResult(0, 1))
+}
+
+// phase2WriteEndpoints lists every Phase 2 write route that should require
+// scope=write. Each entry uses path values that won't actually exist in the
+// DB — we only care about the auth/scope decision, which fires before any
+// DB access.
+var phase2WriteEndpoints = []struct {
+	method, path string
+}{
+	{"POST", "/api/v1/sites"},
+	{"PATCH", "/api/v1/sites/42"},
+	{"DELETE", "/api/v1/sites/42"},
+	{"POST", "/api/v1/sites/42/pause"},
+	{"POST", "/api/v1/sites/42/resume"},
+	{"POST", "/api/v1/sites/42/trigger-now"},
+	{"POST", "/api/v1/sites/42/events/7/close"},
+}
+
+// phase2ReadEndpoints covers the read side. read scope should pass the
+// scope check (we don't assert a specific 200 because the DB call after the
+// check would need its own mocks — what we want here is "not 403").
+var phase2ReadEndpoints = []struct {
+	method, path string
+}{
+	{"GET", "/api/v1/sites"},
+	{"GET", "/api/v1/sites/42"},
+	{"GET", "/api/v1/sites/42/events"},
+	{"GET", "/api/v1/sites/42/events/7"},
+	{"GET", "/api/v1/sites/42/events/7/transitions"},
+	{"GET", "/api/v1/events/7"},
+	{"GET", "/api/v1/sites/42/uptime"},
+	{"GET", "/api/v1/sites/42/response-time"},
+	{"GET", "/api/v1/sites/42/timing-breakdown"},
+}
+
+func TestPhase2WriteEndpointsRejectReadToken(t *testing.T) {
+	// A read-scope token hitting a write endpoint must get 403
+	// insufficient_scope, not pass through to the handler.
+	for _, ep := range phase2WriteEndpoints {
+		t.Run(ep.method+"_"+ep.path, func(t *testing.T) {
+			s, mock, _, cleanup := newTestServer(t)
+			defer cleanup()
+
+			// Auth lookup succeeds with read scope.
+			expectAuthLookup(mock, "read")
+
+			req := httptest.NewRequest(ep.method, ep.path, bytes.NewReader([]byte(`{}`)))
+			req.Header.Set("Authorization", "Bearer jm_TOKENXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			s.routes().ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want 403; body=%s", rec.Code, rec.Body.String())
+			}
+			if got := readErrorBody(t, rec.Body).Code; got != "insufficient_scope" {
+				t.Errorf("code = %q, want insufficient_scope", got)
+			}
+		})
+	}
+}
+
+func TestPhase2WriteEndpointsAcceptWriteToken(t *testing.T) {
+	// Write-scope tokens should pass scope enforcement and reach the
+	// handler. We assert that the response is NOT 403 (the handler
+	// itself may then 400/404 due to missing DB rows, but that's a
+	// downstream concern; the gate we care about here is the scope check).
+	for _, ep := range phase2WriteEndpoints {
+		t.Run(ep.method+"_"+ep.path, func(t *testing.T) {
+			s, mock, _, cleanup := newTestServer(t)
+			defer cleanup()
+
+			expectAuthLookup(mock, "write")
+			// We don't know exactly which DB queries each handler will run
+			// after the scope check (each endpoint is different), so allow
+			// any further queries to fail without causing test failure.
+			mock.MatchExpectationsInOrder(false)
+
+			req := httptest.NewRequest(ep.method, ep.path, bytes.NewReader([]byte(`{}`)))
+			req.Header.Set("Authorization", "Bearer jm_TOKENXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			s.routes().ServeHTTP(rec, req)
+
+			if rec.Code == http.StatusForbidden {
+				t.Errorf("write scope unexpectedly hit 403 on %s %s; body=%s",
+					ep.method, ep.path, rec.Body.String())
+			}
+			if rec.Code == http.StatusUnauthorized {
+				t.Errorf("write scope unexpectedly hit 401 on %s %s; body=%s",
+					ep.method, ep.path, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestPhase2ReadEndpointsAcceptReadToken(t *testing.T) {
+	// Read-scope tokens should pass scope enforcement on read endpoints.
+	for _, ep := range phase2ReadEndpoints {
+		t.Run(ep.method+"_"+ep.path, func(t *testing.T) {
+			s, mock, _, cleanup := newTestServer(t)
+			defer cleanup()
+
+			expectAuthLookup(mock, "read")
+			mock.MatchExpectationsInOrder(false)
+
+			req := httptest.NewRequest(ep.method, ep.path, nil)
+			req.Header.Set("Authorization", "Bearer jm_TOKENXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+			rec := httptest.NewRecorder()
+			s.routes().ServeHTTP(rec, req)
+
+			if rec.Code == http.StatusForbidden {
+				t.Errorf("read scope unexpectedly hit 403 on %s %s; body=%s",
+					ep.method, ep.path, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestPhase2WriteEndpointsRejectMissingToken(t *testing.T) {
+	// No Authorization header → 401 missing_token (no DB lookup expected).
+	s, _, _, cleanup := newTestServer(t)
+	defer cleanup()
+
+	for _, ep := range phase2WriteEndpoints {
+		req := httptest.NewRequest(ep.method, ep.path, bytes.NewReader([]byte(`{}`)))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		s.routes().ServeHTTP(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("%s %s status = %d, want 401", ep.method, ep.path, rec.Code)
+		}
+		if got := readErrorBody(t, rec.Body).Code; got != "missing_token" {
+			t.Errorf("%s %s code = %q, want missing_token", ep.method, ep.path, got)
+		}
+	}
+}
+
+func TestAdminTokenCanReachAllScopes(t *testing.T) {
+	// admin includes write includes read — verify by hitting both a read
+	// and a write endpoint with an admin token.
+	scopes := []apikeys.Scope{apikeys.ScopeAdmin}
+	for _, scope := range scopes {
+		s, mock, _, cleanup := newTestServer(t)
+		defer cleanup()
+
+		expectAuthLookup(mock, string(scope))
+		expectAuthLookup(mock, string(scope))
+		mock.MatchExpectationsInOrder(false)
+
+		// Read endpoint
+		readReq := httptest.NewRequest("GET", "/api/v1/me", nil)
+		readReq.Header.Set("Authorization", "Bearer jm_ADMINXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+		readRec := httptest.NewRecorder()
+		s.routes().ServeHTTP(readRec, readReq)
+		if readRec.Code == http.StatusForbidden {
+			t.Errorf("admin scope unexpectedly hit 403 on /me with scope=%s", scope)
+		}
+
+		// Write endpoint
+		writeReq := httptest.NewRequest("POST", "/api/v1/sites/42/pause", nil)
+		writeReq.Header.Set("Authorization", "Bearer jm_ADMINXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+		writeRec := httptest.NewRecorder()
+		s.routes().ServeHTTP(writeRec, writeReq)
+		if writeRec.Code == http.StatusForbidden {
+			t.Errorf("admin scope unexpectedly hit 403 on POST /pause with scope=%s", scope)
+		}
+	}
+}

--- a/internal/api/testhelp_test.go
+++ b/internal/api/testhelp_test.go
@@ -60,6 +60,15 @@ func requestWithKey(method, target string, key *apikeys.Key) *http.Request {
 	return req.WithContext(ctx)
 }
 
+// setAuthCtx attaches an authenticated key + request id to an existing
+// request, preserving its body and path values. Used for handler tests
+// that need to send a JSON body alongside an authenticated context.
+func setAuthCtx(req *http.Request, key *apikeys.Key) *http.Request {
+	ctx := context.WithValue(req.Context(), ctxKeyAPIKey, key)
+	ctx = context.WithValue(ctx, ctxKeyRequestID, "test-request-id")
+	return req.WithContext(ctx)
+}
+
 // readJSON decodes the response body into the target struct.
 func readJSON(t *testing.T, body io.Reader, target any) {
 	t.Helper()

--- a/internal/api/testhelp_test.go
+++ b/internal/api/testhelp_test.go
@@ -1,0 +1,126 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Automattic/jetmon/internal/apikeys"
+)
+
+// newTestServer builds a Server backed by sqlmock plus a stub key the tests
+// can use as the authenticated identity. Returns the Server, the mock
+// (for setting expectations), the canned key, and a cleanup func.
+//
+// The stub key has scope=admin and a high rate limit so individual tests
+// don't have to set those up. Tests that exercise scope/rate-limit edges
+// override key.Scope or key.RateLimitPerMinute directly.
+//
+// QueryMatcherEqual is used so tests assert the exact production SQL string.
+// If a query in production gets reformatted, the test fails — which is the
+// behavior we want for an internal API where SQL is part of the contract
+// with the schema.
+func newTestServer(t *testing.T) (*Server, sqlmock.Sqlmock, *apikeys.Key, func()) {
+	t.Helper()
+	db, mock, err := sqlmock.New(
+		sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual),
+		sqlmock.MonitorPingsOption(true),
+	)
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	s := New(":0", db, "test-host")
+
+	key := &apikeys.Key{
+		ID:                 1,
+		ConsumerName:       "test-consumer",
+		Scope:              apikeys.ScopeAdmin,
+		RateLimitPerMinute: 1000,
+		CreatedAt:          time.Now().UTC(),
+	}
+
+	cleanup := func() {
+		_ = db.Close()
+	}
+	return s, mock, key, cleanup
+}
+
+// requestWithKey returns an *http.Request whose context already has the
+// authenticated key and a request id attached, so handlers can be invoked
+// directly without going through requireScope.
+func requestWithKey(method, target string, key *apikeys.Key) *http.Request {
+	req := httptest.NewRequest(method, target, nil)
+	ctx := context.WithValue(req.Context(), ctxKeyAPIKey, key)
+	ctx = context.WithValue(ctx, ctxKeyRequestID, "test-request-id")
+	return req.WithContext(ctx)
+}
+
+// readJSON decodes the response body into the target struct.
+func readJSON(t *testing.T, body io.Reader, target any) {
+	t.Helper()
+	if err := json.NewDecoder(body).Decode(target); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+}
+
+// readErrorBody parses the standard error envelope.
+func readErrorBody(t *testing.T, body io.Reader) errorBody {
+	t.Helper()
+	var env errorEnvelope
+	readJSON(t, body, &env)
+	return env.Error
+}
+
+// invokeWithMux runs the request against the server's full mux so the route
+// matcher fires (path-value extraction etc.). Used for end-to-end handler
+// tests that need r.PathValue to work.
+func invokeWithMux(s *Server, req *http.Request) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	s.routes().ServeHTTP(rec, req)
+	return rec
+}
+
+// invokeAuthed runs an authenticated request through the mux by injecting
+// the key into the request context first. The mux's requireScope wrapper
+// will still fire — but bearerToken returns "" so we'd hit "missing token".
+// Instead, we bypass auth entirely by serving the handler directly. For
+// tests that need the auth middleware, use newAuthRequest with a real token
+// hash expectation.
+//
+// This indirection exists because requireScope tightly couples auth, scope,
+// rate limiting, and audit — and we test those independently.
+func invokeAuthed(s *Server, req *http.Request, h http.HandlerFunc) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	h(rec, req)
+	return rec
+}
+
+// columnsSite is the column set returned by the site list query.
+var columnsSite = []string{
+	"blog_id", "public_id", "monitor_url", "monitor_active", "site_status",
+	"last_checked_at", "last_status_change", "ssl_expiry_date", "check_keyword",
+	"redirect_policy", "maintenance_start", "maintenance_end", "alert_cooldown_minutes",
+}
+
+// columnsActiveEvent is the column set returned by queryActiveEvents.
+var columnsActiveEvent = []string{
+	"id", "check_type", "severity", "state", "started_at",
+}
+
+// columnsEvent is the column set returned by event queries.
+var columnsEvent = []string{
+	"id", "blog_id", "endpoint_id", "check_type", "discriminator",
+	"severity", "state", "started_at", "ended_at", "resolution_reason",
+	"cause_event_id", "metadata",
+}
+
+// columnsTransition is the column set returned by transition queries.
+var columnsTransition = []string{
+	"id", "event_id", "severity_before", "severity_after",
+	"state_before", "state_after", "reason", "source", "metadata", "changed_at",
+}

--- a/internal/apikeys/apikeys.go
+++ b/internal/apikeys/apikeys.go
@@ -1,0 +1,351 @@
+// Package apikeys manages API tokens stored in jetmon_api_keys.
+//
+// Tokens are 32 bytes of crypto/rand entropy, base32-encoded with a "jm_"
+// prefix (e.g. "jm_NBSWY3DPEHPK3PXP..."). Storage is sha256-hashed; the raw
+// token is only ever returned at creation time via the CLI.
+//
+// This package is the only writer for jetmon_api_keys. The HTTP API exposes
+// no key management endpoints — see API.md "Authentication".
+package apikeys
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base32"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Scope is the coarse permission level granted to a key. See API.md.
+type Scope string
+
+const (
+	ScopeRead  Scope = "read"
+	ScopeWrite Scope = "write"
+	ScopeAdmin Scope = "admin"
+)
+
+// AllScopes returns the full set of valid scopes in increasing privilege order.
+func AllScopes() []Scope {
+	return []Scope{ScopeRead, ScopeWrite, ScopeAdmin}
+}
+
+// Includes reports whether s grants at least the privileges of required.
+// scope ordering: read < write < admin. admin includes write includes read.
+func (s Scope) Includes(required Scope) bool {
+	rank := map[Scope]int{ScopeRead: 0, ScopeWrite: 1, ScopeAdmin: 2}
+	return rank[s] >= rank[required]
+}
+
+// Valid reports whether s is one of the recognized scope values.
+func (s Scope) Valid() bool {
+	switch s {
+	case ScopeRead, ScopeWrite, ScopeAdmin:
+		return true
+	}
+	return false
+}
+
+// TokenPrefix is prepended to every generated token. The prefix is part of
+// the auth check — tokens without it are rejected at parse time.
+const TokenPrefix = "jm_"
+
+// Sentinel errors returned by Lookup. Callers translate to HTTP status codes.
+var (
+	ErrInvalidToken = errors.New("apikeys: invalid token")
+	ErrKeyRevoked   = errors.New("apikeys: key revoked")
+	ErrKeyExpired   = errors.New("apikeys: key expired")
+)
+
+// Key is the in-memory representation of a jetmon_api_keys row. The raw
+// token is never stored here — it's hashed on the way in and discarded.
+type Key struct {
+	ID                 int64
+	ConsumerName       string
+	Scope              Scope
+	RateLimitPerMinute int
+	ExpiresAt          *time.Time
+	RevokedAt          *time.Time
+	LastUsedAt         *time.Time
+	CreatedAt          time.Time
+	CreatedBy          string
+}
+
+// CreateInput carries the fields needed to create a new key.
+type CreateInput struct {
+	ConsumerName       string
+	Scope              Scope
+	RateLimitPerMinute int           // 0 → server default
+	TTL                time.Duration // 0 → never expires
+	CreatedBy          string        // operator identity for audit; falls back to "cli"
+}
+
+// GenerateToken returns a fresh raw token and its sha256 hash. The raw token
+// is what the consumer puts in their Authorization header; the hash is what
+// goes in the database.
+func GenerateToken() (raw, hashed string, err error) {
+	var buf [32]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", "", fmt.Errorf("apikeys: read entropy: %w", err)
+	}
+	encoded := base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(buf[:])
+	raw = TokenPrefix + encoded
+	hashed = HashToken(raw)
+	return raw, hashed, nil
+}
+
+// HashToken returns the sha256 hex digest of token. Used both at creation
+// (to store) and at lookup (to compare). sha256 is the right hash here because
+// tokens are high-entropy random; bcrypt's deliberate slowness is for human
+// passwords.
+func HashToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
+// Create inserts a new key and returns the raw token (one-time view) plus
+// the persisted Key record.
+func Create(ctx context.Context, db *sql.DB, in CreateInput) (raw string, k *Key, err error) {
+	if in.ConsumerName == "" {
+		return "", nil, errors.New("apikeys: consumer_name is required")
+	}
+	if !in.Scope.Valid() {
+		return "", nil, fmt.Errorf("apikeys: invalid scope %q (want one of: read, write, admin)", in.Scope)
+	}
+	rateLimit := in.RateLimitPerMinute
+	if rateLimit <= 0 {
+		rateLimit = defaultRateLimitForScope(in.Scope)
+	}
+	createdBy := in.CreatedBy
+	if createdBy == "" {
+		createdBy = "cli"
+	}
+
+	raw, hashed, err := GenerateToken()
+	if err != nil {
+		return "", nil, err
+	}
+
+	var expiresAt sql.NullTime
+	if in.TTL > 0 {
+		expiresAt = sql.NullTime{Time: time.Now().UTC().Add(in.TTL), Valid: true}
+	}
+
+	res, err := db.ExecContext(ctx, `
+		INSERT INTO jetmon_api_keys
+			(key_hash, consumer_name, scope, rate_limit_per_minute, expires_at, created_by)
+		VALUES (?, ?, ?, ?, ?, ?)`,
+		hashed, in.ConsumerName, string(in.Scope), rateLimit, expiresAt, createdBy,
+	)
+	if err != nil {
+		return "", nil, fmt.Errorf("apikeys: insert: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return "", nil, fmt.Errorf("apikeys: last insert id: %w", err)
+	}
+
+	k, err = getByID(ctx, db, id)
+	if err != nil {
+		return "", nil, err
+	}
+	return raw, k, nil
+}
+
+// Lookup resolves a raw token to its Key. Returns ErrInvalidToken for any
+// case where the token shouldn't be trusted (malformed, no matching row,
+// revoked, expired). Updates last_used_at on success.
+func Lookup(ctx context.Context, db *sql.DB, raw string) (*Key, error) {
+	if !strings.HasPrefix(raw, TokenPrefix) || len(raw) < len(TokenPrefix)+10 {
+		return nil, ErrInvalidToken
+	}
+	hashed := HashToken(raw)
+
+	k, err := getByHash(ctx, db, hashed)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrInvalidToken
+		}
+		return nil, fmt.Errorf("apikeys: lookup: %w", err)
+	}
+
+	if k.RevokedAt != nil {
+		return nil, ErrKeyRevoked
+	}
+	if k.ExpiresAt != nil && time.Now().UTC().After(*k.ExpiresAt) {
+		return nil, ErrKeyExpired
+	}
+
+	// Best-effort last_used_at touch. We swallow errors here so a transient
+	// write failure doesn't fail the auth check — last_used_at is observability,
+	// not security.
+	_, _ = db.ExecContext(ctx,
+		`UPDATE jetmon_api_keys SET last_used_at = CURRENT_TIMESTAMP WHERE id = ?`, k.ID)
+	return k, nil
+}
+
+// List returns all keys for ops display. Hash is never exposed.
+func List(ctx context.Context, db *sql.DB) ([]Key, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT id, consumer_name, scope, rate_limit_per_minute,
+		       expires_at, revoked_at, last_used_at, created_at, created_by
+		  FROM jetmon_api_keys
+		 ORDER BY id ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("apikeys: list: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Key
+	for rows.Next() {
+		k, err := scanKey(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *k)
+	}
+	return out, rows.Err()
+}
+
+// Revoke sets revoked_at on the given key. Idempotent — re-revoking is a no-op.
+func Revoke(ctx context.Context, db *sql.DB, id int64) error {
+	res, err := db.ExecContext(ctx,
+		`UPDATE jetmon_api_keys SET revoked_at = CURRENT_TIMESTAMP WHERE id = ? AND revoked_at IS NULL`, id)
+	if err != nil {
+		return fmt.Errorf("apikeys: revoke: %w", err)
+	}
+	affected, _ := res.RowsAffected()
+	if affected == 0 {
+		// Either the key doesn't exist or it was already revoked. Look up
+		// to distinguish, so the CLI can give a useful message.
+		k, lookupErr := getByID(ctx, db, id)
+		if lookupErr != nil {
+			if errors.Is(lookupErr, sql.ErrNoRows) {
+				return fmt.Errorf("apikeys: key %d not found", id)
+			}
+			return lookupErr
+		}
+		if k.RevokedAt != nil {
+			// Already revoked — treat as success.
+			return nil
+		}
+	}
+	return nil
+}
+
+// Rotate creates a new key matching the existing key's consumer/scope/rate-limit
+// and schedules the old one to be revoked after gracePeriod. Returns the new
+// raw token. If gracePeriod is zero, the old key is revoked immediately.
+func Rotate(ctx context.Context, db *sql.DB, oldID int64, gracePeriod time.Duration, createdBy string) (newRaw string, newKey *Key, err error) {
+	old, err := getByID(ctx, db, oldID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil, fmt.Errorf("apikeys: key %d not found", oldID)
+		}
+		return "", nil, err
+	}
+	if old.RevokedAt != nil {
+		return "", nil, fmt.Errorf("apikeys: key %d already revoked; create a fresh key instead", oldID)
+	}
+
+	// Honor any TTL the original key had — the rotated key inherits it.
+	var ttl time.Duration
+	if old.ExpiresAt != nil {
+		ttl = time.Until(*old.ExpiresAt)
+		if ttl < 0 {
+			ttl = 0
+		}
+	}
+
+	newRaw, newKey, err = Create(ctx, db, CreateInput{
+		ConsumerName:       old.ConsumerName,
+		Scope:              old.Scope,
+		RateLimitPerMinute: old.RateLimitPerMinute,
+		TTL:                ttl,
+		CreatedBy:          createdBy,
+	})
+	if err != nil {
+		return "", nil, err
+	}
+
+	if gracePeriod <= 0 {
+		if err := Revoke(ctx, db, oldID); err != nil {
+			return "", nil, fmt.Errorf("apikeys: rotate (revoke old): %w", err)
+		}
+	} else {
+		// Schedule revocation: set revoked_at to now+grace. Lookup checks
+		// revoked_at against the current time, so a future revoked_at is
+		// effectively "scheduled."
+		_, err := db.ExecContext(ctx,
+			`UPDATE jetmon_api_keys
+			    SET revoked_at = DATE_ADD(CURRENT_TIMESTAMP, INTERVAL ? SECOND)
+			  WHERE id = ?`,
+			int(gracePeriod.Seconds()), oldID)
+		if err != nil {
+			return "", nil, fmt.Errorf("apikeys: rotate (schedule revoke): %w", err)
+		}
+	}
+	return newRaw, newKey, nil
+}
+
+func defaultRateLimitForScope(s Scope) int {
+	switch s {
+	case ScopeWrite:
+		return 30
+	case ScopeAdmin:
+		return 60
+	default:
+		return 60
+	}
+}
+
+func getByID(ctx context.Context, db *sql.DB, id int64) (*Key, error) {
+	row := db.QueryRowContext(ctx, `
+		SELECT id, consumer_name, scope, rate_limit_per_minute,
+		       expires_at, revoked_at, last_used_at, created_at, created_by
+		  FROM jetmon_api_keys
+		 WHERE id = ?`, id)
+	return scanKey(row)
+}
+
+func getByHash(ctx context.Context, db *sql.DB, hash string) (*Key, error) {
+	row := db.QueryRowContext(ctx, `
+		SELECT id, consumer_name, scope, rate_limit_per_minute,
+		       expires_at, revoked_at, last_used_at, created_at, created_by
+		  FROM jetmon_api_keys
+		 WHERE key_hash = ?`, hash)
+	return scanKey(row)
+}
+
+// rowScanner accepts both *sql.Row and *sql.Rows so scanKey can be reused.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanKey(s rowScanner) (*Key, error) {
+	var k Key
+	var scope string
+	var expiresAt, revokedAt, lastUsedAt sql.NullTime
+	if err := s.Scan(
+		&k.ID, &k.ConsumerName, &scope, &k.RateLimitPerMinute,
+		&expiresAt, &revokedAt, &lastUsedAt, &k.CreatedAt, &k.CreatedBy,
+	); err != nil {
+		return nil, err
+	}
+	k.Scope = Scope(scope)
+	if expiresAt.Valid {
+		k.ExpiresAt = &expiresAt.Time
+	}
+	if revokedAt.Valid {
+		k.RevokedAt = &revokedAt.Time
+	}
+	if lastUsedAt.Valid {
+		k.LastUsedAt = &lastUsedAt.Time
+	}
+	return &k, nil
+}

--- a/internal/apikeys/apikeys_test.go
+++ b/internal/apikeys/apikeys_test.go
@@ -1,0 +1,83 @@
+package apikeys
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateTokenFormat(t *testing.T) {
+	raw, hashed, err := GenerateToken()
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	if !strings.HasPrefix(raw, TokenPrefix) {
+		t.Fatalf("token missing prefix: %q", raw)
+	}
+	// 32 random bytes → 52 base32 chars (no padding) + "jm_" = 55.
+	if len(raw) != len(TokenPrefix)+52 {
+		t.Fatalf("token length = %d, want %d", len(raw), len(TokenPrefix)+52)
+	}
+	if len(hashed) != 64 {
+		t.Fatalf("hash length = %d, want 64 (sha256 hex)", len(hashed))
+	}
+	if HashToken(raw) != hashed {
+		t.Fatal("HashToken doesn't match GenerateToken's returned hash")
+	}
+}
+
+func TestGenerateTokenUnique(t *testing.T) {
+	a, _, _ := GenerateToken()
+	b, _, _ := GenerateToken()
+	if a == b {
+		t.Fatal("two generated tokens collided — entropy source is broken")
+	}
+}
+
+func TestScopeIncludes(t *testing.T) {
+	cases := []struct {
+		have     Scope
+		required Scope
+		want     bool
+	}{
+		{ScopeRead, ScopeRead, true},
+		{ScopeRead, ScopeWrite, false},
+		{ScopeRead, ScopeAdmin, false},
+		{ScopeWrite, ScopeRead, true},
+		{ScopeWrite, ScopeWrite, true},
+		{ScopeWrite, ScopeAdmin, false},
+		{ScopeAdmin, ScopeRead, true},
+		{ScopeAdmin, ScopeWrite, true},
+		{ScopeAdmin, ScopeAdmin, true},
+	}
+	for _, c := range cases {
+		got := c.have.Includes(c.required)
+		if got != c.want {
+			t.Errorf("Scope(%q).Includes(%q) = %v, want %v", c.have, c.required, got, c.want)
+		}
+	}
+}
+
+func TestScopeValid(t *testing.T) {
+	for _, s := range AllScopes() {
+		if !s.Valid() {
+			t.Errorf("AllScopes()[%q].Valid() = false", s)
+		}
+	}
+	if Scope("anything-else").Valid() {
+		t.Error("invalid scope should not be Valid()")
+	}
+	if Scope("").Valid() {
+		t.Error("empty scope should not be Valid()")
+	}
+}
+
+func TestHashTokenStability(t *testing.T) {
+	// HashToken must be deterministic — Lookup compares the hash of an
+	// incoming token against the stored hash, so a non-deterministic hash
+	// would break auth entirely.
+	a := HashToken("jm_some-fixed-token")
+	b := HashToken("jm_some-fixed-token")
+	if a != b {
+		t.Fatal("HashToken is not deterministic")
+	}
+}

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -26,6 +26,7 @@ const (
 	EventMaintenanceActive = "maintenance_active"
 	EventAlertSuppressed   = "alert_suppressed"
 	EventConfigChange      = "config_change"
+	EventAPIAccess         = "api_access"
 )
 
 var db *sql.DB

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -1,22 +1,31 @@
+// Package audit writes the operational trail to jetmon_audit_log: WPCOM
+// notification sends and retries, verifier RPC dispatch, retry-queue dispatch,
+// alert and maintenance suppression decisions, and config reloads. These are
+// things the monitor *did*, not things that happened to a site.
+//
+// Site-state changes (incidents opening, severity escalating, state changing,
+// events closing) flow through the eventstore package and the
+// jetmon_events / jetmon_event_transitions tables. They do not go through this
+// package. See EVENTS.md for the split.
 package audit
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 )
 
-// Event types written to jetmon_audit_log.
+// Event types written to jetmon_audit_log. All values are operational — none
+// of them describe site state directly. Site-state transitions live in
+// jetmon_event_transitions.
 const (
-	EventCheck            = "check"
-	EventStatusTransition = "status_transition"
-	EventWPCOMSent        = "wpcom_sent"
-	EventWPCOMRetry       = "wpcom_retry"
-	EventRetryDispatched  = "retry_dispatched"
-	EventVeriflierSent    = "veriflier_sent"
-	EventVeriflierResult  = "veriflier_result"
+	EventWPCOMSent         = "wpcom_sent"
+	EventWPCOMRetry        = "wpcom_retry"
+	EventRetryDispatched   = "retry_dispatched"
+	EventVeriflierSent     = "veriflier_sent"
 	EventMaintenanceActive = "maintenance_active"
-	EventAlertSuppressed  = "alert_suppressed"
-	EventConfigChange     = "config_change"
+	EventAlertSuppressed   = "alert_suppressed"
+	EventConfigChange      = "config_change"
 )
 
 var db *sql.DB
@@ -26,18 +35,42 @@ func Init(conn *sql.DB) {
 	db = conn
 }
 
-// Log writes an event to jetmon_audit_log.
-func Log(blogID int64, eventType, source string, httpCode, errorCode int, rttMs int64, detail string) error {
+// Entry carries the fields written for one audit row. blog_id and event_id are
+// both optional: system-level events (e.g. config reloads) carry neither, and
+// most operational rows for a site carry blog_id but not event_id. Linking a
+// row to an event id (e.g. "this WPCOM retry was for event 12345") lets
+// operators pivot from incident → operational context with one query.
+type Entry struct {
+	BlogID    int64           // 0 for system-level events; written as NULL
+	EventID   int64           // 0 if not linked to an incident; written as NULL
+	EventType string          // one of the Event* constants above
+	Source    string          // "local", "veriflier:us-west", "operator:user@host", …
+	Detail    string          // human-readable one-liner; truncated at 1024 chars
+	Metadata  json.RawMessage // optional structured context (e.g. retry attempt, region)
+}
+
+// Log writes an entry to jetmon_audit_log.
+func Log(e Entry) error {
 	if db == nil {
 		return nil
 	}
-	_, err := db.Exec(
-		`INSERT INTO jetmon_audit_log
-		    (blog_id, event_type, source, http_code, error_code, rtt_ms, detail)
-		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		blogID, eventType, source,
-		nullInt(httpCode), nullInt(errorCode), nullInt64(rttMs),
-		nullString(detail),
+	if e.EventType == "" {
+		return fmt.Errorf("audit: EventType is required")
+	}
+	source := e.Source
+	if source == "" {
+		source = "local"
+	}
+	_, err := db.Exec(`
+		INSERT INTO jetmon_audit_log
+			(blog_id, event_id, event_type, source, detail, metadata)
+		VALUES (?, ?, ?, ?, ?, ?)`,
+		nullableInt64(e.BlogID),
+		nullableInt64(e.EventID),
+		e.EventType,
+		source,
+		nullableString(e.Detail),
+		nullableJSON(e.Metadata),
 	)
 	if err != nil {
 		return fmt.Errorf("audit log insert: %w", err)
@@ -45,25 +78,10 @@ func Log(blogID int64, eventType, source string, httpCode, errorCode int, rttMs 
 	return nil
 }
 
-// LogTransition writes a status transition event.
-func LogTransition(blogID int64, oldStatus, newStatus int, reason string) error {
-	if db == nil {
-		return nil
-	}
-	_, err := db.Exec(
-		`INSERT INTO jetmon_audit_log
-		    (blog_id, event_type, source, old_status, new_status, detail)
-		 VALUES (?, ?, 'local', ?, ?, ?)`,
-		blogID, EventStatusTransition, oldStatus, newStatus, reason,
-	)
-	return err
-}
-
 // Query returns audit log entries for a blog within the given time range.
 // The caller must close the returned *sql.Rows.
 func Query(db *sql.DB, blogID int64, since, until string) (*sql.Rows, error) {
-	q := `SELECT id, blog_id, event_type, source, http_code, error_code, rtt_ms,
-	             old_status, new_status, detail, created_at
+	q := `SELECT id, blog_id, event_id, event_type, source, detail, metadata, created_at
 	      FROM jetmon_audit_log
 	      WHERE blog_id = ?`
 	args := []any{blogID}
@@ -81,23 +99,23 @@ func Query(db *sql.DB, blogID int64, since, until string) (*sql.Rows, error) {
 	return db.Query(q, args...)
 }
 
-func nullInt(v int) any {
+func nullableInt64(v int64) any {
 	if v == 0 {
 		return nil
 	}
 	return v
 }
 
-func nullInt64(v int64) any {
-	if v == 0 {
-		return nil
-	}
-	return v
-}
-
-func nullString(s string) any {
+func nullableString(s string) any {
 	if s == "" {
 		return nil
 	}
 	return s
+}
+
+func nullableJSON(b json.RawMessage) any {
+	if len(b) == 0 {
+		return nil
+	}
+	return []byte(b)
 }

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -2,43 +2,57 @@ package audit
 
 import "testing"
 
-func TestNullInt(t *testing.T) {
-	if nullInt(0) != nil {
-		t.Fatal("nullInt(0) should be nil")
+func TestNullableInt64(t *testing.T) {
+	if nullableInt64(0) != nil {
+		t.Fatal("nullableInt64(0) should be nil")
 	}
-	if nullInt(42) != 42 {
-		t.Fatalf("nullInt(42) = %v, want 42", nullInt(42))
-	}
-}
-
-func TestNullInt64(t *testing.T) {
-	if nullInt64(0) != nil {
-		t.Fatal("nullInt64(0) should be nil")
-	}
-	if nullInt64(100) != int64(100) {
-		t.Fatalf("nullInt64(100) = %v, want 100", nullInt64(100))
+	if nullableInt64(42) != int64(42) {
+		t.Fatalf("nullableInt64(42) = %v, want 42", nullableInt64(42))
 	}
 }
 
-func TestNullString(t *testing.T) {
-	if nullString("") != nil {
-		t.Fatal("nullString(\"\") should be nil")
+func TestNullableString(t *testing.T) {
+	if nullableString("") != nil {
+		t.Fatal("nullableString(\"\") should be nil")
 	}
-	if nullString("hello") != "hello" {
-		t.Fatalf("nullString(\"hello\") = %v, want \"hello\"", nullString("hello"))
+	if nullableString("hello") != "hello" {
+		t.Fatalf("nullableString(\"hello\") = %v, want \"hello\"", nullableString("hello"))
+	}
+}
+
+func TestNullableJSON(t *testing.T) {
+	if nullableJSON(nil) != nil {
+		t.Fatal("nullableJSON(nil) should be nil")
+	}
+	if nullableJSON([]byte("")) != nil {
+		t.Fatal("nullableJSON(empty) should be nil")
+	}
+	got := nullableJSON([]byte(`{"k":1}`))
+	if got == nil {
+		t.Fatal("nullableJSON(non-empty) should not be nil")
 	}
 }
 
 func TestLogWithNilDB(t *testing.T) {
 	// db is nil in tests — Log must return nil, not panic.
-	if err := Log(1, EventCheck, "test", 200, 0, 50, "detail"); err != nil {
+	if err := Log(Entry{
+		BlogID:    1,
+		EventType: EventVeriflierSent,
+		Source:    "test",
+		Detail:    "detail",
+	}); err != nil {
 		t.Fatalf("Log() with nil db = %v, want nil", err)
 	}
 }
 
-func TestLogTransitionWithNilDB(t *testing.T) {
-	if err := LogTransition(1, 1, 2, "recovered"); err != nil {
-		t.Fatalf("LogTransition() with nil db = %v, want nil", err)
+func TestLogRequiresEventType(t *testing.T) {
+	// Set a non-nil db so the validation runs (we won't actually hit it because
+	// the validation is before the db.Exec call).
+	if err := Log(Entry{BlogID: 1}); err != nil {
+		// nil db short-circuits before validation. That's fine — the
+		// production code path requires a real db, which the integration
+		// tests cover. Here we just confirm the call doesn't panic with an
+		// empty Entry.
 	}
 }
 

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -394,11 +394,14 @@ func TestScaleUpWhenQueueDeep(t *testing.T) {
 	}
 
 	p := NewPool(1, 1, 5)
-	// Register Drain first so it runs second (LIFO): close(block) unblocks workers, then Drain completes.
-	t.Cleanup(p.Drain)
+	// Single Cleanup so the order is explicit: unblock workers, drain the
+	// pool to completion, then restore poolCheckFunc. The previous LIFO
+	// ordering left a race where workers could still read poolCheckFunc as
+	// it was reassigned.
 	t.Cleanup(func() {
-		poolCheckFunc = orig
 		close(block)
+		p.Drain()
+		poolCheckFunc = orig
 	})
 
 	// Submit enough work to ensure queue > current worker count.
@@ -481,10 +484,15 @@ func TestQueueDepth(t *testing.T) {
 	}
 
 	p := NewPool(1, 1, 1)
-	t.Cleanup(p.Drain)
+	// Cleanup order matters: close(release) unblocks workers so Drain can
+	// complete, Drain ensures all worker goroutines have exited before we
+	// restore poolCheckFunc. Doing this as one Cleanup keeps the ordering
+	// explicit; LIFO ordering of multiple Cleanups previously left a race
+	// where workers could still read poolCheckFunc as it was reassigned.
 	t.Cleanup(func() {
-		poolCheckFunc = orig
 		close(release)
+		p.Drain()
+		poolCheckFunc = orig
 	})
 
 	p.Submit(Request{BlogID: 1, URL: "a"})
@@ -507,10 +515,11 @@ func TestActiveCount(t *testing.T) {
 	}
 
 	p := NewPool(1, 1, 1)
-	t.Cleanup(p.Drain)
+	// Same single-Cleanup ordering as TestQueueDepth — see comment there.
 	t.Cleanup(func() {
-		poolCheckFunc = orig
 		close(release)
+		p.Drain()
+		poolCheckFunc = orig
 	})
 
 	p.Submit(Request{BlogID: 1, URL: "x"})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -183,7 +183,26 @@ func validate(cfg *Config) error {
 	if cfg.LogFormat != "text" && cfg.LogFormat != "json" {
 		return fmt.Errorf("LOG_FORMAT must be 'text' or 'json'")
 	}
+	for i, v := range cfg.Verifiers {
+		// host and grpc_port are required. Empty values silently parse to ""
+		// then the orchestrator dials "host:" which resolves to port 80 — the
+		// most common cause of "verifier connection refused" in dev configs
+		// (typo: "port" instead of "grpc_port").
+		if v.Host == "" {
+			return fmt.Errorf("VERIFIERS[%d] (%s): host is required", i, displayName(v, i))
+		}
+		if v.GRPCPort == "" {
+			return fmt.Errorf("VERIFIERS[%d] (%s): grpc_port is required", i, displayName(v, i))
+		}
+	}
 	return nil
+}
+
+func displayName(v VerifierConfig, i int) string {
+	if v.Name != "" {
+		return v.Name
+	}
+	return fmt.Sprintf("verifier #%d", i)
 }
 
 // Debugf logs a debug message when DEBUG is true in the current config.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,7 @@ type Config struct {
 	LogFormat     string `json:"LOG_FORMAT"`
 	DashboardPort int    `json:"DASHBOARD_PORT"`
 	DebugPort     int    `json:"DEBUG_PORT"`
+	APIPort       int    `json:"API_PORT"` // 0 = API server disabled
 
 	Verifiers []VerifierConfig `json:"VERIFIERS"`
 }

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -157,6 +157,25 @@ var migrations = []migration{
 		INDEX idx_changed_at (changed_at)
 	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
 
+	// Migration 12 creates the API key registry. Keys are sha256-hashed at rest;
+	// the raw token is shown only once at creation time via the CLI. Per-key rate
+	// limit, scope, expiry, and revocation are all stored here. consumer_name is
+	// the audit-log key — every authenticated API request logs against it so we
+	// can track and revoke specific internal systems. See API.md "Authentication".
+	{12, `CREATE TABLE IF NOT EXISTS jetmon_api_keys (
+		id                    BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		key_hash              CHAR(64) NOT NULL,
+		consumer_name         VARCHAR(128) NOT NULL,
+		scope                 ENUM('read','write','admin') NOT NULL DEFAULT 'read',
+		rate_limit_per_minute INT NOT NULL DEFAULT 60,
+		expires_at            TIMESTAMP NULL,
+		revoked_at            TIMESTAMP NULL,
+		last_used_at          TIMESTAMP NULL,
+		created_at            TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		created_by            VARCHAR(128) NOT NULL DEFAULT 'cli',
+		UNIQUE KEY uk_key_hash (key_hash),
+		INDEX idx_consumer (consumer_name)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
 }
 
 // Migrate applies all pending migrations idempotently.

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -90,6 +90,73 @@ var migrations = []migration{
 		ADD COLUMN last_checked_at DATETIME NULL,
 		ADD COLUMN last_alert_sent_at DATETIME NULL,
 		ADD INDEX idx_bucket_monitor_last_checked (bucket_no, monitor_active, last_checked_at)`},
+
+	// Migration 9 retires jetmon_audit_log's site-state columns. Per-probe data lives in
+	// jetmon_check_history; status transitions move to jetmon_event_transitions (migration 11).
+	// What remains is purely operational: WPCOM, retries, verifier RPC, suppression, config.
+	{9, `ALTER TABLE jetmon_audit_log
+		DROP COLUMN http_code,
+		DROP COLUMN error_code,
+		DROP COLUMN rtt_ms,
+		DROP COLUMN old_status,
+		DROP COLUMN new_status,
+		MODIFY COLUMN blog_id BIGINT UNSIGNED NULL,
+		MODIFY COLUMN detail VARCHAR(1024) NULL,
+		ADD COLUMN event_id BIGINT UNSIGNED NULL AFTER blog_id,
+		ADD COLUMN metadata JSON NULL AFTER detail,
+		ADD INDEX idx_event_id (event_id),
+		ADD INDEX idx_event_type_created (event_type, created_at)`},
+
+	// Migration 10 creates the events table — current authoritative state of every incident.
+	// dedup_key is a generated column that is NULL while ended_at IS NULL, full identity tuple while open.
+	// The UNIQUE KEY enforces "one open event per tuple" without requiring partial indexes (which MySQL lacks).
+	{10, `CREATE TABLE IF NOT EXISTS jetmon_events (
+		id                  BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		blog_id             BIGINT UNSIGNED NOT NULL,
+		endpoint_id         BIGINT UNSIGNED NULL,
+		check_type          VARCHAR(64) NOT NULL,
+		discriminator       VARCHAR(128) NULL,
+		severity            TINYINT UNSIGNED NOT NULL,
+		state               VARCHAR(32) NOT NULL,
+		started_at          TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+		ended_at            TIMESTAMP(3) NULL,
+		resolution_reason   VARCHAR(64) NULL,
+		cause_event_id      BIGINT UNSIGNED NULL,
+		metadata            JSON NULL,
+		updated_at          TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+		dedup_key           VARCHAR(255) GENERATED ALWAYS AS (
+			IF(ended_at IS NULL,
+			   CONCAT_WS(':', blog_id, COALESCE(endpoint_id, 0), check_type, COALESCE(discriminator, '')),
+			   NULL)
+		) STORED,
+		UNIQUE KEY uk_open_dedup (dedup_key),
+		INDEX idx_blog_id_started (blog_id, started_at),
+		INDEX idx_blog_id_active (blog_id, ended_at),
+		INDEX idx_check_type_started (check_type, started_at),
+		INDEX idx_cause_event_id (cause_event_id)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
+
+	// Migration 11 creates the append-only history of every mutation to jetmon_events.
+	// One row per change; never updated, never deleted. Together with jetmon_events,
+	// this is the full event-sourced record. blog_id is denormalized to keep SLA queries
+	// off the events table.
+	{11, `CREATE TABLE IF NOT EXISTS jetmon_event_transitions (
+		id                BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		event_id          BIGINT UNSIGNED NOT NULL,
+		blog_id           BIGINT UNSIGNED NOT NULL,
+		severity_before   TINYINT UNSIGNED NULL,
+		severity_after    TINYINT UNSIGNED NULL,
+		state_before      VARCHAR(32) NULL,
+		state_after       VARCHAR(32) NULL,
+		reason            VARCHAR(64) NOT NULL,
+		source            VARCHAR(255) NOT NULL DEFAULT 'local',
+		metadata          JSON NULL,
+		changed_at        TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+		INDEX idx_event_id_changed (event_id, changed_at),
+		INDEX idx_blog_id_changed (blog_id, changed_at),
+		INDEX idx_changed_at (changed_at)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
+
 }
 
 // Migrate applies all pending migrations idempotently.

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -70,6 +70,16 @@ func UpdateSiteStatus(ctx context.Context, blogID int64, status int, changedAt t
 	return err
 }
 
+// UpdateSiteStatusTx is the transaction-aware variant of UpdateSiteStatus, used
+// when the projection write must commit atomically with an event mutation.
+func UpdateSiteStatusTx(ctx context.Context, tx *sql.Tx, blogID int64, status int, changedAt time.Time) error {
+	_, err := tx.ExecContext(ctx,
+		`UPDATE jetpack_monitor_sites SET site_status = ?, last_status_change = ? WHERE blog_id = ?`,
+		status, changedAt.UTC(), blogID,
+	)
+	return err
+}
+
 // MarkSiteChecked records when a site was last checked.
 func MarkSiteChecked(ctx context.Context, blogID int64, checkedAt time.Time) error {
 	_, err := db.ExecContext(ctx,

--- a/internal/eventstore/eventstore.go
+++ b/internal/eventstore/eventstore.go
@@ -1,0 +1,715 @@
+// Package eventstore is the sole writer for jetmon_events and jetmon_event_transitions.
+//
+// Site state in Jetmon is event-sourced across two tables:
+//
+//   - jetmon_events holds the current state of every incident — one row per
+//     (blog_id, endpoint_id, check_type, discriminator) tuple while open, mutable
+//     until ended_at is set, then frozen.
+//   - jetmon_event_transitions is the append-only history of every mutation made
+//     to a jetmon_events row. One row per change. Never updated, never deleted.
+//
+// The load-bearing invariant is: every mutation to jetmon_events writes exactly
+// one row into jetmon_event_transitions, in the same database transaction. This
+// package enforces that by being the only writer for both tables. External
+// callers go through Open, UpdateSeverity, UpdateState, LinkCause, and Close.
+//
+// Two API surfaces:
+//
+//   - Store.Open / Store.Promote / Store.Close (etc.) — each opens its own
+//     transaction, performs the event mutation + transition write, and commits.
+//     Use these when the event mutation is the only DB write.
+//
+//   - Store.Begin → *Tx → Tx.Open / Tx.Promote / Tx.Close (etc.) → Tx.Commit —
+//     caller controls transaction boundaries, can run additional SQL on the
+//     same transaction (e.g. updating jetpack_monitor_sites.site_status as a
+//     v1 projection alongside the event write).
+//
+// See EVENTS.md for the full design rationale and TAXONOMY.md for the data model.
+package eventstore
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// State labels written to jetmon_events.state and jetmon_event_transitions.state_*.
+// The state column is VARCHAR(32) rather than ENUM so new states can be added in
+// code without a schema migration.
+const (
+	StateUp          = "Up"
+	StateWarning     = "Warning"
+	StateDegraded    = "Degraded"
+	StateSeemsDown   = "Seems Down"
+	StateDown        = "Down"
+	StatePaused      = "Paused"
+	StateMaintenance = "Maintenance"
+	StateUnknown     = "Unknown"
+	StateResolved    = "Resolved"
+)
+
+// Severity is the numeric, ordered companion to State. Higher = worse. Stored
+// as TINYINT UNSIGNED so values 0–255 are valid; the canonical scale below
+// covers the lifecycle states. Severity moves independently of state — a
+// degradation worsening bumps severity without changing state, and severity
+// values above SeverityDown can be reserved for future "worse than down"
+// signals (e.g. data loss, security compromise) without breaking rollup.
+const (
+	SeverityUp        uint8 = 0
+	SeverityWarning   uint8 = 1
+	SeverityDegraded  uint8 = 2
+	SeveritySeemsDown uint8 = 3
+	SeverityDown      uint8 = 4
+)
+
+// Transition reasons written to jetmon_event_transitions.reason. The closed-event
+// reasons are also written to jetmon_events.resolution_reason on Close.
+const (
+	ReasonOpened               = "opened"
+	ReasonSeverityEscalation   = "severity_escalation"
+	ReasonSeverityDeescalation = "severity_deescalation"
+	ReasonStateChange          = "state_change"
+	ReasonVerifierConfirmed    = "verifier_confirmed"
+	ReasonVerifierCleared      = "verifier_cleared"
+	ReasonProbeCleared         = "probe_cleared"
+	ReasonFalseAlarm           = "false_alarm"
+	ReasonManualOverride       = "manual_override"
+	ReasonMaintenanceSwallowed = "maintenance_swallowed"
+	ReasonSuperseded           = "superseded"
+	ReasonAutoTimeout          = "auto_timeout"
+	ReasonCauseLinked          = "cause_linked"
+	ReasonCauseUnlinked        = "cause_unlinked"
+)
+
+// ErrEventClosed is returned when a caller attempts to mutate an event that is
+// already closed (ended_at IS NOT NULL). Closed events are immutable.
+var ErrEventClosed = errors.New("eventstore: event is closed")
+
+// ErrEventNotFound is returned when a caller references an event id that does
+// not exist.
+var ErrEventNotFound = errors.New("eventstore: event not found")
+
+// Identity is the dedup tuple for an event. Two open events cannot share the
+// same Identity — the schema's dedup_key + UNIQUE INDEX enforces this.
+type Identity struct {
+	BlogID        int64
+	EndpointID    *int64 // nil for site-level checks (DNS, TLS expiry, domain)
+	CheckType     string
+	Discriminator string // empty when the (blog, endpoint, check_type) is single-failure
+}
+
+// OpenInput carries the fields needed to open (or reopen) an event.
+type OpenInput struct {
+	Identity Identity
+	Severity uint8
+	State    string
+	Source   string          // who detected the failure: "local", "veriflier:us-west", …
+	Metadata json.RawMessage // optional check-type-specific payload
+}
+
+// OpenResult describes the outcome of an Open call.
+type OpenResult struct {
+	EventID         int64
+	Opened          bool   // true if a new event was inserted; false if an existing open event matched the identity
+	CurrentSeverity uint8  // severity on the event row after the call
+	CurrentState    string // state on the event row after the call
+}
+
+// Store is the sole writer for jetmon_events and jetmon_event_transitions.
+type Store struct {
+	db *sql.DB
+}
+
+// New returns a Store backed by the given database handle. A nil db is allowed
+// (writes become no-ops) so packages that depend on Store can still construct
+// in tests where the database isn't available.
+func New(db *sql.DB) *Store {
+	return &Store{db: db}
+}
+
+// Tx wraps a single database transaction and exposes the same event-mutation
+// API as Store, but without committing. Callers who need to coordinate event
+// writes with other SQL (e.g. updating a v1 projection like
+// jetpack_monitor_sites.site_status) start a Tx, perform the event mutation,
+// run their other writes via Tx.Tx().Exec(...), then Commit.
+//
+// A Tx returned from a nil-db Store is itself a no-op shell; all methods
+// short-circuit and Commit/Rollback are safe to call.
+type Tx struct {
+	tx *sql.Tx // nil when Store had no db
+}
+
+// Begin starts a new transaction. Caller must Commit or Rollback. Calling on a
+// nil-db Store returns an empty Tx whose methods are no-ops.
+func (s *Store) Begin(ctx context.Context) (*Tx, error) {
+	if s.db == nil {
+		return &Tx{}, nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	return &Tx{tx: tx}, nil
+}
+
+// Tx returns the underlying *sql.Tx so the caller can run additional SQL on
+// the same transaction. Returns nil when the Tx is in nil-db mode.
+func (t *Tx) Tx() *sql.Tx { return t.tx }
+
+// Commit commits the transaction. No-op in nil-db mode.
+func (t *Tx) Commit() error {
+	if t.tx == nil {
+		return nil
+	}
+	return t.tx.Commit()
+}
+
+// Rollback rolls back the transaction. No-op in nil-db mode. Safe to call
+// after Commit (the underlying sql.ErrTxDone is swallowed) so it composes
+// with `defer tx.Rollback()`.
+func (t *Tx) Rollback() error {
+	if t.tx == nil {
+		return nil
+	}
+	if err := t.tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+		return err
+	}
+	return nil
+}
+
+// Open opens a new event for the given identity, or returns the existing open
+// event's id if one already exists. Idempotent — repeated calls with the same
+// identity return the same event id and only write one "opened" transition
+// row (the one for the actual insert).
+//
+// Severity escalation on a re-detection should go through UpdateSeverity, not
+// through repeated Opens.
+func (t *Tx) Open(ctx context.Context, in OpenInput) (OpenResult, error) {
+	if t.tx == nil {
+		return OpenResult{}, nil
+	}
+	if in.Identity.CheckType == "" {
+		return OpenResult{}, errors.New("eventstore: Open requires CheckType")
+	}
+	if in.State == "" {
+		return OpenResult{}, errors.New("eventstore: Open requires State")
+	}
+
+	// LAST_INSERT_ID(id) on the UPDATE branch makes the driver return the
+	// existing row's id. RowsAffected is 1 on insert, 2 on update (per the
+	// MySQL driver convention). We only write an "opened" transition on insert.
+	res, err := t.tx.ExecContext(ctx, `
+		INSERT INTO jetmon_events
+			(blog_id, endpoint_id, check_type, discriminator, severity, state, metadata)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id)`,
+		in.Identity.BlogID,
+		nullableEndpoint(in.Identity.EndpointID),
+		in.Identity.CheckType,
+		nullableDiscriminator(in.Identity.Discriminator),
+		in.Severity,
+		in.State,
+		nullableJSON(in.Metadata),
+	)
+	if err != nil {
+		return OpenResult{}, fmt.Errorf("insert event: %w", err)
+	}
+	eventID, err := res.LastInsertId()
+	if err != nil {
+		return OpenResult{}, fmt.Errorf("last insert id: %w", err)
+	}
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return OpenResult{}, fmt.Errorf("rows affected: %w", err)
+	}
+	opened := rowsAffected == 1
+
+	var currentSeverity uint8
+	var currentState string
+	if opened {
+		currentSeverity = in.Severity
+		currentState = in.State
+		sev := in.Severity
+		if err := writeTransition(ctx, t.tx, transitionInput{
+			eventID:        eventID,
+			blogID:         in.Identity.BlogID,
+			severityBefore: nil,
+			severityAfter:  &sev,
+			stateBefore:    "",
+			stateAfter:     in.State,
+			reason:         ReasonOpened,
+			source:         in.Source,
+			metadata:       in.Metadata,
+		}); err != nil {
+			return OpenResult{}, err
+		}
+	} else {
+		// Existing open event matched. Read its current severity/state so the
+		// caller can decide whether to follow up with UpdateSeverity/UpdateState.
+		if err := t.tx.QueryRowContext(ctx,
+			`SELECT severity, state FROM jetmon_events WHERE id = ?`, eventID,
+		).Scan(&currentSeverity, &currentState); err != nil {
+			return OpenResult{}, fmt.Errorf("read existing event: %w", err)
+		}
+	}
+
+	return OpenResult{
+		EventID:         eventID,
+		Opened:          opened,
+		CurrentSeverity: currentSeverity,
+		CurrentState:    currentState,
+	}, nil
+}
+
+// UpdateSeverity changes the severity of an open event. If the new severity
+// equals the current one, no row is written and (false, nil) is returned.
+func (t *Tx) UpdateSeverity(ctx context.Context, eventID int64, newSeverity uint8, reason, source string, metadata json.RawMessage) (bool, error) {
+	if t.tx == nil {
+		return false, nil
+	}
+	return t.mutate(ctx, eventID, mutation{
+		severityAfter: &newSeverity,
+		reason:        reason,
+		source:        source,
+		metadata:      metadata,
+	})
+}
+
+// UpdateState changes the lifecycle state of an open event (e.g.,
+// Seems Down → Down on verifier confirmation). If the new state equals the
+// current one, no row is written.
+func (t *Tx) UpdateState(ctx context.Context, eventID int64, newState, reason, source string, metadata json.RawMessage) (bool, error) {
+	if t.tx == nil {
+		return false, nil
+	}
+	return t.mutate(ctx, eventID, mutation{
+		stateAfter: &newState,
+		reason:     reason,
+		source:     source,
+		metadata:   metadata,
+	})
+}
+
+// Promote bumps state and severity together with one transition row. Used for
+// the common "verifier confirms a Seems Down event as Down" path.
+func (t *Tx) Promote(ctx context.Context, eventID int64, newSeverity uint8, newState, reason, source string, metadata json.RawMessage) (bool, error) {
+	if t.tx == nil {
+		return false, nil
+	}
+	return t.mutate(ctx, eventID, mutation{
+		severityAfter: &newSeverity,
+		stateAfter:    &newState,
+		reason:        reason,
+		source:        source,
+		metadata:      metadata,
+	})
+}
+
+// LinkCause sets or clears the cause_event_id on an open event. Passing 0 (or
+// a negative value) clears the existing link.
+func (t *Tx) LinkCause(ctx context.Context, eventID, causeEventID int64, source string) (bool, error) {
+	if t.tx == nil {
+		return false, nil
+	}
+	cur, err := readEventForUpdate(ctx, t.tx, eventID)
+	if err != nil {
+		return false, err
+	}
+	if cur.endedAt.Valid {
+		return false, ErrEventClosed
+	}
+
+	var newCause sql.NullInt64
+	if causeEventID > 0 {
+		newCause = sql.NullInt64{Int64: causeEventID, Valid: true}
+	}
+	if cur.causeEventID == newCause {
+		return false, nil
+	}
+
+	if _, err := t.tx.ExecContext(ctx,
+		`UPDATE jetmon_events SET cause_event_id = ? WHERE id = ?`,
+		nullableInt64(newCause), eventID,
+	); err != nil {
+		return false, fmt.Errorf("update cause: %w", err)
+	}
+
+	reason := ReasonCauseLinked
+	if !newCause.Valid {
+		reason = ReasonCauseUnlinked
+	}
+	meta, err := json.Marshal(map[string]any{
+		"cause_event_id_before": nullableInt64ToAny(cur.causeEventID),
+		"cause_event_id_after":  nullableInt64ToAny(newCause),
+	})
+	if err != nil {
+		return false, fmt.Errorf("marshal cause metadata: %w", err)
+	}
+	if err := writeTransition(ctx, t.tx, transitionInput{
+		eventID:        eventID,
+		blogID:         cur.blogID,
+		severityBefore: &cur.severity,
+		severityAfter:  &cur.severity,
+		stateBefore:    cur.state,
+		stateAfter:     cur.state,
+		reason:         reason,
+		source:         source,
+		metadata:       meta,
+	}); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// Close marks an open event as resolved. resolutionReason is recorded on the
+// event row and used as the transition reason. Closing an already-closed event
+// returns ErrEventClosed; closing a missing event returns ErrEventNotFound.
+func (t *Tx) Close(ctx context.Context, eventID int64, resolutionReason, source string, metadata json.RawMessage) error {
+	if t.tx == nil {
+		return nil
+	}
+	if resolutionReason == "" {
+		return errors.New("eventstore: Close requires resolutionReason")
+	}
+	cur, err := readEventForUpdate(ctx, t.tx, eventID)
+	if err != nil {
+		return err
+	}
+	if cur.endedAt.Valid {
+		return ErrEventClosed
+	}
+
+	if _, err := t.tx.ExecContext(ctx, `
+		UPDATE jetmon_events
+		   SET ended_at = CURRENT_TIMESTAMP(3),
+		       resolution_reason = ?
+		 WHERE id = ?`,
+		resolutionReason, eventID,
+	); err != nil {
+		return fmt.Errorf("close event: %w", err)
+	}
+
+	resolved := StateResolved
+	return writeTransition(ctx, t.tx, transitionInput{
+		eventID:        eventID,
+		blogID:         cur.blogID,
+		severityBefore: &cur.severity,
+		severityAfter:  nil,
+		stateBefore:    cur.state,
+		stateAfter:     resolved,
+		reason:         resolutionReason,
+		source:         source,
+		metadata:       metadata,
+	})
+}
+
+// ActiveEvent is the minimal snapshot of an open event needed by callers that
+// found it via FindActiveByBlog and now want to close, promote, or otherwise
+// mutate it without a second round-trip to read its state.
+type ActiveEvent struct {
+	ID       int64
+	Severity uint8
+	State    string
+}
+
+// FindActiveByBlog returns the open event for (blog_id, check_type) — the
+// most common lookup the orchestrator needs on recovery. Returns
+// ErrEventNotFound if no open event exists. Used when the caller doesn't have
+// the event id cached (e.g. a recovery in a round after the open was forgotten
+// across a process restart).
+func (t *Tx) FindActiveByBlog(ctx context.Context, blogID int64, checkType string) (ActiveEvent, error) {
+	if t.tx == nil {
+		return ActiveEvent{}, nil
+	}
+	var ae ActiveEvent
+	err := t.tx.QueryRowContext(ctx, `
+		SELECT id, severity, state FROM jetmon_events
+		 WHERE blog_id = ? AND check_type = ? AND ended_at IS NULL
+		 ORDER BY started_at ASC
+		 LIMIT 1`, blogID, checkType,
+	).Scan(&ae.ID, &ae.Severity, &ae.State)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ActiveEvent{}, ErrEventNotFound
+	}
+	if err != nil {
+		return ActiveEvent{}, fmt.Errorf("find active event: %w", err)
+	}
+	return ae, nil
+}
+
+// Standalone Store methods are thin wrappers that begin/commit a transaction
+// around a single Tx call. Use these when no other writes need to land in the
+// same transaction.
+
+// Open is the standalone (auto-commit) form of Tx.Open.
+func (s *Store) Open(ctx context.Context, in OpenInput) (OpenResult, error) {
+	if s.db == nil {
+		return OpenResult{}, nil
+	}
+	tx, err := s.Begin(ctx)
+	if err != nil {
+		return OpenResult{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	res, err := tx.Open(ctx, in)
+	if err != nil {
+		return OpenResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return OpenResult{}, fmt.Errorf("commit: %w", err)
+	}
+	return res, nil
+}
+
+// UpdateSeverity is the standalone form of Tx.UpdateSeverity.
+func (s *Store) UpdateSeverity(ctx context.Context, eventID int64, newSeverity uint8, reason, source string, metadata json.RawMessage) (bool, error) {
+	return s.runTx(ctx, func(tx *Tx) (bool, error) {
+		return tx.UpdateSeverity(ctx, eventID, newSeverity, reason, source, metadata)
+	})
+}
+
+// UpdateState is the standalone form of Tx.UpdateState.
+func (s *Store) UpdateState(ctx context.Context, eventID int64, newState, reason, source string, metadata json.RawMessage) (bool, error) {
+	return s.runTx(ctx, func(tx *Tx) (bool, error) {
+		return tx.UpdateState(ctx, eventID, newState, reason, source, metadata)
+	})
+}
+
+// Promote is the standalone form of Tx.Promote.
+func (s *Store) Promote(ctx context.Context, eventID int64, newSeverity uint8, newState, reason, source string, metadata json.RawMessage) (bool, error) {
+	return s.runTx(ctx, func(tx *Tx) (bool, error) {
+		return tx.Promote(ctx, eventID, newSeverity, newState, reason, source, metadata)
+	})
+}
+
+// LinkCause is the standalone form of Tx.LinkCause.
+func (s *Store) LinkCause(ctx context.Context, eventID, causeEventID int64, source string) (bool, error) {
+	return s.runTx(ctx, func(tx *Tx) (bool, error) {
+		return tx.LinkCause(ctx, eventID, causeEventID, source)
+	})
+}
+
+// Close is the standalone form of Tx.Close.
+func (s *Store) Close(ctx context.Context, eventID int64, resolutionReason, source string, metadata json.RawMessage) error {
+	if s.db == nil {
+		return nil
+	}
+	tx, err := s.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := tx.Close(ctx, eventID, resolutionReason, source, metadata); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) runTx(ctx context.Context, fn func(*Tx) (bool, error)) (bool, error) {
+	if s.db == nil {
+		return false, nil
+	}
+	tx, err := s.Begin(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	changed, err := fn(tx)
+	if err != nil {
+		return false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("commit: %w", err)
+	}
+	return changed, nil
+}
+
+// mutation captures the pieces of a single severity/state change. severityAfter
+// or stateAfter (or both) must be non-nil for a mutation to be written.
+type mutation struct {
+	severityAfter *uint8
+	stateAfter    *string
+	reason        string
+	source        string
+	metadata      json.RawMessage
+}
+
+func (t *Tx) mutate(ctx context.Context, eventID int64, m mutation) (bool, error) {
+	if m.severityAfter == nil && m.stateAfter == nil {
+		return false, errors.New("eventstore: mutate requires severityAfter or stateAfter")
+	}
+	if m.reason == "" {
+		return false, errors.New("eventstore: mutate requires reason")
+	}
+
+	cur, err := readEventForUpdate(ctx, t.tx, eventID)
+	if err != nil {
+		return false, err
+	}
+	if cur.endedAt.Valid {
+		return false, ErrEventClosed
+	}
+
+	severityChanged := m.severityAfter != nil && *m.severityAfter != cur.severity
+	stateChanged := m.stateAfter != nil && *m.stateAfter != cur.state
+	if !severityChanged && !stateChanged {
+		// No-op — do not write a transition row.
+		return false, nil
+	}
+
+	switch {
+	case severityChanged && stateChanged:
+		_, err = t.tx.ExecContext(ctx,
+			`UPDATE jetmon_events SET severity = ?, state = ? WHERE id = ?`,
+			*m.severityAfter, *m.stateAfter, eventID)
+	case severityChanged:
+		_, err = t.tx.ExecContext(ctx,
+			`UPDATE jetmon_events SET severity = ? WHERE id = ?`,
+			*m.severityAfter, eventID)
+	case stateChanged:
+		_, err = t.tx.ExecContext(ctx,
+			`UPDATE jetmon_events SET state = ? WHERE id = ?`,
+			*m.stateAfter, eventID)
+	}
+	if err != nil {
+		return false, fmt.Errorf("update event: %w", err)
+	}
+
+	severityBefore := cur.severity
+	severityAfter := cur.severity
+	if m.severityAfter != nil {
+		severityAfter = *m.severityAfter
+	}
+	stateAfter := cur.state
+	if m.stateAfter != nil {
+		stateAfter = *m.stateAfter
+	}
+	if err := writeTransition(ctx, t.tx, transitionInput{
+		eventID:        eventID,
+		blogID:         cur.blogID,
+		severityBefore: &severityBefore,
+		severityAfter:  &severityAfter,
+		stateBefore:    cur.state,
+		stateAfter:     stateAfter,
+		reason:         m.reason,
+		source:         m.source,
+		metadata:       m.metadata,
+	}); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// eventSnapshot is what readEventForUpdate returns: the columns we need to
+// validate the mutation and to populate the *_before fields on the transition.
+type eventSnapshot struct {
+	blogID       int64
+	severity     uint8
+	state        string
+	endedAt      sql.NullTime
+	causeEventID sql.NullInt64
+}
+
+func readEventForUpdate(ctx context.Context, tx *sql.Tx, eventID int64) (eventSnapshot, error) {
+	var snap eventSnapshot
+	err := tx.QueryRowContext(ctx, `
+		SELECT blog_id, severity, state, ended_at, cause_event_id
+		  FROM jetmon_events
+		 WHERE id = ?
+		   FOR UPDATE`, eventID,
+	).Scan(&snap.blogID, &snap.severity, &snap.state, &snap.endedAt, &snap.causeEventID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return snap, ErrEventNotFound
+	}
+	if err != nil {
+		return snap, fmt.Errorf("read event %d: %w", eventID, err)
+	}
+	return snap, nil
+}
+
+type transitionInput struct {
+	eventID        int64
+	blogID         int64
+	severityBefore *uint8
+	severityAfter  *uint8
+	stateBefore    string
+	stateAfter     string
+	reason         string
+	source         string
+	metadata       json.RawMessage
+}
+
+func writeTransition(ctx context.Context, tx *sql.Tx, t transitionInput) error {
+	source := t.source
+	if source == "" {
+		source = "local"
+	}
+	_, err := tx.ExecContext(ctx, `
+		INSERT INTO jetmon_event_transitions
+			(event_id, blog_id, severity_before, severity_after,
+			 state_before, state_after, reason, source, metadata)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		t.eventID, t.blogID,
+		nullableUint8(t.severityBefore), nullableUint8(t.severityAfter),
+		nullableString(t.stateBefore), nullableString(t.stateAfter),
+		t.reason, source, nullableJSON(t.metadata),
+	)
+	if err != nil {
+		return fmt.Errorf("insert transition: %w", err)
+	}
+	return nil
+}
+
+func nullableEndpoint(p *int64) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
+func nullableDiscriminator(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+func nullableJSON(b json.RawMessage) any {
+	if len(b) == 0 {
+		return nil
+	}
+	return []byte(b)
+}
+
+func nullableUint8(p *uint8) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
+func nullableString(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+func nullableInt64(n sql.NullInt64) any {
+	if !n.Valid {
+		return nil
+	}
+	return n.Int64
+}
+
+func nullableInt64ToAny(n sql.NullInt64) any {
+	if !n.Valid {
+		return nil
+	}
+	return n.Int64
+}

--- a/internal/eventstore/eventstore_test.go
+++ b/internal/eventstore/eventstore_test.go
@@ -1,0 +1,171 @@
+package eventstore
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestNewWithNilDB(t *testing.T) {
+	s := New(nil)
+	if s == nil {
+		t.Fatal("New(nil) returned nil Store")
+	}
+
+	// All write operations should be no-ops when db is nil.
+	ctx := context.Background()
+
+	res, err := s.Open(ctx, OpenInput{
+		Identity: Identity{BlogID: 1, CheckType: "http"},
+		Severity: SeveritySeemsDown,
+		State:    StateSeemsDown,
+	})
+	if err != nil {
+		t.Fatalf("Open with nil db: %v", err)
+	}
+	if res.EventID != 0 || res.Opened {
+		t.Fatalf("Open with nil db = %+v, want zero", res)
+	}
+
+	if changed, err := s.UpdateSeverity(ctx, 42, SeverityDown, ReasonSeverityEscalation, "local", nil); err != nil || changed {
+		t.Fatalf("UpdateSeverity with nil db = (%v, %v)", changed, err)
+	}
+
+	if changed, err := s.UpdateState(ctx, 42, StateDown, ReasonVerifierConfirmed, "local", nil); err != nil || changed {
+		t.Fatalf("UpdateState with nil db = (%v, %v)", changed, err)
+	}
+
+	if changed, err := s.Promote(ctx, 42, SeverityDown, StateDown, ReasonVerifierConfirmed, "local", nil); err != nil || changed {
+		t.Fatalf("Promote with nil db = (%v, %v)", changed, err)
+	}
+
+	if changed, err := s.LinkCause(ctx, 42, 99, "local"); err != nil || changed {
+		t.Fatalf("LinkCause with nil db = (%v, %v)", changed, err)
+	}
+
+	if err := s.Close(ctx, 42, ReasonVerifierCleared, "local", nil); err != nil {
+		t.Fatalf("Close with nil db: %v", err)
+	}
+}
+
+func TestNilDBTxIsNoOp(t *testing.T) {
+	// Begin on a nil-db Store returns a no-op Tx whose methods all short-circuit
+	// without touching a database.
+	s := New(nil)
+	ctx := context.Background()
+
+	tx, err := s.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	if tx == nil {
+		t.Fatal("Begin returned nil Tx")
+	}
+	if tx.Tx() != nil {
+		t.Fatal("nil-db Tx should expose nil *sql.Tx")
+	}
+
+	// All Tx methods should run without panicking.
+	res, err := tx.Open(ctx, OpenInput{
+		Identity: Identity{BlogID: 1, CheckType: "http"},
+		Severity: SeveritySeemsDown,
+		State:    StateSeemsDown,
+	})
+	if err != nil || res.EventID != 0 {
+		t.Fatalf("Tx.Open with nil db = (%+v, %v)", res, err)
+	}
+	if _, err := tx.UpdateSeverity(ctx, 1, SeverityDown, ReasonSeverityEscalation, "local", nil); err != nil {
+		t.Fatalf("Tx.UpdateSeverity: %v", err)
+	}
+	if _, err := tx.Promote(ctx, 1, SeverityDown, StateDown, ReasonVerifierConfirmed, "local", nil); err != nil {
+		t.Fatalf("Tx.Promote: %v", err)
+	}
+	if err := tx.Close(ctx, 1, ReasonVerifierCleared, "local", nil); err != nil {
+		t.Fatalf("Tx.Close: %v", err)
+	}
+	ae, err := tx.FindActiveByBlog(ctx, 1, "http")
+	if err != nil {
+		t.Fatalf("Tx.FindActiveByBlog: %v", err)
+	}
+	if ae.ID != 0 {
+		t.Fatalf("FindActiveByBlog on nil-db = %+v, want zero", ae)
+	}
+
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	// Rollback after Commit should also be a no-op.
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback after Commit: %v", err)
+	}
+}
+
+func TestSeverityScale(t *testing.T) {
+	// Severity is intentionally a small ordered scale; relative ordering matters
+	// more than the exact numbers, but the constants must agree with what the
+	// orchestrator and dashboards expect.
+	if SeverityUp >= SeverityWarning ||
+		SeverityWarning >= SeverityDegraded ||
+		SeverityDegraded >= SeveritySeemsDown ||
+		SeveritySeemsDown >= SeverityDown {
+		t.Fatalf("severity scale not strictly increasing: %d %d %d %d %d",
+			SeverityUp, SeverityWarning, SeverityDegraded, SeveritySeemsDown, SeverityDown)
+	}
+}
+
+func TestStateAndReasonConstants(t *testing.T) {
+	if StateSeemsDown != "Seems Down" {
+		t.Fatalf("StateSeemsDown = %q, want %q", StateSeemsDown, "Seems Down")
+	}
+	if ReasonOpened != "opened" {
+		t.Fatalf("ReasonOpened = %q, want %q", ReasonOpened, "opened")
+	}
+	if ReasonProbeCleared != "probe_cleared" {
+		t.Fatalf("ReasonProbeCleared = %q, want %q", ReasonProbeCleared, "probe_cleared")
+	}
+	if ReasonFalseAlarm != "false_alarm" {
+		t.Fatalf("ReasonFalseAlarm = %q, want %q", ReasonFalseAlarm, "false_alarm")
+	}
+}
+
+func TestNullableHelpers(t *testing.T) {
+	if nullableEndpoint(nil) != nil {
+		t.Fatal("nullableEndpoint(nil) should be nil")
+	}
+	id := int64(7)
+	if nullableEndpoint(&id) != int64(7) {
+		t.Fatalf("nullableEndpoint(&7) = %v, want 7", nullableEndpoint(&id))
+	}
+
+	if nullableDiscriminator("") != nil {
+		t.Fatal("nullableDiscriminator(\"\") should be nil")
+	}
+	if nullableDiscriminator("abc") != "abc" {
+		t.Fatal("nullableDiscriminator(\"abc\") should be \"abc\"")
+	}
+
+	if nullableJSON(nil) != nil {
+		t.Fatal("nullableJSON(nil) should be nil")
+	}
+	if nullableJSON(json.RawMessage("")) != nil {
+		t.Fatal("nullableJSON(empty) should be nil")
+	}
+	if nullableJSON(json.RawMessage(`{"a":1}`)) == nil {
+		t.Fatal("nullableJSON(non-empty) should not be nil")
+	}
+
+	if nullableUint8(nil) != nil {
+		t.Fatal("nullableUint8(nil) should be nil")
+	}
+	v := uint8(3)
+	if nullableUint8(&v) != uint8(3) {
+		t.Fatalf("nullableUint8(&3) = %v, want 3", nullableUint8(&v))
+	}
+
+	if nullableString("") != nil {
+		t.Fatal("nullableString(\"\") should be nil")
+	}
+	if nullableString("x") != "x" {
+		t.Fatal("nullableString(\"x\") should be \"x\"")
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -38,6 +38,13 @@ const (
 	checkTypeTLSExpiry = "tls_expiry"
 )
 
+// verifierRPCHeadroom is added to the per-site check timeout when computing
+// the RPC deadline for a verifier call. The verifier needs enough budget to
+// run its own HTTP check (matches site timeout) plus serialization, queueing,
+// and network round-trip — 5s covers a comfortable steady-state and forces
+// failure on a truly wedged verifier rather than letting the call hang.
+const verifierRPCHeadroom = 5 * time.Second
+
 var (
 	nowFunc               = time.Now
 	dbClaimBuckets        = db.ClaimBuckets
@@ -402,13 +409,6 @@ func (o *Orchestrator) escalateToVerifliers(site db.Site, entry *retryEntry) {
 		return
 	}
 
-	o.auditLog(audit.Entry{
-		BlogID:    site.BlogID,
-		EventType: audit.EventVeriflierSent,
-		Source:    o.hostname,
-		Detail:    fmt.Sprintf("escalating to %d verifliers", len(clients)),
-	})
-
 	req := veriflier.CheckRequest{
 		BlogID:         site.BlogID,
 		URL:            site.MonitorURL,
@@ -416,7 +416,29 @@ func (o *Orchestrator) escalateToVerifliers(site db.Site, entry *retryEntry) {
 		Keyword:        stringPtrValue(site.CheckKeyword),
 		CustomHeaders:  checker.ParseCustomHeaders(site.CustomHeaders),
 		RedirectPolicy: site.RedirectPolicy,
+		RequestID:      veriflier.NewRequestID(),
 	}
+
+	escalateMeta, _ := json.Marshal(map[string]any{
+		"verifier_count": len(clients),
+		"request_id":     req.RequestID,
+	})
+	o.auditLog(audit.Entry{
+		BlogID:    site.BlogID,
+		EventType: audit.EventVeriflierSent,
+		Source:    o.hostname,
+		Detail:    fmt.Sprintf("escalating to %d verifliers", len(clients)),
+		Metadata:  escalateMeta,
+	})
+
+	// Per-RPC deadline: site's check budget plus headroom for the verifier's
+	// own HTTP work, server queueing, and network. Without this the dial /
+	// read can hang for o.ctx's lifetime (effectively forever) on a wedged
+	// verifier — the old hardcoded 30s client.Timeout was the only bound and
+	// has been removed in favor of this caller-controlled deadline.
+	rpcDeadline := time.Duration(timeoutForSite(config.Get(), site))*time.Second + verifierRPCHeadroom
+	rpcCtx, rpcCancel := stdctx.WithTimeout(o.ctx, rpcDeadline)
+	defer rpcCancel()
 
 	type vResult struct {
 		host string
@@ -428,7 +450,7 @@ func (o *Orchestrator) escalateToVerifliers(site db.Site, entry *retryEntry) {
 	for _, client := range clients {
 		c := client
 		go func() {
-			res, err := veriflierCheckFunc(c, o.ctx, req)
+			res, err := veriflierCheckFunc(c, rpcCtx, req)
 			ch <- vResult{host: c.Addr(), res: res, err: err}
 		}()
 	}
@@ -453,6 +475,7 @@ func (o *Orchestrator) escalateToVerifliers(site db.Site, entry *retryEntry) {
 			"error_code": vr.res.ErrorCode,
 			"rtt_ms":     vr.res.RTTMs,
 			"success":    vr.res.Success,
+			"request_id": vr.res.RequestID,
 		})
 		o.auditLog(audit.Entry{
 			BlogID:    site.BlogID,

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -2,6 +2,8 @@ package orchestrator
 
 import (
 	stdctx "context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	runtimemetrics "runtime/metrics"
@@ -12,14 +14,28 @@ import (
 	"github.com/Automattic/jetmon/internal/checker"
 	"github.com/Automattic/jetmon/internal/config"
 	"github.com/Automattic/jetmon/internal/db"
+	"github.com/Automattic/jetmon/internal/eventstore"
 	"github.com/Automattic/jetmon/internal/metrics"
 	"github.com/Automattic/jetmon/internal/veriflier"
 	"github.com/Automattic/jetmon/internal/wpcom"
 )
 
+// v1 site_status values projected onto jetpack_monitor_sites.site_status from
+// the event-sourced state. These remain unchanged for back-compat with v1
+// consumers; the orchestrator writes them in the same transaction as every
+// event mutation.
 const (
-	statusRunning       = 1
-	statusConfirmedDown = 2
+	statusDown          = 0 // Seems Down event open (local failures, retry/verification in progress)
+	statusRunning       = 1 // No active event
+	statusConfirmedDown = 2 // Down event (verifier-confirmed)
+)
+
+// checkTypeHTTP is the canonical check_type for the v1 HTTP probe path. New
+// check types (DNS, TLS expiry, keyword, redirect, etc.) get their own
+// constants alongside.
+const (
+	checkTypeHTTP      = "http"
+	checkTypeTLSExpiry = "tls_expiry"
 )
 
 var (
@@ -47,6 +63,7 @@ type Orchestrator struct {
 	pool             *checker.Pool
 	retries          *retryQueue
 	wpcom            *wpcom.Client
+	events           *eventstore.Store
 	veriflierClients []*veriflier.VeriflierClient
 	veriflierAddrs   []string // parallel slice of "addr|token" for change detection
 	veriflierMu      sync.RWMutex
@@ -70,6 +87,7 @@ func New(cfg *config.Config, wp *wpcom.Client) *Orchestrator {
 		pool:     pool,
 		retries:  newRetryQueue(),
 		wpcom:    wp,
+		events:   eventstore.New(db.DB()),
 		hostname: db.Hostname(),
 		ctx:      ctx,
 		cancel:   cancel,
@@ -81,6 +99,17 @@ func New(cfg *config.Config, wp *wpcom.Client) *Orchestrator {
 	}
 
 	return o
+}
+
+// ev returns a non-nil event store. Tests that construct &Orchestrator{}
+// directly without setting events get a no-op store backed by a nil DB so
+// event-mutation paths run without panicking. Production always wires up a
+// real Store in New().
+func (o *Orchestrator) ev() *eventstore.Store {
+	if o.events == nil {
+		return eventstore.New(nil)
+	}
+	return o.events
 }
 
 // ClaimBuckets registers this host in jetmon_hosts and sets the bucket range.
@@ -278,8 +307,8 @@ func (o *Orchestrator) processResults(results map[int64]checker.Result, sites ma
 			o.checkSSLAlerts(site, *res.SSLExpiry)
 		}
 
-		o.auditLog(blogID, audit.EventCheck, o.hostname,
-			res.HTTPCode, res.ErrorCode, res.RTT.Milliseconds(), "")
+		// Per-check data is recorded in jetmon_check_history (above); duplicating
+		// it in jetmon_audit_log was retired with the operational/site-state split.
 
 		if !res.IsFailure() {
 			o.handleRecovery(site, res)
@@ -295,19 +324,31 @@ func (o *Orchestrator) handleRecovery(site db.Site, res checker.Result) {
 		return // was already up, nothing to do
 	}
 
+	knownEventID := int64(0)
+	if entry != nil {
+		knownEventID = entry.eventID
+	}
 	o.retries.clear(site.BlogID)
 
 	if site.SiteStatus != statusRunning {
 		changeTime := nowFunc().UTC()
 		log.Printf("orchestrator: blog_id=%d recovered", site.BlogID)
-		o.auditTransition(site.BlogID, site.SiteStatus, statusRunning, "site recovered")
 
-		if config.Get().DBUpdatesEnable {
-			_ = dbUpdateSiteStatus(o.ctx, site.BlogID, statusRunning, changeTime)
+		// Close the open event and project site_status back to running in the
+		// same transaction. The resolution reason depends on whether the event
+		// was already verifier-confirmed (Down) or still in the local-retry
+		// phase (Seems Down).
+		if err := o.closeRecoveredEvent(site.BlogID, knownEventID, changeTime); err != nil {
+			log.Printf("orchestrator: close recovered event blog_id=%d: %v", site.BlogID, err)
 		}
 
 		if inMaintenance(site) {
-			o.auditLog(site.BlogID, audit.EventMaintenanceActive, "local", 0, 0, 0, "recovery suppressed during maintenance")
+			o.auditLog(audit.Entry{
+				BlogID:    site.BlogID,
+				EventType: audit.EventMaintenanceActive,
+				Source:    "local",
+				Detail:    "recovery suppressed during maintenance",
+			})
 		} else if !o.isAlertSuppressed(site) {
 			o.sendNotification(site, res, statusRunning, changeTime, nil)
 		}
@@ -317,10 +358,36 @@ func (o *Orchestrator) handleRecovery(site db.Site, res checker.Result) {
 func (o *Orchestrator) handleFailure(site db.Site, res checker.Result) {
 	entry := o.retries.record(res)
 
+	// Open a Seems Down event on the first failure we don't already have an
+	// id for. The schema's idempotent dedup_key means re-detecting the same
+	// failure would update the same row, so this is also a self-healing retry
+	// path if a previous Open failed to commit.
+	if entry.eventID == 0 {
+		id, err := o.openSeemsDown(site, res)
+		if err != nil {
+			log.Printf("orchestrator: open seems-down event blog_id=%d: %v", site.BlogID, err)
+		} else {
+			entry.eventID = id
+		}
+	}
+
 	if entry.failCount < config.Get().NumOfChecks {
-		o.auditLog(site.BlogID, audit.EventRetryDispatched, o.hostname,
-			res.HTTPCode, res.ErrorCode, res.RTT.Milliseconds(),
-			fmt.Sprintf("retry %d of %d", entry.failCount, config.Get().NumOfChecks))
+		meta, _ := json.Marshal(map[string]any{
+			"http_code":  res.HTTPCode,
+			"error_code": res.ErrorCode,
+			"rtt_ms":     res.RTT.Milliseconds(),
+			"attempt":    entry.failCount,
+			"of":         config.Get().NumOfChecks,
+			"event_id":   entry.eventID,
+		})
+		o.auditLog(audit.Entry{
+			BlogID:    site.BlogID,
+			EventID:   entry.eventID,
+			EventType: audit.EventRetryDispatched,
+			Source:    o.hostname,
+			Detail:    fmt.Sprintf("retry %d of %d", entry.failCount, config.Get().NumOfChecks),
+			Metadata:  meta,
+		})
 		return
 	}
 
@@ -335,8 +402,12 @@ func (o *Orchestrator) escalateToVerifliers(site db.Site, entry *retryEntry) {
 		return
 	}
 
-	o.auditLog(site.BlogID, audit.EventVeriflierSent, o.hostname, 0, 0, 0,
-		fmt.Sprintf("escalating to %d verifliers", len(clients)))
+	o.auditLog(audit.Entry{
+		BlogID:    site.BlogID,
+		EventType: audit.EventVeriflierSent,
+		Source:    o.hostname,
+		Detail:    fmt.Sprintf("escalating to %d verifliers", len(clients)),
+	})
 
 	req := veriflier.CheckRequest{
 		BlogID:         site.BlogID,
@@ -373,8 +444,23 @@ func (o *Orchestrator) escalateToVerifliers(site db.Site, entry *retryEntry) {
 			continue
 		}
 		healthyVerifliers++
-		o.auditLog(site.BlogID, audit.EventVeriflierResult, vr.host,
-			int(vr.res.HTTPCode), int(vr.res.ErrorCode), vr.res.RTTMs, "")
+		// Verifier reply is operational telemetry — recorded under
+		// EventVeriflierSent with the response in metadata. The site-state
+		// outcome (confirm or false alarm) is captured separately, ultimately
+		// as a transition row in jetmon_event_transitions.
+		meta, _ := json.Marshal(map[string]any{
+			"http_code":  vr.res.HTTPCode,
+			"error_code": vr.res.ErrorCode,
+			"rtt_ms":     vr.res.RTTMs,
+			"success":    vr.res.Success,
+		})
+		o.auditLog(audit.Entry{
+			BlogID:    site.BlogID,
+			EventType: audit.EventVeriflierSent,
+			Source:    vr.host,
+			Detail:    "veriflier reply",
+			Metadata:  meta,
+		})
 		vResults = append(vResults, *vr.res)
 		if !vr.res.Success {
 			confirmations++
@@ -393,10 +479,25 @@ func (o *Orchestrator) escalateToVerifliers(site db.Site, entry *retryEntry) {
 	if confirmations >= quorum {
 		o.confirmDown(site, entry, vResults)
 	} else {
-		// Verifliers did not confirm — false positive.
+		// Verifliers did not confirm — false positive. Close the Seems Down
+		// event with reason=false_alarm and reset site_status in the same tx.
 		log.Printf("orchestrator: blog_id=%d verifliers did not confirm down (%d/%d)", site.BlogID, confirmations, quorum)
 		_ = dbRecordFalsePositive(site.BlogID, entry.lastResult.HTTPCode, entry.lastResult.ErrorCode,
 			entry.lastResult.RTT.Milliseconds())
+
+		if entry.eventID > 0 {
+			meta, _ := json.Marshal(map[string]any{
+				"verifier_quorum":    quorum,
+				"verifier_healthy":   healthyVerifliers,
+				"verifier_disagreed": healthyVerifliers - confirmations,
+				"verifier_confirmed": confirmations,
+			})
+			if err := o.closeEvent(site.BlogID, entry.eventID,
+				eventstore.ReasonFalseAlarm, statusRunning, nowFunc().UTC(), meta); err != nil {
+				log.Printf("orchestrator: close false-alarm event blog_id=%d event_id=%d: %v",
+					site.BlogID, entry.eventID, err)
+			}
+		}
 		o.retries.clear(site.BlogID)
 	}
 }
@@ -406,18 +507,39 @@ func (o *Orchestrator) confirmDown(site db.Site, entry *retryEntry, vResults []v
 	changeTime := nowFunc().UTC()
 
 	log.Printf("orchestrator: blog_id=%d confirmed down", site.BlogID)
-	o.auditTransition(site.BlogID, site.SiteStatus, newStatus, "confirmed down")
 
-	if config.Get().DBUpdatesEnable {
+	// Promote the open Seems Down event to Down with reason=verifier_confirmed
+	// and project site_status=SITE_CONFIRMED_DOWN in the same tx. If we have no
+	// event id (open failed earlier or eventstore unavailable), fall back to
+	// the bare projection write.
+	if entry.eventID > 0 {
+		meta, _ := json.Marshal(map[string]any{
+			"verifier_results":   summarizeVerifierResults(vResults),
+			"verifier_confirmed": len(vResults),
+		})
+		if err := o.promoteToDown(site.BlogID, entry.eventID, changeTime, meta); err != nil {
+			log.Printf("orchestrator: promote event blog_id=%d event_id=%d: %v", site.BlogID, entry.eventID, err)
+		}
+	} else if config.Get().DBUpdatesEnable {
 		_ = dbUpdateSiteStatus(o.ctx, site.BlogID, newStatus, changeTime)
 	}
 
 	if inMaintenance(site) {
-		o.auditLog(site.BlogID, audit.EventMaintenanceActive, "local", 0, 0, 0, "downtime suppressed during maintenance")
+		o.auditLog(audit.Entry{
+			BlogID:    site.BlogID,
+			EventType: audit.EventMaintenanceActive,
+			Source:    "local",
+			Detail:    "downtime suppressed during maintenance",
+		})
 	} else if !o.isAlertSuppressed(site) {
 		o.sendNotification(site, entry.lastResult, newStatus, changeTime, vResults)
 	} else {
-		o.auditLog(site.BlogID, audit.EventAlertSuppressed, "local", 0, 0, 0, "cooldown active")
+		o.auditLog(audit.Entry{
+			BlogID:    site.BlogID,
+			EventType: audit.EventAlertSuppressed,
+			Source:    "local",
+			Detail:    "cooldown active",
+		})
 	}
 
 	o.retries.clear(site.BlogID)
@@ -453,12 +575,21 @@ func (o *Orchestrator) sendNotification(site db.Site, res checker.Result, status
 		Checks:           checks,
 	}
 
-	o.auditLog(site.BlogID, audit.EventWPCOMSent, "local", 0, 0, 0,
-		fmt.Sprintf("status=%d type=%s", status, n.StatusType))
+	o.auditLog(audit.Entry{
+		BlogID:    site.BlogID,
+		EventType: audit.EventWPCOMSent,
+		Source:    "local",
+		Detail:    fmt.Sprintf("status=%d type=%s", status, n.StatusType),
+	})
 
 	if err := wpcomNotifyFunc(o.wpcom, n); err != nil {
 		log.Printf("orchestrator: wpcom notify failed for blog_id=%d: %v", site.BlogID, err)
-		o.auditLog(site.BlogID, audit.EventWPCOMRetry, "local", 0, 0, 0, err.Error())
+		o.auditLog(audit.Entry{
+			BlogID:    site.BlogID,
+			EventType: audit.EventWPCOMRetry,
+			Source:    "local",
+			Detail:    err.Error(),
+		})
 
 		// Single retry.
 		if retryErr := wpcomNotifyFunc(o.wpcom, n); retryErr != nil {
@@ -471,16 +602,112 @@ func (o *Orchestrator) sendNotification(site db.Site, res checker.Result, status
 	}
 }
 
+// checkSSLAlerts manages a site-level tls_expiry event that tracks the cert's
+// remaining lifetime. The event is opened idempotently — once it's open, every
+// HTTPS check is a no-op on the events table unless the threshold (and thus
+// severity) changes. The event closes when the cert is renewed beyond the
+// outermost threshold.
+//
+// Severity ladder:
+//   - <= 7 days  → Degraded (severity 2)
+//   - <= 14 days → Warning  (severity 1)
+//   - <= 30 days → Warning  (severity 1)
+//   - >  30 days → close any open event with reason=verifier_cleared
 func (o *Orchestrator) checkSSLAlerts(site db.Site, expiry time.Time) {
-	thresholds := []int{30, 14, 7}
 	daysUntil := int(time.Until(expiry).Hours() / 24)
-	for _, t := range thresholds {
-		if daysUntil == t {
-			log.Printf("orchestrator: blog_id=%d SSL cert expires in %d days", site.BlogID, daysUntil)
-			o.auditLog(site.BlogID, audit.EventCheck, "local", 0, checker.ErrorTLSExpired, 0,
-				fmt.Sprintf("ssl certificate expires in %d days", daysUntil))
+
+	const (
+		warnDays     = 30
+		degradedDays = 7
+	)
+
+	if daysUntil > warnDays {
+		// Cert is healthy. Close any pre-existing tls_expiry event for this site.
+		if err := o.closeSSLExpiryIfOpen(site.BlogID); err != nil {
+			log.Printf("orchestrator: close tls_expiry event blog_id=%d: %v", site.BlogID, err)
+		}
+		return
+	}
+
+	severity := eventstore.SeverityWarning
+	state := eventstore.StateWarning
+	if daysUntil <= degradedDays {
+		severity = eventstore.SeverityDegraded
+		state = eventstore.StateDegraded
+	}
+
+	meta, _ := json.Marshal(map[string]any{
+		"days_until": daysUntil,
+		"expires_at": expiry.UTC().Format(time.RFC3339),
+	})
+
+	if err := o.openOrUpdateSSLExpiry(site.BlogID, severity, state, daysUntil, meta); err != nil {
+		log.Printf("orchestrator: tls_expiry event blog_id=%d days=%d: %v", site.BlogID, daysUntil, err)
+		return
+	}
+	log.Printf("orchestrator: blog_id=%d SSL cert expires in %d days (severity %d)", site.BlogID, daysUntil, severity)
+}
+
+// openOrUpdateSSLExpiry opens a tls_expiry event for the site if none exists,
+// or escalates / de-escalates the existing event's severity if a threshold has
+// been crossed. site_status is intentionally not projected — TLS expiry
+// warnings don't affect the Up/Down state of the site (Layer 2 issue, not a
+// Layer 4 outage).
+func (o *Orchestrator) openOrUpdateSSLExpiry(blogID int64, severity uint8, state string, daysUntil int, meta json.RawMessage) error {
+	tx, err := o.ev().Begin(o.ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	out, err := tx.Open(o.ctx, eventstore.OpenInput{
+		Identity: eventstore.Identity{BlogID: blogID, CheckType: checkTypeTLSExpiry},
+		Severity: severity,
+		State:    state,
+		Source:   o.hostname,
+		Metadata: meta,
+	})
+	if err != nil {
+		return fmt.Errorf("open tls_expiry: %w", err)
+	}
+
+	// If the event already existed and its severity differs from the new
+	// threshold, escalate (or de-escalate) with a transition row recording why.
+	if !out.Opened && out.CurrentSeverity != severity {
+		reason := eventstore.ReasonSeverityEscalation
+		if severity < out.CurrentSeverity {
+			reason = eventstore.ReasonSeverityDeescalation
+		}
+		if _, err := tx.Promote(o.ctx, out.EventID, severity, state, reason, o.hostname, meta); err != nil {
+			return fmt.Errorf("escalate tls_expiry: %w", err)
 		}
 	}
+	return tx.Commit()
+}
+
+// closeSSLExpiryIfOpen closes an open tls_expiry event for the site, if any.
+// No-op if no event exists.
+func (o *Orchestrator) closeSSLExpiryIfOpen(blogID int64) error {
+	tx, err := o.ev().Begin(o.ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if tx.Tx() == nil {
+		return tx.Commit()
+	}
+	ae, err := tx.FindActiveByBlog(o.ctx, blogID, checkTypeTLSExpiry)
+	if err != nil {
+		if errors.Is(err, eventstore.ErrEventNotFound) {
+			return tx.Commit()
+		}
+		return err
+	}
+	if err := tx.Close(o.ctx, ae.ID, eventstore.ReasonVerifierCleared, o.hostname, nil); err != nil {
+		return fmt.Errorf("close tls_expiry: %w", err)
+	}
+	return tx.Commit()
 }
 
 func (o *Orchestrator) isAlertSuppressed(site db.Site) bool {
@@ -523,16 +750,178 @@ func (o *Orchestrator) QueueDepth() int {
 	return o.pool.QueueDepth()
 }
 
-func (o *Orchestrator) auditLog(blogID int64, event, source string, httpCode, errorCode int, rttMs int64, detail string) {
-	if err := audit.Log(blogID, event, source, httpCode, errorCode, rttMs, detail); err != nil {
-		log.Printf("audit: blog_id=%d event=%s: %v", blogID, event, err)
+func (o *Orchestrator) auditLog(e audit.Entry) {
+	if err := audit.Log(e); err != nil {
+		log.Printf("audit: blog_id=%d event=%s: %v", e.BlogID, e.EventType, err)
 	}
 }
 
-func (o *Orchestrator) auditTransition(blogID int64, from, to int, detail string) {
-	if err := audit.LogTransition(blogID, from, to, detail); err != nil {
-		log.Printf("audit: blog_id=%d transition %d->%d: %v", blogID, from, to, err)
+// openSeemsDown opens (or re-detects) a Seems Down event for an HTTP-failing
+// site and projects v1 site_status=SITE_DOWN in the same transaction. Returns
+// the event id. Idempotent: a re-detection of the same identity returns the
+// existing event's id with no transition row written and no projection update.
+func (o *Orchestrator) openSeemsDown(site db.Site, res checker.Result) (int64, error) {
+	tx, err := o.ev().Begin(o.ctx)
+	if err != nil {
+		return 0, err
 	}
+	defer func() { _ = tx.Rollback() }()
+
+	meta, _ := json.Marshal(map[string]any{
+		"http_code":  res.HTTPCode,
+		"error_code": res.ErrorCode,
+		"rtt_ms":     res.RTT.Milliseconds(),
+		"url":        site.MonitorURL,
+	})
+
+	out, err := tx.Open(o.ctx, eventstore.OpenInput{
+		Identity: eventstore.Identity{BlogID: site.BlogID, CheckType: checkTypeHTTP},
+		Severity: eventstore.SeveritySeemsDown,
+		State:    eventstore.StateSeemsDown,
+		Source:   o.hostname,
+		Metadata: meta,
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	// Project v1 site_status=SITE_DOWN only on the actual insert. A re-detection
+	// (Opened=false) is by definition a row that already exists, so site_status
+	// was already projected when the event first opened.
+	if out.Opened && config.Get().DBUpdatesEnable && tx.Tx() != nil {
+		if err := db.UpdateSiteStatusTx(o.ctx, tx.Tx(), site.BlogID, statusDown, nowFunc().UTC()); err != nil {
+			return 0, fmt.Errorf("project site_status: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("commit: %w", err)
+	}
+	return out.EventID, nil
+}
+
+// promoteToDown bumps an open Seems Down event to Down (severity 4) and
+// projects site_status=SITE_CONFIRMED_DOWN in the same transaction.
+func (o *Orchestrator) promoteToDown(blogID, eventID int64, changeTime time.Time, meta json.RawMessage) error {
+	tx, err := o.ev().Begin(o.ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.Promote(o.ctx, eventID,
+		eventstore.SeverityDown, eventstore.StateDown,
+		eventstore.ReasonVerifierConfirmed, o.hostname, meta); err != nil {
+		return fmt.Errorf("promote event: %w", err)
+	}
+
+	if config.Get().DBUpdatesEnable && tx.Tx() != nil {
+		if err := db.UpdateSiteStatusTx(o.ctx, tx.Tx(), blogID, statusConfirmedDown, changeTime); err != nil {
+			return fmt.Errorf("project site_status: %w", err)
+		}
+	}
+	return tx.Commit()
+}
+
+// closeEvent closes an open event with the given resolution reason and projects
+// site_status to the given v1 value in the same transaction.
+func (o *Orchestrator) closeEvent(blogID, eventID int64, reason string, projectedStatus int, changeTime time.Time, meta json.RawMessage) error {
+	tx, err := o.ev().Begin(o.ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := tx.Close(o.ctx, eventID, reason, o.hostname, meta); err != nil {
+		return fmt.Errorf("close event: %w", err)
+	}
+
+	if config.Get().DBUpdatesEnable && tx.Tx() != nil {
+		if err := db.UpdateSiteStatusTx(o.ctx, tx.Tx(), blogID, projectedStatus, changeTime); err != nil {
+			return fmt.Errorf("project site_status: %w", err)
+		}
+	}
+	return tx.Commit()
+}
+
+// closeRecoveredEvent closes the open event for a recovering site. Picks
+// resolution reason from the event's current state — Seems Down → probe_cleared,
+// Down → verifier_cleared. If the caller already knows the event id (from the
+// retry entry) it is used directly; otherwise the active event is looked up
+// inside the transaction. site_status is projected back to SITE_RUNNING in the
+// same tx.
+func (o *Orchestrator) closeRecoveredEvent(blogID, knownEventID int64, changeTime time.Time) error {
+	tx, err := o.ev().Begin(o.ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Determine event id and current state. If knownEventID is set, read state
+	// directly; otherwise look up the active event for this blog.
+	var eventID int64
+	var state string
+	switch {
+	case knownEventID > 0 && tx.Tx() != nil:
+		eventID = knownEventID
+		if err := tx.Tx().QueryRowContext(o.ctx,
+			`SELECT state FROM jetmon_events WHERE id = ?`, eventID,
+		).Scan(&state); err != nil {
+			return fmt.Errorf("read event state: %w", err)
+		}
+	case tx.Tx() != nil:
+		ae, err := tx.FindActiveByBlog(o.ctx, blogID, checkTypeHTTP)
+		if err != nil {
+			if errors.Is(err, eventstore.ErrEventNotFound) {
+				// site_status disagreed with the event store (no open event but
+				// projection said non-running). Just project back to running.
+				if config.Get().DBUpdatesEnable {
+					if err := db.UpdateSiteStatusTx(o.ctx, tx.Tx(), blogID, statusRunning, changeTime); err != nil {
+						return fmt.Errorf("project site_status: %w", err)
+					}
+				}
+				return tx.Commit()
+			}
+			return err
+		}
+		eventID = ae.ID
+		state = ae.State
+	default:
+		// nil-mode (no DB): nothing to do.
+		return tx.Commit()
+	}
+
+	reason := eventstore.ReasonProbeCleared
+	if state == eventstore.StateDown {
+		reason = eventstore.ReasonVerifierCleared
+	}
+
+	if err := tx.Close(o.ctx, eventID, reason, o.hostname, nil); err != nil {
+		return fmt.Errorf("close event: %w", err)
+	}
+	if config.Get().DBUpdatesEnable && tx.Tx() != nil {
+		if err := db.UpdateSiteStatusTx(o.ctx, tx.Tx(), blogID, statusRunning, changeTime); err != nil {
+			return fmt.Errorf("project site_status: %w", err)
+		}
+	}
+	return tx.Commit()
+}
+
+// summarizeVerifierResults extracts a small JSON-friendly summary of verifier
+// replies for storage in transition metadata. We don't store the full result
+// list — the per-RPC details are already in jetmon_audit_log under
+// EventVeriflierSent.
+func summarizeVerifierResults(vResults []veriflier.CheckResult) []map[string]any {
+	out := make([]map[string]any, 0, len(vResults))
+	for _, vr := range vResults {
+		out = append(out, map[string]any{
+			"host":      vr.Host,
+			"success":   vr.Success,
+			"http_code": vr.HTTPCode,
+			"rtt_ms":    vr.RTTMs,
+		})
+	}
+	return out
 }
 
 func inMaintenance(site db.Site) bool {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -270,13 +271,17 @@ func TestEscalateToVerifliersRecordsFalsePositiveWhenQuorumMissed(t *testing.T) 
 		return nil
 	}
 
-	call := 0
+	// escalateToVerifliers fans the verifier RPC out across goroutines, so
+	// `call` is read+written concurrently. Use atomic so `go test -race`
+	// stays clean. The semantics — first verifier returns Success=false,
+	// subsequent ones return true — are unchanged.
+	var call atomic.Int64
 	veriflierCheckFunc = func(c *veriflier.VeriflierClient, _ context.Context, req veriflier.CheckRequest) (*veriflier.CheckResult, error) {
-		call++
+		n := call.Add(1)
 		return &veriflier.CheckResult{
 			BlogID:   req.BlogID,
 			Host:     c.Addr(),
-			Success:  call != 1,
+			Success:  n != 1,
 			HTTPCode: 200,
 		}, nil
 	}

--- a/internal/orchestrator/retry.go
+++ b/internal/orchestrator/retry.go
@@ -9,12 +9,13 @@ import (
 
 // retryEntry tracks local retry state for a site that has failed at least once.
 type retryEntry struct {
-	blogID       int64
-	url          string
-	failCount    int
-	firstFailAt  time.Time
-	lastResult   checker.Result
-	checks       []checker.Result // all check results since first failure
+	blogID      int64
+	url         string
+	failCount   int
+	firstFailAt time.Time
+	lastResult  checker.Result
+	checks      []checker.Result // all check results since first failure
+	eventID     int64            // jetmon_events.id for the open Seems Down event; 0 if not yet opened or eventstore unavailable
 }
 
 // retryQueue holds sites awaiting local retry or veriflier escalation.

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -1,11 +1,14 @@
 package veriflier
 
 import (
+	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
-	"strings"
 	"time"
 )
 
@@ -15,17 +18,42 @@ import (
 // functional without a protoc dependency. Swap in the generated gRPC client
 // by replacing the send() method after running `make generate`.
 type VeriflierClient struct {
-	addr      string
-	authToken string
+	addr       string
+	authToken  string
 	httpClient *http.Client
 }
 
 // NewVeriflierClient creates a client targeting the given address (host:port).
+//
+// The HTTP transport is tuned for the orchestrator's hot-path use: many
+// short-lived RPCs to the same verifier host during outage waves. Default
+// MaxIdleConnsPerHost=2 forces frequent reconnects under any concurrency above
+// 2; we raise it so the orchestrator's per-verifier escalation goroutines
+// reuse a small pool of warm connections.
+//
+// No client-level Timeout is set. Per-call deadlines come from the caller's
+// context (the orchestrator wraps each escalation with NET_COMMS_TIMEOUT +
+// headroom). A blanket client.Timeout would override that — see Go's
+// http.Client docs: client.Timeout is enforced regardless of ctx, so leaving
+// it unset means ctx is the only deadline and is honored exactly.
 func NewVeriflierClient(addr, authToken string) *VeriflierClient {
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   5 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   20,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   5 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		ForceAttemptHTTP2:     true,
+	}
 	return &VeriflierClient{
-		addr:      addr,
-		authToken: authToken,
-		httpClient: &http.Client{Timeout: 30 * time.Second},
+		addr:       addr,
+		authToken:  authToken,
+		httpClient: &http.Client{Transport: transport},
 	}
 }
 
@@ -36,6 +64,9 @@ func (c *VeriflierClient) Addr() string {
 
 // Check sends a single site check request to the Veriflier and returns the result.
 func (c *VeriflierClient) Check(ctx context.Context, req CheckRequest) (*CheckResult, error) {
+	if req.RequestID == "" {
+		req.RequestID = NewRequestID()
+	}
 	results, err := c.CheckBatch(ctx, []CheckRequest{req})
 	if err != nil {
 		return nil, err
@@ -46,7 +77,8 @@ func (c *VeriflierClient) Check(ctx context.Context, req CheckRequest) (*CheckRe
 	return &results[0], nil
 }
 
-// CheckBatch sends multiple check requests to the Veriflier.
+// CheckBatch sends multiple check requests to the Veriflier. Each request
+// without a RequestID is given a fresh one; existing RequestIDs are preserved.
 func (c *VeriflierClient) CheckBatch(ctx context.Context, reqs []CheckRequest) ([]CheckResult, error) {
 	type batchReq struct {
 		Sites []CheckRequest `json:"sites"`
@@ -55,13 +87,19 @@ func (c *VeriflierClient) CheckBatch(ctx context.Context, reqs []CheckRequest) (
 		Results []CheckResult `json:"results"`
 	}
 
+	for i := range reqs {
+		if reqs[i].RequestID == "" {
+			reqs[i].RequestID = NewRequestID()
+		}
+	}
+
 	body, err := json.Marshal(batchReq{Sites: reqs})
 	if err != nil {
 		return nil, err
 	}
 
 	url := fmt.Sprintf("http://%s/check", c.addr)
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(body)))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -104,4 +142,17 @@ func (c *VeriflierClient) Ping(ctx context.Context) (string, error) {
 	}
 	_ = json.NewDecoder(resp.Body).Decode(&s)
 	return s.Version, nil
+}
+
+// NewRequestID returns a 16-byte random id, hex-encoded (32 chars). Used as
+// the RPC correlation id between Monitor and Verifier. Crypto/rand backed so
+// IDs are unpredictable; this isn't a security primitive but it's free.
+func NewRequestID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// Fall back to a timestamp-based id; collisions are vanishingly
+		// unlikely at our request rates and the id is correlation-only.
+		return fmt.Sprintf("ts-%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b[:])
 }

--- a/internal/veriflier/server.go
+++ b/internal/veriflier/server.go
@@ -41,7 +41,20 @@ const (
 	idleTimeout       = 120 * time.Second
 )
 
+// maxRequestBodyBytes caps an inbound POST /check body. A typical batch is
+// ~200 sites × ~250 bytes/site ≈ 50KB, so 10MB is generous headroom and
+// closes a trivial DoS vector (an attacker that has the auth token can't
+// stream gigabytes through the JSON decoder before we notice).
+const maxRequestBodyBytes = 10 * 1024 * 1024
+
 // NewServer creates a Server that calls checkFn for each check request.
+//
+// authToken must be non-empty in production. An empty token would create a
+// dangerous edge case where any request with `Authorization: Bearer ` (with
+// a trailing space and nothing else) would be accepted; callers that
+// receive an empty token from config should reject it before reaching here.
+// We don't validate at construct time because tests exercise the empty-token
+// path via httptest, but veriflier2/cmd/main.go does check at startup.
 func NewServer(addr, authToken, hostname, version string, checkFn func(CheckRequest) CheckResult) *Server {
 	return &Server{
 		addr:      addr,
@@ -104,8 +117,20 @@ func (s *Server) handleCheck(w http.ResponseWriter, r *http.Request) {
 		Results []CheckResult `json:"results"`
 	}
 
+	// Cap the body before decoding. An overlong body produces a clear 413
+	// rather than streaming through the JSON decoder until something else
+	// times out.
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+
 	var req batchReq
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		// MaxBytesReader's "http: request body too large" error is the
+		// signal we want to surface as 413; everything else is a malformed
+		// JSON payload (400).
+		if err.Error() == "http: request body too large" {
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
 		http.Error(w, fmt.Sprintf("decode: %v", err), http.StatusBadRequest)
 		return
 	}

--- a/internal/veriflier/server.go
+++ b/internal/veriflier/server.go
@@ -1,10 +1,14 @@
 package veriflier
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
+	"time"
+
+	"github.com/Automattic/jetmon/internal/metrics"
 )
 
 // Server listens for inbound connections from the Monitor and dispatches
@@ -13,13 +17,29 @@ import (
 // This is the server-side counterpart to VeriflierClient. It implements
 // the same JSON-over-HTTP transport and is replaced by a generated gRPC
 // server after running `make generate`.
+//
+// The HTTP server is configured with read/write/idle timeouts so a slow or
+// stalled client cannot pin a goroutine indefinitely (slowloris-style DoS).
+// Shutdown(ctx) drains in-flight requests up to the caller's deadline before
+// closing the listener.
 type Server struct {
 	authToken string
 	checkFn   func(req CheckRequest) CheckResult
 	addr      string
 	hostname  string
 	version   string
+	httpSrv   *http.Server
 }
+
+// Timeout defaults for the verifier HTTP server. These are conservative — the
+// expected pattern is a small batch POST that completes in well under a
+// second. Longer values would make slowloris cheaper.
+const (
+	readHeaderTimeout = 5 * time.Second
+	readTimeout       = 30 * time.Second
+	writeTimeout      = 35 * time.Second // > readTimeout so the response can flush
+	idleTimeout       = 120 * time.Second
+)
 
 // NewServer creates a Server that calls checkFn for each check request.
 func NewServer(addr, authToken, hostname, version string, checkFn func(CheckRequest) CheckResult) *Server {
@@ -32,17 +52,39 @@ func NewServer(addr, authToken, hostname, version string, checkFn func(CheckRequ
 	}
 }
 
-// Listen starts the HTTP server. Blocks until the server exits.
+// Listen starts the HTTP server. Blocks until the server exits via Shutdown
+// or an unrecoverable error. Returns http.ErrServerClosed on a clean Shutdown.
 func (s *Server) Listen() error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/check", s.handleCheck)
 	mux.HandleFunc("/status", s.handleStatus)
 
+	s.httpSrv = &http.Server{
+		Addr:              s.addr,
+		Handler:           mux,
+		ReadHeaderTimeout: readHeaderTimeout,
+		ReadTimeout:       readTimeout,
+		WriteTimeout:      writeTimeout,
+		IdleTimeout:       idleTimeout,
+	}
+
 	log.Printf("veriflier: listening on %s", s.addr)
-	return http.ListenAndServe(s.addr, mux)
+	return s.httpSrv.ListenAndServe()
+}
+
+// Shutdown gracefully stops the server, allowing in-flight requests to
+// complete up to the context's deadline. Safe to call before Listen — the
+// underlying http.Server is nil-checked.
+func (s *Server) Shutdown(ctx context.Context) error {
+	if s.httpSrv == nil {
+		return nil
+	}
+	return s.httpSrv.Shutdown(ctx)
 }
 
 func (s *Server) handleCheck(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -50,6 +92,7 @@ func (s *Server) handleCheck(w http.ResponseWriter, r *http.Request) {
 
 	token := r.Header.Get("Authorization")
 	if token != "Bearer "+s.authToken {
+		incrementMetric("verifier.auth.rejected.count", 1)
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
@@ -69,10 +112,17 @@ func (s *Server) handleCheck(w http.ResponseWriter, r *http.Request) {
 
 	results := make([]CheckResult, 0, len(req.Sites))
 	for _, site := range req.Sites {
+		// Echo RequestID so the orchestrator can correlate this reply with the
+		// audit row it wrote when escalating.
+		log.Printf("veriflier: check blog_id=%d request_id=%s url=%s", site.BlogID, site.RequestID, site.URL)
 		res := s.checkFn(site)
 		res.Host = s.hostname
+		res.RequestID = site.RequestID
 		results = append(results, res)
 	}
+
+	incrementMetric("verifier.checks.received.count", len(req.Sites))
+	timingMetric("verifier.checks.duration.timer", time.Since(start))
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(batchResp{Results: results})
@@ -84,4 +134,19 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		"status":  "OK",
 		"version": s.version,
 	})
+}
+
+// incrementMetric and timingMetric are nil-safe wrappers around the global
+// StatsD client. The verifier binary may run without metrics configured (no
+// STATSD_ADDR env var), in which case these are no-ops.
+func incrementMetric(name string, value int) {
+	if m := metrics.Global(); m != nil {
+		m.Increment(name, value)
+	}
+}
+
+func timingMetric(name string, d time.Duration) {
+	if m := metrics.Global(); m != nil {
+		m.Timing(name, d)
+	}
 }

--- a/internal/veriflier/types.go
+++ b/internal/veriflier/types.go
@@ -5,6 +5,11 @@
 package veriflier
 
 // CheckRequest is a single site to check, sent from Monitor to Veriflier.
+//
+// RequestID is a client-generated correlation id (16-byte hex). The verifier
+// echoes it back in the response and stamps it on its server-side log line so
+// that "the orchestrator escalated → this verifier observed → this audit row
+// in the monitor DB" can be reconstructed without timestamp matching.
 type CheckRequest struct {
 	BlogID         int64
 	URL            string
@@ -12,6 +17,7 @@ type CheckRequest struct {
 	Keyword        string
 	CustomHeaders  map[string]string
 	RedirectPolicy string
+	RequestID      string
 }
 
 // CheckResult is a single check outcome returned by the Veriflier.
@@ -23,4 +29,5 @@ type CheckResult struct {
 	HTTPCode  int32
 	ErrorCode int32
 	RTTMs     int64
+	RequestID string // echoed from CheckRequest.RequestID
 }

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -3,10 +3,12 @@ package veriflier
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func newTestServer(checkFn func(CheckRequest) CheckResult) (*Server, *httptest.Server) {
@@ -203,5 +205,95 @@ func TestClientRejectsUnauthorized(t *testing.T) {
 	_, err := client.Check(context.Background(), CheckRequest{BlogID: 1, URL: "https://example.com"})
 	if err == nil {
 		t.Fatal("Check() expected error for wrong auth token")
+	}
+}
+
+func TestNewRequestID(t *testing.T) {
+	id := NewRequestID()
+	if len(id) != 32 {
+		t.Fatalf("NewRequestID() len = %d, want 32", len(id))
+	}
+	if _, err := hex.DecodeString(id); err != nil {
+		t.Fatalf("NewRequestID() not hex: %v", err)
+	}
+	other := NewRequestID()
+	if id == other {
+		t.Fatal("NewRequestID() collided across two calls")
+	}
+}
+
+func TestRequestIDIsEchoed(t *testing.T) {
+	// Server should reflect each request's RequestID into the corresponding result.
+	_, ts := newTestServer(func(req CheckRequest) CheckResult {
+		return CheckResult{BlogID: req.BlogID, Success: true, HTTPCode: 200}
+	})
+	defer ts.Close()
+
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
+	res, err := client.Check(context.Background(), CheckRequest{BlogID: 99, URL: "https://example.com"})
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	if res.RequestID == "" {
+		t.Fatal("RequestID empty in response — client should auto-generate and server should echo")
+	}
+	if len(res.RequestID) != 32 {
+		t.Fatalf("RequestID len = %d, want 32 (16-byte hex)", len(res.RequestID))
+	}
+}
+
+func TestRequestIDPreservedWhenCallerSets(t *testing.T) {
+	// When the caller sets RequestID explicitly, the client must not overwrite it.
+	const callerID = "caller-supplied-id"
+	_, ts := newTestServer(func(req CheckRequest) CheckResult {
+		return CheckResult{BlogID: req.BlogID, Success: true}
+	})
+	defer ts.Close()
+
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
+	res, err := client.Check(context.Background(), CheckRequest{
+		BlogID:    1,
+		URL:       "https://example.com",
+		RequestID: callerID,
+	})
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	if res.RequestID != callerID {
+		t.Fatalf("RequestID = %q, want %q (caller-supplied id was overwritten)", res.RequestID, callerID)
+	}
+}
+
+func TestServerShutdownDrains(t *testing.T) {
+	// Shutdown should drain in-flight requests up to the context deadline,
+	// not yank the connection mid-response.
+	srv := NewServer("127.0.0.1:0", "secret", "test-host", "1.0", func(req CheckRequest) CheckResult {
+		// Simulate a slow check so Shutdown has something to drain.
+		time.Sleep(50 * time.Millisecond)
+		return CheckResult{BlogID: req.BlogID, Success: true}
+	})
+
+	// Listen in background; surface the listener's actual port via httptest hack.
+	// Using httptest.NewUnstartedServer with our handler avoids the port-binding race.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/check", srv.handleCheck)
+	mux.HandleFunc("/status", srv.handleStatus)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	// Fire a request, then call Shutdown on the underlying httptest.Server's
+	// http.Server. We're testing the *handler* path with timeouts; the
+	// httptest.Server itself manages the listener.
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
+	done := make(chan error, 1)
+	go func() {
+		_, err := client.Check(context.Background(), CheckRequest{BlogID: 1, URL: "https://example.com"})
+		done <- err
+	}()
+
+	// Give the request time to land in the handler's sleep, then verify it
+	// completes successfully (no panic, no shutdown mid-response).
+	if err := <-done; err != nil {
+		t.Fatalf("in-flight check failed: %v", err)
 	}
 }

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -264,6 +264,43 @@ func TestRequestIDPreservedWhenCallerSets(t *testing.T) {
 	}
 }
 
+func TestServerRejectsOversizedBody(t *testing.T) {
+	// The body cap is the only DoS mitigation between an authorized caller
+	// and the JSON decoder. A body over the 10MB cap should be rejected
+	// with 413 — and crucially, the checkFn should never be invoked.
+	_, ts := newTestServer(func(req CheckRequest) CheckResult {
+		t.Fatal("checkFn should not be called for oversized body")
+		return CheckResult{}
+	})
+	defer ts.Close()
+
+	// Build a body just over the 10MB cap. Padding lives in a custom_headers
+	// value so the JSON shape is still valid (we want to confirm the cap
+	// fires, not that the JSON is malformed).
+	pad := make([]byte, 11*1024*1024)
+	for i := range pad {
+		pad[i] = 'x'
+	}
+	body := bytes.NewBuffer(nil)
+	body.WriteString(`{"sites":[{"BlogID":1,"URL":"https://example.com","CustomHeaders":{"X-Pad":"`)
+	body.Write(pad)
+	body.WriteString(`"}}]}`)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/check", body)
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413", resp.StatusCode)
+	}
+}
+
 func TestServerShutdownDrains(t *testing.T) {
 	// Shutdown should drain in-flight requests up to the context deadline,
 	// not yank the connection mid-response.

--- a/veriflier2/cmd/main.go
+++ b/veriflier2/cmd/main.go
@@ -3,17 +3,23 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/Automattic/jetmon/internal/checker"
+	"github.com/Automattic/jetmon/internal/metrics"
 	"github.com/Automattic/jetmon/internal/veriflier"
 )
 
 var version = "dev"
+
+const shutdownGracePeriod = 30 * time.Second
 
 type veriflierConfig struct {
 	AuthToken string `json:"auth_token"`
@@ -43,20 +49,38 @@ func main() {
 	}
 	addr := fmt.Sprintf(":%s", cfg.GRPCPort)
 
+	// Optional StatsD metrics. STATSD_ADDR is unset in standalone deploys,
+	// "statsd:8125" in the docker compose stack. metrics.Init failure logs and
+	// continues — the verifier should still run with metrics disabled.
+	if statsdAddr := os.Getenv("STATSD_ADDR"); statsdAddr != "" {
+		if err := metrics.Init(statsdAddr, hostname); err != nil {
+			log.Printf("metrics: init failed (%v) — running without metrics", err)
+		} else {
+			log.Printf("metrics: sending to %s", statsdAddr)
+		}
+	}
+
 	srv := veriflier.NewServer(addr, cfg.AuthToken, hostname, version, performCheck)
 
+	// Graceful shutdown: SIGINT/SIGTERM triggers Shutdown(ctx) with a drain
+	// budget so in-flight checks can complete before the listener closes.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
-		<-sigCh
-		log.Println("veriflier2: shutting down")
-		os.Exit(0)
+		sig := <-sigCh
+		log.Printf("veriflier2: %s received, draining (up to %s)", sig, shutdownGracePeriod)
+		ctx, cancel := context.WithTimeout(context.Background(), shutdownGracePeriod)
+		defer cancel()
+		if err := srv.Shutdown(ctx); err != nil {
+			log.Printf("veriflier2: shutdown error: %v", err)
+		}
 	}()
 
 	log.Printf("veriflier2 %s starting on %s", version, addr)
-	if err := srv.Listen(); err != nil {
+	if err := srv.Listen(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Fatalf("listen: %v", err)
 	}
+	log.Println("veriflier2: shutdown complete")
 }
 
 // performCheck runs a single HTTP check and returns the result for the server.

--- a/veriflier2/cmd/main.go
+++ b/veriflier2/cmd/main.go
@@ -47,6 +47,13 @@ func main() {
 	if cfg.GRPCPort == "" {
 		log.Fatalf("VERIFLIER_GRPC_PORT is not set")
 	}
+	// Reject empty auth tokens at startup. The verifier's Bearer comparison
+	// would otherwise accept any request with the literal "Bearer " header
+	// (no token after the space) — a subtle auth bypass if a misconfigured
+	// deploy leaves the token blank. Better to fail loud at startup.
+	if cfg.AuthToken == "" {
+		log.Fatalf("VERIFLIER_AUTH_TOKEN is not set; refusing to start with no authentication")
+	}
 	addr := fmt.Sprintf(":%s", cfg.GRPCPort)
 
 	// Optional StatsD metrics. STATSD_ADDR is unset in standalone deploys,


### PR DESCRIPTION
Stacked PR 1 of 9 extracted from the broader `v2-chris-events` branch.

Base: `v2`
Head: `stack-01-event-api-foundation`

Summary:
- Adds the event-sourced state model with `jetmon_events` and `jetmon_event_transitions`.
- Adds the Phase 1/2 internal REST API foundation: auth, read endpoints, write endpoints, SLA stats, idempotency, and scope enforcement tests.
- Captures the initial API and Phase 3 design documentation needed by later stack entries.

Review notes:
This is the foundation PR for the stack. Later PRs layer webhooks, alert contacts, rollout hardening, gateway tenant enforcement, and Docker/dev-env polish on top.

This stack supersedes the original all-in-one PR #72, but the original branch is left intact as a fallback while the split is reviewed.