### PR TITLE
Add webhook registry and delivery worker

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -171,18 +171,27 @@ This is fine for now but won't scale operationally. Different concerns have very
 |---------|--------------|------------------|
 | Orchestrator | bucket count, check rate | stateful (claims buckets in `jetmon_hosts`); horizontal via bucket coordination |
 | API server | request rate | stateless; horizontal behind a load balancer |
-| Webhook delivery | event volume + slow consumers | stateless; horizontal via row-claim on `jetmon_webhook_deliveries` |
+| Outbound delivery | event volume + slow third parties | stateless; horizontal via row-claim on per-transport delivery tables |
 | Operator dashboard | one-off operator sessions | one per ops region |
 | Veriflier | geo-distributed vantage points | one per region |
 
 Putting everything in one binary means scaling the most expensive concern scales the cheap ones with it (CPU and memory headroom that's only used for one purpose). It also concentrates failure modes — a panic in the API server takes down the orchestrator.
 
 **Plausible split:**
-- `jetmon-orchestrator` — round loop, check pool, WPCOM notifications, DB writes
+- `jetmon-orchestrator` — round loop, check pool, DB writes
 - `jetmon-api` — REST API server, auth, rate limiting (read/write surface)
-- `jetmon-deliverer` — webhook delivery worker (Phase 3)
+- `jetmon-deliverer` — all outbound dispatch: webhooks (Phase 3), alert contacts, WPCOM notifications
 - `jetmon-dashboard` — operator UI / SSE state stream
 - `jetmon-verifier` — standalone HTTP check executor (today: `veriflier2`; rename TBD)
+
+**Why `jetmon-deliverer` is one binary, not three.** Webhooks, alert contacts, and WPCOM notifications all share the same plumbing: poll `jetmon_event_transitions` (or a similar source), build a frozen-at-fire-time payload, dispatch with a per-destination in-flight cap, retry on failure with exponential backoff, mark abandoned after N attempts. Only the transport differs (HTTPS POST + HMAC for webhooks, transport-specific protocols for PagerDuty/Slack/email/SMS, internal RPC for WPCOM). Splitting them into separate binaries would triple the operational surface (three deploy units, three retry queues, three sets of metrics) for what is fundamentally one job — outbound dispatch — with pluggable transports. Keeping them in one process also means a single circuit-breaker registry across destinations, which is the natural place to enforce shared-resource caps (e.g. "don't open 5,000 outbound connections during a regional outage").
+
+What this means concretely:
+- The Phase 3 webhook worker (`internal/webhooks/worker.go`) is the seed. Its `dispatchTick` / `deliverTick` shape generalizes — the matching, claiming, retry, and abandon logic is transport-agnostic.
+- A future refactor abstracts the transport behind a `Dispatcher` interface (`Send(ctx, dest, payload) (status, error)`), with concrete implementations per channel.
+- Per-channel state (webhook subscriptions, alert contacts, WPCOM circuit breaker counters) stays in its own table; the worker loops over each.
+
+**Trigger that justifies the split.** A single outbound transport doesn't justify its own binary — webhooks alone could stay co-located with the orchestrator. The argument gets compelling once there are *multiple* transports to dispatch and a shared retry/circuit-breaker substrate to amortize. Adding alert contacts is the moment the abstraction earns its keep; pulling WPCOM notifications out of the orchestrator at the same time is the cleanup that pays off the extraction.
 
 The MySQL schema is already the implicit bus between these — each service reads/writes specific tables. Splitting would mostly be:
 1. Extract each concern into its own `cmd/<name>/` directory with a thin main
@@ -191,7 +200,7 @@ The MySQL schema is already the implicit bus between these — each service read
 
 **Naming opportunity:** "veriflier" is a long-standing typo of "verifier" that has stuck around through the rewrite. A split is a natural moment to rename. Candidates: `verifier`, `witness`, `probe-worker`, `vantage`. Worth deciding before the split happens, not during.
 
-**When to revisit:** when a single binary's resource needs (CPU, memory, restart blast radius) starts working against the operational sweet spot for one of the concerns. Likely first trigger: the webhook deliverer's I/O profile (lots of slow outbound HTTP) wanting different sizing than the orchestrator's tight check loop.
+**When to revisit:** when a single binary's resource needs (CPU, memory, restart blast radius) starts working against the operational sweet spot for one of the concerns. The deliverer split specifically becomes worthwhile when alert contacts ship — that's the second outbound transport, and a third (WPCOM notifications) follows for free since they already exist as code that wants to live next to the others.
 
 ### Path to a public API
 

--- a/cmd/jetmon2/main.go
+++ b/cmd/jetmon2/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Automattic/jetmon/internal/db"
 	"github.com/Automattic/jetmon/internal/metrics"
 	"github.com/Automattic/jetmon/internal/orchestrator"
+	"github.com/Automattic/jetmon/internal/webhooks"
 	"github.com/Automattic/jetmon/internal/wpcom"
 )
 
@@ -131,6 +132,20 @@ func runServe() {
 		}()
 	}
 
+	// Webhook delivery worker. Polls jetmon_event_transitions for new rows,
+	// matches against active webhooks, fans out signed POSTs with retry.
+	// Disabled when API_PORT is 0 (no consumers to fire to without the
+	// API to manage webhooks).
+	var hookWorker *webhooks.Worker
+	if cfg.APIPort > 0 {
+		hookWorker = webhooks.NewWorker(webhooks.WorkerConfig{
+			DB:         db.DB(),
+			InstanceID: db.Hostname(),
+		})
+		hookWorker.Start()
+		log.Println("webhooks: delivery worker started")
+	}
+
 	// Push dashboard state every stats interval.
 	if dash != nil {
 		go func() {
@@ -175,6 +190,10 @@ func runServe() {
 						log.Printf("api: shutdown error: %v", err)
 					}
 					cancel()
+				}
+				if hookWorker != nil {
+					hookWorker.Stop()
+					log.Println("webhooks: delivery worker stopped")
 				}
 				orch.Stop()
 				// Hard kill if drain takes too long (e.g. a stalled HTTP check).

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -125,6 +125,29 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("GET /api/v1/sites/{id}/response-time", s.requireScope(scopeRead, s.handleSiteResponseTime))
 	mux.HandleFunc("GET /api/v1/sites/{id}/timing-breakdown", s.requireScope(scopeRead, s.handleSiteTimingBreakdown))
 
+	// Webhooks — read.
+	mux.HandleFunc("GET /api/v1/webhooks",
+		s.requireScope(scopeRead, s.handleListWebhooks))
+	mux.HandleFunc("GET /api/v1/webhooks/{id}",
+		s.requireScope(scopeRead, s.handleGetWebhook))
+
+	// Webhooks — write. POST endpoints route through idempotency middleware
+	// so a retry after a network blip doesn't double-create a webhook.
+	mux.HandleFunc("POST /api/v1/webhooks",
+		s.requireScope(scopeWrite, s.withIdempotency(s.handleCreateWebhook)))
+	mux.HandleFunc("PATCH /api/v1/webhooks/{id}",
+		s.requireScope(scopeWrite, s.handleUpdateWebhook))
+	mux.HandleFunc("DELETE /api/v1/webhooks/{id}",
+		s.requireScope(scopeWrite, s.handleDeleteWebhook))
+	mux.HandleFunc("POST /api/v1/webhooks/{id}/rotate-secret",
+		s.requireScope(scopeWrite, s.withIdempotency(s.handleRotateWebhookSecret)))
+
+	// Deliveries — read history, manually retry abandoned rows.
+	mux.HandleFunc("GET /api/v1/webhooks/{id}/deliveries",
+		s.requireScope(scopeRead, s.handleListDeliveries))
+	mux.HandleFunc("POST /api/v1/webhooks/{id}/deliveries/{delivery_id}/retry",
+		s.requireScope(scopeWrite, s.withIdempotency(s.handleRetryDelivery)))
+
 	// Catch-all → 404 with a useful message rather than the default empty body.
 	mux.HandleFunc("/", s.handleNotFound)
 

--- a/internal/api/handlers_deliveries.go
+++ b/internal/api/handlers_deliveries.go
@@ -1,0 +1,182 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/Automattic/jetmon/internal/webhooks"
+)
+
+// deliveryResponse is the JSON shape for a webhook delivery row. Fields are
+// flat (not nested) so consumers can easily filter and sort. payload is
+// pass-through json.RawMessage — whatever the dispatcher froze at fire time.
+type deliveryResponse struct {
+	ID             int64           `json:"id"`
+	WebhookID      int64           `json:"webhook_id"`
+	TransitionID   int64           `json:"transition_id"`
+	EventID        int64           `json:"event_id"`
+	EventType      string          `json:"event_type"`
+	Payload        json.RawMessage `json:"payload"`
+	Status         string          `json:"status"`
+	Attempt        int             `json:"attempt"`
+	NextAttemptAt  *string         `json:"next_attempt_at"`
+	LastStatusCode *int            `json:"last_status_code"`
+	LastResponse   *string         `json:"last_response"`
+	LastAttemptAt  *string         `json:"last_attempt_at"`
+	DeliveredAt    *string         `json:"delivered_at"`
+	CreatedAt      string          `json:"created_at"`
+}
+
+func toDeliveryResponse(d *webhooks.Delivery) deliveryResponse {
+	out := deliveryResponse{
+		ID:             d.ID,
+		WebhookID:      d.WebhookID,
+		TransitionID:   d.TransitionID,
+		EventID:        d.EventID,
+		EventType:      d.EventType,
+		Payload:        d.Payload,
+		Status:         string(d.Status),
+		Attempt:        d.Attempt,
+		LastStatusCode: d.LastStatusCode,
+		LastResponse:   d.LastResponse,
+		CreatedAt:      d.CreatedAt.UTC().Format(time.RFC3339),
+	}
+	if d.NextAttemptAt != nil {
+		v := d.NextAttemptAt.UTC().Format(time.RFC3339)
+		out.NextAttemptAt = &v
+	}
+	if d.LastAttemptAt != nil {
+		v := d.LastAttemptAt.UTC().Format(time.RFC3339)
+		out.LastAttemptAt = &v
+	}
+	if d.DeliveredAt != nil {
+		v := d.DeliveredAt.UTC().Format(time.RFC3339)
+		out.DeliveredAt = &v
+	}
+	return out
+}
+
+// handleListDeliveries implements GET /api/v1/webhooks/{id}/deliveries.
+//
+// Filters:
+//   - status: pending | delivered | failed | abandoned (single value)
+//
+// Cursor pagination on id (descending — most recent first).
+func (s *Server) handleListDeliveries(w http.ResponseWriter, r *http.Request) {
+	webhookID, err := parseIDPath(r, "id")
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_webhook_id",
+			"webhook id must be a positive integer")
+		return
+	}
+
+	q := r.URL.Query()
+	limit, err := parseLimit(q.Get("limit"), 50, 200)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_limit", err.Error())
+		return
+	}
+	cursor, err := decodeIDCursor(q.Get("cursor"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_cursor", err.Error())
+		return
+	}
+
+	var status webhooks.Status
+	if v := q.Get("status"); v != "" {
+		switch webhooks.Status(v) {
+		case webhooks.StatusPending, webhooks.StatusDelivered,
+			webhooks.StatusFailed, webhooks.StatusAbandoned:
+			status = webhooks.Status(v)
+		default:
+			writeError(w, r, http.StatusBadRequest, "invalid_status",
+				"status must be one of: pending, delivered, failed, abandoned")
+			return
+		}
+	}
+
+	// Fetch limit+1 to detect a next-page boundary without an extra count.
+	rows, err := webhooks.ListDeliveries(r.Context(), s.db, webhookID, status, cursor, limit+1)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"deliveries list failed: "+err.Error())
+		return
+	}
+
+	out := make([]deliveryResponse, 0, len(rows))
+	for i := range rows {
+		out = append(out, toDeliveryResponse(&rows[i]))
+	}
+
+	var nextCursor *string
+	if len(out) > limit {
+		out = out[:limit]
+		c := encodeIDCursor(out[len(out)-1].ID)
+		nextCursor = &c
+	}
+
+	writeJSON(w, http.StatusOK, ListEnvelope{
+		Data: out,
+		Page: Page{Next: nextCursor, Limit: limit},
+	})
+}
+
+// handleRetryDelivery implements POST /api/v1/webhooks/{id}/deliveries/{delivery_id}/retry.
+//
+// Resets an abandoned delivery row to pending so the worker picks it up
+// on the next tick. Used by operators after fixing a previously-broken
+// consumer endpoint. Only abandoned deliveries can be retried — pending
+// ones are already in the queue, delivered ones don't need to fire again.
+func (s *Server) handleRetryDelivery(w http.ResponseWriter, r *http.Request) {
+	webhookID, err := parseIDPath(r, "id")
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_webhook_id",
+			"webhook id must be a positive integer")
+		return
+	}
+	deliveryID, err := parseIDPath(r, "delivery_id")
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_delivery_id",
+			"delivery id must be a positive integer")
+		return
+	}
+
+	// Cross-check: the delivery must belong to the named webhook. This
+	// matches the cross-site protection we use elsewhere — an explicit
+	// 404 if the consumer asks under the wrong webhook.
+	d, err := webhooks.GetDelivery(r.Context(), s.db, deliveryID)
+	if err != nil {
+		if errors.Is(err, webhooks.ErrDeliveryNotFound) {
+			writeError(w, r, http.StatusNotFound, "delivery_not_found",
+				fmt.Sprintf("Delivery %d does not exist", deliveryID))
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"delivery lookup failed: "+err.Error())
+		return
+	}
+	if d.WebhookID != webhookID {
+		writeError(w, r, http.StatusNotFound, "delivery_not_found",
+			fmt.Sprintf("Delivery %d does not belong to webhook %d", deliveryID, webhookID))
+		return
+	}
+
+	if err := webhooks.RetryDelivery(r.Context(), s.db, deliveryID); err != nil {
+		// Distinguish "not abandoned" (currently pending or delivered) from
+		// other DB errors so the caller gets a useful message.
+		writeError(w, r, http.StatusConflict, "delivery_not_retryable", err.Error())
+		return
+	}
+
+	// Read back the updated row so the caller sees the new pending state.
+	d, err = webhooks.GetDelivery(r.Context(), s.db, deliveryID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"read-back failed: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, toDeliveryResponse(d))
+}

--- a/internal/api/handlers_webhooks.go
+++ b/internal/api/handlers_webhooks.go
@@ -1,0 +1,281 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/Automattic/jetmon/internal/webhooks"
+)
+
+// webhookResponse is the JSON shape for a webhook in list/single responses.
+// secret is omitted by default — only the create and rotate-secret endpoints
+// return it (one-time view). secret_preview is the safe permanent view.
+type webhookResponse struct {
+	ID            int64               `json:"id"`
+	URL           string              `json:"url"`
+	Active        bool                `json:"active"`
+	Events        []string            `json:"events"`
+	SiteFilter    webhooks.SiteFilter `json:"site_filter"`
+	StateFilter   webhooks.StateFilter `json:"state_filter"`
+	SecretPreview string              `json:"secret_preview"`
+	CreatedBy     string              `json:"created_by"`
+	CreatedAt     string              `json:"created_at"`
+	UpdatedAt     string              `json:"updated_at"`
+}
+
+// createWebhookResponse extends webhookResponse with the raw secret. Used
+// once at create + rotate time; afterwards the caller stores the secret.
+type createWebhookResponse struct {
+	webhookResponse
+	Secret string `json:"secret"`
+}
+
+func toWebhookResponse(w *webhooks.Webhook) webhookResponse {
+	events := w.Events
+	if events == nil {
+		events = []string{}
+	}
+	return webhookResponse{
+		ID:            w.ID,
+		URL:           w.URL,
+		Active:        w.Active,
+		Events:        events,
+		SiteFilter:    w.SiteFilter,
+		StateFilter:   w.StateFilter,
+		SecretPreview: w.SecretPreview,
+		CreatedBy:     w.CreatedBy,
+		CreatedAt:     w.CreatedAt.UTC().Format(time.RFC3339),
+		UpdatedAt:     w.UpdatedAt.UTC().Format(time.RFC3339),
+	}
+}
+
+// createWebhookRequest is the body shape for POST /api/v1/webhooks.
+type createWebhookRequest struct {
+	URL         string                `json:"url"`
+	Active      *bool                 `json:"active"`
+	Events      []string              `json:"events"`
+	SiteFilter  webhooks.SiteFilter   `json:"site_filter"`
+	StateFilter webhooks.StateFilter  `json:"state_filter"`
+}
+
+// updateWebhookRequest is the body shape for PATCH /api/v1/webhooks/{id}.
+// Pointer fields distinguish "absent" from "explicitly empty"; an explicit
+// empty list/object clears the filter to "match all" semantics.
+type updateWebhookRequest struct {
+	URL         *string                `json:"url"`
+	Active      *bool                  `json:"active"`
+	Events      *[]string              `json:"events"`
+	SiteFilter  *webhooks.SiteFilter   `json:"site_filter"`
+	StateFilter *webhooks.StateFilter  `json:"state_filter"`
+}
+
+// handleCreateWebhook implements POST /api/v1/webhooks. Returns 201 with
+// the full webhook + the one-time raw secret. The secret is shown ONCE —
+// after this response, only secret_preview is returned.
+func (s *Server) handleCreateWebhook(w http.ResponseWriter, r *http.Request) {
+	var body createWebhookRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_body",
+			"request body must be valid JSON: "+err.Error())
+		return
+	}
+	if err := validateMonitorURL(body.URL); err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_url",
+			"webhook url: "+err.Error())
+		return
+	}
+
+	createdBy := ""
+	if k := keyFromRequest(r); k != nil {
+		createdBy = k.ConsumerName
+	}
+
+	rawSecret, hook, err := webhooks.Create(r.Context(), s.db, webhooks.CreateInput{
+		URL:         body.URL,
+		Active:      body.Active,
+		Events:      body.Events,
+		SiteFilter:  body.SiteFilter,
+		StateFilter: body.StateFilter,
+		CreatedBy:   createdBy,
+	})
+	if err != nil {
+		if errors.Is(err, webhooks.ErrInvalidEvent) {
+			writeError(w, r, http.StatusUnprocessableEntity, "invalid_event_type",
+				err.Error())
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"webhook create failed: "+err.Error())
+		return
+	}
+
+	resp := createWebhookResponse{
+		webhookResponse: toWebhookResponse(hook),
+		Secret:          rawSecret,
+	}
+	writeJSON(w, http.StatusCreated, resp)
+}
+
+// handleListWebhooks implements GET /api/v1/webhooks. No pagination yet —
+// webhook count is bounded by registered consumers. List endpoint returns
+// the full set; if a deployment ever grows past hundreds, add cursor
+// pagination here mirroring the sites endpoint.
+func (s *Server) handleListWebhooks(w http.ResponseWriter, r *http.Request) {
+	hooks, err := webhooks.List(r.Context(), s.db)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"webhook list failed: "+err.Error())
+		return
+	}
+	out := make([]webhookResponse, 0, len(hooks))
+	for i := range hooks {
+		out = append(out, toWebhookResponse(&hooks[i]))
+	}
+	writeJSON(w, http.StatusOK, ListEnvelope{
+		Data: out,
+		Page: Page{Next: nil, Limit: len(out)},
+	})
+}
+
+// handleGetWebhook implements GET /api/v1/webhooks/{id}.
+func (s *Server) handleGetWebhook(w http.ResponseWriter, r *http.Request) {
+	id, err := parseIDPath(r, "id")
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_webhook_id",
+			"webhook id must be a positive integer")
+		return
+	}
+	hook, err := webhooks.Get(r.Context(), s.db, id)
+	if err != nil {
+		if errors.Is(err, webhooks.ErrWebhookNotFound) {
+			writeError(w, r, http.StatusNotFound, "webhook_not_found",
+				fmt.Sprintf("Webhook %d does not exist", id))
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"webhook lookup failed: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, toWebhookResponse(hook))
+}
+
+// handleUpdateWebhook implements PATCH /api/v1/webhooks/{id}.
+func (s *Server) handleUpdateWebhook(w http.ResponseWriter, r *http.Request) {
+	id, err := parseIDPath(r, "id")
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_webhook_id",
+			"webhook id must be a positive integer")
+		return
+	}
+
+	var body updateWebhookRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_body",
+			"request body must be valid JSON: "+err.Error())
+		return
+	}
+	if body.URL != nil {
+		if err := validateMonitorURL(*body.URL); err != nil {
+			writeError(w, r, http.StatusBadRequest, "invalid_url",
+				"webhook url: "+err.Error())
+			return
+		}
+	}
+
+	hook, err := webhooks.Update(r.Context(), s.db, id, webhooks.UpdateInput{
+		URL:         body.URL,
+		Active:      body.Active,
+		Events:      body.Events,
+		SiteFilter:  body.SiteFilter,
+		StateFilter: body.StateFilter,
+	})
+	if err != nil {
+		if errors.Is(err, webhooks.ErrInvalidEvent) {
+			writeError(w, r, http.StatusUnprocessableEntity, "invalid_event_type",
+				err.Error())
+			return
+		}
+		if errors.Is(err, webhooks.ErrWebhookNotFound) {
+			writeError(w, r, http.StatusNotFound, "webhook_not_found",
+				fmt.Sprintf("Webhook %d does not exist", id))
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"webhook update failed: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, toWebhookResponse(hook))
+}
+
+// handleDeleteWebhook implements DELETE /api/v1/webhooks/{id}.
+//
+// Delete is hard, not soft. The dispatcher's ListActive filter would also
+// stop a soft-deleted webhook from receiving new deliveries, but a real
+// DELETE keeps the registry clean and matches consumer expectations
+// ("I revoked my webhook subscription"). Existing rows in
+// jetmon_webhook_deliveries are preserved for audit and manual retry.
+func (s *Server) handleDeleteWebhook(w http.ResponseWriter, r *http.Request) {
+	id, err := parseIDPath(r, "id")
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_webhook_id",
+			"webhook id must be a positive integer")
+		return
+	}
+	if err := webhooks.Delete(r.Context(), s.db, id); err != nil {
+		if errors.Is(err, webhooks.ErrWebhookNotFound) {
+			writeError(w, r, http.StatusNotFound, "webhook_not_found",
+				fmt.Sprintf("Webhook %d does not exist", id))
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"webhook delete failed: "+err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleRotateWebhookSecret implements POST /api/v1/webhooks/{id}/rotate-secret.
+//
+// v1 behaviour: immediate revocation. The new secret is returned ONCE in
+// the response; the old secret stops working immediately. Failed deliveries
+// during the consumer's deploy window go into the retry queue and clear
+// when the consumer rolls. Grace-period rotation is in ROADMAP.md as a
+// non-breaking future addition.
+func (s *Server) handleRotateWebhookSecret(w http.ResponseWriter, r *http.Request) {
+	id, err := parseIDPath(r, "id")
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_webhook_id",
+			"webhook id must be a positive integer")
+		return
+	}
+	rawSecret, hook, err := webhooks.RotateSecret(r.Context(), s.db, id)
+	if err != nil {
+		if errors.Is(err, webhooks.ErrWebhookNotFound) {
+			writeError(w, r, http.StatusNotFound, "webhook_not_found",
+				fmt.Sprintf("Webhook %d does not exist", id))
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"webhook rotate-secret failed: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, createWebhookResponse{
+		webhookResponse: toWebhookResponse(hook),
+		Secret:          rawSecret,
+	})
+}
+
+// parseIDPath extracts a positive int64 from the named path parameter.
+// Returns 0 + error for anything malformed; handlers translate to
+// invalid_<resource>_id 400.
+func parseIDPath(r *http.Request, name string) (int64, error) {
+	id, err := strconv.ParseInt(r.PathValue(name), 10, 64)
+	if err != nil || id <= 0 {
+		return 0, errors.New("must be a positive integer")
+	}
+	return id, nil
+}

--- a/internal/api/handlers_webhooks_test.go
+++ b/internal/api/handlers_webhooks_test.go
@@ -1,0 +1,231 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+const insertWebhookSQL = ` INSERT INTO jetmon_webhooks (url, active, events, site_filter, state_filter, secret, secret_preview, created_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+
+const selectWebhookOneSQL = ` SELECT id, url, active, events, site_filter, state_filter, secret_preview, created_by, created_at, updated_at FROM jetmon_webhooks WHERE id = ?`
+
+// columnsWebhook is the column set returned by webhook SELECT queries.
+var columnsWebhook = []string{
+	"id", "url", "active", "events", "site_filter", "state_filter",
+	"secret_preview", "created_by", "created_at", "updated_at",
+}
+
+func makeWebhookRow(id int64, url string, active uint8) *sqlmock.Rows {
+	now := time.Now().UTC()
+	return sqlmock.NewRows(columnsWebhook).AddRow(
+		id, url, active, []byte(`["event.opened"]`),
+		[]byte(`{"site_ids":[]}`), []byte(`{"states":[]}`),
+		"abcd", "test-consumer", now, now,
+	)
+}
+
+func TestCreateWebhookHappyPath(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectExec(insertWebhookSQL).
+		WithArgs(
+			"https://example.com/hook", 1,
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+			sqlmock.AnyArg(), sqlmock.AnyArg(), "test-consumer",
+		).
+		WillReturnResult(sqlmock.NewResult(7, 1))
+	mock.ExpectQuery(selectWebhookOneSQL).WithArgs(int64(7)).
+		WillReturnRows(makeWebhookRow(7, "https://example.com/hook", 1))
+
+	body := []byte(`{"url":"https://example.com/hook","events":["event.opened"]}`)
+	req := newPOSTWithBody("/api/v1/webhooks", body)
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleCreateWebhook)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp createWebhookResponse
+	readJSON(t, rec.Body, &resp)
+	if resp.ID != 7 {
+		t.Errorf("id = %d, want 7", resp.ID)
+	}
+	if resp.Secret == "" {
+		t.Error("expected raw secret in response")
+	}
+}
+
+func TestCreateWebhookRejectsBadURL(t *testing.T) {
+	s, _, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	cases := [][]byte{
+		[]byte(`{"url":""}`),
+		[]byte(`{"url":"not-a-url"}`),
+		[]byte(`{"url":"ftp://example.com"}`),
+	}
+	for _, body := range cases {
+		req := newPOSTWithBody("/api/v1/webhooks", body)
+		req = setAuthCtx(req, key)
+		rec := invokeAuthed(s, req, s.handleCreateWebhook)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("body=%s status=%d, want 400", body, rec.Code)
+		}
+	}
+}
+
+func TestCreateWebhookRejectsBadEventType(t *testing.T) {
+	s, _, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	body := []byte(`{"url":"https://x.example.com","events":["event.bogus"]}`)
+	req := newPOSTWithBody("/api/v1/webhooks", body)
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleCreateWebhook)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", rec.Code)
+	}
+	if got := readErrorBody(t, rec.Body).Code; got != "invalid_event_type" {
+		t.Errorf("code = %q, want invalid_event_type", got)
+	}
+}
+
+func TestGetWebhookHappyPath(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(selectWebhookOneSQL).WithArgs(int64(42)).
+		WillReturnRows(makeWebhookRow(42, "https://x.example.com", 1))
+
+	req := httptest.NewRequest("GET", "/api/v1/webhooks/42", nil)
+	req.SetPathValue("id", "42")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleGetWebhook)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestGetWebhookNotFound(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(selectWebhookOneSQL).WithArgs(int64(999)).
+		WillReturnRows(sqlmock.NewRows(columnsWebhook))
+
+	req := httptest.NewRequest("GET", "/api/v1/webhooks/999", nil)
+	req.SetPathValue("id", "999")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleGetWebhook)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestUpdateWebhookHappyPath(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectExec(`UPDATE jetmon_webhooks SET active = ? WHERE id = ?`).
+		WithArgs(0, int64(42)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(selectWebhookOneSQL).WithArgs(int64(42)).
+		WillReturnRows(makeWebhookRow(42, "https://x.example.com", 0))
+
+	body := []byte(`{"active": false}`)
+	req := newPATCHWithBody("/api/v1/webhooks/42", body)
+	req.SetPathValue("id", "42")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleUpdateWebhook)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestDeleteWebhookHappyPath(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectExec(`DELETE FROM jetmon_webhooks WHERE id = ?`).
+		WithArgs(int64(42)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	req := httptest.NewRequest("DELETE", "/api/v1/webhooks/42", nil)
+	req.SetPathValue("id", "42")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleDeleteWebhook)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rec.Code)
+	}
+}
+
+func TestDeleteWebhookNotFound(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectExec(`DELETE FROM jetmon_webhooks WHERE id = ?`).
+		WithArgs(int64(999)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	req := httptest.NewRequest("DELETE", "/api/v1/webhooks/999", nil)
+	req.SetPathValue("id", "999")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleDeleteWebhook)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestRotateWebhookSecretHappyPath(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectExec(`UPDATE jetmon_webhooks SET secret = ?, secret_preview = ? WHERE id = ?`).
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), int64(42)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(selectWebhookOneSQL).WithArgs(int64(42)).
+		WillReturnRows(makeWebhookRow(42, "https://x.example.com", 1))
+
+	req := newPOSTWithBody("/api/v1/webhooks/42/rotate-secret", nil)
+	req.SetPathValue("id", "42")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleRotateWebhookSecret)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp createWebhookResponse
+	readJSON(t, rec.Body, &resp)
+	if resp.Secret == "" {
+		t.Error("expected new raw secret in rotate response")
+	}
+}
+
+func TestRotateWebhookSecretNotFound(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectExec(`UPDATE jetmon_webhooks SET secret = ?, secret_preview = ? WHERE id = ?`).
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), int64(999)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	req := newPOSTWithBody("/api/v1/webhooks/999/rotate-secret", nil)
+	req.SetPathValue("id", "999")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleRotateWebhookSecret)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -176,6 +176,83 @@ var migrations = []migration{
 		UNIQUE KEY uk_key_hash (key_hash),
 		INDEX idx_consumer (consumer_name)
 	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
+
+	// Migration 13 creates the webhook registry. secret_hash is sha256 of the
+	// raw secret (which is shown once at creation, mirrors jetmon_api_keys).
+	// events / site_filter / state_filter are JSON to allow flexible filter
+	// shapes without per-filter columns; semantics: empty = match all, AND
+	// across dimensions, whitelist within each. See API.md "Family 4".
+	// secret stores the raw HMAC signing key in plaintext. Unlike
+	// jetmon_api_keys (sha256-hashed at rest, used for inbound auth where
+	// hash is sufficient), webhook secrets are used to SIGN outbound
+	// deliveries — HMAC needs the actual key material in memory, not its
+	// hash. We never verify inbound signatures with this secret, so
+	// hash-at-rest would buy us no verification benefit while making
+	// signing impossible.
+	//
+	// Threat model: anyone with read access to jetmon_webhooks can mint
+	// valid deliveries. For the internal API behind a gateway, that's
+	// equivalent to the existing access-to-events threat. Encryption at
+	// rest with a master key (KMS-style) is in ROADMAP.md as a future
+	// hardening step.
+	{13, `CREATE TABLE IF NOT EXISTS jetmon_webhooks (
+		id              BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		url             VARCHAR(2083) NOT NULL,
+		active          TINYINT UNSIGNED NOT NULL DEFAULT 1,
+		events          JSON NULL,
+		site_filter     JSON NULL,
+		state_filter    JSON NULL,
+		secret          VARCHAR(80) NOT NULL,
+		secret_preview  VARCHAR(8) NOT NULL DEFAULT '',
+		created_by      VARCHAR(128) NOT NULL DEFAULT '',
+		created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		updated_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+		INDEX idx_active (active)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
+
+	// Migration 14 creates the per-fire delivery records. One row per
+	// (webhook, transition) match — transition_id is the fan-in point: a
+	// single jetmon_event_transitions row can produce many deliveries (one
+	// per matching webhook), but a webhook gets at most one delivery per
+	// transition (enforced by uk_webhook_transition).
+	//
+	// payload is frozen at row creation: consumer sees the event as it was
+	// when the webhook fired, not as it is now (closed-and-amended events
+	// don't retroactively change delivery contents — that's the contract).
+	//
+	// status lifecycle: pending → (delivered | abandoned). "failed" is reserved
+	// for permanent client/server errors that we wouldn't retry (currently
+	// unused; pending captures the in-retry case).
+	{14, `CREATE TABLE IF NOT EXISTS jetmon_webhook_deliveries (
+		id               BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		webhook_id       BIGINT UNSIGNED NOT NULL,
+		transition_id    BIGINT UNSIGNED NOT NULL,
+		event_id         BIGINT UNSIGNED NOT NULL,
+		event_type       VARCHAR(64) NOT NULL,
+		payload          JSON NOT NULL,
+		status           ENUM('pending','delivered','failed','abandoned') NOT NULL DEFAULT 'pending',
+		attempt          INT UNSIGNED NOT NULL DEFAULT 0,
+		next_attempt_at  TIMESTAMP NULL,
+		last_status_code INT NULL,
+		last_response    VARCHAR(2048) NULL,
+		last_attempt_at  TIMESTAMP NULL,
+		delivered_at     TIMESTAMP NULL,
+		created_at       TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		UNIQUE KEY uk_webhook_transition (webhook_id, transition_id),
+		INDEX idx_status_next_attempt (status, next_attempt_at),
+		INDEX idx_webhook_id_created (webhook_id, created_at),
+		INDEX idx_event_id (event_id)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
+
+	// Migration 15 records the webhook dispatcher's progress. One row per
+	// jetmon2 instance keeps last_transition_id high-water mark so the
+	// dispatcher polls only new transitions. The UNIQUE KEY on instance_id
+	// makes upsert (INSERT … ON DUPLICATE KEY UPDATE) trivial.
+	{15, `CREATE TABLE IF NOT EXISTS jetmon_webhook_dispatch_progress (
+		instance_id          VARCHAR(255) NOT NULL PRIMARY KEY,
+		last_transition_id   BIGINT UNSIGNED NOT NULL DEFAULT 0,
+		updated_at           TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
 }
 
 // Migrate applies all pending migrations idempotently.

--- a/internal/webhooks/deliveries.go
+++ b/internal/webhooks/deliveries.go
@@ -1,0 +1,309 @@
+package webhooks
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ErrDeliveryNotFound is returned by Get / Retry when the delivery row
+// doesn't exist.
+var ErrDeliveryNotFound = errors.New("webhooks: delivery not found")
+
+// Delivery is the in-memory shape of a jetmon_webhook_deliveries row.
+type Delivery struct {
+	ID             int64
+	WebhookID      int64
+	TransitionID   int64
+	EventID        int64
+	EventType      string
+	Payload        json.RawMessage // frozen at create time
+	Status         Status
+	Attempt        int
+	NextAttemptAt  *time.Time
+	LastStatusCode *int
+	LastResponse   *string
+	LastAttemptAt  *time.Time
+	DeliveredAt    *time.Time
+	CreatedAt      time.Time
+}
+
+// EnqueueInput carries everything needed to insert a delivery row. payload
+// is captured by the caller (the dispatcher builds it from the event +
+// transition + site context) and stored verbatim.
+type EnqueueInput struct {
+	WebhookID    int64
+	TransitionID int64
+	EventID      int64
+	EventType    string
+	Payload      json.RawMessage
+}
+
+// Enqueue inserts a pending delivery with attempt=0 and next_attempt_at=now,
+// signaling the worker to pick it up on the next tick. Uses INSERT IGNORE
+// against the (webhook_id, transition_id) UNIQUE KEY so concurrent
+// dispatchers don't create duplicate deliveries.
+//
+// Returns the new delivery's id, or 0 if the row was a duplicate (in which
+// case some other dispatcher already enqueued this combination).
+func Enqueue(ctx context.Context, db *sql.DB, in EnqueueInput) (int64, error) {
+	res, err := db.ExecContext(ctx, `
+		INSERT IGNORE INTO jetmon_webhook_deliveries
+			(webhook_id, transition_id, event_id, event_type, payload,
+			 status, attempt, next_attempt_at)
+		VALUES (?, ?, ?, ?, ?, 'pending', 0, CURRENT_TIMESTAMP)`,
+		in.WebhookID, in.TransitionID, in.EventID, in.EventType, []byte(in.Payload),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("webhooks: enqueue: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		// MySQL's LastInsertId after INSERT IGNORE that didn't insert returns
+		// 0 with no error; getting an error here is an unusual driver quirk.
+		return 0, fmt.Errorf("webhooks: last insert id: %w", err)
+	}
+	affected, _ := res.RowsAffected()
+	if affected == 0 {
+		// Row was a duplicate — another dispatcher already enqueued this
+		// (webhook, transition) combination. Not an error condition.
+		return 0, nil
+	}
+	return id, nil
+}
+
+// ClaimReady returns up to limit pending deliveries whose next_attempt_at
+// is in the past, ordered by next_attempt_at ASC (oldest first). The
+// worker should claim, attempt, and update each row.
+//
+// Multi-instance safety: this implementation does NOT lock claimed rows.
+// Two instances polling simultaneously could pick up the same row and
+// fire duplicate deliveries. For single-instance deployment that's fine;
+// for multi-instance we add row-level claim via SELECT … FOR UPDATE SKIP
+// LOCKED in a transaction. Tracked in ROADMAP.md notes — see Architectural
+// roadmap "multi-repo split" (the deliverer process is the natural place
+// to add the locking when we extract it).
+func ClaimReady(ctx context.Context, db *sql.DB, limit int) ([]Delivery, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT id, webhook_id, transition_id, event_id, event_type, payload,
+		       status, attempt, next_attempt_at, last_status_code, last_response,
+		       last_attempt_at, delivered_at, created_at
+		  FROM jetmon_webhook_deliveries
+		 WHERE status = 'pending'
+		   AND (next_attempt_at IS NULL OR next_attempt_at <= CURRENT_TIMESTAMP)
+		 ORDER BY next_attempt_at ASC
+		 LIMIT ?`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("webhooks: claim ready: %w", err)
+	}
+	defer rows.Close()
+	var out []Delivery
+	for rows.Next() {
+		d, err := scanDeliveryRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *d)
+	}
+	return out, rows.Err()
+}
+
+// MarkDelivered records a successful delivery with the response status.
+// Sets status=delivered, captures last_status_code, last_response, and
+// delivered_at. Subsequent retries are not scheduled — the row is terminal.
+func MarkDelivered(ctx context.Context, db *sql.DB, id int64, statusCode int, responseBody string) error {
+	_, err := db.ExecContext(ctx, `
+		UPDATE jetmon_webhook_deliveries
+		   SET status = 'delivered',
+		       last_status_code = ?,
+		       last_response = ?,
+		       last_attempt_at = CURRENT_TIMESTAMP,
+		       delivered_at = CURRENT_TIMESTAMP,
+		       attempt = attempt + 1,
+		       next_attempt_at = NULL
+		 WHERE id = ?`,
+		statusCode, truncate(responseBody, 2048), id)
+	if err != nil {
+		return fmt.Errorf("webhooks: mark delivered: %w", err)
+	}
+	return nil
+}
+
+// ScheduleRetry bumps the attempt counter and sets next_attempt_at per the
+// retry schedule. Captures the status/response from the failed attempt.
+// If the next attempt would exceed maxAttempts, the row is marked
+// abandoned instead.
+func ScheduleRetry(ctx context.Context, db *sql.DB, id int64, statusCode int, responseBody string, nextAttempt time.Time, abandon bool) error {
+	if abandon {
+		_, err := db.ExecContext(ctx, `
+			UPDATE jetmon_webhook_deliveries
+			   SET status = 'abandoned',
+			       last_status_code = ?,
+			       last_response = ?,
+			       last_attempt_at = CURRENT_TIMESTAMP,
+			       attempt = attempt + 1,
+			       next_attempt_at = NULL
+			 WHERE id = ?`,
+			statusCode, truncate(responseBody, 2048), id)
+		if err != nil {
+			return fmt.Errorf("webhooks: abandon: %w", err)
+		}
+		return nil
+	}
+	_, err := db.ExecContext(ctx, `
+		UPDATE jetmon_webhook_deliveries
+		   SET last_status_code = ?,
+		       last_response = ?,
+		       last_attempt_at = CURRENT_TIMESTAMP,
+		       attempt = attempt + 1,
+		       next_attempt_at = ?
+		 WHERE id = ?`,
+		statusCode, truncate(responseBody, 2048), nextAttempt.UTC(), id)
+	if err != nil {
+		return fmt.Errorf("webhooks: schedule retry: %w", err)
+	}
+	return nil
+}
+
+// GetDelivery returns a single delivery row by id.
+func GetDelivery(ctx context.Context, db *sql.DB, id int64) (*Delivery, error) {
+	row := db.QueryRowContext(ctx, `
+		SELECT id, webhook_id, transition_id, event_id, event_type, payload,
+		       status, attempt, next_attempt_at, last_status_code, last_response,
+		       last_attempt_at, delivered_at, created_at
+		  FROM jetmon_webhook_deliveries
+		 WHERE id = ?`, id)
+	d, err := scanDeliveryRow(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrDeliveryNotFound
+		}
+		return nil, err
+	}
+	return d, nil
+}
+
+// ListDeliveries returns deliveries for a webhook, optionally filtered by
+// status, ordered by created_at DESC. Cursor-paginated on id.
+func ListDeliveries(ctx context.Context, db *sql.DB, webhookID int64, status Status, cursorID int64, limit int) ([]Delivery, error) {
+	args := []any{webhookID}
+	q := `
+		SELECT id, webhook_id, transition_id, event_id, event_type, payload,
+		       status, attempt, next_attempt_at, last_status_code, last_response,
+		       last_attempt_at, delivered_at, created_at
+		  FROM jetmon_webhook_deliveries
+		 WHERE webhook_id = ?`
+	if status != "" {
+		q += " AND status = ?"
+		args = append(args, string(status))
+	}
+	if cursorID > 0 {
+		q += " AND id < ?"
+		args = append(args, cursorID)
+	}
+	q += " ORDER BY id DESC LIMIT ?"
+	args = append(args, limit)
+
+	rows, err := db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("webhooks: list deliveries: %w", err)
+	}
+	defer rows.Close()
+	var out []Delivery
+	for rows.Next() {
+		d, err := scanDeliveryRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *d)
+	}
+	return out, rows.Err()
+}
+
+// RetryDelivery resets an abandoned delivery to pending so the worker
+// picks it up on the next tick. Manual operator path: consumer fixed
+// their endpoint, wants the previously-failed delivery to fire again.
+//
+// Resets attempt to 0 (new retry sequence) so the consumer gets the full
+// 6 attempts again — they may have just brought their service back and a
+// transient failure deserves a fresh budget.
+//
+// Only abandoned deliveries can be retried via this path. pending
+// deliveries are already in the worker's queue; delivered deliveries
+// were already accepted by the consumer.
+func RetryDelivery(ctx context.Context, db *sql.DB, id int64) error {
+	res, err := db.ExecContext(ctx, `
+		UPDATE jetmon_webhook_deliveries
+		   SET status = 'pending',
+		       attempt = 0,
+		       next_attempt_at = CURRENT_TIMESTAMP,
+		       last_status_code = NULL,
+		       last_response = NULL,
+		       last_attempt_at = NULL
+		 WHERE id = ? AND status = 'abandoned'`, id)
+	if err != nil {
+		return fmt.Errorf("webhooks: retry delivery: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		// Either the row doesn't exist or it isn't abandoned. Distinguish
+		// for a useful error message.
+		d, getErr := GetDelivery(ctx, db, id)
+		if getErr != nil {
+			return getErr
+		}
+		return fmt.Errorf("webhooks: delivery %d is %s, only abandoned deliveries can be retried", id, d.Status)
+	}
+	return nil
+}
+
+func scanDeliveryRow(s rowScanner) (*Delivery, error) {
+	var (
+		d                Delivery
+		payload          sql.NullString
+		nextAttemptAt    sql.NullTime
+		lastStatusCode   sql.NullInt64
+		lastResponse     sql.NullString
+		lastAttemptAt    sql.NullTime
+		deliveredAt      sql.NullTime
+		statusStr        string
+	)
+	if err := s.Scan(
+		&d.ID, &d.WebhookID, &d.TransitionID, &d.EventID, &d.EventType, &payload,
+		&statusStr, &d.Attempt, &nextAttemptAt, &lastStatusCode, &lastResponse,
+		&lastAttemptAt, &deliveredAt, &d.CreatedAt,
+	); err != nil {
+		return nil, err
+	}
+	d.Status = Status(statusStr)
+	if payload.Valid {
+		d.Payload = json.RawMessage(payload.String)
+	}
+	if nextAttemptAt.Valid {
+		d.NextAttemptAt = &nextAttemptAt.Time
+	}
+	if lastStatusCode.Valid {
+		v := int(lastStatusCode.Int64)
+		d.LastStatusCode = &v
+	}
+	if lastResponse.Valid {
+		d.LastResponse = &lastResponse.String
+	}
+	if lastAttemptAt.Valid {
+		d.LastAttemptAt = &lastAttemptAt.Time
+	}
+	if deliveredAt.Valid {
+		d.DeliveredAt = &deliveredAt.Time
+	}
+	return &d, nil
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max]
+}

--- a/internal/webhooks/webhooks.go
+++ b/internal/webhooks/webhooks.go
@@ -1,0 +1,507 @@
+// Package webhooks manages outbound webhook subscriptions and HMAC-signed
+// deliveries. Sole writer for jetmon_webhooks and jetmon_webhook_deliveries.
+//
+// A webhook is a registration that says "POST to this URL when matching
+// events fire." A delivery is one webhook firing — created when an event
+// transition matches the webhook's filters, then dispatched by the
+// background delivery worker.
+//
+// See API.md "Family 4" for the public design and ROADMAP.md for deferred
+// items (site.state_changed events, grace-period secret rotation).
+package webhooks
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base32"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// Storage note: the raw secret is stored in plaintext in jetmon_webhooks.
+// Webhooks are outbound-only — the server signs every delivery, so the HMAC
+// key has to be available in plaintext at signing time. Hashing the secret
+// at rest (the API-key pattern) would make signing impossible. Encryption
+// at rest with a master key is on ROADMAP.md as a future hardening step.
+
+// Status enumerates the lifecycle states of a delivery row.
+type Status string
+
+const (
+	StatusPending   Status = "pending"
+	StatusDelivered Status = "delivered"
+	StatusFailed    Status = "failed"
+	StatusAbandoned Status = "abandoned"
+)
+
+// Webhook event type strings — what consumers see in the X-Jetmon-Event
+// header and the events filter array. Stable identifiers; new types are
+// added (never renamed) so existing webhook configs don't break.
+const (
+	EventOpened          = "event.opened"
+	EventSeverityChanged = "event.severity_changed"
+	EventStateChanged    = "event.state_changed"
+	EventCauseLinked     = "event.cause_linked"
+	EventCauseUnlinked   = "event.cause_unlinked"
+	EventClosed          = "event.closed"
+)
+
+// AllEventTypes returns the canonical set of webhook event types. Used by
+// validators (a webhook's events filter must use values from this set) and
+// by docs/listings.
+func AllEventTypes() []string {
+	return []string{
+		EventOpened,
+		EventSeverityChanged,
+		EventStateChanged,
+		EventCauseLinked,
+		EventCauseUnlinked,
+		EventClosed,
+	}
+}
+
+// SecretPrefix is the leak-detection hint on every raw secret. Stripe
+// convention: a string that starts with this is unmistakably a webhook
+// signing secret if it shows up in logs or git diffs.
+const SecretPrefix = "whsec_"
+
+// Sentinel errors returned by package functions.
+var (
+	ErrWebhookNotFound = errors.New("webhooks: webhook not found")
+	ErrInvalidEvent    = errors.New("webhooks: unknown event type")
+)
+
+// Webhook is the in-memory shape of a jetmon_webhooks row. The raw secret
+// is never stored here — it's hashed at create/rotate time and discarded.
+type Webhook struct {
+	ID            int64
+	URL           string
+	Active        bool
+	Events        []string    // empty slice = match all
+	SiteFilter    SiteFilter  // empty = match all
+	StateFilter   StateFilter // empty = match all
+	SecretPreview string      // last 4 chars of the raw secret, for display
+	CreatedBy     string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+}
+
+// SiteFilter restricts deliveries to a fixed list of sites. Empty SiteIDs
+// (or a nil filter) means "match all sites."
+type SiteFilter struct {
+	SiteIDs []int64 `json:"site_ids,omitempty"`
+}
+
+// StateFilter restricts deliveries to events with one of the given states.
+// Empty States means "match all states."
+type StateFilter struct {
+	States []string `json:"states,omitempty"`
+}
+
+// Matches reports whether the filter set as a whole accepts a given
+// (event_type, site_id, state) combination. Filters AND together; empty
+// dimensions are unrestricted.
+func (w *Webhook) Matches(eventType string, siteID int64, state string) bool {
+	if !w.Active {
+		return false
+	}
+	if len(w.Events) > 0 && !contains(w.Events, eventType) {
+		return false
+	}
+	if len(w.SiteFilter.SiteIDs) > 0 && !containsInt64(w.SiteFilter.SiteIDs, siteID) {
+		return false
+	}
+	if len(w.StateFilter.States) > 0 && !contains(w.StateFilter.States, state) {
+		return false
+	}
+	return true
+}
+
+// CreateInput is the data needed to insert a new webhook. URL is required;
+// everything else has sensible defaults (Active=true, all filters empty =
+// match-all).
+type CreateInput struct {
+	URL         string
+	Active      *bool // nil → true
+	Events      []string
+	SiteFilter  SiteFilter
+	StateFilter StateFilter
+	CreatedBy   string
+}
+
+// UpdateInput is a sparse patch. nil fields are unchanged. Empty slices
+// (vs. nil slices) are meaningful: an explicit empty slice clears the
+// filter, restoring "match all" semantics.
+type UpdateInput struct {
+	URL         *string
+	Active      *bool
+	Events      *[]string
+	SiteFilter  *SiteFilter
+	StateFilter *StateFilter
+}
+
+// Create inserts a webhook and returns the one-time raw secret plus the
+// persisted record. The raw secret is also stored in the DB (see Storage
+// note above) so the delivery worker can sign with it.
+func Create(ctx context.Context, db *sql.DB, in CreateInput) (rawSecret string, w *Webhook, err error) {
+	if in.URL == "" {
+		return "", nil, errors.New("webhooks: URL is required")
+	}
+	if err := validateEvents(in.Events); err != nil {
+		return "", nil, err
+	}
+	active := true
+	if in.Active != nil {
+		active = *in.Active
+	}
+
+	rawSecret, err = GenerateSecret()
+	if err != nil {
+		return "", nil, err
+	}
+	preview := previewOf(rawSecret)
+
+	eventsJSON, _ := json.Marshal(in.Events)
+	siteFilterJSON, _ := json.Marshal(in.SiteFilter)
+	stateFilterJSON, _ := json.Marshal(in.StateFilter)
+
+	res, err := db.ExecContext(ctx, `
+		INSERT INTO jetmon_webhooks
+			(url, active, events, site_filter, state_filter,
+			 secret, secret_preview, created_by)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		in.URL, boolToTinyint(active), eventsJSON, siteFilterJSON, stateFilterJSON,
+		rawSecret, preview, in.CreatedBy,
+	)
+	if err != nil {
+		return "", nil, fmt.Errorf("webhooks: insert: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return "", nil, fmt.Errorf("webhooks: last insert id: %w", err)
+	}
+
+	w, err = Get(ctx, db, id)
+	if err != nil {
+		return "", nil, err
+	}
+	return rawSecret, w, nil
+}
+
+// Get returns a single webhook by id, or ErrWebhookNotFound.
+func Get(ctx context.Context, db *sql.DB, id int64) (*Webhook, error) {
+	row := db.QueryRowContext(ctx, selectWebhookSQL+" WHERE id = ?", id)
+	w, err := scanWebhookRow(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrWebhookNotFound
+		}
+		return nil, err
+	}
+	return w, nil
+}
+
+// List returns all webhooks ordered by id ASC. Webhook count is bounded by
+// the number of registered consumers; we don't paginate today. If a future
+// deployment grows past hundreds of webhooks, add cursor pagination here.
+func List(ctx context.Context, db *sql.DB) ([]Webhook, error) {
+	rows, err := db.QueryContext(ctx, selectWebhookSQL+" ORDER BY id ASC")
+	if err != nil {
+		return nil, fmt.Errorf("webhooks: list: %w", err)
+	}
+	defer rows.Close()
+	var out []Webhook
+	for rows.Next() {
+		w, err := scanWebhookRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *w)
+	}
+	return out, rows.Err()
+}
+
+// ListActive returns only webhooks with active=1. Used by the delivery
+// dispatcher; inactive webhooks don't get matched against new transitions.
+func ListActive(ctx context.Context, db *sql.DB) ([]Webhook, error) {
+	rows, err := db.QueryContext(ctx, selectWebhookSQL+" WHERE active = 1 ORDER BY id ASC")
+	if err != nil {
+		return nil, fmt.Errorf("webhooks: list active: %w", err)
+	}
+	defer rows.Close()
+	var out []Webhook
+	for rows.Next() {
+		w, err := scanWebhookRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *w)
+	}
+	return out, rows.Err()
+}
+
+// Update applies a partial patch and returns the updated webhook. Fields
+// left nil in UpdateInput are unchanged; an explicitly empty slice clears
+// the corresponding filter to "match all" semantics.
+func Update(ctx context.Context, db *sql.DB, id int64, in UpdateInput) (*Webhook, error) {
+	if in.Events != nil {
+		if err := validateEvents(*in.Events); err != nil {
+			return nil, err
+		}
+	}
+
+	clauses := []string{}
+	args := []any{}
+	if in.URL != nil {
+		clauses = append(clauses, "url = ?")
+		args = append(args, *in.URL)
+	}
+	if in.Active != nil {
+		clauses = append(clauses, "active = ?")
+		args = append(args, boolToTinyint(*in.Active))
+	}
+	if in.Events != nil {
+		b, _ := json.Marshal(*in.Events)
+		clauses = append(clauses, "events = ?")
+		args = append(args, b)
+	}
+	if in.SiteFilter != nil {
+		b, _ := json.Marshal(*in.SiteFilter)
+		clauses = append(clauses, "site_filter = ?")
+		args = append(args, b)
+	}
+	if in.StateFilter != nil {
+		b, _ := json.Marshal(*in.StateFilter)
+		clauses = append(clauses, "state_filter = ?")
+		args = append(args, b)
+	}
+
+	if len(clauses) == 0 {
+		// No-op patch — return current state.
+		return Get(ctx, db, id)
+	}
+
+	args = append(args, id)
+	q := "UPDATE jetmon_webhooks SET "
+	for i, c := range clauses {
+		if i > 0 {
+			q += ", "
+		}
+		q += c
+	}
+	q += " WHERE id = ?"
+	if _, err := db.ExecContext(ctx, q, args...); err != nil {
+		return nil, fmt.Errorf("webhooks: update: %w", err)
+	}
+	return Get(ctx, db, id)
+}
+
+// Delete removes a webhook from jetmon_webhooks. Existing rows in
+// jetmon_webhook_deliveries are intentionally NOT cascaded — they remain
+// for audit and manual retry. The dispatcher won't create new deliveries
+// for a deleted webhook because ListActive filters it out.
+func Delete(ctx context.Context, db *sql.DB, id int64) error {
+	res, err := db.ExecContext(ctx, "DELETE FROM jetmon_webhooks WHERE id = ?", id)
+	if err != nil {
+		return fmt.Errorf("webhooks: delete: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrWebhookNotFound
+	}
+	return nil
+}
+
+// RotateSecret generates a new secret, replaces the stored value, and
+// returns the new raw secret (one-time view in API responses). The old
+// secret stops working immediately — see API.md "Signing and secret
+// rotation" for why this is the v1 behavior and how grace-period rotation
+// will be added later.
+func RotateSecret(ctx context.Context, db *sql.DB, id int64) (string, *Webhook, error) {
+	rawSecret, err := GenerateSecret()
+	if err != nil {
+		return "", nil, err
+	}
+	preview := previewOf(rawSecret)
+	res, err := db.ExecContext(ctx,
+		`UPDATE jetmon_webhooks SET secret = ?, secret_preview = ? WHERE id = ?`,
+		rawSecret, preview, id)
+	if err != nil {
+		return "", nil, fmt.Errorf("webhooks: rotate-secret: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return "", nil, ErrWebhookNotFound
+	}
+	w, err := Get(ctx, db, id)
+	if err != nil {
+		return "", nil, err
+	}
+	return rawSecret, w, nil
+}
+
+// LoadSecret returns the raw signing secret for a webhook. Used by the
+// delivery worker only — every public-facing handler returns SecretPreview
+// instead. Kept as a separate function (not a field on Webhook) so the
+// raw value can't leak through serialization of the Webhook struct.
+func LoadSecret(ctx context.Context, db *sql.DB, id int64) (string, error) {
+	var s string
+	err := db.QueryRowContext(ctx,
+		`SELECT secret FROM jetmon_webhooks WHERE id = ?`, id,
+	).Scan(&s)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", ErrWebhookNotFound
+		}
+		return "", fmt.Errorf("webhooks: load secret: %w", err)
+	}
+	return s, nil
+}
+
+// GenerateSecret returns a fresh raw secret. 32 random bytes encoded as
+// base32 with the "whsec_" prefix. Same shape as apikeys — high-entropy
+// random; the leak-detection prefix is the only thing that distinguishes
+// it from a generic random string.
+func GenerateSecret() (string, error) {
+	var buf [32]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", fmt.Errorf("webhooks: read entropy: %w", err)
+	}
+	encoded := base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(buf[:])
+	return SecretPrefix + encoded, nil
+}
+
+// Sign produces the X-Jetmon-Signature header value for a delivery.
+// Format: "t=<unix>,v1=<hex_hmac_sha256(t.body)>" — see API.md.
+//
+// The timestamp is part of the signature input so consumers can reject
+// stale (replayed) deliveries by checking the t= value against their
+// own clock and refusing anything older than ~5 minutes.
+func Sign(timestamp time.Time, body []byte, secret string) string {
+	ts := strconv.FormatInt(timestamp.Unix(), 10)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(ts))
+	mac.Write([]byte("."))
+	mac.Write(body)
+	sig := hex.EncodeToString(mac.Sum(nil))
+	return "t=" + ts + ",v1=" + sig
+}
+
+// EventTypeForReason maps a jetmon_event_transitions.reason value to the
+// webhook event type that should fire. Returns "" if the reason should
+// produce no webhook (used for cause-link reasons that are stored as
+// transitions but not surfaced as separate webhook events in v1).
+//
+// The mapping is fixed in code — adding new transition reasons requires
+// extending this function so consumers see the right webhook event type.
+func EventTypeForReason(reason string) string {
+	switch reason {
+	case "opened":
+		return EventOpened
+	case "severity_escalation", "severity_deescalation":
+		return EventSeverityChanged
+	case "state_change", "verifier_confirmed":
+		return EventStateChanged
+	case "cause_linked":
+		return EventCauseLinked
+	case "cause_unlinked":
+		return EventCauseUnlinked
+	case "verifier_cleared", "probe_cleared", "false_alarm",
+		"manual_override", "maintenance_swallowed", "superseded", "auto_timeout":
+		return EventClosed
+	default:
+		return ""
+	}
+}
+
+// validateEvents rejects an events list that includes an unknown event
+// type. Empty list is fine — that's the "match all" sentinel.
+func validateEvents(events []string) error {
+	all := AllEventTypes()
+	for _, e := range events {
+		if !contains(all, e) {
+			return fmt.Errorf("%w: %q (allowed: %v)", ErrInvalidEvent, e, all)
+		}
+	}
+	return nil
+}
+
+// previewOf returns the last 4 characters of a raw secret for display.
+// Short enough to fit on a one-line listing; long enough to disambiguate
+// among a handful of webhooks.
+func previewOf(s string) string {
+	if len(s) <= 4 {
+		return s
+	}
+	return s[len(s)-4:]
+}
+
+// selectWebhookSQL is shared by Get / List / ListActive so the column
+// order matches scanWebhookRow.
+const selectWebhookSQL = `
+	SELECT id, url, active, events, site_filter, state_filter,
+	       secret_preview, created_by, created_at, updated_at
+	  FROM jetmon_webhooks`
+
+type rowScanner interface {
+	Scan(...any) error
+}
+
+func scanWebhookRow(s rowScanner) (*Webhook, error) {
+	var (
+		w               Webhook
+		active          uint8
+		eventsJSON      sql.NullString
+		siteFilterJSON  sql.NullString
+		stateFilterJSON sql.NullString
+	)
+	if err := s.Scan(
+		&w.ID, &w.URL, &active, &eventsJSON, &siteFilterJSON, &stateFilterJSON,
+		&w.SecretPreview, &w.CreatedBy, &w.CreatedAt, &w.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	w.Active = active == 1
+	if eventsJSON.Valid && eventsJSON.String != "" {
+		_ = json.Unmarshal([]byte(eventsJSON.String), &w.Events)
+	}
+	if siteFilterJSON.Valid && siteFilterJSON.String != "" {
+		_ = json.Unmarshal([]byte(siteFilterJSON.String), &w.SiteFilter)
+	}
+	if stateFilterJSON.Valid && stateFilterJSON.String != "" {
+		_ = json.Unmarshal([]byte(stateFilterJSON.String), &w.StateFilter)
+	}
+	return &w, nil
+}
+
+func boolToTinyint(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func containsInt64(haystack []int64, needle int64) bool {
+	for _, v := range haystack {
+		if v == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/webhooks/webhooks_test.go
+++ b/internal/webhooks/webhooks_test.go
@@ -1,0 +1,238 @@
+package webhooks
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGenerateSecretShape(t *testing.T) {
+	raw, err := GenerateSecret()
+	if err != nil {
+		t.Fatalf("GenerateSecret: %v", err)
+	}
+	if !strings.HasPrefix(raw, SecretPrefix) {
+		t.Fatalf("missing prefix: %q", raw)
+	}
+	// 32 random bytes → 52 base32 chars (no padding) + len(SecretPrefix).
+	if len(raw) != len(SecretPrefix)+52 {
+		t.Errorf("raw length = %d, want %d", len(raw), len(SecretPrefix)+52)
+	}
+}
+
+func TestGenerateSecretUnique(t *testing.T) {
+	a, _ := GenerateSecret()
+	b, _ := GenerateSecret()
+	if a == b {
+		t.Fatal("two generated secrets collided")
+	}
+}
+
+func TestSignDeterministicWithSameInputs(t *testing.T) {
+	ts := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	body := []byte(`{"event":"event.opened","id":42}`)
+	a := Sign(ts, body, "whsec_TESTSECRET")
+	b := Sign(ts, body, "whsec_TESTSECRET")
+	if a != b {
+		t.Errorf("Sign should be deterministic; got %q vs %q", a, b)
+	}
+}
+
+func TestSignFormat(t *testing.T) {
+	ts := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	body := []byte(`{"hello":"world"}`)
+	secret := "whsec_TESTSECRET"
+	got := Sign(ts, body, secret)
+	if !strings.HasPrefix(got, "t=") {
+		t.Errorf("signature = %q, want prefix t=", got)
+	}
+	if !strings.Contains(got, ",v1=") {
+		t.Errorf("signature = %q, want ,v1=", got)
+	}
+	// Compute the expected signature independently — same algorithm but with
+	// the timestamp pulled from ts so the test stays correct under any clock.
+	tsStr := strconv.FormatInt(ts.Unix(), 10)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(tsStr))
+	mac.Write([]byte("."))
+	mac.Write(body)
+	expected := "t=" + tsStr + ",v1=" + hex.EncodeToString(mac.Sum(nil))
+	if got != expected {
+		t.Errorf("Sign computed unexpectedly\n got: %s\nwant: %s", got, expected)
+	}
+}
+
+func TestSignDiffersOnTimestamp(t *testing.T) {
+	t1 := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	t2 := t1.Add(1 * time.Second)
+	body := []byte(`{}`)
+	a := Sign(t1, body, "whsec_x")
+	b := Sign(t2, body, "whsec_x")
+	if a == b {
+		t.Errorf("signature should change with timestamp; both = %q", a)
+	}
+}
+
+func TestSignDiffersOnSecret(t *testing.T) {
+	ts := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	body := []byte(`{}`)
+	if Sign(ts, body, "whsec_a") == Sign(ts, body, "whsec_b") {
+		t.Error("signature should differ between secrets")
+	}
+}
+
+func TestEventTypeForReason(t *testing.T) {
+	cases := map[string]string{
+		"opened":                EventOpened,
+		"severity_escalation":   EventSeverityChanged,
+		"severity_deescalation": EventSeverityChanged,
+		"state_change":          EventStateChanged,
+		"verifier_confirmed":    EventStateChanged,
+		"cause_linked":          EventCauseLinked,
+		"cause_unlinked":        EventCauseUnlinked,
+		"verifier_cleared":      EventClosed,
+		"probe_cleared":         EventClosed,
+		"false_alarm":           EventClosed,
+		"manual_override":       EventClosed,
+		"maintenance_swallowed": EventClosed,
+		"superseded":            EventClosed,
+		"auto_timeout":          EventClosed,
+		"unknown_reason":        "",
+		"":                      "",
+	}
+	for reason, want := range cases {
+		got := EventTypeForReason(reason)
+		if got != want {
+			t.Errorf("EventTypeForReason(%q) = %q, want %q", reason, got, want)
+		}
+	}
+}
+
+func TestWebhookMatchesAllFiltersEmpty(t *testing.T) {
+	// No filters set — webhook should match everything.
+	w := &Webhook{Active: true}
+	if !w.Matches(EventOpened, 12345, "Down") {
+		t.Error("empty filters should match all events")
+	}
+	if !w.Matches(EventClosed, 99999, "Up") {
+		t.Error("empty filters should match unrelated event/state")
+	}
+}
+
+func TestWebhookMatchesInactive(t *testing.T) {
+	w := &Webhook{Active: false}
+	if w.Matches(EventOpened, 1, "Down") {
+		t.Error("inactive webhook should never match")
+	}
+}
+
+func TestWebhookMatchesEventFilter(t *testing.T) {
+	w := &Webhook{
+		Active: true,
+		Events: []string{EventOpened, EventClosed},
+	}
+	if !w.Matches(EventOpened, 1, "Down") {
+		t.Error("event in filter should match")
+	}
+	if w.Matches(EventSeverityChanged, 1, "Down") {
+		t.Error("event not in filter should not match")
+	}
+}
+
+func TestWebhookMatchesSiteFilter(t *testing.T) {
+	w := &Webhook{
+		Active:     true,
+		SiteFilter: SiteFilter{SiteIDs: []int64{101, 102}},
+	}
+	if !w.Matches(EventOpened, 101, "Down") {
+		t.Error("site in filter should match")
+	}
+	if w.Matches(EventOpened, 999, "Down") {
+		t.Error("site not in filter should not match")
+	}
+}
+
+func TestWebhookMatchesStateFilter(t *testing.T) {
+	w := &Webhook{
+		Active:      true,
+		StateFilter: StateFilter{States: []string{"Down", "Seems Down"}},
+	}
+	if !w.Matches(EventOpened, 1, "Down") {
+		t.Error("state in filter should match")
+	}
+	if w.Matches(EventOpened, 1, "Warning") {
+		t.Error("state not in filter should not match")
+	}
+}
+
+func TestWebhookMatchesAllDimensions(t *testing.T) {
+	// All three filters set — must AND across dimensions.
+	w := &Webhook{
+		Active:      true,
+		Events:      []string{EventOpened},
+		SiteFilter:  SiteFilter{SiteIDs: []int64{42}},
+		StateFilter: StateFilter{States: []string{"Down"}},
+	}
+	if !w.Matches(EventOpened, 42, "Down") {
+		t.Error("all three dimensions match → should fire")
+	}
+	if w.Matches(EventClosed, 42, "Down") {
+		t.Error("event mismatch → should not fire (AND semantics)")
+	}
+	if w.Matches(EventOpened, 99, "Down") {
+		t.Error("site mismatch → should not fire (AND semantics)")
+	}
+	if w.Matches(EventOpened, 42, "Up") {
+		t.Error("state mismatch → should not fire (AND semantics)")
+	}
+}
+
+func TestPreviewOf(t *testing.T) {
+	if got := previewOf("whsec_LONG_SECRET_VALUE_XYZ"); got != "_XYZ" {
+		t.Errorf("previewOf long = %q, want _XYZ", got)
+	}
+	if got := previewOf("ab"); got != "ab" {
+		t.Errorf("previewOf short = %q, want ab", got)
+	}
+}
+
+func TestValidateEventsRejectsUnknown(t *testing.T) {
+	if err := validateEvents([]string{EventOpened, "event.bogus"}); err == nil {
+		t.Error("unknown event type should be rejected")
+	}
+	if err := validateEvents([]string{EventOpened, EventClosed}); err != nil {
+		t.Errorf("known events rejected: %v", err)
+	}
+	if err := validateEvents(nil); err != nil {
+		t.Errorf("empty events list rejected: %v", err)
+	}
+}
+
+func TestAllEventTypesIsCanonical(t *testing.T) {
+	all := AllEventTypes()
+	expected := []string{
+		EventOpened, EventSeverityChanged, EventStateChanged,
+		EventCauseLinked, EventCauseUnlinked, EventClosed,
+	}
+	if len(all) != len(expected) {
+		t.Fatalf("AllEventTypes() len = %d, want %d", len(all), len(expected))
+	}
+	for i, e := range expected {
+		if all[i] != e {
+			t.Errorf("AllEventTypes()[%d] = %q, want %q", i, all[i], e)
+		}
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	if got := truncate("hello", 10); got != "hello" {
+		t.Errorf("truncate(short) = %q", got)
+	}
+	if got := truncate("hello world", 5); got != "hello" {
+		t.Errorf("truncate(long) = %q", got)
+	}
+}

--- a/internal/webhooks/worker.go
+++ b/internal/webhooks/worker.go
@@ -1,0 +1,464 @@
+package webhooks
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// retrySchedule maps the *next* attempt number to its delay from the
+// previous attempt. attempt 1 is the initial enqueue (immediate); attempts
+// 2–6 retry at the documented intervals.
+//
+// After attempt 6 fails, the delivery is abandoned. Total elapsed time
+// from first attempt to abandonment: ~7h36m. See API.md for rationale.
+var retrySchedule = []time.Duration{
+	0,                // attempt 1 — initial enqueue, no retry delay
+	1 * time.Minute,  // attempt 2
+	5 * time.Minute,  // attempt 3
+	30 * time.Minute, // attempt 4
+	1 * time.Hour,    // attempt 5
+	6 * time.Hour,    // attempt 6
+}
+
+// maxAttempts is the highest attempt number we'll try. After attempt 6
+// fails, the row is marked abandoned.
+const maxAttempts = 6
+
+// nextRetryDelay returns the delay until the next attempt given the
+// current attempt count (1-indexed: 1 is the first POST, 6 is the last).
+// abandoned=true means there is no next attempt — the delivery should
+// be marked abandoned.
+func nextRetryDelay(currentAttempt int) (delay time.Duration, abandoned bool) {
+	next := currentAttempt + 1
+	if next > maxAttempts {
+		return 0, true
+	}
+	return retrySchedule[next-1], false
+}
+
+// WorkerConfig configures the delivery worker. Defaults are sensible for
+// a single jetmon2 instance; multi-instance deployments should set
+// InstanceID to a unique value per instance so each tracks its own
+// dispatch progress.
+type WorkerConfig struct {
+	DB            *sql.DB
+	InstanceID    string        // key into jetmon_webhook_dispatch_progress
+	PollInterval  time.Duration // default 1s
+	MaxConcurrent int           // shared deliverer pool size; default 50
+	PerWebhookCap int           // per-webhook in-flight cap; default 3
+	HTTPTimeout   time.Duration // per-delivery HTTP timeout; default 30s
+	BatchSize     int           // dispatcher's transition fetch + deliverer's claim batch; default 200
+}
+
+func (c *WorkerConfig) applyDefaults() {
+	if c.PollInterval == 0 {
+		c.PollInterval = 1 * time.Second
+	}
+	if c.MaxConcurrent == 0 {
+		c.MaxConcurrent = 50
+	}
+	if c.PerWebhookCap == 0 {
+		c.PerWebhookCap = 3
+	}
+	if c.HTTPTimeout == 0 {
+		c.HTTPTimeout = 30 * time.Second
+	}
+	if c.BatchSize == 0 {
+		c.BatchSize = 200
+	}
+	if c.InstanceID == "" {
+		c.InstanceID = "default"
+	}
+}
+
+// Worker drives webhook delivery. Two background goroutines:
+//
+//   - dispatcher: every PollInterval, polls jetmon_event_transitions for
+//     new rows since last_seen, matches each against active webhooks,
+//     and enqueues a delivery per match.
+//   - deliverer: every PollInterval, claims pending deliveries whose
+//     next_attempt_at has passed and POSTs them with HMAC signing.
+//     Successes mark delivered; failures schedule retries on the
+//     exponential backoff schedule until attempt 6, then abandon.
+//
+// Both goroutines run continuously until Stop is called. Stop blocks
+// until both have exited cleanly.
+type Worker struct {
+	cfg        WorkerConfig
+	httpClient *http.Client
+
+	inFlightMu sync.Mutex
+	inFlight   map[int64]int // webhook_id → current in-flight count
+
+	stop chan struct{}
+	done chan struct{}
+}
+
+// NewWorker constructs a Worker. Call Start to launch the goroutines.
+func NewWorker(cfg WorkerConfig) *Worker {
+	cfg.applyDefaults()
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   5 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   10,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   5 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		ForceAttemptHTTP2:     true,
+	}
+	return &Worker{
+		cfg:        cfg,
+		httpClient: &http.Client{Transport: transport, Timeout: cfg.HTTPTimeout},
+		inFlight:   make(map[int64]int),
+		stop:       make(chan struct{}),
+		done:       make(chan struct{}),
+	}
+}
+
+// Start launches the dispatcher and deliverer goroutines. Call Stop to
+// signal shutdown. Start is non-blocking.
+func (w *Worker) Start() {
+	go w.run()
+}
+
+// Stop signals the goroutines to exit and waits for them.
+func (w *Worker) Stop() {
+	close(w.stop)
+	<-w.done
+}
+
+func (w *Worker) run() {
+	defer close(w.done)
+
+	dispatcherDone := make(chan struct{})
+	delivererDone := make(chan struct{})
+
+	go func() {
+		defer close(dispatcherDone)
+		w.dispatchLoop()
+	}()
+	go func() {
+		defer close(delivererDone)
+		w.deliverLoop()
+	}()
+
+	<-dispatcherDone
+	<-delivererDone
+}
+
+// dispatchLoop is the polling loop for the dispatcher.
+func (w *Worker) dispatchLoop() {
+	ticker := time.NewTicker(w.cfg.PollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-w.stop:
+			return
+		case <-ticker.C:
+			if err := w.dispatchTick(); err != nil {
+				log.Printf("webhooks: dispatcher tick error: %v", err)
+			}
+		}
+	}
+}
+
+// dispatchTick polls jetmon_event_transitions for new rows and creates
+// deliveries for each match against an active webhook.
+func (w *Worker) dispatchTick() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	lastID, err := w.loadProgress(ctx)
+	if err != nil {
+		return fmt.Errorf("load progress: %w", err)
+	}
+
+	type transitionRow struct {
+		id         int64
+		eventID    int64
+		blogID     int64
+		stateAfter sql.NullString
+		reason     string
+		changedAt  time.Time
+	}
+	rows, err := w.cfg.DB.QueryContext(ctx, `
+		SELECT id, event_id, blog_id, state_after, reason, changed_at
+		  FROM jetmon_event_transitions
+		 WHERE id > ?
+		 ORDER BY id ASC
+		 LIMIT ?`, lastID, w.cfg.BatchSize)
+	if err != nil {
+		return fmt.Errorf("query transitions: %w", err)
+	}
+	defer rows.Close()
+
+	var transitions []transitionRow
+	for rows.Next() {
+		var t transitionRow
+		if err := rows.Scan(&t.id, &t.eventID, &t.blogID, &t.stateAfter, &t.reason, &t.changedAt); err != nil {
+			return fmt.Errorf("scan transition: %w", err)
+		}
+		transitions = append(transitions, t)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("transitions iterate: %w", err)
+	}
+	if len(transitions) == 0 {
+		return nil
+	}
+
+	hooks, err := ListActive(ctx, w.cfg.DB)
+	if err != nil {
+		return fmt.Errorf("list active webhooks: %w", err)
+	}
+
+	for _, t := range transitions {
+		eventType := EventTypeForReason(t.reason)
+		if eventType == "" {
+			continue
+		}
+		state := ""
+		if t.stateAfter.Valid {
+			state = t.stateAfter.String
+		}
+		for i := range hooks {
+			h := &hooks[i]
+			if !h.Matches(eventType, t.blogID, state) {
+				continue
+			}
+			payload, err := w.buildPayload(eventType, t.id, t.eventID, t.blogID, t.reason, state, t.changedAt)
+			if err != nil {
+				log.Printf("webhooks: build payload event_id=%d transition_id=%d: %v",
+					t.eventID, t.id, err)
+				continue
+			}
+			if _, err := Enqueue(ctx, w.cfg.DB, EnqueueInput{
+				WebhookID:    h.ID,
+				TransitionID: t.id,
+				EventID:      t.eventID,
+				EventType:    eventType,
+				Payload:      payload,
+			}); err != nil {
+				log.Printf("webhooks: enqueue webhook_id=%d transition_id=%d: %v",
+					h.ID, t.id, err)
+				continue
+			}
+		}
+	}
+
+	if err := w.saveProgress(ctx, transitions[len(transitions)-1].id); err != nil {
+		return fmt.Errorf("save progress: %w", err)
+	}
+	return nil
+}
+
+// buildPayload returns the JSON body that the consumer receives. Frozen at
+// enqueue time — see API.md "frozen-at-fire-time" contract.
+//
+// Shape is flat: type, occurred_at, ids, and the relevant event/transition
+// fields. Consumers who want full event detail call GET /events/{id}.
+func (w *Worker) buildPayload(eventType string, transitionID, eventID, blogID int64, reason, state string, occurredAt time.Time) (json.RawMessage, error) {
+	body := map[string]any{
+		"type":          eventType,
+		"occurred_at":   occurredAt.UTC().Format(time.RFC3339Nano),
+		"transition_id": transitionID,
+		"event_id":      eventID,
+		"site_id":       blogID,
+		"reason":        reason,
+		"state":         state,
+	}
+	return json.Marshal(body)
+}
+
+// loadProgress reads the last_transition_id high-water mark for this
+// instance from jetmon_webhook_dispatch_progress. Returns 0 if no row
+// exists yet (first tick).
+func (w *Worker) loadProgress(ctx context.Context) (int64, error) {
+	var lastID int64
+	err := w.cfg.DB.QueryRowContext(ctx,
+		`SELECT last_transition_id FROM jetmon_webhook_dispatch_progress WHERE instance_id = ?`,
+		w.cfg.InstanceID,
+	).Scan(&lastID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return lastID, nil
+}
+
+// saveProgress upserts the last_transition_id high-water mark for this
+// instance. Multi-instance: each instance has its own row keyed on
+// instance_id, so they don't trample each other's progress.
+func (w *Worker) saveProgress(ctx context.Context, lastID int64) error {
+	_, err := w.cfg.DB.ExecContext(ctx, `
+		INSERT INTO jetmon_webhook_dispatch_progress (instance_id, last_transition_id)
+		VALUES (?, ?)
+		ON DUPLICATE KEY UPDATE last_transition_id = VALUES(last_transition_id)`,
+		w.cfg.InstanceID, lastID)
+	return err
+}
+
+// deliverLoop is the polling loop for the deliverer. It pulls ready
+// deliveries from the queue and dispatches each as a goroutine, subject
+// to the per-webhook in-flight cap.
+func (w *Worker) deliverLoop() {
+	ticker := time.NewTicker(w.cfg.PollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-w.stop:
+			return
+		case <-ticker.C:
+			if err := w.deliverTick(); err != nil {
+				log.Printf("webhooks: deliverer tick error: %v", err)
+			}
+		}
+	}
+}
+
+func (w *Worker) deliverTick() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	deliveries, err := ClaimReady(ctx, w.cfg.DB, w.cfg.MaxConcurrent)
+	if err != nil {
+		return err
+	}
+	for i := range deliveries {
+		d := deliveries[i]
+		if !w.acquireSlot(d.WebhookID) {
+			// Per-webhook cap reached; row stays pending and we'll pick
+			// it up next tick.
+			continue
+		}
+		go func(d Delivery) {
+			defer w.releaseSlot(d.WebhookID)
+			w.deliver(d)
+		}(d)
+	}
+	return nil
+}
+
+// acquireSlot tries to reserve a per-webhook in-flight slot. Returns true
+// if reserved, false if the webhook is already at its cap.
+func (w *Worker) acquireSlot(webhookID int64) bool {
+	w.inFlightMu.Lock()
+	defer w.inFlightMu.Unlock()
+	if w.inFlight[webhookID] >= w.cfg.PerWebhookCap {
+		return false
+	}
+	w.inFlight[webhookID]++
+	return true
+}
+
+func (w *Worker) releaseSlot(webhookID int64) {
+	w.inFlightMu.Lock()
+	defer w.inFlightMu.Unlock()
+	w.inFlight[webhookID]--
+	if w.inFlight[webhookID] <= 0 {
+		delete(w.inFlight, webhookID)
+	}
+}
+
+// deliver runs one POST attempt against the consumer URL. Updates the
+// delivery row with success/retry/abandon based on the response.
+func (w *Worker) deliver(d Delivery) {
+	ctx, cancel := context.WithTimeout(context.Background(), w.cfg.HTTPTimeout+5*time.Second)
+	defer cancel()
+
+	// Look up the URL and signing secret from the webhook row. Either may
+	// be missing if the webhook was deleted between dispatch and deliver,
+	// in which case we abandon the row (the delivery target is gone).
+	hook, err := Get(ctx, w.cfg.DB, d.WebhookID)
+	if err != nil {
+		w.handleResult(ctx, d, 0, fmt.Sprintf("webhook lookup: %v", err), true)
+		return
+	}
+	secret, err := LoadSecret(ctx, w.cfg.DB, d.WebhookID)
+	if err != nil {
+		w.handleResult(ctx, d, 0, fmt.Sprintf("secret lookup: %v", err), true)
+		return
+	}
+	if !hook.Active {
+		// Webhook was paused between dispatch and deliver. Abandon: the
+		// caller doesn't want this delivery anymore.
+		w.handleResult(ctx, d, 0, "webhook is inactive", true)
+		return
+	}
+
+	timestamp := time.Now()
+	signature := Sign(timestamp, d.Payload, secret)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, hook.URL, bytes.NewReader(d.Payload))
+	if err != nil {
+		w.handleResult(ctx, d, 0, fmt.Sprintf("build request: %v", err), false)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Jetmon-Event", d.EventType)
+	req.Header.Set("X-Jetmon-Delivery", strconv.FormatInt(d.ID, 10))
+	req.Header.Set("X-Jetmon-Signature", signature)
+
+	resp, err := w.httpClient.Do(req)
+	if err != nil {
+		// Network-level failure: connection refused, DNS, timeout, TLS.
+		// Record the error message as last_response and schedule retry.
+		w.handleResult(ctx, d, 0, "transport: "+err.Error(), false)
+		return
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		if err := MarkDelivered(ctx, w.cfg.DB, d.ID, resp.StatusCode, string(body)); err != nil {
+			log.Printf("webhooks: mark delivered id=%d: %v", d.ID, err)
+		}
+		return
+	}
+	// Any non-2xx is retried. Some 4xx (404, 410) might warrant immediate
+	// abandonment, but for v1 we treat all non-2xx alike — consumers
+	// occasionally return 4xx during deploys, and a single 4xx shouldn't
+	// permanently fail an otherwise-recoverable webhook.
+	w.handleResult(ctx, d, resp.StatusCode, string(body), false)
+}
+
+// handleResult writes the delivery outcome to the database. forceAbandon
+// is true for non-retryable failures (webhook deleted/inactive, request
+// build error); otherwise the retry schedule decides whether to retry or
+// abandon based on the attempt count.
+func (w *Worker) handleResult(ctx context.Context, d Delivery, statusCode int, responseBody string, forceAbandon bool) {
+	currentAttempt := d.Attempt + 1 // we just completed this attempt
+	var (
+		next      time.Time
+		abandoned bool
+	)
+	if forceAbandon {
+		abandoned = true
+	} else {
+		delay, ab := nextRetryDelay(currentAttempt)
+		abandoned = ab
+		if !abandoned {
+			next = time.Now().Add(delay)
+		}
+	}
+	if err := ScheduleRetry(ctx, w.cfg.DB, d.ID, statusCode, responseBody, next, abandoned); err != nil {
+		log.Printf("webhooks: schedule retry id=%d: %v", d.ID, err)
+	}
+}

--- a/internal/webhooks/worker_test.go
+++ b/internal/webhooks/worker_test.go
@@ -1,0 +1,175 @@
+package webhooks
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNextRetryDelayFollowsSchedule(t *testing.T) {
+	cases := []struct {
+		current   int
+		want      time.Duration
+		abandoned bool
+	}{
+		{1, 1 * time.Minute, false},
+		{2, 5 * time.Minute, false},
+		{3, 30 * time.Minute, false},
+		{4, 1 * time.Hour, false},
+		{5, 6 * time.Hour, false},
+		{6, 0, true}, // last attempt failed → abandon
+		{7, 0, true}, // beyond max → still abandon (defensive)
+	}
+	for _, c := range cases {
+		got, ab := nextRetryDelay(c.current)
+		if ab != c.abandoned {
+			t.Errorf("nextRetryDelay(%d).abandoned = %v, want %v", c.current, ab, c.abandoned)
+		}
+		if !c.abandoned && got != c.want {
+			t.Errorf("nextRetryDelay(%d).delay = %v, want %v", c.current, got, c.want)
+		}
+	}
+}
+
+// TestSignatureRoundTrip verifies that consumers can recompute and verify
+// the signature we send. This is the contract test — if it ever fails,
+// every consumer's signature verification breaks.
+func TestSignatureRoundTrip(t *testing.T) {
+	secret := "whsec_TEST_SECRET_VALUE"
+	body := []byte(`{"type":"event.opened","event_id":42}`)
+	timestamp := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+
+	signature := Sign(timestamp, body, secret)
+
+	// Parse the signature: t=<unix>,v1=<hex>
+	parts := strings.Split(signature, ",")
+	if len(parts) != 2 {
+		t.Fatalf("signature should have 2 parts, got %d: %s", len(parts), signature)
+	}
+	if !strings.HasPrefix(parts[0], "t=") {
+		t.Fatalf("part 0 should start with t=, got %s", parts[0])
+	}
+	if !strings.HasPrefix(parts[1], "v1=") {
+		t.Fatalf("part 1 should start with v1=, got %s", parts[1])
+	}
+	tsStr := strings.TrimPrefix(parts[0], "t=")
+	sigHex := strings.TrimPrefix(parts[1], "v1=")
+
+	// Recompute on the consumer side.
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(tsStr))
+	mac.Write([]byte("."))
+	mac.Write(body)
+	expected := hex.EncodeToString(mac.Sum(nil))
+
+	if !hmac.Equal([]byte(sigHex), []byte(expected)) {
+		t.Errorf("signature mismatch:\n  got %s\n want %s", sigHex, expected)
+	}
+
+	// Verify timestamp is parseable and matches what we sent.
+	ts, err := strconv.ParseInt(tsStr, 10, 64)
+	if err != nil {
+		t.Errorf("timestamp not parseable: %v", err)
+	}
+	if ts != timestamp.Unix() {
+		t.Errorf("timestamp = %d, want %d", ts, timestamp.Unix())
+	}
+}
+
+func TestApplyDefaults(t *testing.T) {
+	c := WorkerConfig{}
+	c.applyDefaults()
+	if c.PollInterval != 1*time.Second {
+		t.Errorf("PollInterval = %v, want 1s", c.PollInterval)
+	}
+	if c.MaxConcurrent != 50 {
+		t.Errorf("MaxConcurrent = %d, want 50", c.MaxConcurrent)
+	}
+	if c.PerWebhookCap != 3 {
+		t.Errorf("PerWebhookCap = %d, want 3", c.PerWebhookCap)
+	}
+	if c.HTTPTimeout != 30*time.Second {
+		t.Errorf("HTTPTimeout = %v, want 30s", c.HTTPTimeout)
+	}
+	if c.BatchSize != 200 {
+		t.Errorf("BatchSize = %d, want 200", c.BatchSize)
+	}
+	if c.InstanceID != "default" {
+		t.Errorf("InstanceID = %q, want default", c.InstanceID)
+	}
+}
+
+func TestApplyDefaultsPreservesExplicit(t *testing.T) {
+	c := WorkerConfig{
+		PollInterval:  5 * time.Second,
+		MaxConcurrent: 10,
+		InstanceID:    "host-a",
+	}
+	c.applyDefaults()
+	if c.PollInterval != 5*time.Second {
+		t.Errorf("PollInterval = %v, want 5s (explicit)", c.PollInterval)
+	}
+	if c.MaxConcurrent != 10 {
+		t.Errorf("MaxConcurrent = %d, want 10 (explicit)", c.MaxConcurrent)
+	}
+	if c.InstanceID != "host-a" {
+		t.Errorf("InstanceID = %q, want host-a (explicit)", c.InstanceID)
+	}
+	// Unset fields should still get defaults.
+	if c.PerWebhookCap != 3 {
+		t.Errorf("PerWebhookCap = %d, want 3 (default)", c.PerWebhookCap)
+	}
+}
+
+func TestAcquireSlotRespectsCap(t *testing.T) {
+	w := &Worker{
+		cfg:      WorkerConfig{PerWebhookCap: 2},
+		inFlight: make(map[int64]int),
+	}
+	if !w.acquireSlot(1) {
+		t.Fatal("first acquire should succeed")
+	}
+	if !w.acquireSlot(1) {
+		t.Fatal("second acquire should succeed (under cap)")
+	}
+	if w.acquireSlot(1) {
+		t.Fatal("third acquire should fail (cap=2)")
+	}
+	w.releaseSlot(1)
+	if !w.acquireSlot(1) {
+		t.Fatal("acquire after release should succeed")
+	}
+}
+
+func TestAcquireSlotIsolatesWebhooks(t *testing.T) {
+	w := &Worker{
+		cfg:      WorkerConfig{PerWebhookCap: 1},
+		inFlight: make(map[int64]int),
+	}
+	if !w.acquireSlot(1) {
+		t.Fatal("webhook 1 first acquire failed")
+	}
+	if w.acquireSlot(1) {
+		t.Fatal("webhook 1 second acquire should fail (cap=1)")
+	}
+	// Different webhook should be unaffected.
+	if !w.acquireSlot(2) {
+		t.Fatal("webhook 2 acquire should succeed even though webhook 1 is at cap")
+	}
+}
+
+func TestReleaseSlotCleansUpZeroCounts(t *testing.T) {
+	w := &Worker{
+		cfg:      WorkerConfig{PerWebhookCap: 5},
+		inFlight: make(map[int64]int),
+	}
+	w.acquireSlot(1)
+	w.releaseSlot(1)
+	if _, ok := w.inFlight[1]; ok {
+		t.Error("zero-count entry should be deleted from map")
+	}
+}


### PR DESCRIPTION
Stacked PR 2 of 9.

Base: `stack-01-event-api-foundation`
Head: `stack-02-webhooks`
Previous PR: #73

Summary:
- Adds the webhook CRUD API, registry storage, delivery worker, retry ladder, HMAC signing, and manual retry path.
- Reframes the future `jetmon-deliverer` split as the owner for all outbound dispatch.

Review notes:
This PR should be reviewed after #73. It depends on the event transition stream and API foundation from the previous PR.