### PR TITLE
Add alert contacts and managed delivery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,14 @@ See `PROJECT.md` for the full project description, feature list, and performance
 | `internal/wpcom/` | WPCOM API client, circuit breaker |
 | `internal/audit/` | Operational log writes to `jetmon_audit_log` (WPCOM, retries, verifier RPCs, config reloads) |
 | `internal/eventstore/` | Event-sourced site state — manages `jetmon_events` + `jetmon_event_transitions` writes in single transactions |
+| `internal/api/` | Internal REST API server (`/api/v1/...`) — auth, rate limiting, idempotency, sites/events/SLA/webhooks/alert-contacts handlers |
+| `internal/apikeys/` | API key registry, sha256-hashed at rest; `./jetmon2 keys` CLI |
+| `internal/webhooks/` | Webhook registry + delivery worker — outbound HMAC-signed POSTs of event transitions, retry ladder 1m/5m/30m/1h/6h |
+| `internal/alerting/` | Alert contact registry + delivery worker — managed channels (email/PagerDuty/Slack/Teams) with site_filter + severity gate + per-hour rate cap |
 | `internal/dashboard/` | Operator dashboard, SSE handler |
 | `veriflier2/` | Go Veriflier binary |
+| `API.md` | Internal REST API reference (auth, all endpoints, payload shapes) |
+| `ROADMAP.md` | Deferred features and architectural roadmap (multi-binary split, public-API path) |
 | `PROJECT.md` | Full project description and feature specification |
 
 ## Build and Run

--- a/API.md
+++ b/API.md
@@ -735,13 +735,152 @@ This is appropriate **only** because Jetmon is internal-only with all consumers 
 
 The decision to defer ownership today should be reread before any public-API conversation actually starts.
 
-### Family 5: Alert contacts (legacy bridge)
+### Family 5: Alert contacts
 
-For drop-in compatibility with the existing WPCOM notification flow, alert contacts are first-class but optional. Most modern integrations use webhooks. Documented here for completeness:
+Managed notification channels for human destinations: email, PagerDuty, Slack, Microsoft Teams. Where webhooks (Family 4) deliver a raw signed event stream that the consumer renders, alert contacts deliver a Jetmon-rendered notification through a transport Jetmon owns end-to-end (subject lines, message formatting, transport-specific quirks).
 
-- `GET /api/v1/contacts` / `POST` / `PATCH` / `DELETE`
-- Contact types: `email`, `sms`, `webhook` (delegates to webhook system above), `slack`
-- Per-site contact assignment via `POST /api/v1/sites/{id}/contacts/{contact_id}`
+#### When to use which
+
+- **Alert contact** — you want a person notified through a managed channel (their email, your team's PagerDuty service, your team's Slack channel). You don't want to operate a receiver, you want Jetmon to handle rendering and retries.
+- **Webhook** — you want a *system* notified, you control the receiver, and you want the raw signed event payload to render or route however you want. Use this for custom Slack bots that aren't a vanilla incoming-webhook URL, internal SIEM ingestion, custom alerting middleware, or anything that wants the structured event rather than a pre-formatted message.
+
+The two surfaces share the same event source (`jetmon_event_transitions`); a customer can use both simultaneously without dedup concerns at the source.
+
+#### `GET /api/v1/alert-contacts` / `POST` / `PATCH` / `DELETE`
+
+Standard CRUD. An alert contact is:
+
+```json
+{
+  "id": 17,
+  "label": "platform-oncall",
+  "active": true,
+  "transport": "pagerduty",
+  "destination": { "integration_key": "***" },
+  "site_filter": { "site_ids": [12345, 67890] },
+  "min_severity": "Critical",
+  "max_per_hour": 60,
+  "secret_preview": "abcd",
+  "created_by": "alerts-admin",
+  "created_at": "2026-04-25T00:00:00Z"
+}
+```
+
+`destination` shape varies by transport (see below); credential fields are write-only and only `secret_preview` (last 4 chars of the credential) is returned on subsequent reads.
+
+#### Transports
+
+| Transport | `destination` shape | Notes |
+|-----------|---------------------|-------|
+| `email` | `{ "address": "ops@example.com" }` | Rendered as a plain-text + HTML email. Sent via the configured email transport (see "Email delivery" below). |
+| `pagerduty` | `{ "integration_key": "<events-v2 routing key>" }` | Posts to PagerDuty Events API v2. `min_severity` maps to PagerDuty severity (Down → critical, Slow → warning, etc.). |
+| `slack` | `{ "webhook_url": "https://hooks.slack.com/..." }` | Posts to a Slack incoming-webhook URL. Renders a Block Kit message with site, state, severity, and an event link. |
+| `teams` | `{ "webhook_url": "https://outlook.office.com/webhook/..." }` | Posts to a Microsoft Teams incoming-webhook URL. Renders an Adaptive Card with the same fields as Slack. |
+
+Custom transports (Slack via OAuth bot, OpsGenie, internal SIEM, etc.) go through the webhooks API instead — register a webhook, render however you want.
+
+#### Filter semantics
+
+Alert contacts use a simpler filter model than webhooks: **site list + severity gate**. A contact fires when:
+
+```
+site_id ∈ site_filter.site_ids   (or site_filter == {} → all sites)
+AND new_severity >= min_severity (Info < Notice < Warning < Critical)
+```
+
+Empty `site_filter` means "all sites." `min_severity` is required and defaults to `Critical` on create — this is the most common case (page me only on real outages) and avoids accidental noise from new contacts.
+
+The simpler filter model is intentional. Most alert contact configs are "this person, these sites, only when something serious happens"; event-type and state filters (which webhooks support) are rarely useful for human pagers — if you got the open page you almost always want the close page too. Customers who need finer-grained filtering register a webhook instead.
+
+#### Severity gate
+
+Severity ordering: `Info < Notice < Warning < Critical`. The gate matches `new_severity >= min_severity` on each transition; events that *increase* in severity through `min_severity` send a page, events that *resolve below* `min_severity` send a recovery notification, events that move between two severities both below the gate are silently dropped.
+
+This lets agencies and VIPs configure low-severity contacts that catch every flicker while still letting normal users configure `Critical`-only contacts that only fire on real outages — both from the same plumbing.
+
+#### Per-contact rate cap
+
+`max_per_hour` (default 60, set to `0` for unlimited) caps how many notifications a single contact can receive per rolling hour. Designed against the pager-storm scenario where a regional outage flips 200 sites at once; without a cap, on-call gets paged 200 times in 30 seconds. When the cap is hit, further transitions for that contact are recorded but not dispatched, and a single "rate-limit hit, N notifications suppressed in the last hour" digest is sent at the next tick under the cap.
+
+This is a per-contact field, not global — different contacts have different tolerance (a Slack channel can take far more than a PagerDuty oncall can).
+
+#### Send-test
+
+```
+POST /api/v1/alert-contacts/{id}/test
+```
+
+Sends a synthetic notification through the contact's transport — same rendering, same dispatch path, but with payload `{"test": true, "message": "Jetmon test notification", ...}`. Used by operators to verify a newly-created contact actually reaches its destination. Test sends are exempt from `max_per_hour`, are logged in `jetmon_audit_log` under `event_type=alert_test`, and bypass the severity gate (always delivered).
+
+Returns `200 OK` with the test delivery row, or surfaces the transport error (e.g. invalid Slack webhook URL) directly so operators can debug without spelunking through worker logs.
+
+#### Email delivery
+
+Email is unique among the transports in that there is no equivalent of "post to this URL" — it requires a sender. Three implementations selectable at startup via `EMAIL_TRANSPORT` config:
+
+| `EMAIL_TRANSPORT` | Use case | Behavior |
+|-------------------|----------|----------|
+| `wpcom` | Production | Calls existing WPCOM email infrastructure. Default in production deploys. |
+| `smtp` | Local dev / staging | Connects to an SMTP server (e.g. MailHog/Mailpit in docker compose). Configurable host/port/auth. |
+| `stub` | Unit testing | Logs the rendered email to stdout; no actual send. |
+
+The `Sender` interface is internal to the alerting package, so swapping transports is a config change — no code path differences. SMTP support specifically exists so docker-based integration tests can verify rendering and addressing end-to-end without depending on WPCOM infrastructure.
+
+#### Subscription assignment
+
+Site assignment is via `site_filter.site_ids` on the contact row itself, not a separate join table. Mirrors the webhooks API. Empty list = all sites. Setting `site_filter: {"site_ids": []}` is "subscribe to all sites"; setting `site_filter: null` (or omitting it) is "subscribe to none and don't fire" — consistent with webhooks' empty=match-all convention.
+
+#### Detection mechanism
+
+Same as webhooks — pull-only, polling `jetmon_event_transitions` on a high-water mark. Different worker (`internal/alerting/`) with the same dispatch shape: claim → match contacts → enqueue per-contact deliveries in `jetmon_alert_deliveries` → dispatch with retry. Worker placement is intentionally parallel to webhooks rather than unified; see ROADMAP for the rationale and the future revisit point.
+
+#### Retry policy
+
+Same schedule as webhooks: 1m, 5m, 30m, 1h, 6h, then abandon. Different transports have different idempotency stories — PagerDuty Events API is idempotent on `dedup_key`, Slack webhooks are not — so each transport implementation owns its retry-safety guarantee. Worker-level retry is conservative; if the transport library returns success, we never re-send.
+
+#### Relationship to legacy WPCOM notifications
+
+The existing WPCOM notification flow (orchestrator-side, hard-coded recipients) **continues to operate independently** in v1. Alert contacts are a parallel programmable path; they don't replace WPCOM notifications, they coexist.
+
+This means:
+- An incident may notify the same human twice if they're configured in both paths. Document this on the operator side and avoid duplicate configuration.
+- The two paths have separate retry state, separate metrics, separate audit trails.
+- Migrating WPCOM notifications behind alert contacts is a future cleanup tracked in the roadmap, gated on alert contacts proving out in production.
+
+The boundary is: WPCOM = built-in path for existing internal Jetpack notifications; alert contacts = customer-managed destinations through the API. Anything new should go through alert contacts.
+
+#### Schema
+
+```sql
+jetmon_alert_contacts (
+  id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  label VARCHAR(80) NOT NULL,
+  active TINYINT(1) NOT NULL DEFAULT 1,
+  transport ENUM('email','pagerduty','slack','teams') NOT NULL,
+  destination JSON NOT NULL,          -- transport-specific, secret in plaintext (outbound dispatch needs raw value)
+  destination_preview VARCHAR(8) NOT NULL,
+  site_filter JSON NOT NULL,          -- {"site_ids":[...]} or {} for all
+  min_severity ENUM('Info','Notice','Warning','Critical') NOT NULL DEFAULT 'Critical',
+  max_per_hour INT NOT NULL DEFAULT 60,
+  created_by VARCHAR(80) NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+)
+
+jetmon_alert_deliveries (
+  -- mirrors jetmon_webhook_deliveries; dedup on (alert_contact_id, transition_id)
+)
+
+jetmon_alert_dispatch_progress (
+  -- mirrors jetmon_webhook_dispatch_progress; high-water mark for the worker
+)
+```
+
+`destination` stores the credential in plaintext. Same rationale as `jetmon_webhooks.secret`: outbound dispatch needs the raw value (PagerDuty integration key, Slack webhook URL, SMTP password) at every send — a hash is useless because we'd have to recover the original to call the transport. The threat model is the database itself; encryption-at-rest on the storage layer is the correct mitigation, not application-level hashing.
+
+#### Alert contact ownership
+
+Same model as webhooks: any `write`-scope token can manage any alert contact, `created_by` is audit-only. The "Webhook ownership and scope" section above applies verbatim — the gateway handles tenant isolation; if Jetmon ever exposes the API directly to customers, ownership columns get added then.
 
 ### Family 6: Identity and utility
 
@@ -795,9 +934,16 @@ Phase 2 (write surface):
 - Family 2 manual close
 - Idempotency keys + tighter rate limit on triggers
 
-Phase 3 (delivery):
+Phase 3 (webhook delivery):
 - Family 4 webhooks (CRUD + delivery infrastructure with HMAC signing + retry backoff)
-- Family 5 alert contacts (bridge to existing WPCOM flow)
+
+Phase 3.x (alert contacts):
+- Family 5 alert contacts: managed channels (email, PagerDuty, Slack, Teams)
+- `internal/alerting/` package — parallel to `internal/webhooks/`, same dispatch shape
+- Email transport interface with `wpcom` / `smtp` / `stub` implementations
+- Per-contact severity gate + per-hour rate cap
+- `POST /alert-contacts/{id}/test` send-test endpoint
+- Legacy WPCOM notification flow continues to operate in parallel; future migration tracked in ROADMAP
 
 Phase 4 (polish):
 - OpenAPI spec generation

--- a/API.md
+++ b/API.md
@@ -814,6 +814,8 @@ POST /api/v1/alert-contacts/{id}/test
 
 Sends a synthetic notification through the contact's transport — same rendering, same dispatch path, but with payload `{"test": true, "message": "Jetmon test notification", ...}`. Used by operators to verify a newly-created contact actually reaches its destination. Test sends are exempt from `max_per_hour`, are logged in `jetmon_audit_log` under `event_type=alert_test`, and bypass the severity gate (always delivered).
 
+Honors `Idempotency-Key` like the other write POSTs — a retried request with the same key returns the original response without re-firing the test, so a network blip during the operator's "click to test" doesn't double-page the destination.
+
 Returns `200 OK` with the test delivery row, or surfaces the transport error (e.g. invalid Slack webhook URL) directly so operators can debug without spelunking through worker logs.
 
 #### Email delivery

--- a/API.md
+++ b/API.md
@@ -758,7 +758,7 @@ Standard CRUD. An alert contact is:
   "transport": "pagerduty",
   "destination": { "integration_key": "***" },
   "site_filter": { "site_ids": [12345, 67890] },
-  "min_severity": "Critical",
+  "min_severity": "Down",
   "max_per_hour": 60,
   "secret_preview": "abcd",
   "created_by": "alerts-admin",
@@ -773,7 +773,7 @@ Standard CRUD. An alert contact is:
 | Transport | `destination` shape | Notes |
 |-----------|---------------------|-------|
 | `email` | `{ "address": "ops@example.com" }` | Rendered as a plain-text + HTML email. Sent via the configured email transport (see "Email delivery" below). |
-| `pagerduty` | `{ "integration_key": "<events-v2 routing key>" }` | Posts to PagerDuty Events API v2. `min_severity` maps to PagerDuty severity (Down → critical, Slow → warning, etc.). |
+| `pagerduty` | `{ "integration_key": "<events-v2 routing key>" }` | Posts to PagerDuty Events API v2. Jetmon severity maps to PagerDuty severity: `Down`/`SeemsDown` → `critical`, `Degraded` → `warning`, `Warning` → `info`, `Up` → resolves the alert. |
 | `slack` | `{ "webhook_url": "https://hooks.slack.com/..." }` | Posts to a Slack incoming-webhook URL. Renders a Block Kit message with site, state, severity, and an event link. |
 | `teams` | `{ "webhook_url": "https://outlook.office.com/webhook/..." }` | Posts to a Microsoft Teams incoming-webhook URL. Renders an Adaptive Card with the same fields as Slack. |
 
@@ -785,18 +785,20 @@ Alert contacts use a simpler filter model than webhooks: **site list + severity 
 
 ```
 site_id ∈ site_filter.site_ids   (or site_filter == {} → all sites)
-AND new_severity >= min_severity (Info < Notice < Warning < Critical)
+AND new_severity >= min_severity (Up=0 < Warning=1 < Degraded=2 < SeemsDown=3 < Down=4)
 ```
 
-Empty `site_filter` means "all sites." `min_severity` is required and defaults to `Critical` on create — this is the most common case (page me only on real outages) and avoids accidental noise from new contacts.
+Empty `site_filter` means "all sites." `min_severity` is required and defaults to `Down` on create — this is the most common case (page me only on real outages) and avoids accidental noise from new contacts.
+
+The severity values match `internal/eventstore.Severity*` constants directly; the API exposes them by string name in JSON (`"Down"`, `"SeemsDown"`, etc.) and stores them as the underlying `uint8` in the database.
 
 The simpler filter model is intentional. Most alert contact configs are "this person, these sites, only when something serious happens"; event-type and state filters (which webhooks support) are rarely useful for human pagers — if you got the open page you almost always want the close page too. Customers who need finer-grained filtering register a webhook instead.
 
 #### Severity gate
 
-Severity ordering: `Info < Notice < Warning < Critical`. The gate matches `new_severity >= min_severity` on each transition; events that *increase* in severity through `min_severity` send a page, events that *resolve below* `min_severity` send a recovery notification, events that move between two severities both below the gate are silently dropped.
+Severity ordering: `Up < Warning < Degraded < SeemsDown < Down`. The gate matches `new_severity >= min_severity` on each transition; events that *increase* into the gated band send a page, events that *resolve back to `Up`* send a recovery notification, events that move between two severities both below the gate are silently dropped.
 
-This lets agencies and VIPs configure low-severity contacts that catch every flicker while still letting normal users configure `Critical`-only contacts that only fire on real outages — both from the same plumbing.
+This lets agencies and VIPs configure low-severity contacts (e.g. `min_severity: "Warning"`) that catch every flicker while still letting normal users configure `Down`-only contacts that only fire on real outages — both from the same plumbing.
 
 #### Per-contact rate cap
 
@@ -860,7 +862,7 @@ jetmon_alert_contacts (
   destination JSON NOT NULL,          -- transport-specific, secret in plaintext (outbound dispatch needs raw value)
   destination_preview VARCHAR(8) NOT NULL,
   site_filter JSON NOT NULL,          -- {"site_ids":[...]} or {} for all
-  min_severity ENUM('Info','Notice','Warning','Critical') NOT NULL DEFAULT 'Critical',
+  min_severity TINYINT UNSIGNED NOT NULL DEFAULT 4,  -- matches eventstore.Severity* (0=Up..4=Down); default 4=Down
   max_per_hour INT NOT NULL DEFAULT 60,
   created_by VARCHAR(80) NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,23 @@ because it is intentionally **not** drop-in with the Jetmon 1 wire format
   caveat (SELECT ... FOR UPDATE SKIP LOCKED) still tracked alongside the
   deliverer-binary extraction in ROADMAP.md.
 
+**Polish:**
+- `alerting.Update` now validates `label` (must be non-empty) and
+  `max_per_hour` (must be ≥ 0) at input time, surfacing 422
+  `invalid_alert_contact` instead of letting an empty label silently
+  persist or a negative `max_per_hour` surface as a generic 500 from
+  MySQL's `INT UNSIGNED` constraint. Validations that don't depend on
+  the existing row run before the DB lookup so obviously bad PATCH
+  bodies don't pay for a round-trip.
+- Email transport strips CR and LF from MIME header values
+  (`From` / `To` / `Subject`) as defense-in-depth against header
+  injection via untrusted strings (`monitor_url` is operator-controlled
+  but the column doesn't enforce CRLF-free). Body content with newlines
+  is unaffected.
+- `POST /api/v1/alert-contacts/{id}/test` now honors `Idempotency-Key`
+  like the other write POSTs, so a retried "click to test" during a
+  network blip doesn't double-page the destination.
+
 ### Jetmon 2 — initial Go rewrite
 
 Complete rewrite of the Node.js + C++ uptime monitor as a single static Go binary.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,81 @@ Breaking changes are marked **BREAKING**.
 
 ## Unreleased
 
+### v2 branch — site health platform
+
+The v2 branch builds on the Go rewrite to turn Jetmon from a status-flipper
+into a full event-sourced health platform with an internal REST API,
+HMAC-signed webhooks, and managed alert contacts. Kept on a parallel branch
+because it is intentionally **not** drop-in with the Jetmon 1 wire format
+(see PR #61 — DO NOT MERGE).
+
+**New — event sourcing:**
+- `jetmon_events` (current authoritative state per incident) and
+  `jetmon_event_transitions` (every status/severity change, append-only)
+  tables; `internal/eventstore` writes both in a single transaction
+- Five-layer severity ladder: `Up < Warning < Degraded < SeemsDown < Down`
+  matching `internal/eventstore.Severity*` constants
+
+**New — internal REST API (`/api/v1/`, internal-only behind a gateway):**
+- Per-consumer Bearer token auth with three scopes (`read` / `write` /
+  `admin`); `./jetmon2 keys create/list/revoke/rotate` CLI
+- Per-key token-bucket rate limiter with `X-RateLimit-*` headers
+- Stripe-style idempotency keys on POST endpoints
+- Sites CRUD + pause/resume/trigger-now
+- Events list + single + transitions list + manual close
+- SLA endpoints: uptime, response-time, timing-breakdown
+- Audit logging via `jetmon_audit_log` with `event_type=api_access`
+- See API.md for full surface and design rationale
+
+**New — webhooks (Phase 3):**
+- `jetmon_webhooks` registry + `jetmon_webhook_deliveries` per-fire records
+- Stripe-style HMAC-SHA256 signatures (`t=<unix>,v1=<hex>` over
+  `{ts}.{body}`); plaintext secret storage with documented threat model
+- Filter dimensions: `events` + `site_filter` + `state_filter` (AND across,
+  whitelist within, empty=match all)
+- Delivery worker with per-webhook in-flight cap (default 3) and shared
+  pool (default 50), retry ladder 1m / 5m / 30m / 1h / 6h then abandon
+- Frozen-at-fire-time payload contract — consumer sees the event as it was
+  when the webhook fired, not as it is now
+- POST `/webhooks/{id}/rotate-secret` (immediate revocation; grace-period
+  rotation deferred — see ROADMAP.md)
+- POST `/webhooks/{id}/deliveries/{delivery_id}/retry` for operator manual
+  retry of abandoned rows
+
+**New — alert contacts (Phase 3.x):**
+- Managed channels for human destinations: `email`, `pagerduty`, `slack`,
+  `teams`. Boundary with webhooks: alert contacts deliver Jetmon-rendered
+  notifications through Jetmon-owned transports; webhooks deliver the raw
+  signed event stream for custom rendering
+- Filter shape: `site_filter` + `min_severity` (default `Down`); per-contact
+  `max_per_hour` rate cap (default 60) as pager-storm insurance
+- POST `/alert-contacts/{id}/test` for synthetic send-tests through the
+  same dispatch path
+- Email transport pluggable via `EMAIL_TRANSPORT` config: `wpcom`
+  (production), `smtp` (dev / staging with MailHog), `stub` (unit tests)
+- PagerDuty Events API v2 with severity mapping and event_action
+  trigger/resolve based on the recovery flag
+- Slack Block Kit + Microsoft Teams Adaptive Card rendering
+- Plaintext credential storage in `destination` JSON; same outbound-dispatch
+  rationale as webhook secrets, threat model documented inline
+- Legacy WPCOM notification flow continues alongside; migration tracked
+  in ROADMAP.md
+
+**Verifier hardening:**
+- Body size cap and empty-token guard on the JSON-over-HTTP transport
+- Verifier config validation: required `host` and `grpc_port` per entry,
+  PID file location now respects `JETMON_PID_FILE` env var
+
+**Worker fixes:**
+- Soft-lock fix for both webhooks and alerting deliver loops: `ClaimReady`
+  pushes `next_attempt_at` out by 60s so the 1s tick doesn't re-claim a
+  still-in-flight row. Without this, the per-contact in-flight cap (3)
+  was producing concurrent dispatches that inflated the attempt counter
+  and effectively skipped retry-schedule steps; the documented 7h36m
+  retry window was being collapsed to ~1h. Multi-instance row-claim
+  caveat (SELECT ... FOR UPDATE SKIP LOCKED) still tracked alongside the
+  deliverer-binary extraction in ROADMAP.md.
+
 ### Jetmon 2 — initial Go rewrite
 
 Complete rewrite of the Node.js + C++ uptime monitor as a single static Go binary.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -159,6 +159,75 @@ A future Phase 3.x extension is **grace-period rotation**: server signs with bot
 
 ---
 
+## Deferred from Phase 3.x (alert contacts)
+
+These were considered during Phase 3.x design and intentionally left out of v1. Each has a clean addition path that doesn't disturb the v1 schema or worker shape.
+
+### Generic outbound webhook as an alert-contact transport
+
+Phase 3.x ships four managed transports: email, PagerDuty, Slack, Teams. A "generic webhook" alert-contact transport (POST a Jetmon-formatted JSON payload to any URL) was considered and rejected because the webhooks API (Family 4) already covers it — and covers it better, with HMAC signing, configurable filters across more dimensions, and a fully programmable payload shape.
+
+**The boundary:** alert contacts deliver Jetmon-rendered notifications through Jetmon-owned transports. Webhooks deliver the raw signed event stream for the consumer to render. A customer who wants "POST to my URL when sites change" should register a webhook; we shouldn't ship a duplicate surface that does the same thing worse.
+
+**When to revisit:** never, unless the boundary itself shifts (e.g. webhooks API gets removed, or alert contacts grows into a fundamentally different abstraction).
+
+### SMS notifications
+
+Skipped in v1. WPCOM SMS infrastructure availability is unclear, and a third-party SMS provider integration (Twilio/MessageBird/etc.) is a non-trivial credentialing and billing addition. PagerDuty already offers SMS as a downstream config — the dominant SMS use case is "page me," and that's already covered.
+
+**When to revisit:** a customer asks specifically for direct SMS without going through PagerDuty, AND a stable SMS sending channel (WPCOM-owned or vendor-procured) is available.
+
+### OpsGenie transport
+
+Skipped in v1. Same shape as PagerDuty but a different vendor; PagerDuty covers the dominant slice of customers who want incident-management routing. Adding OpsGenie is mechanical (new transport implementation, ~100 LoC) once a customer asks.
+
+**When to revisit:** a customer running OpsGenie asks for direct integration. Until then, they can route via webhook to OpsGenie's events API themselves.
+
+### Quiet hours / on-call schedules
+
+Per-contact "don't page me between 11pm and 7am" or "route to alternate contact during my vacation" was considered and deferred. Reasons:
+
+- PagerDuty already handles this on its end with full schedule support; customers using PagerDuty don't need it from Jetmon.
+- For Slack/email/Teams contacts, channel-level mute or auto-responders work as a workaround.
+- Building scheduling into Jetmon is a rabbit hole — timezone handling, recurring patterns, escalation overrides, holiday lists. Each of those is a feature in itself.
+
+**When to revisit:** strong customer demand specifically for non-PagerDuty contacts AND a clear scope for what "scheduling" means in v1 (probably starts with a single per-contact `quiet_hours: {start, end, tz}` field, not full PagerDuty parity).
+
+### Alert acknowledgements
+
+"Operator acks an alert from PagerDuty/Slack and Jetmon stops re-paging" was considered and deferred because it's bidirectional — Jetmon would need to receive callbacks from each transport, store ack state, and gate further deliveries against it. That's a significant new surface (inbound webhooks from PagerDuty, Slack interactivity API, etc.) for a feature most customers handle within their incident-management tool.
+
+**When to revisit:** a customer specifically asks for cross-channel ack state (e.g. "I acked in PagerDuty, don't keep posting to Slack"). Probably ships as a per-contact `respect_external_ack: bool` flag plus per-transport ack-receiver implementations.
+
+### Alert grouping / digest mode
+
+When a regional outage flips 50 sites at once, v1 sends 50 separate notifications per matching contact (modulo the per-hour rate cap, which kicks in but only as a brake, not a grouping mechanism). A real grouping/digest feature — "send one email containing all transitions in the last 5 minutes" — was deferred.
+
+**Why deferred:** per-event delivery matches webhook semantics, is the simplest semantic to reason about, and is what most monitoring tools start with. Grouping introduces real questions (window size, group boundary criteria, what happens if a transition arrives mid-group) that benefit from real customer feedback.
+
+**When to revisit:** real users complain about pager noise during regional outages even with `max_per_hour` set. Likely shape: per-contact `digest_window_seconds` field; transitions within the window batch into one notification at window end.
+
+### Migrate WPCOM notifications behind alert contacts
+
+Phase 3.x ships alert contacts alongside the existing WPCOM notification flow rather than migrating the WPCOM flow to be a transport behind alert contacts. The two paths coexist; same human can be in both and receive duplicate notifications.
+
+**Why deferred:** drop-in compatibility with the existing v1 deployment shape is more important than architectural unification. Migrating WPCOM-flow consumers to alert contacts requires:
+- Inventorying all current WPCOM notification recipients and their subscription patterns
+- Building a `wpcom` transport (or reusing an existing one) that delivers through the same channel
+- Migrating the per-recipient subscription data into `jetmon_alert_contacts`
+- Verifying nothing regresses for the existing recipients during cutover
+
+This is a coordinated migration, not a code change — and it's safer to do once alert contacts has proven out in production with real customers.
+
+**Why this is a clean future addition:**
+- The transport interface is already pluggable; adding a `wpcom` transport is the same shape as `email`/`pagerduty`/`slack`/`teams`.
+- The orchestrator's existing WPCOM notification call site becomes a simple "delete this code path" once parity is verified.
+- The deliverer-binary extraction (see Architectural roadmap below) becomes meaningfully cleaner with WPCOM unified — it's the third transport that justifies the split.
+
+**When to revisit:** alert contacts has been in production for 1–3 months without major issues, AND the deliverer-binary extraction is being actively planned. The two are the same conversation.
+
+---
+
 ## Architectural roadmap
 
 ### Multi-repo / multi-binary split
@@ -190,6 +259,15 @@ What this means concretely:
 - The Phase 3 webhook worker (`internal/webhooks/worker.go`) is the seed. Its `dispatchTick` / `deliverTick` shape generalizes — the matching, claiming, retry, and abandon logic is transport-agnostic.
 - A future refactor abstracts the transport behind a `Dispatcher` interface (`Send(ctx, dest, payload) (status, error)`), with concrete implementations per channel.
 - Per-channel state (webhook subscriptions, alert contacts, WPCOM circuit breaker counters) stays in its own table; the worker loops over each.
+
+**Revisit point: unify `internal/alerting/` and `internal/webhooks/`.** Phase 3.x ships alert contacts as a separate package (`internal/alerting/`) parallel to webhooks, deliberately *not* extending the webhook worker. The reasoning at the time was: alerting hadn't been built yet, we didn't know what shape it would actually take (fan-out? escalation? digest mode?), and forcing a shared abstraction with one known user (webhooks) and one guessed-at user (alerting) risked an abstraction that fits neither well. Better to build alerting concretely, see where the duplication actually lands, and factor with two real implementations in hand.
+
+The deliverer-binary extraction is the natural moment to revisit. By then we'll have:
+- Two concrete dispatch workers in production with known operational profiles.
+- A clear picture of what alerting actually grew into vs. what webhooks needed.
+- A real third transport on the way (WPCOM migration), which validates the abstraction against three users instead of two.
+
+At that point, factor a `Dispatcher` interface against the three known shapes — not before. The duplication cost between `internal/webhooks/` and `internal/alerting/` is bounded (~300 lines); the cost of a wrong abstraction is unbounded.
 
 **Trigger that justifies the split.** A single outbound transport doesn't justify its own binary — webhooks alone could stay co-located with the orchestrator. The argument gets compelling once there are *multiple* transports to dispatch and a shared retry/circuit-breaker substrate to amortize. Adding alert contacts is the moment the abstraction earns its keep; pulling WPCOM notifications out of the orchestrator at the same time is the cleanup that pays off the extraction.
 

--- a/cmd/jetmon2/main.go
+++ b/cmd/jetmon2/main.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/Automattic/jetmon/internal/alerting"
 	"github.com/Automattic/jetmon/internal/api"
 	"github.com/Automattic/jetmon/internal/apikeys"
 	"github.com/Automattic/jetmon/internal/audit"
@@ -146,6 +147,26 @@ func runServe() {
 		log.Println("webhooks: delivery worker started")
 	}
 
+	// Alert contact delivery worker. Same shape as webhooks but a
+	// separate package so the two can evolve independently — the future
+	// "deliverer binary" extraction is the moment to factor out a
+	// shared abstraction. Disabled when API_PORT is 0 (no contacts to
+	// fire to without the API to manage them).
+	var alertWorker *alerting.Worker
+	if cfg.APIPort > 0 {
+		dispatchers := buildAlertDispatchers(cfg)
+		alertWorker = alerting.NewWorker(alerting.WorkerConfig{
+			DB:          db.DB(),
+			InstanceID:  db.Hostname(),
+			Dispatchers: dispatchers,
+		})
+		alertWorker.Start()
+		if apiSrv != nil {
+			apiSrv.SetAlertDispatchers(dispatchers)
+		}
+		log.Printf("alerting: delivery worker started (transports=%d)", len(dispatchers))
+	}
+
 	// Push dashboard state every stats interval.
 	if dash != nil {
 		go func() {
@@ -194,6 +215,10 @@ func runServe() {
 				if hookWorker != nil {
 					hookWorker.Stop()
 					log.Println("webhooks: delivery worker stopped")
+				}
+				if alertWorker != nil {
+					alertWorker.Stop()
+					log.Println("alerting: delivery worker stopped")
 				}
 				orch.Stop()
 				// Hard kill if drain takes too long (e.g. a stalled HTTP check).
@@ -571,5 +596,45 @@ func repeat(s string, n int) string {
 	for range n {
 		out += s
 	}
+	return out
+}
+
+
+// buildAlertDispatchers constructs the per-transport Dispatcher map
+// from runtime config. Always returns the three webhook-shaped
+// transports (PagerDuty, Slack, Teams) — they have no per-instance
+// config beyond the destination credential which lives on each
+// alert contact row. Email is conditionally included based on
+// EMAIL_TRANSPORT: "wpcom"/"smtp" wire the corresponding sender,
+// "stub" or empty falls back to log-only.
+func buildAlertDispatchers(cfg *config.Config) map[alerting.Transport]alerting.Dispatcher {
+	out := map[alerting.Transport]alerting.Dispatcher{
+		alerting.TransportPagerDuty: &alerting.PagerDutyDispatcher{},
+		alerting.TransportSlack:     &alerting.SlackDispatcher{},
+		alerting.TransportTeams:     &alerting.TeamsDispatcher{},
+	}
+
+	var sender alerting.Sender
+	switch cfg.EmailTransport {
+	case "wpcom":
+		sender = &alerting.WPCOMSender{
+			Endpoint:  cfg.WPCOMEmailEndpoint,
+			AuthToken: cfg.WPCOMEmailAuthToken,
+		}
+		log.Printf("alerting/email: using wpcom sender (endpoint=%s)", cfg.WPCOMEmailEndpoint)
+	case "smtp":
+		sender = &alerting.SMTPSender{
+			Host:     cfg.SMTPHost,
+			Port:     cfg.SMTPPort,
+			Username: cfg.SMTPUsername,
+			Password: cfg.SMTPPassword,
+			UseTLS:   cfg.SMTPUseTLS,
+		}
+		log.Printf("alerting/email: using smtp sender (%s:%d)", cfg.SMTPHost, cfg.SMTPPort)
+	default:
+		sender = &alerting.StubSender{}
+		log.Println("alerting/email: using stub sender (set EMAIL_TRANSPORT to enable real delivery)")
+	}
+	out[alerting.TransportEmail] = alerting.NewEmailDispatcher(sender, cfg.EmailFrom)
 	return out
 }

--- a/internal/alerting/alerting.go
+++ b/internal/alerting/alerting.go
@@ -1,0 +1,273 @@
+// Package alerting manages outbound alert contact subscriptions and the
+// delivery worker that fans transitions out to managed transports.
+//
+// An alert contact is a registration that says "send a Jetmon-rendered
+// notification through this transport when matching transitions fire."
+// A delivery is one alert contact firing — created when an event
+// transition matches the contact's site_filter and severity gate, then
+// dispatched by the background worker through the configured transport.
+//
+// Where webhooks (internal/webhooks) deliver a raw signed event stream
+// for the consumer to render, alert contacts deliver a Jetmon-rendered
+// notification through a transport Jetmon owns end-to-end (subject lines,
+// PagerDuty severity mapping, Slack Block Kit rendering, etc.).
+//
+// See API.md "Family 5" for the public design and ROADMAP.md for deferred
+// items (SMS, OpsGenie, alert grouping, WPCOM-flow migration).
+package alerting
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/Automattic/jetmon/internal/eventstore"
+)
+
+// Storage note: destination credentials are stored in plaintext in
+// jetmon_alert_contacts.destination. Same rationale as
+// jetmon_webhooks.secret — outbound dispatch needs the raw value at
+// every send. A hash is useless because we'd have to recover the
+// original to call the transport. Encryption at rest with a master
+// key is on ROADMAP.md as a future hardening step.
+
+// Status enumerates the lifecycle states of a delivery row.
+type Status string
+
+const (
+	StatusPending   Status = "pending"
+	StatusDelivered Status = "delivered"
+	StatusFailed    Status = "failed"
+	StatusAbandoned Status = "abandoned"
+)
+
+// Transport identifies which managed channel a contact delivers through.
+// New transports are added (never renamed) so existing contact configs
+// don't break — the ENUM in the migration mirrors this set.
+type Transport string
+
+const (
+	TransportEmail     Transport = "email"
+	TransportPagerDuty Transport = "pagerduty"
+	TransportSlack     Transport = "slack"
+	TransportTeams     Transport = "teams"
+)
+
+// AllTransports returns the canonical set of transport identifiers.
+// Used by validators (a contact's transport must be one of these) and
+// by docs/listings.
+func AllTransports() []Transport {
+	return []Transport{TransportEmail, TransportPagerDuty, TransportSlack, TransportTeams}
+}
+
+// IsValidTransport reports whether s is one of the known transports.
+func IsValidTransport(s string) bool {
+	for _, t := range AllTransports() {
+		if string(t) == s {
+			return true
+		}
+	}
+	return false
+}
+
+// Sentinel errors returned by package functions.
+var (
+	ErrContactNotFound  = errors.New("alerting: alert contact not found")
+	ErrDeliveryNotFound = errors.New("alerting: alert delivery not found")
+	ErrInvalidTransport = errors.New("alerting: unknown transport")
+	ErrInvalidSeverity  = errors.New("alerting: unknown severity")
+)
+
+// AlertContact is the in-memory shape of a jetmon_alert_contacts row.
+// The raw destination credential is never stored here — it's loaded
+// separately by the worker via LoadDestination so it can't leak through
+// serialization of the AlertContact struct.
+type AlertContact struct {
+	ID                 int64
+	Label              string
+	Active             bool
+	Transport          Transport
+	DestinationPreview string     // last 4 chars of the credential, for display
+	SiteFilter         SiteFilter // empty = match all sites
+	MinSeverity        uint8      // matches eventstore.Severity* (0=Up..4=Down)
+	MaxPerHour         int        // 0 = unlimited
+	CreatedBy          string
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
+}
+
+// SiteFilter restricts deliveries to a fixed list of sites. Empty
+// SiteIDs (or a nil filter) means "match all sites." Same shape as
+// webhooks.SiteFilter — kept as a separate type so alerting can evolve
+// independently of the webhooks package.
+type SiteFilter struct {
+	SiteIDs []int64 `json:"site_ids,omitempty"`
+}
+
+// Matches reports whether this contact should fire for a given
+// transition. The filter rule is:
+//
+//	site_id ∈ site_filter.site_ids   (or site_filter empty → all sites)
+//	AND (
+//	    new_severity >= min_severity              // escalation / sustained
+//	    OR (prev_severity >= min_severity         // recovery from a
+//	        AND new_severity == SeverityUp)       //   previously-paging state
+//	)
+//
+// Within-band changes (e.g. Down → SeemsDown when min_severity=Warning)
+// fire as flickers. The per-contact max_per_hour cap absorbs the noise.
+//
+// Recovery firing requires both prev and new severity because Matches
+// doesn't see the transition reason — it can't distinguish "resolved"
+// from "transitioned through Up by accident." Practically, transitions
+// to Up only happen on real recoveries.
+func (c *AlertContact) Matches(prevSeverity, newSeverity uint8, siteID int64) bool {
+	if !c.Active {
+		return false
+	}
+	if len(c.SiteFilter.SiteIDs) > 0 && !containsInt64(c.SiteFilter.SiteIDs, siteID) {
+		return false
+	}
+	if newSeverity >= c.MinSeverity {
+		return true
+	}
+	if prevSeverity >= c.MinSeverity && newSeverity == eventstore.SeverityUp {
+		return true
+	}
+	return false
+}
+
+// CreateInput is the data needed to insert a new alert contact.
+// Label, Transport, and Destination are required; everything else has
+// sensible defaults (Active=true, SiteFilter empty=match-all,
+// MinSeverity=SeverityDown, MaxPerHour=60).
+type CreateInput struct {
+	Label       string
+	Active      *bool // nil → true
+	Transport   Transport
+	Destination json.RawMessage // transport-specific shape; validated per transport
+	SiteFilter  SiteFilter
+	MinSeverity *uint8 // nil → SeverityDown
+	MaxPerHour  *int   // nil → 60
+	CreatedBy   string
+}
+
+// UpdateInput is a sparse patch. nil fields are unchanged. An explicit
+// empty SiteFilter clears the filter (restores match-all). Transport
+// and Destination cannot be updated together via PATCH — change of
+// transport requires creating a new contact (the destination shape
+// is transport-specific and validating cross-transport changes is
+// more brittle than just deleting+recreating).
+type UpdateInput struct {
+	Label       *string
+	Active      *bool
+	Destination json.RawMessage // transport-specific; nil = unchanged
+	SiteFilter  *SiteFilter
+	MinSeverity *uint8
+	MaxPerHour  *int
+}
+
+// Notification is the rendered shape passed to a Transport.Send
+// implementation. The worker builds this once per delivery from the
+// frozen-at-fire-time payload; transports translate it into their
+// channel-specific representation.
+//
+// IsTest=true is used by the send-test endpoint to flag synthetic
+// notifications. Transports may use this to add a banner ("This is a
+// Jetmon test notification") or to choose dedup keys that won't
+// collide with real alerts.
+type Notification struct {
+	SiteID       int64
+	SiteURL      string
+	EventID      int64
+	EventType    string
+	Severity     uint8
+	SeverityName string
+	State        string
+	Reason       string
+	Timestamp    time.Time
+	DedupKey     string
+	Recovery     bool
+	IsTest       bool
+}
+
+// Dispatcher defines the contract every concrete transport
+// (email/pagerduty/slack/teams) implements. Send is responsible for
+// translating Notification into the channel-specific request and
+// reporting the outcome.
+//
+// statusCode is the channel's idiomatic status (HTTP code for
+// HTTP-based transports, SMTP reply class for email — e.g. 250
+// becomes 250). responseBody is a truncated summary suitable for
+// storing in jetmon_alert_deliveries.last_response (max 2048 chars;
+// the worker truncates if needed).
+//
+// Returning err != nil means the dispatch failed in a way the worker
+// should retry on the standard ladder. Returning err == nil with a
+// non-2xx-equivalent status also schedules a retry; the worker
+// treats both as failures for retry purposes but distinguishes them
+// for diagnostics.
+type Dispatcher interface {
+	Send(ctx context.Context, destination json.RawMessage, n Notification) (statusCode int, responseBody string, err error)
+}
+
+// SeverityName returns the canonical string form of a severity uint8,
+// matching the constants in internal/eventstore. Used by the API
+// layer (which returns severity names in JSON) and by transport
+// renderers (PagerDuty severity field, email subjects, Slack message
+// bodies).
+//
+// Returns "" for unknown values rather than panicking — some callers
+// pass user-supplied input that hasn't been validated yet.
+func SeverityName(s uint8) string {
+	switch s {
+	case eventstore.SeverityUp:
+		return "Up"
+	case eventstore.SeverityWarning:
+		return "Warning"
+	case eventstore.SeverityDegraded:
+		return "Degraded"
+	case eventstore.SeveritySeemsDown:
+		return "SeemsDown"
+	case eventstore.SeverityDown:
+		return "Down"
+	default:
+		return ""
+	}
+}
+
+// SeverityFromName parses a severity string back into the eventstore
+// uint8 constant. Used by the API layer to validate min_severity
+// inputs from JSON. Returns ErrInvalidSeverity on unknown names.
+func SeverityFromName(s string) (uint8, error) {
+	switch s {
+	case "Up":
+		return eventstore.SeverityUp, nil
+	case "Warning":
+		return eventstore.SeverityWarning, nil
+	case "Degraded":
+		return eventstore.SeverityDegraded, nil
+	case "SeemsDown":
+		return eventstore.SeveritySeemsDown, nil
+	case "Down":
+		return eventstore.SeverityDown, nil
+	default:
+		return 0, ErrInvalidSeverity
+	}
+}
+
+// AllSeverityNames returns the full ordered list of severity names,
+// least-to-most severe. Used by docs and validators.
+func AllSeverityNames() []string {
+	return []string{"Up", "Warning", "Degraded", "SeemsDown", "Down"}
+}
+
+func containsInt64(haystack []int64, needle int64) bool {
+	for _, v := range haystack {
+		if v == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/alerting/alerting_test.go
+++ b/internal/alerting/alerting_test.go
@@ -1,0 +1,159 @@
+package alerting
+
+import (
+	"testing"
+
+	"github.com/Automattic/jetmon/internal/eventstore"
+)
+
+func TestSeverityNameRoundTrip(t *testing.T) {
+	for _, name := range AllSeverityNames() {
+		s, err := SeverityFromName(name)
+		if err != nil {
+			t.Errorf("SeverityFromName(%q) returned error: %v", name, err)
+			continue
+		}
+		if got := SeverityName(s); got != name {
+			t.Errorf("round-trip %q → %d → %q failed", name, s, got)
+		}
+	}
+}
+
+func TestSeverityNameUnknown(t *testing.T) {
+	if got := SeverityName(99); got != "" {
+		t.Errorf("SeverityName(99) = %q, want empty string", got)
+	}
+	if _, err := SeverityFromName("Bogus"); err == nil {
+		t.Error("SeverityFromName(\"Bogus\") should error")
+	}
+}
+
+func TestIsValidTransport(t *testing.T) {
+	for _, valid := range []string{"email", "pagerduty", "slack", "teams"} {
+		if !IsValidTransport(valid) {
+			t.Errorf("IsValidTransport(%q) = false, want true", valid)
+		}
+	}
+	for _, bad := range []string{"", "Email", "sms", "opsgenie", "EMAIL"} {
+		if IsValidTransport(bad) {
+			t.Errorf("IsValidTransport(%q) = true, want false", bad)
+		}
+	}
+}
+
+// TestMatchesInactive verifies an inactive contact never fires regardless
+// of severity — a deactivated contact should be invisible to the worker.
+func TestMatchesInactive(t *testing.T) {
+	c := &AlertContact{
+		Active:      false,
+		MinSeverity: eventstore.SeverityWarning,
+	}
+	if c.Matches(eventstore.SeverityUp, eventstore.SeverityDown, 1) {
+		t.Error("inactive contact should not match")
+	}
+}
+
+// TestMatchesEmptySiteFilter verifies an empty site filter matches all sites
+// — the documented "empty = match all" semantic.
+func TestMatchesEmptySiteFilter(t *testing.T) {
+	c := &AlertContact{
+		Active:      true,
+		MinSeverity: eventstore.SeverityDown,
+		// SiteFilter is zero value → empty SiteIDs → match all.
+	}
+	for _, siteID := range []int64{1, 42, 99999} {
+		if !c.Matches(eventstore.SeverityUp, eventstore.SeverityDown, siteID) {
+			t.Errorf("empty site filter should match site %d", siteID)
+		}
+	}
+}
+
+func TestMatchesSiteFilterWhitelist(t *testing.T) {
+	c := &AlertContact{
+		Active:      true,
+		SiteFilter:  SiteFilter{SiteIDs: []int64{42, 99}},
+		MinSeverity: eventstore.SeverityDown,
+	}
+	if !c.Matches(eventstore.SeverityUp, eventstore.SeverityDown, 42) {
+		t.Error("site 42 should match")
+	}
+	if !c.Matches(eventstore.SeverityUp, eventstore.SeverityDown, 99) {
+		t.Error("site 99 should match")
+	}
+	if c.Matches(eventstore.SeverityUp, eventstore.SeverityDown, 7) {
+		t.Error("site 7 should not match (not in whitelist)")
+	}
+}
+
+// TestMatchesSeverityGate covers the escalation half of the gate:
+// new_severity >= min_severity fires, regardless of prev_severity.
+func TestMatchesSeverityGate(t *testing.T) {
+	c := &AlertContact{
+		Active:      true,
+		MinSeverity: eventstore.SeverityDegraded, // 2
+	}
+	cases := []struct {
+		prev, next uint8
+		want       bool
+		desc       string
+	}{
+		{eventstore.SeverityUp, eventstore.SeverityWarning, false, "Up→Warning, both below gate"},
+		{eventstore.SeverityUp, eventstore.SeverityDegraded, true, "Up→Degraded, crosses gate"},
+		{eventstore.SeverityWarning, eventstore.SeverityDegraded, true, "Warning→Degraded, crosses gate"},
+		{eventstore.SeverityDegraded, eventstore.SeveritySeemsDown, true, "Degraded→SeemsDown, within gated band"},
+		{eventstore.SeveritySeemsDown, eventstore.SeverityDown, true, "SeemsDown→Down, within gated band"},
+	}
+	for _, tc := range cases {
+		got := c.Matches(tc.prev, tc.next, 0)
+		if got != tc.want {
+			t.Errorf("%s: Matches(%d,%d) = %v, want %v", tc.desc, tc.prev, tc.next, got, tc.want)
+		}
+	}
+}
+
+// TestMatchesRecovery covers the recovery half: a transition back to Up
+// fires only if prev_severity was at or above the gate.
+func TestMatchesRecovery(t *testing.T) {
+	c := &AlertContact{
+		Active:      true,
+		MinSeverity: eventstore.SeverityDegraded, // 2
+	}
+	cases := []struct {
+		prev, next uint8
+		want       bool
+		desc       string
+	}{
+		{eventstore.SeverityDown, eventstore.SeverityUp, true, "Down→Up: previously paged, now recovered"},
+		{eventstore.SeverityDegraded, eventstore.SeverityUp, true, "Degraded→Up: at-gate recovery fires"},
+		{eventstore.SeverityWarning, eventstore.SeverityUp, false, "Warning→Up: never paged, no recovery to send"},
+		{eventstore.SeverityUp, eventstore.SeverityUp, false, "Up→Up: no transition meaning"},
+	}
+	for _, tc := range cases {
+		got := c.Matches(tc.prev, tc.next, 0)
+		if got != tc.want {
+			t.Errorf("%s: Matches(%d,%d) = %v, want %v", tc.desc, tc.prev, tc.next, got, tc.want)
+		}
+	}
+}
+
+// TestMatchesAllDimensions verifies the AND across all dimensions:
+// a contact must satisfy active, site_filter, and severity gate.
+func TestMatchesAllDimensions(t *testing.T) {
+	c := &AlertContact{
+		Active:      true,
+		SiteFilter:  SiteFilter{SiteIDs: []int64{42}},
+		MinSeverity: eventstore.SeverityDown, // 4
+	}
+	// All dimensions match.
+	if !c.Matches(eventstore.SeverityUp, eventstore.SeverityDown, 42) {
+		t.Error("all dimensions matching should fire")
+	}
+	// Wrong site, severity matches.
+	if c.Matches(eventstore.SeverityUp, eventstore.SeverityDown, 7) {
+		t.Error("wrong site should not fire")
+	}
+	// Right site, severity below gate (and no recovery: prev was below gate too).
+	if c.Matches(eventstore.SeverityUp, eventstore.SeverityWarning, 42) {
+		t.Error("severity below gate should not fire when prev also below")
+	}
+}

--- a/internal/alerting/contacts.go
+++ b/internal/alerting/contacts.go
@@ -108,20 +108,28 @@ func ListActive(ctx context.Context, db *sql.DB) ([]AlertContact, error) {
 // is transport-specific and validating cross-transport changes is
 // brittle); callers who want to switch transport delete and re-create.
 func Update(ctx context.Context, db *sql.DB, id int64, in UpdateInput) (*AlertContact, error) {
-	// Need the current row to validate destination patches against the
-	// existing transport (the only place we know what shape destination
-	// should have).
+	// Validate input fields that don't depend on the existing row first
+	// (fail fast — no DB hit on obviously bad PATCH bodies).
+	if in.Label != nil && *in.Label == "" {
+		return nil, errors.New("alerting: label must not be empty")
+	}
+	if in.MinSeverity != nil {
+		if err := validateSeverity(*in.MinSeverity); err != nil {
+			return nil, err
+		}
+	}
+	if in.MaxPerHour != nil && *in.MaxPerHour < 0 {
+		return nil, errors.New("alerting: max_per_hour must be >= 0")
+	}
+
+	// The destination shape is transport-specific, so we need the
+	// existing row to know what to validate against.
 	current, err := Get(ctx, db, id)
 	if err != nil {
 		return nil, err
 	}
 	if in.Destination != nil {
 		if err := validateDestination(current.Transport, in.Destination); err != nil {
-			return nil, err
-		}
-	}
-	if in.MinSeverity != nil {
-		if err := validateSeverity(*in.MinSeverity); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/alerting/contacts.go
+++ b/internal/alerting/contacts.go
@@ -1,0 +1,349 @@
+package alerting
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Create inserts a new alert contact and returns the persisted record.
+// Unlike webhooks.Create (which returns the one-time raw secret), the
+// destination is supplied by the caller — they already know the
+// credential, so there's nothing to return-once. Subsequent reads
+// expose only DestinationPreview.
+func Create(ctx context.Context, db *sql.DB, in CreateInput) (*AlertContact, error) {
+	if err := validateCreateInput(in); err != nil {
+		return nil, err
+	}
+	active := true
+	if in.Active != nil {
+		active = *in.Active
+	}
+	minSev := uint8(4) // SeverityDown
+	if in.MinSeverity != nil {
+		minSev = *in.MinSeverity
+	}
+	maxPerHour := 60
+	if in.MaxPerHour != nil {
+		maxPerHour = *in.MaxPerHour
+	}
+	preview := destinationPreview(in.Transport, in.Destination)
+	siteFilterJSON, _ := json.Marshal(in.SiteFilter)
+
+	res, err := db.ExecContext(ctx, `
+		INSERT INTO jetmon_alert_contacts
+			(label, active, transport, destination, destination_preview,
+			 site_filter, min_severity, max_per_hour, created_by)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		in.Label, boolToTinyint(active), string(in.Transport), []byte(in.Destination), preview,
+		siteFilterJSON, minSev, maxPerHour, in.CreatedBy,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("alerting: insert contact: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return nil, fmt.Errorf("alerting: last insert id: %w", err)
+	}
+	return Get(ctx, db, id)
+}
+
+// Get returns a single contact by id, or ErrContactNotFound. Does not
+// load the destination credential — use LoadDestination for that.
+func Get(ctx context.Context, db *sql.DB, id int64) (*AlertContact, error) {
+	row := db.QueryRowContext(ctx, selectContactSQL+" WHERE id = ?", id)
+	c, err := scanContactRow(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrContactNotFound
+		}
+		return nil, err
+	}
+	return c, nil
+}
+
+// List returns all contacts ordered by id ASC.
+func List(ctx context.Context, db *sql.DB) ([]AlertContact, error) {
+	rows, err := db.QueryContext(ctx, selectContactSQL+" ORDER BY id ASC")
+	if err != nil {
+		return nil, fmt.Errorf("alerting: list contacts: %w", err)
+	}
+	defer rows.Close()
+	var out []AlertContact
+	for rows.Next() {
+		c, err := scanContactRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *c)
+	}
+	return out, rows.Err()
+}
+
+// ListActive returns only contacts with active=1. Used by the delivery
+// dispatcher; inactive contacts don't get matched against new
+// transitions.
+func ListActive(ctx context.Context, db *sql.DB) ([]AlertContact, error) {
+	rows, err := db.QueryContext(ctx, selectContactSQL+" WHERE active = 1 ORDER BY id ASC")
+	if err != nil {
+		return nil, fmt.Errorf("alerting: list active contacts: %w", err)
+	}
+	defer rows.Close()
+	var out []AlertContact
+	for rows.Next() {
+		c, err := scanContactRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *c)
+	}
+	return out, rows.Err()
+}
+
+// Update applies a partial patch and returns the updated contact. The
+// transport itself cannot be changed via PATCH (the destination shape
+// is transport-specific and validating cross-transport changes is
+// brittle); callers who want to switch transport delete and re-create.
+func Update(ctx context.Context, db *sql.DB, id int64, in UpdateInput) (*AlertContact, error) {
+	// Need the current row to validate destination patches against the
+	// existing transport (the only place we know what shape destination
+	// should have).
+	current, err := Get(ctx, db, id)
+	if err != nil {
+		return nil, err
+	}
+	if in.Destination != nil {
+		if err := validateDestination(current.Transport, in.Destination); err != nil {
+			return nil, err
+		}
+	}
+	if in.MinSeverity != nil {
+		if err := validateSeverity(*in.MinSeverity); err != nil {
+			return nil, err
+		}
+	}
+
+	clauses := []string{}
+	args := []any{}
+	if in.Label != nil {
+		clauses = append(clauses, "label = ?")
+		args = append(args, *in.Label)
+	}
+	if in.Active != nil {
+		clauses = append(clauses, "active = ?")
+		args = append(args, boolToTinyint(*in.Active))
+	}
+	if in.Destination != nil {
+		clauses = append(clauses, "destination = ?", "destination_preview = ?")
+		args = append(args, []byte(in.Destination), destinationPreview(current.Transport, in.Destination))
+	}
+	if in.SiteFilter != nil {
+		b, _ := json.Marshal(*in.SiteFilter)
+		clauses = append(clauses, "site_filter = ?")
+		args = append(args, b)
+	}
+	if in.MinSeverity != nil {
+		clauses = append(clauses, "min_severity = ?")
+		args = append(args, *in.MinSeverity)
+	}
+	if in.MaxPerHour != nil {
+		clauses = append(clauses, "max_per_hour = ?")
+		args = append(args, *in.MaxPerHour)
+	}
+
+	if len(clauses) == 0 {
+		return current, nil
+	}
+
+	args = append(args, id)
+	q := "UPDATE jetmon_alert_contacts SET " + strings.Join(clauses, ", ") + " WHERE id = ?"
+	if _, err := db.ExecContext(ctx, q, args...); err != nil {
+		return nil, fmt.Errorf("alerting: update contact: %w", err)
+	}
+	return Get(ctx, db, id)
+}
+
+// Delete removes an alert contact. Existing rows in
+// jetmon_alert_deliveries are intentionally NOT cascaded — they
+// remain for audit and manual retry, mirroring webhooks.Delete.
+func Delete(ctx context.Context, db *sql.DB, id int64) error {
+	res, err := db.ExecContext(ctx, "DELETE FROM jetmon_alert_contacts WHERE id = ?", id)
+	if err != nil {
+		return fmt.Errorf("alerting: delete contact: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrContactNotFound
+	}
+	return nil
+}
+
+// LoadDestination returns the raw destination JSON for a contact,
+// used by the worker to call the configured Dispatcher. Kept as a
+// separate function (not a field on AlertContact) so the credential
+// can't leak through serialization of the AlertContact struct.
+func LoadDestination(ctx context.Context, db *sql.DB, id int64) (json.RawMessage, error) {
+	var raw []byte
+	err := db.QueryRowContext(ctx,
+		`SELECT destination FROM jetmon_alert_contacts WHERE id = ?`, id,
+	).Scan(&raw)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrContactNotFound
+		}
+		return nil, fmt.Errorf("alerting: load destination: %w", err)
+	}
+	return raw, nil
+}
+
+// validateCreateInput enforces the required-fields contract for Create.
+func validateCreateInput(in CreateInput) error {
+	if in.Label == "" {
+		return errors.New("alerting: label is required")
+	}
+	if !IsValidTransport(string(in.Transport)) {
+		return fmt.Errorf("%w: %q", ErrInvalidTransport, in.Transport)
+	}
+	if err := validateDestination(in.Transport, in.Destination); err != nil {
+		return err
+	}
+	if in.MinSeverity != nil {
+		if err := validateSeverity(*in.MinSeverity); err != nil {
+			return err
+		}
+	}
+	if in.MaxPerHour != nil && *in.MaxPerHour < 0 {
+		return errors.New("alerting: max_per_hour must be >= 0")
+	}
+	return nil
+}
+
+// validateDestination checks that the destination JSON has the shape
+// the transport requires. Validates field presence, not field
+// well-formedness — a malformed Slack webhook URL surfaces as a
+// transport error at delivery time, which is fine because operators
+// can use the send-test endpoint to catch it before real alerts fire.
+func validateDestination(t Transport, dest json.RawMessage) error {
+	if len(dest) == 0 {
+		return errors.New("alerting: destination is required")
+	}
+	switch t {
+	case TransportEmail:
+		var d emailDestination
+		if err := json.Unmarshal(dest, &d); err != nil {
+			return fmt.Errorf("alerting: destination not valid JSON: %w", err)
+		}
+		if d.Address == "" {
+			return errors.New("alerting: email destination requires an address")
+		}
+	case TransportPagerDuty:
+		var d pagerDutyDestination
+		if err := json.Unmarshal(dest, &d); err != nil {
+			return fmt.Errorf("alerting: destination not valid JSON: %w", err)
+		}
+		if d.IntegrationKey == "" {
+			return errors.New("alerting: pagerduty destination requires an integration_key")
+		}
+	case TransportSlack:
+		var d slackDestination
+		if err := json.Unmarshal(dest, &d); err != nil {
+			return fmt.Errorf("alerting: destination not valid JSON: %w", err)
+		}
+		if d.WebhookURL == "" {
+			return errors.New("alerting: slack destination requires a webhook_url")
+		}
+	case TransportTeams:
+		var d teamsDestination
+		if err := json.Unmarshal(dest, &d); err != nil {
+			return fmt.Errorf("alerting: destination not valid JSON: %w", err)
+		}
+		if d.WebhookURL == "" {
+			return errors.New("alerting: teams destination requires a webhook_url")
+		}
+	default:
+		return fmt.Errorf("%w: %q", ErrInvalidTransport, t)
+	}
+	return nil
+}
+
+// validateSeverity rejects severity values outside the eventstore range.
+// Anything 0..4 is accepted; 5+ is reserved per the eventstore comment
+// for future "worse than down" signals but isn't usable as a gate yet.
+func validateSeverity(s uint8) error {
+	if s > 4 {
+		return fmt.Errorf("%w: %d (allowed 0-4)", ErrInvalidSeverity, s)
+	}
+	return nil
+}
+
+// destinationPreview returns the last 4 chars of the credential field
+// for the given transport. Used as a UI hint so operators can identify
+// a contact without exposing the full credential.
+func destinationPreview(t Transport, dest json.RawMessage) string {
+	var s string
+	switch t {
+	case TransportEmail:
+		var d emailDestination
+		_ = json.Unmarshal(dest, &d)
+		s = d.Address
+	case TransportPagerDuty:
+		var d pagerDutyDestination
+		_ = json.Unmarshal(dest, &d)
+		s = d.IntegrationKey
+	case TransportSlack:
+		var d slackDestination
+		_ = json.Unmarshal(dest, &d)
+		s = d.WebhookURL
+	case TransportTeams:
+		var d teamsDestination
+		_ = json.Unmarshal(dest, &d)
+		s = d.WebhookURL
+	}
+	if len(s) <= 4 {
+		return s
+	}
+	return s[len(s)-4:]
+}
+
+// boolToTinyint mirrors the helper in internal/webhooks/webhooks.go.
+func boolToTinyint(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+const selectContactSQL = `
+	SELECT id, label, active, transport, destination_preview,
+	       site_filter, min_severity, max_per_hour,
+	       created_by, created_at, updated_at
+	  FROM jetmon_alert_contacts`
+
+type rowScanner interface {
+	Scan(...any) error
+}
+
+func scanContactRow(s rowScanner) (*AlertContact, error) {
+	var (
+		c              AlertContact
+		active         uint8
+		transport      string
+		siteFilterJSON sql.NullString
+	)
+	if err := s.Scan(
+		&c.ID, &c.Label, &active, &transport, &c.DestinationPreview,
+		&siteFilterJSON, &c.MinSeverity, &c.MaxPerHour,
+		&c.CreatedBy, &c.CreatedAt, &c.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	c.Active = active == 1
+	c.Transport = Transport(transport)
+	if siteFilterJSON.Valid && siteFilterJSON.String != "" {
+		_ = json.Unmarshal([]byte(siteFilterJSON.String), &c.SiteFilter)
+	}
+	return &c, nil
+}

--- a/internal/alerting/deliveries.go
+++ b/internal/alerting/deliveries.go
@@ -65,9 +65,32 @@ func Enqueue(ctx context.Context, db *sql.DB, in EnqueueInput) (int64, error) {
 	return id, nil
 }
 
+// claimLockDuration is how far ClaimReady pushes next_attempt_at out
+// when it claims a row. Must outlast the worker's per-delivery wall
+// clock so an in-flight goroutine has time to write its real result
+// before the soft lock would expire. The default DispatchTimeout is
+// 30s with a 5s buffer; 60s gives comfortable headroom. A crashed
+// goroutine that never updates the row recovers naturally when the
+// lock expires.
+const claimLockDuration = 60 * time.Second
+
 // ClaimReady returns up to limit pending deliveries whose
-// next_attempt_at is in the past. Same multi-instance caveat as the
-// webhooks claim — see internal/webhooks/deliveries.go for context.
+// next_attempt_at is in the past. Each claimed row is soft-locked by
+// pushing next_attempt_at to NOW + claimLockDuration so subsequent
+// ticks don't re-claim a row whose dispatch is still in-flight. The
+// dispatch goroutine overwrites next_attempt_at with its real value
+// when it finishes.
+//
+// Without the soft lock, the deliver loop's 1-second tick re-claims
+// any in-flight row up to the per-contact cap, producing concurrent
+// dispatches that inflate the attempt counter and effectively skip
+// retry-schedule steps. The soft lock prevents that.
+//
+// Multi-instance caveat: same as webhooks — two instances polling
+// simultaneously could both pick up a row in the SELECT phase, with
+// only the UPDATE differentiating winners. For multi-instance the
+// claim should move to SELECT ... FOR UPDATE SKIP LOCKED in a
+// transaction. Tracked alongside the deliverer-binary extraction.
 func ClaimReady(ctx context.Context, db *sql.DB, limit int) ([]Delivery, error) {
 	rows, err := db.QueryContext(ctx, `
 		SELECT id, alert_contact_id, transition_id, event_id, event_type, severity, payload,
@@ -81,16 +104,36 @@ func ClaimReady(ctx context.Context, db *sql.DB, limit int) ([]Delivery, error) 
 	if err != nil {
 		return nil, fmt.Errorf("alerting: claim ready: %w", err)
 	}
-	defer rows.Close()
-	var out []Delivery
+	var candidates []Delivery
 	for rows.Next() {
 		d, err := scanDeliveryRow(rows)
 		if err != nil {
+			rows.Close()
 			return nil, err
 		}
-		out = append(out, *d)
+		candidates = append(candidates, *d)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, err
+	}
+	rows.Close()
+
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	lockUntil := time.Now().Add(claimLockDuration).UTC()
+	for i := range candidates {
+		if _, err := db.ExecContext(ctx, `
+			UPDATE jetmon_alert_deliveries
+			   SET next_attempt_at = ?
+			 WHERE id = ? AND status = 'pending'`,
+			lockUntil, candidates[i].ID); err != nil {
+			return nil, fmt.Errorf("alerting: soft-lock row %d: %w", candidates[i].ID, err)
+		}
+	}
+	return candidates, nil
 }
 
 // MarkDelivered records a successful delivery.

--- a/internal/alerting/deliveries.go
+++ b/internal/alerting/deliveries.go
@@ -1,0 +1,298 @@
+package alerting
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Delivery is the in-memory shape of a jetmon_alert_deliveries row.
+type Delivery struct {
+	ID             int64
+	AlertContactID int64
+	TransitionID   int64
+	EventID        int64
+	EventType      string
+	Severity       uint8
+	Payload        json.RawMessage
+	Status         Status
+	Attempt        int
+	NextAttemptAt  *time.Time
+	LastStatusCode *int
+	LastResponse   *string
+	LastAttemptAt  *time.Time
+	DeliveredAt    *time.Time
+	CreatedAt      time.Time
+}
+
+// EnqueueInput carries everything needed to insert a delivery row.
+type EnqueueInput struct {
+	AlertContactID int64
+	TransitionID   int64
+	EventID        int64
+	EventType      string
+	Severity       uint8
+	Payload        json.RawMessage
+}
+
+// Enqueue inserts a pending delivery with attempt=0 and
+// next_attempt_at=now. Uses INSERT IGNORE against the
+// (alert_contact_id, transition_id) UNIQUE KEY so concurrent
+// dispatchers don't create duplicate deliveries. Returns the new id,
+// or 0 if the row was a duplicate.
+func Enqueue(ctx context.Context, db *sql.DB, in EnqueueInput) (int64, error) {
+	res, err := db.ExecContext(ctx, `
+		INSERT IGNORE INTO jetmon_alert_deliveries
+			(alert_contact_id, transition_id, event_id, event_type, severity,
+			 payload, status, attempt, next_attempt_at)
+		VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, CURRENT_TIMESTAMP)`,
+		in.AlertContactID, in.TransitionID, in.EventID, in.EventType, in.Severity,
+		[]byte(in.Payload),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("alerting: enqueue delivery: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("alerting: last insert id: %w", err)
+	}
+	if affected, _ := res.RowsAffected(); affected == 0 {
+		return 0, nil
+	}
+	return id, nil
+}
+
+// ClaimReady returns up to limit pending deliveries whose
+// next_attempt_at is in the past. Same multi-instance caveat as the
+// webhooks claim — see internal/webhooks/deliveries.go for context.
+func ClaimReady(ctx context.Context, db *sql.DB, limit int) ([]Delivery, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT id, alert_contact_id, transition_id, event_id, event_type, severity, payload,
+		       status, attempt, next_attempt_at, last_status_code, last_response,
+		       last_attempt_at, delivered_at, created_at
+		  FROM jetmon_alert_deliveries
+		 WHERE status = 'pending'
+		   AND (next_attempt_at IS NULL OR next_attempt_at <= CURRENT_TIMESTAMP)
+		 ORDER BY next_attempt_at ASC
+		 LIMIT ?`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("alerting: claim ready: %w", err)
+	}
+	defer rows.Close()
+	var out []Delivery
+	for rows.Next() {
+		d, err := scanDeliveryRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *d)
+	}
+	return out, rows.Err()
+}
+
+// MarkDelivered records a successful delivery.
+func MarkDelivered(ctx context.Context, db *sql.DB, id int64, statusCode int, responseBody string) error {
+	_, err := db.ExecContext(ctx, `
+		UPDATE jetmon_alert_deliveries
+		   SET status = 'delivered',
+		       last_status_code = ?,
+		       last_response = ?,
+		       last_attempt_at = CURRENT_TIMESTAMP,
+		       delivered_at = CURRENT_TIMESTAMP,
+		       attempt = attempt + 1,
+		       next_attempt_at = NULL
+		 WHERE id = ?`,
+		statusCode, truncate(responseBody, 2048), id)
+	if err != nil {
+		return fmt.Errorf("alerting: mark delivered: %w", err)
+	}
+	return nil
+}
+
+// MarkSuppressed records a delivery that was dropped by the per-contact
+// rate cap. The delivery never went out and is terminal — there's no
+// useful retry because by the time the cap re-opens, the alert is
+// stale. Status='abandoned' with a distinguishing last_response so
+// operators can see why.
+func MarkSuppressed(ctx context.Context, db *sql.DB, id int64, reason string) error {
+	_, err := db.ExecContext(ctx, `
+		UPDATE jetmon_alert_deliveries
+		   SET status = 'abandoned',
+		       last_status_code = 429,
+		       last_response = ?,
+		       last_attempt_at = CURRENT_TIMESTAMP,
+		       attempt = attempt + 1,
+		       next_attempt_at = NULL
+		 WHERE id = ?`, truncate(reason, 2048), id)
+	if err != nil {
+		return fmt.Errorf("alerting: mark suppressed: %w", err)
+	}
+	return nil
+}
+
+// ScheduleRetry bumps the attempt counter and sets next_attempt_at
+// per the retry schedule. abandon=true marks the row terminal instead.
+func ScheduleRetry(ctx context.Context, db *sql.DB, id int64, statusCode int, responseBody string, nextAttempt time.Time, abandon bool) error {
+	if abandon {
+		_, err := db.ExecContext(ctx, `
+			UPDATE jetmon_alert_deliveries
+			   SET status = 'abandoned',
+			       last_status_code = ?,
+			       last_response = ?,
+			       last_attempt_at = CURRENT_TIMESTAMP,
+			       attempt = attempt + 1,
+			       next_attempt_at = NULL
+			 WHERE id = ?`,
+			statusCode, truncate(responseBody, 2048), id)
+		if err != nil {
+			return fmt.Errorf("alerting: abandon: %w", err)
+		}
+		return nil
+	}
+	_, err := db.ExecContext(ctx, `
+		UPDATE jetmon_alert_deliveries
+		   SET last_status_code = ?,
+		       last_response = ?,
+		       last_attempt_at = CURRENT_TIMESTAMP,
+		       attempt = attempt + 1,
+		       next_attempt_at = ?
+		 WHERE id = ?`,
+		statusCode, truncate(responseBody, 2048), nextAttempt.UTC(), id)
+	if err != nil {
+		return fmt.Errorf("alerting: schedule retry: %w", err)
+	}
+	return nil
+}
+
+// GetDelivery returns a single delivery row by id.
+func GetDelivery(ctx context.Context, db *sql.DB, id int64) (*Delivery, error) {
+	row := db.QueryRowContext(ctx, `
+		SELECT id, alert_contact_id, transition_id, event_id, event_type, severity, payload,
+		       status, attempt, next_attempt_at, last_status_code, last_response,
+		       last_attempt_at, delivered_at, created_at
+		  FROM jetmon_alert_deliveries
+		 WHERE id = ?`, id)
+	d, err := scanDeliveryRow(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrDeliveryNotFound
+		}
+		return nil, err
+	}
+	return d, nil
+}
+
+// ListDeliveries returns deliveries for a contact, optionally filtered
+// by status, ordered by id DESC. Cursor-paginated on id.
+func ListDeliveries(ctx context.Context, db *sql.DB, contactID int64, status Status, cursorID int64, limit int) ([]Delivery, error) {
+	args := []any{contactID}
+	q := `
+		SELECT id, alert_contact_id, transition_id, event_id, event_type, severity, payload,
+		       status, attempt, next_attempt_at, last_status_code, last_response,
+		       last_attempt_at, delivered_at, created_at
+		  FROM jetmon_alert_deliveries
+		 WHERE alert_contact_id = ?`
+	if status != "" {
+		q += " AND status = ?"
+		args = append(args, string(status))
+	}
+	if cursorID > 0 {
+		q += " AND id < ?"
+		args = append(args, cursorID)
+	}
+	q += " ORDER BY id DESC LIMIT ?"
+	args = append(args, limit)
+
+	rows, err := db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("alerting: list deliveries: %w", err)
+	}
+	defer rows.Close()
+	var out []Delivery
+	for rows.Next() {
+		d, err := scanDeliveryRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *d)
+	}
+	return out, rows.Err()
+}
+
+// RetryDelivery resets an abandoned delivery to pending so the worker
+// picks it up on the next tick. Mirrors webhooks.RetryDelivery — only
+// abandoned deliveries can be retried.
+func RetryDelivery(ctx context.Context, db *sql.DB, id int64) error {
+	res, err := db.ExecContext(ctx, `
+		UPDATE jetmon_alert_deliveries
+		   SET status = 'pending',
+		       attempt = 0,
+		       next_attempt_at = CURRENT_TIMESTAMP,
+		       last_status_code = NULL,
+		       last_response = NULL,
+		       last_attempt_at = NULL
+		 WHERE id = ? AND status = 'abandoned'`, id)
+	if err != nil {
+		return fmt.Errorf("alerting: retry delivery: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		d, getErr := GetDelivery(ctx, db, id)
+		if getErr != nil {
+			return getErr
+		}
+		return fmt.Errorf("alerting: delivery %d is %s, only abandoned deliveries can be retried", id, d.Status)
+	}
+	return nil
+}
+
+func scanDeliveryRow(s rowScanner) (*Delivery, error) {
+	var (
+		d              Delivery
+		payload        sql.NullString
+		nextAttemptAt  sql.NullTime
+		lastStatusCode sql.NullInt64
+		lastResponse   sql.NullString
+		lastAttemptAt  sql.NullTime
+		deliveredAt    sql.NullTime
+		statusStr      string
+	)
+	if err := s.Scan(
+		&d.ID, &d.AlertContactID, &d.TransitionID, &d.EventID, &d.EventType, &d.Severity,
+		&payload, &statusStr, &d.Attempt, &nextAttemptAt, &lastStatusCode, &lastResponse,
+		&lastAttemptAt, &deliveredAt, &d.CreatedAt,
+	); err != nil {
+		return nil, err
+	}
+	d.Status = Status(statusStr)
+	if payload.Valid {
+		d.Payload = json.RawMessage(payload.String)
+	}
+	if nextAttemptAt.Valid {
+		d.NextAttemptAt = &nextAttemptAt.Time
+	}
+	if lastStatusCode.Valid {
+		v := int(lastStatusCode.Int64)
+		d.LastStatusCode = &v
+	}
+	if lastResponse.Valid {
+		d.LastResponse = &lastResponse.String
+	}
+	if lastAttemptAt.Valid {
+		d.LastAttemptAt = &lastAttemptAt.Time
+	}
+	if deliveredAt.Valid {
+		d.DeliveredAt = &deliveredAt.Time
+	}
+	return &d, nil
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max]
+}

--- a/internal/alerting/deliveries_test.go
+++ b/internal/alerting/deliveries_test.go
@@ -1,0 +1,86 @@
+package alerting
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+const selectClaimReadySQL = ` SELECT id, alert_contact_id, transition_id, event_id, event_type, severity, payload, status, attempt, next_attempt_at, last_status_code, last_response, last_attempt_at, delivered_at, created_at FROM jetmon_alert_deliveries WHERE status = 'pending' AND (next_attempt_at IS NULL OR next_attempt_at <= CURRENT_TIMESTAMP) ORDER BY next_attempt_at ASC LIMIT ?`
+
+const softLockClaimedSQL = ` UPDATE jetmon_alert_deliveries SET next_attempt_at = ? WHERE id = ? AND status = 'pending'`
+
+var columnsClaimedDelivery = []string{
+	"id", "alert_contact_id", "transition_id", "event_id", "event_type", "severity",
+	"payload", "status", "attempt", "next_attempt_at", "last_status_code", "last_response",
+	"last_attempt_at", "delivered_at", "created_at",
+}
+
+// TestClaimReadySoftLocksEachRow verifies the contract that ClaimReady
+// follows its SELECT with one UPDATE per claimed row, pushing
+// next_attempt_at out so subsequent ticks won't re-claim the still-
+// in-flight row. Without this, the deliver loop's 1s tick re-claims
+// pending rows and produces concurrent dispatches that inflate the
+// attempt counter (the bug that motivated the soft lock).
+func TestClaimReadySoftLocksEachRow(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	now := time.Now().UTC()
+	rows := sqlmock.NewRows(columnsClaimedDelivery).
+		AddRow(int64(1), int64(11), int64(100), int64(900), "alert.opened", uint8(4),
+			[]byte(`{}`), "pending", 0, now, nil, nil, nil, nil, now).
+		AddRow(int64(2), int64(11), int64(101), int64(901), "alert.opened", uint8(4),
+			[]byte(`{}`), "pending", 0, now, nil, nil, nil, nil, now)
+
+	mock.ExpectQuery(selectClaimReadySQL).WithArgs(50).WillReturnRows(rows)
+
+	// Each candidate gets a soft-lock UPDATE.
+	mock.ExpectExec(softLockClaimedSQL).
+		WithArgs(sqlmock.AnyArg(), int64(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(softLockClaimedSQL).
+		WithArgs(sqlmock.AnyArg(), int64(2)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	out, err := ClaimReady(context.Background(), db, 50)
+	if err != nil {
+		t.Fatalf("ClaimReady: %v", err)
+	}
+	if len(out) != 2 {
+		t.Errorf("got %d claimed, want 2", len(out))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("expectations: %v", err)
+	}
+}
+
+// TestClaimReadyNoCandidatesSkipsLockUpdates verifies that when the
+// SELECT returns nothing, ClaimReady issues no UPDATEs (no extra DB
+// traffic on idle ticks).
+func TestClaimReadyNoCandidatesSkipsLockUpdates(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(selectClaimReadySQL).WithArgs(50).
+		WillReturnRows(sqlmock.NewRows(columnsClaimedDelivery))
+
+	out, err := ClaimReady(context.Background(), db, 50)
+	if err != nil {
+		t.Fatalf("ClaimReady: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("got %d claimed, want 0", len(out))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("expectations: %v", err)
+	}
+}

--- a/internal/alerting/email.go
+++ b/internal/alerting/email.go
@@ -1,0 +1,324 @@
+package alerting
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/smtp"
+	"strings"
+	"sync"
+	"time"
+)
+
+// EmailMessage is the rendered email handed to a Sender. It's
+// transport-agnostic — the Sender translates it into whatever the
+// underlying channel needs (HTTP POST body for WPCOM, MIME for SMTP,
+// log line for stub).
+type EmailMessage struct {
+	From      string
+	To        string
+	Subject   string
+	PlainBody string
+	HTMLBody  string
+}
+
+// Sender abstracts the actual email-sending mechanism. Concrete impls
+// in this file: WPCOMSender (production), SMTPSender (dev / staging),
+// StubSender (unit tests).
+//
+// Send returns an error if the email could not be delivered. The
+// returned error string is recorded in jetmon_alert_deliveries for
+// debugging — keep it short and useful, not a stack trace.
+type Sender interface {
+	Send(ctx context.Context, msg EmailMessage) error
+}
+
+// emailDispatcher implements alerting.Dispatcher by translating a
+// Notification into an EmailMessage and delegating to a Sender. The
+// rendering lives here (not in the Sender) so swapping transports
+// doesn't require re-implementing the subject/body logic.
+type emailDispatcher struct {
+	sender Sender
+	from   string
+}
+
+// NewEmailDispatcher returns a Dispatcher that renders Notifications
+// into emails and delivers them via the given Sender. The from address
+// becomes the EmailMessage.From for every dispatched message.
+func NewEmailDispatcher(sender Sender, from string) Dispatcher {
+	return &emailDispatcher{sender: sender, from: from}
+}
+
+// emailDestination is the contact's destination JSON shape for email.
+type emailDestination struct {
+	Address string `json:"address"`
+}
+
+// Send renders the Notification into an EmailMessage and hands it to
+// the configured Sender. Returns SMTP-style status codes for symmetry
+// with the HTTP-based transports: 250 on success, 5xx on failure.
+func (d *emailDispatcher) Send(ctx context.Context, destination json.RawMessage, n Notification) (int, string, error) {
+	var dest emailDestination
+	if err := json.Unmarshal(destination, &dest); err != nil {
+		return 550, "invalid destination JSON", fmt.Errorf("parse email destination: %w", err)
+	}
+	if dest.Address == "" {
+		return 550, "destination missing address", errors.New("alerting/email: destination missing address")
+	}
+
+	msg := EmailMessage{
+		From:      d.from,
+		To:        dest.Address,
+		Subject:   renderEmailSubject(n),
+		PlainBody: renderEmailPlain(n),
+		HTMLBody:  renderEmailHTML(n),
+	}
+
+	if err := d.sender.Send(ctx, msg); err != nil {
+		// Cap the error message at last_response's column width.
+		summary := err.Error()
+		if len(summary) > 2048 {
+			summary = summary[:2048]
+		}
+		return 554, summary, err
+	}
+	return 250, "delivered", nil
+}
+
+// renderEmailSubject is short enough to fit in mobile notification
+// previews. Severity name and site URL are the most-relevant info at
+// a glance; recovery and test prefixes are explicit.
+func renderEmailSubject(n Notification) string {
+	switch {
+	case n.IsTest:
+		return fmt.Sprintf("[Jetmon test] %s", n.SiteURL)
+	case n.Recovery:
+		return fmt.Sprintf("[Recovered] %s", n.SiteURL)
+	default:
+		return fmt.Sprintf("[%s] %s", n.SeverityName, n.SiteURL)
+	}
+}
+
+// renderEmailPlain is the plain-text body. Same fields as the HTML
+// version; consumers receiving multipart see whichever their client
+// prefers. The plain body is also the fallback for email clients
+// that strip HTML.
+func renderEmailPlain(n Notification) string {
+	var b strings.Builder
+	if n.IsTest {
+		b.WriteString("*** Jetmon test notification ***\n\n")
+	}
+	if n.Recovery {
+		b.WriteString("Recovery: site is back to Up.\n\n")
+	}
+	fmt.Fprintf(&b, "Site: %s (id %d)\n", n.SiteURL, n.SiteID)
+	fmt.Fprintf(&b, "Severity: %s\n", n.SeverityName)
+	if n.State != "" {
+		fmt.Fprintf(&b, "State: %s\n", n.State)
+	}
+	fmt.Fprintf(&b, "Event: #%d (%s)\n", n.EventID, n.EventType)
+	if n.Reason != "" {
+		fmt.Fprintf(&b, "Reason: %s\n", n.Reason)
+	}
+	fmt.Fprintf(&b, "Time: %s\n", n.Timestamp.UTC().Format(time.RFC3339))
+	return b.String()
+}
+
+// renderEmailHTML mirrors the plain body in a minimal HTML wrapper.
+// No external CSS or images — keeps the payload small and renders
+// the same in every client.
+func renderEmailHTML(n Notification) string {
+	var b strings.Builder
+	b.WriteString("<html><body style=\"font-family:sans-serif;\">")
+	if n.IsTest {
+		b.WriteString("<p><strong>*** Jetmon test notification ***</strong></p>")
+	}
+	if n.Recovery {
+		b.WriteString("<p><strong>Recovery:</strong> site is back to Up.</p>")
+	}
+	b.WriteString("<table cellpadding=\"4\">")
+	fmt.Fprintf(&b, "<tr><td><strong>Site</strong></td><td>%s (id %d)</td></tr>", htmlEscape(n.SiteURL), n.SiteID)
+	fmt.Fprintf(&b, "<tr><td><strong>Severity</strong></td><td>%s</td></tr>", htmlEscape(n.SeverityName))
+	if n.State != "" {
+		fmt.Fprintf(&b, "<tr><td><strong>State</strong></td><td>%s</td></tr>", htmlEscape(n.State))
+	}
+	fmt.Fprintf(&b, "<tr><td><strong>Event</strong></td><td>#%d (%s)</td></tr>", n.EventID, htmlEscape(n.EventType))
+	if n.Reason != "" {
+		fmt.Fprintf(&b, "<tr><td><strong>Reason</strong></td><td>%s</td></tr>", htmlEscape(n.Reason))
+	}
+	fmt.Fprintf(&b, "<tr><td><strong>Time</strong></td><td>%s</td></tr>", n.Timestamp.UTC().Format(time.RFC3339))
+	b.WriteString("</table></body></html>")
+	return b.String()
+}
+
+func htmlEscape(s string) string {
+	r := strings.NewReplacer(
+		"&", "&amp;",
+		"<", "&lt;",
+		">", "&gt;",
+		"\"", "&quot;",
+		"'", "&#39;",
+	)
+	return r.Replace(s)
+}
+
+// StubSender records every message in memory and (by default) also
+// logs a one-line summary to stdout. Used by unit tests and by
+// EMAIL_TRANSPORT="stub" in environments where a real send is not
+// configured. Never returns an error.
+type StubSender struct {
+	Logger func(EmailMessage) // optional; defaults to log.Printf
+
+	mu   sync.Mutex
+	sent []EmailMessage
+}
+
+// Send records the message and (optionally) logs a summary.
+func (s *StubSender) Send(_ context.Context, m EmailMessage) error {
+	s.mu.Lock()
+	s.sent = append(s.sent, m)
+	s.mu.Unlock()
+	if s.Logger != nil {
+		s.Logger(m)
+	} else {
+		log.Printf("alerting/email: stub send From=%s To=%s Subject=%q", m.From, m.To, m.Subject)
+	}
+	return nil
+}
+
+// Sent returns a snapshot of every message recorded so far. Used by
+// tests to assert against rendered output.
+func (s *StubSender) Sent() []EmailMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]EmailMessage, len(s.sent))
+	copy(out, s.sent)
+	return out
+}
+
+// Reset clears the sent buffer. Useful between test cases.
+func (s *StubSender) Reset() {
+	s.mu.Lock()
+	s.sent = nil
+	s.mu.Unlock()
+}
+
+// SMTPSender connects to an SMTP server and sends multipart emails.
+// Uses Go's stdlib net/smtp; doesn't take a per-call context (smtp
+// package predates context). The worker bounds runtime via its own
+// timeouts; an SMTP send that hangs blocks the worker goroutine until
+// the underlying socket times out (typically 5–10 minutes on Linux).
+//
+// For dev/staging only — production uses WPCOMSender. STARTTLS is
+// optional; AUTH PLAIN is used when Username is non-empty.
+type SMTPSender struct {
+	Host     string
+	Port     int
+	Username string // optional; if empty, no AUTH is performed
+	Password string
+	UseTLS   bool // controls whether AUTH PLAIN is sent (auth on plaintext SMTP is rejected by net/smtp without UseTLS)
+}
+
+// Send delivers msg via SMTP. The MIME body is multipart/alternative
+// with both plain and HTML parts.
+func (s *SMTPSender) Send(_ context.Context, m EmailMessage) error {
+	addr := fmt.Sprintf("%s:%d", s.Host, s.Port)
+	body := buildMIMEMessage(m)
+	var auth smtp.Auth
+	if s.Username != "" && s.UseTLS {
+		auth = smtp.PlainAuth("", s.Username, s.Password, s.Host)
+	}
+	if err := smtp.SendMail(addr, auth, m.From, []string{m.To}, []byte(body)); err != nil {
+		return fmt.Errorf("alerting/email/smtp: send to %s: %w", addr, err)
+	}
+	return nil
+}
+
+// buildMIMEMessage produces a multipart/alternative MIME body with
+// both plain-text and HTML parts. Boundary is fixed; the message is
+// short and self-contained, so collisions are not a concern.
+func buildMIMEMessage(m EmailMessage) string {
+	const boundary = "JetmonAlertBoundary_4d8f31a2"
+	var b strings.Builder
+	fmt.Fprintf(&b, "From: %s\r\n", m.From)
+	fmt.Fprintf(&b, "To: %s\r\n", m.To)
+	fmt.Fprintf(&b, "Subject: %s\r\n", m.Subject)
+	b.WriteString("MIME-Version: 1.0\r\n")
+	fmt.Fprintf(&b, "Content-Type: multipart/alternative; boundary=%q\r\n\r\n", boundary)
+
+	fmt.Fprintf(&b, "--%s\r\n", boundary)
+	b.WriteString("Content-Type: text/plain; charset=\"UTF-8\"\r\n\r\n")
+	b.WriteString(m.PlainBody)
+	b.WriteString("\r\n")
+
+	fmt.Fprintf(&b, "--%s\r\n", boundary)
+	b.WriteString("Content-Type: text/html; charset=\"UTF-8\"\r\n\r\n")
+	b.WriteString(m.HTMLBody)
+	b.WriteString("\r\n")
+
+	fmt.Fprintf(&b, "--%s--\r\n", boundary)
+	return b.String()
+}
+
+// WPCOMSender posts to a WPCOM-owned email API endpoint with a Bearer
+// token. Same shape as the existing internal/wpcom client — Bearer
+// auth, JSON body, 4xx/5xx → error. Body shape is intentionally
+// generic; the production endpoint can adapt or we wrap the body in
+// whatever shape they require.
+type WPCOMSender struct {
+	Endpoint   string
+	AuthToken  string
+	HTTPClient *http.Client // if nil, a default with a 10s timeout is used
+}
+
+// wpcomEmailRequest is the JSON body posted to the WPCOM email API.
+type wpcomEmailRequest struct {
+	From      string `json:"from"`
+	To        string `json:"to"`
+	Subject   string `json:"subject"`
+	PlainBody string `json:"plain"`
+	HTMLBody  string `json:"html"`
+}
+
+// Send POSTs the message to the configured endpoint.
+func (s *WPCOMSender) Send(ctx context.Context, m EmailMessage) error {
+	if s.Endpoint == "" {
+		return errors.New("alerting/email/wpcom: endpoint not configured")
+	}
+	body, err := json.Marshal(wpcomEmailRequest{
+		From: m.From, To: m.To, Subject: m.Subject,
+		PlainBody: m.PlainBody, HTMLBody: m.HTMLBody,
+	})
+	if err != nil {
+		return fmt.Errorf("alerting/email/wpcom: marshal: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.Endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("alerting/email/wpcom: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if s.AuthToken != "" {
+		req.Header.Set("Authorization", "Bearer "+s.AuthToken)
+	}
+
+	client := s.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("alerting/email/wpcom: post: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("alerting/email/wpcom: status %d: %s", resp.StatusCode, respBody)
+	}
+	return nil
+}

--- a/internal/alerting/email.go
+++ b/internal/alerting/email.go
@@ -92,16 +92,28 @@ func (d *emailDispatcher) Send(ctx context.Context, destination json.RawMessage,
 
 // renderEmailSubject is short enough to fit in mobile notification
 // previews. Severity name and site URL are the most-relevant info at
-// a glance; recovery and test prefixes are explicit.
+// a glance; recovery and test prefixes are explicit. Strips CRLF
+// from the URL to prevent MIME header injection — the URL is
+// operator-controlled (jetpack_monitor_sites.monitor_url) but the
+// column doesn't enforce CRLF-free, so defense-in-depth lives here.
 func renderEmailSubject(n Notification) string {
+	url := stripCRLF(n.SiteURL)
 	switch {
 	case n.IsTest:
-		return fmt.Sprintf("[Jetmon test] %s", n.SiteURL)
+		return fmt.Sprintf("[Jetmon test] %s", url)
 	case n.Recovery:
-		return fmt.Sprintf("[Recovered] %s", n.SiteURL)
+		return fmt.Sprintf("[Recovered] %s", url)
 	default:
-		return fmt.Sprintf("[%s] %s", n.SeverityName, n.SiteURL)
+		return fmt.Sprintf("[%s] %s", stripCRLF(n.SeverityName), url)
 	}
+}
+
+// stripCRLF removes carriage return and newline characters. Used on
+// any field that becomes part of a MIME header (Subject, From, To)
+// to prevent header injection via untrusted strings.
+func stripCRLF(s string) string {
+	r := strings.NewReplacer("\r", "", "\n", "")
+	return r.Replace(s)
 }
 
 // renderEmailPlain is the plain-text body. Same fields as the HTML
@@ -242,12 +254,16 @@ func (s *SMTPSender) Send(_ context.Context, m EmailMessage) error {
 // buildMIMEMessage produces a multipart/alternative MIME body with
 // both plain-text and HTML parts. Boundary is fixed; the message is
 // short and self-contained, so collisions are not a concern.
+//
+// CRLF is stripped from From/To/Subject to prevent header injection.
+// The body parts are content, not headers — CRLF inside them is
+// expected and handled by the MIME boundary structure.
 func buildMIMEMessage(m EmailMessage) string {
 	const boundary = "JetmonAlertBoundary_4d8f31a2"
 	var b strings.Builder
-	fmt.Fprintf(&b, "From: %s\r\n", m.From)
-	fmt.Fprintf(&b, "To: %s\r\n", m.To)
-	fmt.Fprintf(&b, "Subject: %s\r\n", m.Subject)
+	fmt.Fprintf(&b, "From: %s\r\n", stripCRLF(m.From))
+	fmt.Fprintf(&b, "To: %s\r\n", stripCRLF(m.To))
+	fmt.Fprintf(&b, "Subject: %s\r\n", stripCRLF(m.Subject))
 	b.WriteString("MIME-Version: 1.0\r\n")
 	fmt.Fprintf(&b, "Content-Type: multipart/alternative; boundary=%q\r\n\r\n", boundary)
 

--- a/internal/alerting/email_test.go
+++ b/internal/alerting/email_test.go
@@ -163,6 +163,51 @@ func TestEmailDispatcherRejectsBadDestination(t *testing.T) {
 	}
 }
 
+// TestRenderEmailSubjectStripsCRLF verifies that CRLF in untrusted
+// fields (site URL is operator-controlled but the DB column doesn't
+// enforce CRLF-free) doesn't leak into the Subject header. Defense-
+// in-depth against MIME header injection.
+func TestRenderEmailSubjectStripsCRLF(t *testing.T) {
+	n := makeTestNotification()
+	n.SiteURL = "https://example.com\r\nBcc: attacker@evil.com"
+	got := renderEmailSubject(n)
+	if strings.ContainsAny(got, "\r\n") {
+		t.Errorf("subject contains CRLF: %q", got)
+	}
+	if !strings.Contains(got, "https://example.com") {
+		t.Errorf("subject lost the legitimate URL portion: %q", got)
+	}
+}
+
+func TestBuildMIMEMessageStripsHeaderCRLF(t *testing.T) {
+	mime := buildMIMEMessage(EmailMessage{
+		From:      "from@example.com\r\nX-Injected: yes",
+		To:        "to@example.com\r\nBcc: attacker@evil.com",
+		Subject:   "test\r\nX-Header: malicious",
+		PlainBody: "plain\r\nwith\r\nnewlines\r\nis fine in body",
+		HTMLBody:  "<b>html</b>",
+	})
+	// Split headers from body and assert no injected header lines.
+	parts := strings.SplitN(mime, "\r\n\r\n", 2)
+	if len(parts) != 2 {
+		t.Fatalf("MIME missing header/body separator:\n%s", mime)
+	}
+	headers := parts[0]
+	// A successful injection would put the bad token at the start of a
+	// header line (preceded by \r\n). The strip merges the malicious
+	// content into the legitimate header value, but no new header line
+	// should be created.
+	for _, bad := range []string{"\r\nX-Injected:", "\r\nBcc:", "\r\nX-Header:"} {
+		if strings.Contains(headers, bad) {
+			t.Errorf("header injection succeeded with token %q:\n%s", bad, headers)
+		}
+	}
+	// The legitimate body CRLFs should pass through unchanged.
+	if !strings.Contains(parts[1], "plain\r\nwith\r\nnewlines") {
+		t.Errorf("body CRLF was incorrectly stripped:\n%s", parts[1])
+	}
+}
+
 func TestBuildMIMEMessageHasBothParts(t *testing.T) {
 	mime := buildMIMEMessage(EmailMessage{
 		From:      "from@example.com",

--- a/internal/alerting/email_test.go
+++ b/internal/alerting/email_test.go
@@ -1,0 +1,279 @@
+package alerting
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Automattic/jetmon/internal/eventstore"
+)
+
+func makeTestNotification() Notification {
+	return Notification{
+		SiteID:       42,
+		SiteURL:      "https://example.com",
+		EventID:      777,
+		EventType:    "event.opened",
+		Severity:     eventstore.SeverityDown,
+		SeverityName: "Down",
+		State:        "Down",
+		Reason:       "verifier_confirmed",
+		Timestamp:    time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+func TestRenderEmailSubjectVariants(t *testing.T) {
+	cases := []struct {
+		mutate func(*Notification)
+		want   string
+	}{
+		{func(n *Notification) {}, "[Down] https://example.com"},
+		{func(n *Notification) { n.Recovery = true }, "[Recovered] https://example.com"},
+		{func(n *Notification) { n.IsTest = true }, "[Jetmon test] https://example.com"},
+	}
+	for i, tc := range cases {
+		n := makeTestNotification()
+		tc.mutate(&n)
+		got := renderEmailSubject(n)
+		if got != tc.want {
+			t.Errorf("case %d: got %q, want %q", i, got, tc.want)
+		}
+	}
+}
+
+func TestRenderEmailPlainContainsKeyFields(t *testing.T) {
+	n := makeTestNotification()
+	body := renderEmailPlain(n)
+	for _, want := range []string{
+		"https://example.com",
+		"id 42",
+		"Down",
+		"#777",
+		"event.opened",
+		"verifier_confirmed",
+		"2026-04-25T12:00:00Z",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("plain body missing %q\nbody:\n%s", want, body)
+		}
+	}
+}
+
+func TestRenderEmailHTMLEscapesUntrustedFields(t *testing.T) {
+	n := makeTestNotification()
+	n.SiteURL = `<script>alert("x")</script>`
+	n.Reason = `a & b`
+	body := renderEmailHTML(n)
+	// The raw script tag must not appear.
+	if strings.Contains(body, "<script>") {
+		t.Errorf("HTML body contains unescaped <script> tag:\n%s", body)
+	}
+	// The escaped form must appear.
+	if !strings.Contains(body, "&lt;script&gt;") {
+		t.Errorf("HTML body missing escaped <script>:\n%s", body)
+	}
+	if !strings.Contains(body, "a &amp; b") {
+		t.Errorf("HTML body did not escape ampersand:\n%s", body)
+	}
+}
+
+func TestRenderEmailRecoveryBannerPresent(t *testing.T) {
+	n := makeTestNotification()
+	n.Recovery = true
+	if !strings.Contains(renderEmailPlain(n), "Recovery") {
+		t.Error("plain body missing recovery banner")
+	}
+	if !strings.Contains(renderEmailHTML(n), "Recovery") {
+		t.Error("HTML body missing recovery banner")
+	}
+}
+
+func TestRenderEmailTestBannerPresent(t *testing.T) {
+	n := makeTestNotification()
+	n.IsTest = true
+	if !strings.Contains(renderEmailPlain(n), "test notification") {
+		t.Error("plain body missing test banner")
+	}
+	if !strings.Contains(renderEmailHTML(n), "test notification") {
+		t.Error("HTML body missing test banner")
+	}
+}
+
+// TestEmailDispatcherDelegatesToSender verifies the destination is parsed
+// correctly and the rendered fields land in the EmailMessage.
+func TestEmailDispatcherDelegatesToSender(t *testing.T) {
+	stub := &StubSender{Logger: func(EmailMessage) {}} // silence test output
+	d := NewEmailDispatcher(stub, "from@example.com")
+
+	dest := json.RawMessage(`{"address":"ops@example.com"}`)
+	n := makeTestNotification()
+
+	status, _, err := d.Send(context.Background(), dest, n)
+	if err != nil {
+		t.Fatalf("Send returned error: %v", err)
+	}
+	if status != 250 {
+		t.Errorf("status = %d, want 250", status)
+	}
+
+	sent := stub.Sent()
+	if len(sent) != 1 {
+		t.Fatalf("got %d messages, want 1", len(sent))
+	}
+	m := sent[0]
+	if m.From != "from@example.com" {
+		t.Errorf("From = %q", m.From)
+	}
+	if m.To != "ops@example.com" {
+		t.Errorf("To = %q", m.To)
+	}
+	if !strings.Contains(m.Subject, "Down") {
+		t.Errorf("Subject missing severity: %q", m.Subject)
+	}
+	if !strings.Contains(m.PlainBody, "https://example.com") {
+		t.Errorf("PlainBody missing site URL")
+	}
+}
+
+func TestEmailDispatcherRejectsBadDestination(t *testing.T) {
+	stub := &StubSender{Logger: func(EmailMessage) {}}
+	d := NewEmailDispatcher(stub, "from@example.com")
+
+	cases := []json.RawMessage{
+		json.RawMessage(`{}`),
+		json.RawMessage(`{"address":""}`),
+		json.RawMessage(`not json`),
+	}
+	for i, dest := range cases {
+		status, _, err := d.Send(context.Background(), dest, makeTestNotification())
+		if err == nil {
+			t.Errorf("case %d: expected error for destination %s", i, dest)
+		}
+		if status < 500 {
+			t.Errorf("case %d: status = %d, want >=500", i, status)
+		}
+	}
+	if len(stub.Sent()) != 0 {
+		t.Error("StubSender should not have been invoked on bad destination")
+	}
+}
+
+func TestBuildMIMEMessageHasBothParts(t *testing.T) {
+	mime := buildMIMEMessage(EmailMessage{
+		From:      "from@example.com",
+		To:        "to@example.com",
+		Subject:   "test",
+		PlainBody: "plain content",
+		HTMLBody:  "<b>html content</b>",
+	})
+	for _, want := range []string{
+		"From: from@example.com",
+		"To: to@example.com",
+		"Subject: test",
+		"multipart/alternative",
+		"text/plain",
+		"plain content",
+		"text/html",
+		"<b>html content</b>",
+	} {
+		if !strings.Contains(mime, want) {
+			t.Errorf("MIME missing %q", want)
+		}
+	}
+}
+
+func TestWPCOMSenderPostsCorrectly(t *testing.T) {
+	var (
+		gotAuth    string
+		gotCT      string
+		gotBody    wpcomEmailRequest
+		decodeErr  error
+		hits       int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		gotAuth = r.Header.Get("Authorization")
+		gotCT = r.Header.Get("Content-Type")
+		body, _ := io.ReadAll(r.Body)
+		decodeErr = json.Unmarshal(body, &gotBody)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	s := &WPCOMSender{
+		Endpoint:  srv.URL,
+		AuthToken: "TEST_TOKEN",
+	}
+	err := s.Send(context.Background(), EmailMessage{
+		From:      "from@example.com",
+		To:        "ops@example.com",
+		Subject:   "test subject",
+		PlainBody: "plain",
+		HTMLBody:  "<b>html</b>",
+	})
+	if err != nil {
+		t.Fatalf("Send error: %v", err)
+	}
+	if hits != 1 {
+		t.Errorf("hits = %d, want 1", hits)
+	}
+	if gotAuth != "Bearer TEST_TOKEN" {
+		t.Errorf("Authorization = %q", gotAuth)
+	}
+	if gotCT != "application/json" {
+		t.Errorf("Content-Type = %q", gotCT)
+	}
+	if decodeErr != nil {
+		t.Errorf("body decode: %v", decodeErr)
+	}
+	if gotBody.Subject != "test subject" || gotBody.To != "ops@example.com" {
+		t.Errorf("body fields wrong: %+v", gotBody)
+	}
+}
+
+func TestWPCOMSenderSurfacesErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
+	}))
+	defer srv.Close()
+
+	s := &WPCOMSender{Endpoint: srv.URL, AuthToken: "x"}
+	err := s.Send(context.Background(), EmailMessage{
+		From: "f@x", To: "t@x", Subject: "s", PlainBody: "p", HTMLBody: "h",
+	})
+	if err == nil {
+		t.Fatal("expected error on 500")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error should mention status 500: %v", err)
+	}
+}
+
+func TestWPCOMSenderRequiresEndpoint(t *testing.T) {
+	s := &WPCOMSender{}
+	err := s.Send(context.Background(), EmailMessage{})
+	if err == nil {
+		t.Fatal("expected error when endpoint missing")
+	}
+}
+
+func TestStubSenderRecordsAndReset(t *testing.T) {
+	s := &StubSender{Logger: func(EmailMessage) {}}
+	for i := 0; i < 3; i++ {
+		_ = s.Send(context.Background(), EmailMessage{Subject: "n"})
+	}
+	if got := len(s.Sent()); got != 3 {
+		t.Errorf("Sent count = %d, want 3", got)
+	}
+	s.Reset()
+	if got := len(s.Sent()); got != 0 {
+		t.Errorf("after Reset, Sent count = %d, want 0", got)
+	}
+}

--- a/internal/alerting/transports.go
+++ b/internal/alerting/transports.go
@@ -1,0 +1,384 @@
+package alerting
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Automattic/jetmon/internal/eventstore"
+)
+
+// defaultTransportTimeout bounds every outbound HTTP transport call.
+// Short enough that a hung receiver doesn't wedge the worker for long;
+// long enough to absorb normal third-party API latency.
+const defaultTransportTimeout = 10 * time.Second
+
+// httpClientOrDefault returns c if non-nil, otherwise a fresh client
+// with defaultTransportTimeout. Tests inject their own client to
+// point at httptest servers.
+func httpClientOrDefault(c *http.Client) *http.Client {
+	if c != nil {
+		return c
+	}
+	return &http.Client{Timeout: defaultTransportTimeout}
+}
+
+// truncateResponseBody caps a transport response at the
+// jetmon_alert_deliveries.last_response column width. Keeps the
+// most recent bytes since failure messages tend to be at the start
+// but trailing context (e.g. "rate-limit reset at ...") is also
+// useful.
+func truncateResponseBody(s string) string {
+	const cap = 2048
+	if len(s) <= cap {
+		return s
+	}
+	return s[:cap]
+}
+
+// readResponseBody reads up to 4 KB so a misbehaving server can't
+// fill memory on a 200 OK with a giant body.
+func readResponseBody(r io.Reader) string {
+	b, _ := io.ReadAll(io.LimitReader(r, 4096))
+	return string(b)
+}
+
+// ─── PagerDuty ────────────────────────────────────────────────────────
+
+// PagerDutyDispatcher implements Dispatcher for the PagerDuty Events
+// API v2. Each notification becomes an event of action "trigger"
+// (or "resolve" for recoveries) with a stable dedup_key derived from
+// the Jetmon event id, so PagerDuty groups all transitions of the
+// same incident under one alert.
+type PagerDutyDispatcher struct {
+	Endpoint   string       // override for tests; defaults to events.pagerduty.com/v2/enqueue
+	HTTPClient *http.Client // override for tests
+}
+
+// pagerDutyDestination is the contact's destination JSON shape for
+// the pagerduty transport.
+type pagerDutyDestination struct {
+	IntegrationKey string `json:"integration_key"`
+}
+
+// pagerDutyEvent is the Events API v2 request body. See
+// https://developer.pagerduty.com/docs/events-api-v2-overview.
+type pagerDutyEvent struct {
+	RoutingKey  string             `json:"routing_key"`
+	EventAction string             `json:"event_action"` // trigger | resolve
+	DedupKey    string             `json:"dedup_key,omitempty"`
+	Payload     pagerDutyEventBody `json:"payload"`
+}
+
+type pagerDutyEventBody struct {
+	Summary       string                 `json:"summary"`
+	Source        string                 `json:"source"`
+	Severity      string                 `json:"severity"` // critical | error | warning | info
+	CustomDetails map[string]interface{} `json:"custom_details,omitempty"`
+}
+
+// Send delivers n to the PagerDuty Events API v2.
+func (d *PagerDutyDispatcher) Send(ctx context.Context, destination json.RawMessage, n Notification) (int, string, error) {
+	var dest pagerDutyDestination
+	if err := json.Unmarshal(destination, &dest); err != nil {
+		return 0, "invalid destination JSON", fmt.Errorf("alerting/pagerduty: parse destination: %w", err)
+	}
+	if dest.IntegrationKey == "" {
+		return 0, "destination missing integration_key", errors.New("alerting/pagerduty: destination missing integration_key")
+	}
+
+	endpoint := d.Endpoint
+	if endpoint == "" {
+		endpoint = "https://events.pagerduty.com/v2/enqueue"
+	}
+
+	action := "trigger"
+	if n.Recovery {
+		action = "resolve"
+	}
+
+	dedup := fmt.Sprintf("jetmon-event-%d", n.EventID)
+	if n.IsTest {
+		// Test sends use a dedicated dedup key so they don't accidentally
+		// resolve a real alert when a test follows a real trigger.
+		dedup = fmt.Sprintf("jetmon-test-%d-%d", n.SiteID, n.Timestamp.Unix())
+	}
+
+	body := pagerDutyEvent{
+		RoutingKey:  dest.IntegrationKey,
+		EventAction: action,
+		DedupKey:    dedup,
+		Payload: pagerDutyEventBody{
+			Summary:  pagerDutySummary(n),
+			Source:   n.SiteURL,
+			Severity: pagerDutySeverity(n.Severity),
+			CustomDetails: map[string]interface{}{
+				"site_id":    n.SiteID,
+				"event_id":   n.EventID,
+				"event_type": n.EventType,
+				"state":      n.State,
+				"reason":     n.Reason,
+				"is_test":    n.IsTest,
+			},
+		},
+	}
+
+	return postJSON(ctx, httpClientOrDefault(d.HTTPClient), endpoint, body, nil)
+}
+
+// pagerDutySummary is the short string PagerDuty shows in its UI and
+// pager notifications. Subject-line equivalent.
+func pagerDutySummary(n Notification) string {
+	switch {
+	case n.IsTest:
+		return fmt.Sprintf("[Jetmon test] %s", n.SiteURL)
+	case n.Recovery:
+		return fmt.Sprintf("Recovered: %s", n.SiteURL)
+	default:
+		return fmt.Sprintf("%s: %s", n.SeverityName, n.SiteURL)
+	}
+}
+
+// pagerDutySeverity maps Jetmon's severity uint8 to PagerDuty's
+// severity string. Up never fires here (it routes through resolve).
+func pagerDutySeverity(s uint8) string {
+	switch s {
+	case eventstore.SeverityDown, eventstore.SeveritySeemsDown:
+		return "critical"
+	case eventstore.SeverityDegraded:
+		return "warning"
+	case eventstore.SeverityWarning:
+		return "info"
+	default:
+		// Up still gets a value because the events-v2 schema requires it
+		// even on resolve actions; PagerDuty ignores it on resolve.
+		return "info"
+	}
+}
+
+// ─── Slack ────────────────────────────────────────────────────────────
+
+// SlackDispatcher implements Dispatcher for Slack incoming-webhook URLs.
+// Each notification becomes a Block Kit message with site, severity,
+// state, time, and (for recoveries) a green-highlighted recovery banner.
+type SlackDispatcher struct {
+	HTTPClient *http.Client
+}
+
+type slackDestination struct {
+	WebhookURL string `json:"webhook_url"`
+}
+
+// slackMessage is the request body for an incoming-webhook POST. We
+// use blocks (the modern format) rather than text+attachments.
+type slackMessage struct {
+	Text   string       `json:"text"` // fallback for old clients / mobile previews
+	Blocks []slackBlock `json:"blocks"`
+}
+
+type slackBlock struct {
+	Type string                 `json:"type"`
+	Text *slackText             `json:"text,omitempty"`
+	Fields []slackText          `json:"fields,omitempty"`
+}
+
+type slackText struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// Send POSTs a Block Kit message to the destination's webhook URL.
+func (d *SlackDispatcher) Send(ctx context.Context, destination json.RawMessage, n Notification) (int, string, error) {
+	var dest slackDestination
+	if err := json.Unmarshal(destination, &dest); err != nil {
+		return 0, "invalid destination JSON", fmt.Errorf("alerting/slack: parse destination: %w", err)
+	}
+	if dest.WebhookURL == "" {
+		return 0, "destination missing webhook_url", errors.New("alerting/slack: destination missing webhook_url")
+	}
+
+	body := slackMessage{
+		Text:   slackFallbackText(n),
+		Blocks: slackBlocks(n),
+	}
+	return postJSON(ctx, httpClientOrDefault(d.HTTPClient), dest.WebhookURL, body, nil)
+}
+
+func slackFallbackText(n Notification) string {
+	switch {
+	case n.IsTest:
+		return fmt.Sprintf("Jetmon test notification for %s", n.SiteURL)
+	case n.Recovery:
+		return fmt.Sprintf("Jetmon recovery: %s", n.SiteURL)
+	default:
+		return fmt.Sprintf("Jetmon %s alert: %s", n.SeverityName, n.SiteURL)
+	}
+}
+
+func slackBlocks(n Notification) []slackBlock {
+	var headerEmoji string
+	switch {
+	case n.IsTest:
+		headerEmoji = ":mag:"
+	case n.Recovery:
+		headerEmoji = ":white_check_mark:"
+	case n.Severity >= eventstore.SeveritySeemsDown:
+		headerEmoji = ":rotating_light:"
+	default:
+		headerEmoji = ":warning:"
+	}
+	header := fmt.Sprintf("%s *%s* — %s", headerEmoji, n.SeverityName, n.SiteURL)
+	if n.Recovery {
+		header = fmt.Sprintf("%s *Recovered* — %s", headerEmoji, n.SiteURL)
+	}
+	if n.IsTest {
+		header = fmt.Sprintf("%s *Jetmon test* — %s", headerEmoji, n.SiteURL)
+	}
+
+	fields := []slackText{
+		{Type: "mrkdwn", Text: fmt.Sprintf("*Site ID*\n%d", n.SiteID)},
+		{Type: "mrkdwn", Text: fmt.Sprintf("*Event*\n#%d", n.EventID)},
+	}
+	if n.State != "" {
+		fields = append(fields, slackText{Type: "mrkdwn", Text: fmt.Sprintf("*State*\n%s", n.State)})
+	}
+	if n.Reason != "" {
+		fields = append(fields, slackText{Type: "mrkdwn", Text: fmt.Sprintf("*Reason*\n%s", n.Reason)})
+	}
+	fields = append(fields, slackText{Type: "mrkdwn", Text: fmt.Sprintf("*Time*\n%s", n.Timestamp.UTC().Format(time.RFC3339))})
+
+	return []slackBlock{
+		{Type: "section", Text: &slackText{Type: "mrkdwn", Text: header}},
+		{Type: "section", Fields: fields},
+	}
+}
+
+// ─── Microsoft Teams ──────────────────────────────────────────────────
+
+// TeamsDispatcher implements Dispatcher for Microsoft Teams incoming-
+// webhook URLs. Each notification becomes an Adaptive Card sent via
+// a "message" envelope — same shape as Slack but Teams-specific JSON.
+type TeamsDispatcher struct {
+	HTTPClient *http.Client
+}
+
+type teamsDestination struct {
+	WebhookURL string `json:"webhook_url"`
+}
+
+type teamsMessage struct {
+	Type        string             `json:"type"`        // always "message"
+	Attachments []teamsAttachment  `json:"attachments"`
+}
+
+type teamsAttachment struct {
+	ContentType string         `json:"contentType"`
+	Content     teamsCardBody  `json:"content"`
+}
+
+type teamsCardBody struct {
+	Schema  string                   `json:"$schema"`
+	Type    string                   `json:"type"`
+	Version string                   `json:"version"`
+	Body    []map[string]interface{} `json:"body"`
+}
+
+// Send POSTs an Adaptive Card to the destination's webhook URL.
+func (d *TeamsDispatcher) Send(ctx context.Context, destination json.RawMessage, n Notification) (int, string, error) {
+	var dest teamsDestination
+	if err := json.Unmarshal(destination, &dest); err != nil {
+		return 0, "invalid destination JSON", fmt.Errorf("alerting/teams: parse destination: %w", err)
+	}
+	if dest.WebhookURL == "" {
+		return 0, "destination missing webhook_url", errors.New("alerting/teams: destination missing webhook_url")
+	}
+
+	header := fmt.Sprintf("**%s** — %s", n.SeverityName, n.SiteURL)
+	switch {
+	case n.IsTest:
+		header = fmt.Sprintf("**Jetmon test** — %s", n.SiteURL)
+	case n.Recovery:
+		header = fmt.Sprintf("**Recovered** — %s", n.SiteURL)
+	}
+
+	facts := []map[string]string{
+		{"title": "Site ID", "value": fmt.Sprintf("%d", n.SiteID)},
+		{"title": "Event", "value": fmt.Sprintf("#%d (%s)", n.EventID, n.EventType)},
+	}
+	if n.State != "" {
+		facts = append(facts, map[string]string{"title": "State", "value": n.State})
+	}
+	if n.Reason != "" {
+		facts = append(facts, map[string]string{"title": "Reason", "value": n.Reason})
+	}
+	facts = append(facts, map[string]string{"title": "Time", "value": n.Timestamp.UTC().Format(time.RFC3339)})
+
+	body := teamsMessage{
+		Type: "message",
+		Attachments: []teamsAttachment{
+			{
+				ContentType: "application/vnd.microsoft.card.adaptive",
+				Content: teamsCardBody{
+					Schema:  "http://adaptivecards.io/schemas/adaptive-card.json",
+					Type:    "AdaptiveCard",
+					Version: "1.4",
+					Body: []map[string]interface{}{
+						{
+							"type":   "TextBlock",
+							"text":   header,
+							"wrap":   true,
+							"size":   "Large",
+							"weight": "Bolder",
+						},
+						{
+							"type":  "FactSet",
+							"facts": facts,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return postJSON(ctx, httpClientOrDefault(d.HTTPClient), dest.WebhookURL, body, nil)
+}
+
+// ─── Shared helpers ──────────────────────────────────────────────────
+
+// postJSON serializes body and POSTs it to url with optional extra
+// headers. Returns (statusCode, truncatedResponseBody, err) shaped for
+// the Dispatcher interface. err is non-nil when the HTTP call failed
+// at the transport layer (DNS, TCP, TLS, timeout) OR when the response
+// status indicates a permanent or retryable failure (>=400).
+func postJSON(ctx context.Context, client *http.Client, url string, body any, extraHeaders map[string]string) (int, string, error) {
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return 0, "", fmt.Errorf("marshal body: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(buf))
+	if err != nil {
+		return 0, "", fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range extraHeaders {
+		req.Header.Set(k, v)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, "", fmt.Errorf("post: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody := truncateResponseBody(strings.TrimSpace(readResponseBody(resp.Body)))
+
+	if resp.StatusCode >= 400 {
+		return resp.StatusCode, respBody, fmt.Errorf("status %d", resp.StatusCode)
+	}
+	return resp.StatusCode, respBody, nil
+}

--- a/internal/alerting/transports_test.go
+++ b/internal/alerting/transports_test.go
@@ -1,0 +1,347 @@
+package alerting
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Automattic/jetmon/internal/eventstore"
+)
+
+// captureServer is a tiny httptest.Server wrapper that records the
+// most recent request body and headers, returning a configurable
+// response status and body.
+type captureServer struct {
+	srv         *httptest.Server
+	gotBody     []byte
+	gotHeaders  http.Header
+	gotMethod   string
+	hits        int
+	respStatus  int
+	respBody    string
+}
+
+func newCaptureServer() *captureServer {
+	c := &captureServer{respStatus: http.StatusOK, respBody: `{"ok":true}`}
+	c.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.hits++
+		c.gotMethod = r.Method
+		c.gotHeaders = r.Header.Clone()
+		c.gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(c.respStatus)
+		_, _ = w.Write([]byte(c.respBody))
+	}))
+	return c
+}
+
+func (c *captureServer) URL() string { return c.srv.URL }
+func (c *captureServer) Close()      { c.srv.Close() }
+
+// ─── PagerDuty ────────────────────────────────────────────────────────
+
+func TestPagerDutyTriggerHappyPath(t *testing.T) {
+	cap := newCaptureServer()
+	defer cap.Close()
+
+	d := &PagerDutyDispatcher{Endpoint: cap.URL()}
+	dest := json.RawMessage(`{"integration_key":"PDKEY"}`)
+	n := makeTestNotification()
+
+	status, _, err := d.Send(context.Background(), dest, n)
+	if err != nil {
+		t.Fatalf("Send error: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Errorf("status = %d, want 200", status)
+	}
+
+	var got pagerDutyEvent
+	if err := json.Unmarshal(cap.gotBody, &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if got.RoutingKey != "PDKEY" {
+		t.Errorf("RoutingKey = %q", got.RoutingKey)
+	}
+	if got.EventAction != "trigger" {
+		t.Errorf("EventAction = %q, want trigger", got.EventAction)
+	}
+	if got.Payload.Severity != "critical" {
+		t.Errorf("Severity = %q, want critical (Down)", got.Payload.Severity)
+	}
+	if !strings.Contains(got.Payload.Summary, "https://example.com") {
+		t.Errorf("Summary missing site URL: %q", got.Payload.Summary)
+	}
+	if got.DedupKey != "jetmon-event-777" {
+		t.Errorf("DedupKey = %q", got.DedupKey)
+	}
+}
+
+func TestPagerDutyResolveOnRecovery(t *testing.T) {
+	cap := newCaptureServer()
+	defer cap.Close()
+
+	d := &PagerDutyDispatcher{Endpoint: cap.URL()}
+	n := makeTestNotification()
+	n.Recovery = true
+	n.Severity = eventstore.SeverityUp
+	n.SeverityName = "Up"
+
+	if _, _, err := d.Send(context.Background(), json.RawMessage(`{"integration_key":"K"}`), n); err != nil {
+		t.Fatalf("Send error: %v", err)
+	}
+
+	var got pagerDutyEvent
+	_ = json.Unmarshal(cap.gotBody, &got)
+	if got.EventAction != "resolve" {
+		t.Errorf("EventAction = %q, want resolve", got.EventAction)
+	}
+	if got.DedupKey != "jetmon-event-777" {
+		t.Errorf("DedupKey for resolve must match trigger: %q", got.DedupKey)
+	}
+}
+
+func TestPagerDutyTestUsesDistinctDedupKey(t *testing.T) {
+	cap := newCaptureServer()
+	defer cap.Close()
+
+	d := &PagerDutyDispatcher{Endpoint: cap.URL()}
+	n := makeTestNotification()
+	n.IsTest = true
+
+	if _, _, err := d.Send(context.Background(), json.RawMessage(`{"integration_key":"K"}`), n); err != nil {
+		t.Fatalf("Send error: %v", err)
+	}
+	var got pagerDutyEvent
+	_ = json.Unmarshal(cap.gotBody, &got)
+	if !strings.HasPrefix(got.DedupKey, "jetmon-test-") {
+		t.Errorf("test send should use jetmon-test- dedup_key, got %q", got.DedupKey)
+	}
+}
+
+func TestPagerDutySeverityMapping(t *testing.T) {
+	cases := map[uint8]string{
+		eventstore.SeverityDown:      "critical",
+		eventstore.SeveritySeemsDown: "critical",
+		eventstore.SeverityDegraded:  "warning",
+		eventstore.SeverityWarning:   "info",
+	}
+	for sev, want := range cases {
+		if got := pagerDutySeverity(sev); got != want {
+			t.Errorf("pagerDutySeverity(%d) = %q, want %q", sev, got, want)
+		}
+	}
+}
+
+func TestPagerDutyRejectsBadDestination(t *testing.T) {
+	d := &PagerDutyDispatcher{Endpoint: "https://nowhere.invalid"}
+	cases := []json.RawMessage{
+		json.RawMessage(`{}`),
+		json.RawMessage(`{"integration_key":""}`),
+		json.RawMessage(`not json`),
+	}
+	for i, dest := range cases {
+		_, _, err := d.Send(context.Background(), dest, makeTestNotification())
+		if err == nil {
+			t.Errorf("case %d: expected error for %s", i, dest)
+		}
+	}
+}
+
+func TestPagerDutySurfacesUpstreamError(t *testing.T) {
+	cap := newCaptureServer()
+	cap.respStatus = http.StatusBadRequest
+	cap.respBody = `{"error":"missing routing_key"}`
+	defer cap.Close()
+
+	d := &PagerDutyDispatcher{Endpoint: cap.URL()}
+	status, body, err := d.Send(context.Background(), json.RawMessage(`{"integration_key":"K"}`), makeTestNotification())
+	if err == nil {
+		t.Fatal("expected error on 400")
+	}
+	if status != 400 {
+		t.Errorf("status = %d", status)
+	}
+	if !strings.Contains(body, "missing routing_key") {
+		t.Errorf("body should include upstream error: %q", body)
+	}
+}
+
+// ─── Slack ────────────────────────────────────────────────────────────
+
+func TestSlackHappyPath(t *testing.T) {
+	cap := newCaptureServer()
+	defer cap.Close()
+
+	d := &SlackDispatcher{}
+	dest, _ := json.Marshal(slackDestination{WebhookURL: cap.URL()})
+
+	status, _, err := d.Send(context.Background(), dest, makeTestNotification())
+	if err != nil {
+		t.Fatalf("Send error: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Errorf("status = %d", status)
+	}
+
+	var got slackMessage
+	if err := json.Unmarshal(cap.gotBody, &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if got.Text == "" {
+		t.Error("Slack body must include fallback text")
+	}
+	if len(got.Blocks) < 2 {
+		t.Errorf("Slack body should have at least 2 blocks, got %d", len(got.Blocks))
+	}
+	headerText := got.Blocks[0].Text.Text
+	if !strings.Contains(headerText, "Down") {
+		t.Errorf("header should include severity: %q", headerText)
+	}
+	if !strings.Contains(headerText, "https://example.com") {
+		t.Errorf("header should include site URL: %q", headerText)
+	}
+}
+
+func TestSlackRecoveryHeader(t *testing.T) {
+	cap := newCaptureServer()
+	defer cap.Close()
+
+	d := &SlackDispatcher{}
+	dest, _ := json.Marshal(slackDestination{WebhookURL: cap.URL()})
+	n := makeTestNotification()
+	n.Recovery = true
+
+	if _, _, err := d.Send(context.Background(), dest, n); err != nil {
+		t.Fatalf("Send error: %v", err)
+	}
+	var got slackMessage
+	_ = json.Unmarshal(cap.gotBody, &got)
+	if !strings.Contains(got.Blocks[0].Text.Text, "Recovered") {
+		t.Errorf("recovery header expected, got %q", got.Blocks[0].Text.Text)
+	}
+}
+
+func TestSlackTestHeader(t *testing.T) {
+	cap := newCaptureServer()
+	defer cap.Close()
+
+	d := &SlackDispatcher{}
+	dest, _ := json.Marshal(slackDestination{WebhookURL: cap.URL()})
+	n := makeTestNotification()
+	n.IsTest = true
+
+	if _, _, err := d.Send(context.Background(), dest, n); err != nil {
+		t.Fatalf("Send error: %v", err)
+	}
+	var got slackMessage
+	_ = json.Unmarshal(cap.gotBody, &got)
+	if !strings.Contains(got.Blocks[0].Text.Text, "Jetmon test") {
+		t.Errorf("test header expected, got %q", got.Blocks[0].Text.Text)
+	}
+}
+
+func TestSlackRejectsBadDestination(t *testing.T) {
+	d := &SlackDispatcher{}
+	for _, dest := range []json.RawMessage{
+		json.RawMessage(`{}`),
+		json.RawMessage(`{"webhook_url":""}`),
+		json.RawMessage(`not json`),
+	} {
+		if _, _, err := d.Send(context.Background(), dest, makeTestNotification()); err == nil {
+			t.Errorf("expected error for %s", dest)
+		}
+	}
+}
+
+// ─── Teams ────────────────────────────────────────────────────────────
+
+func TestTeamsHappyPath(t *testing.T) {
+	cap := newCaptureServer()
+	defer cap.Close()
+
+	d := &TeamsDispatcher{}
+	dest, _ := json.Marshal(teamsDestination{WebhookURL: cap.URL()})
+
+	status, _, err := d.Send(context.Background(), dest, makeTestNotification())
+	if err != nil {
+		t.Fatalf("Send error: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Errorf("status = %d", status)
+	}
+
+	// Decode loosely; the Adaptive Card JSON has nested polymorphic
+	// content that's painful to model fully — we check the key fields.
+	var generic map[string]any
+	if err := json.Unmarshal(cap.gotBody, &generic); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if generic["type"] != "message" {
+		t.Errorf("type = %v", generic["type"])
+	}
+	atts, _ := generic["attachments"].([]any)
+	if len(atts) != 1 {
+		t.Fatalf("attachments len = %d", len(atts))
+	}
+	att := atts[0].(map[string]any)
+	if att["contentType"] != "application/vnd.microsoft.card.adaptive" {
+		t.Errorf("contentType = %v", att["contentType"])
+	}
+	// Spot check: serialize the attachment back and verify the
+	// header text contains the severity.
+	raw, _ := json.Marshal(att)
+	if !strings.Contains(string(raw), "Down") {
+		t.Errorf("Teams card missing severity in body: %s", raw)
+	}
+	if !strings.Contains(string(raw), "https://example.com") {
+		t.Errorf("Teams card missing site URL: %s", raw)
+	}
+}
+
+func TestTeamsRecoveryHeader(t *testing.T) {
+	cap := newCaptureServer()
+	defer cap.Close()
+
+	d := &TeamsDispatcher{}
+	dest, _ := json.Marshal(teamsDestination{WebhookURL: cap.URL()})
+	n := makeTestNotification()
+	n.Recovery = true
+
+	if _, _, err := d.Send(context.Background(), dest, n); err != nil {
+		t.Fatalf("Send error: %v", err)
+	}
+	if !strings.Contains(string(cap.gotBody), "Recovered") {
+		t.Errorf("recovery body should mention Recovered: %s", cap.gotBody)
+	}
+}
+
+func TestTeamsRejectsBadDestination(t *testing.T) {
+	d := &TeamsDispatcher{}
+	for _, dest := range []json.RawMessage{
+		json.RawMessage(`{}`),
+		json.RawMessage(`{"webhook_url":""}`),
+		json.RawMessage(`not json`),
+	} {
+		if _, _, err := d.Send(context.Background(), dest, makeTestNotification()); err == nil {
+			t.Errorf("expected error for %s", dest)
+		}
+	}
+}
+
+// ─── Shared helpers ──────────────────────────────────────────────────
+
+func TestTruncateResponseBody(t *testing.T) {
+	short := strings.Repeat("a", 100)
+	if got := truncateResponseBody(short); got != short {
+		t.Error("short body should pass through unchanged")
+	}
+	long := strings.Repeat("b", 3000)
+	got := truncateResponseBody(long)
+	if len(got) != 2048 {
+		t.Errorf("long body length = %d, want 2048", len(got))
+	}
+}

--- a/internal/alerting/worker.go
+++ b/internal/alerting/worker.go
@@ -1,0 +1,553 @@
+package alerting
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/Automattic/jetmon/internal/eventstore"
+)
+
+// retrySchedule mirrors the webhooks worker schedule. Same trade-offs:
+// six attempts over ~7h36m total elapsed, then abandon.
+var retrySchedule = []time.Duration{
+	0,
+	1 * time.Minute,
+	5 * time.Minute,
+	30 * time.Minute,
+	1 * time.Hour,
+	6 * time.Hour,
+}
+
+const maxAttempts = 6
+
+func nextRetryDelay(currentAttempt int) (delay time.Duration, abandoned bool) {
+	next := currentAttempt + 1
+	if next > maxAttempts {
+		return 0, true
+	}
+	return retrySchedule[next-1], false
+}
+
+// WorkerConfig configures the delivery worker.
+type WorkerConfig struct {
+	DB             *sql.DB
+	InstanceID     string
+	Dispatchers    map[Transport]Dispatcher
+	PollInterval   time.Duration
+	MaxConcurrent  int           // shared deliverer pool size
+	PerContactCap  int           // per-contact in-flight cap
+	BatchSize      int           // dispatch + claim batch size
+	DispatchTimeout time.Duration // per-delivery wall-clock limit
+}
+
+func (c *WorkerConfig) applyDefaults() {
+	if c.PollInterval == 0 {
+		c.PollInterval = 1 * time.Second
+	}
+	if c.MaxConcurrent == 0 {
+		c.MaxConcurrent = 50
+	}
+	if c.PerContactCap == 0 {
+		c.PerContactCap = 3
+	}
+	if c.BatchSize == 0 {
+		c.BatchSize = 200
+	}
+	if c.DispatchTimeout == 0 {
+		c.DispatchTimeout = 30 * time.Second
+	}
+	if c.InstanceID == "" {
+		c.InstanceID = "default"
+	}
+}
+
+// Worker drives alert contact delivery. Two background goroutines:
+//
+//   - dispatcher: every PollInterval, polls jetmon_event_transitions for
+//     new rows since last_seen, matches each against active contacts
+//     (site_filter + min_severity gate), and enqueues a delivery per
+//     match.
+//   - deliverer: every PollInterval, claims pending deliveries, picks
+//     the right Dispatcher per contact, builds a Notification, and
+//     calls Send. Successes mark delivered; failures schedule retries
+//     on the standard ladder. Per-contact rate cap drops dispatches
+//     when a contact's per-hour budget is exhausted.
+type Worker struct {
+	cfg WorkerConfig
+
+	inFlightMu sync.Mutex
+	inFlight   map[int64]int // contactID → current in-flight count
+
+	rateLimit *rateLimitWindow
+
+	stop chan struct{}
+	done chan struct{}
+}
+
+// NewWorker constructs a Worker. Call Start to launch goroutines.
+// Dispatchers map is required — without it, all dispatches fail with
+// "transport not configured."
+func NewWorker(cfg WorkerConfig) *Worker {
+	cfg.applyDefaults()
+	return &Worker{
+		cfg:       cfg,
+		inFlight:  make(map[int64]int),
+		rateLimit: newRateLimitWindow(),
+		stop:      make(chan struct{}),
+		done:      make(chan struct{}),
+	}
+}
+
+// Start launches the background goroutines. Non-blocking.
+func (w *Worker) Start() {
+	go w.run()
+}
+
+// Stop signals shutdown and blocks until both goroutines exit.
+func (w *Worker) Stop() {
+	close(w.stop)
+	<-w.done
+}
+
+func (w *Worker) run() {
+	defer close(w.done)
+
+	dispatcherDone := make(chan struct{})
+	delivererDone := make(chan struct{})
+
+	go func() {
+		defer close(dispatcherDone)
+		w.dispatchLoop()
+	}()
+	go func() {
+		defer close(delivererDone)
+		w.deliverLoop()
+	}()
+
+	<-dispatcherDone
+	<-delivererDone
+}
+
+// ─── Dispatch loop ────────────────────────────────────────────────────
+
+func (w *Worker) dispatchLoop() {
+	ticker := time.NewTicker(w.cfg.PollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-w.stop:
+			return
+		case <-ticker.C:
+			if err := w.dispatchTick(); err != nil {
+				log.Printf("alerting: dispatcher tick error: %v", err)
+			}
+		}
+	}
+}
+
+// dispatchTick polls jetmon_event_transitions for new rows and
+// enqueues per-contact deliveries for each match.
+func (w *Worker) dispatchTick() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	lastID, err := w.loadProgress(ctx)
+	if err != nil {
+		return fmt.Errorf("load progress: %w", err)
+	}
+
+	type transitionRow struct {
+		id             int64
+		eventID        int64
+		blogID         int64
+		severityBefore sql.NullInt64
+		severityAfter  sql.NullInt64
+		stateAfter     sql.NullString
+		reason         string
+		changedAt      time.Time
+	}
+
+	rows, err := w.cfg.DB.QueryContext(ctx, `
+		SELECT id, event_id, blog_id, severity_before, severity_after, state_after, reason, changed_at
+		  FROM jetmon_event_transitions
+		 WHERE id > ?
+		 ORDER BY id ASC
+		 LIMIT ?`, lastID, w.cfg.BatchSize)
+	if err != nil {
+		return fmt.Errorf("query transitions: %w", err)
+	}
+	defer rows.Close()
+
+	var transitions []transitionRow
+	for rows.Next() {
+		var t transitionRow
+		if err := rows.Scan(&t.id, &t.eventID, &t.blogID, &t.severityBefore, &t.severityAfter, &t.stateAfter, &t.reason, &t.changedAt); err != nil {
+			return fmt.Errorf("scan transition: %w", err)
+		}
+		transitions = append(transitions, t)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("transitions iterate: %w", err)
+	}
+	if len(transitions) == 0 {
+		return nil
+	}
+
+	contacts, err := ListActive(ctx, w.cfg.DB)
+	if err != nil {
+		return fmt.Errorf("list active contacts: %w", err)
+	}
+
+	for _, t := range transitions {
+		// Use SeverityUp as the conservative default when severity is
+		// unknown. severity_after may be NULL on certain non-severity
+		// transitions; the gate then evaluates as "not above any cap"
+		// and Matches returns false unless prev_severity caused a
+		// recovery.
+		prev := uint8(eventstore.SeverityUp)
+		if t.severityBefore.Valid {
+			prev = uint8(t.severityBefore.Int64)
+		}
+		next := uint8(eventstore.SeverityUp)
+		if t.severityAfter.Valid {
+			next = uint8(t.severityAfter.Int64)
+		}
+		eventType := eventTypeForReason(t.reason)
+		if eventType == "" {
+			continue
+		}
+		state := ""
+		if t.stateAfter.Valid {
+			state = t.stateAfter.String
+		}
+
+		for i := range contacts {
+			c := &contacts[i]
+			if !c.Matches(prev, next, t.blogID) {
+				continue
+			}
+			payload, err := buildPayload(eventType, t.id, t.eventID, t.blogID, t.reason, state, prev, next, t.changedAt)
+			if err != nil {
+				log.Printf("alerting: build payload event_id=%d transition_id=%d: %v", t.eventID, t.id, err)
+				continue
+			}
+			if _, err := Enqueue(ctx, w.cfg.DB, EnqueueInput{
+				AlertContactID: c.ID,
+				TransitionID:   t.id,
+				EventID:        t.eventID,
+				EventType:      eventType,
+				Severity:       next,
+				Payload:        payload,
+			}); err != nil {
+				log.Printf("alerting: enqueue contact_id=%d transition_id=%d: %v", c.ID, t.id, err)
+				continue
+			}
+		}
+	}
+
+	if err := w.saveProgress(ctx, transitions[len(transitions)-1].id); err != nil {
+		return fmt.Errorf("save progress: %w", err)
+	}
+	return nil
+}
+
+// eventTypeForReason maps a transition reason to a coarse alerting
+// event type. Less granular than the webhook event-type set because
+// alert contacts care primarily about "did something happen" and let
+// the severity gate drive what gets sent.
+func eventTypeForReason(reason string) string {
+	switch reason {
+	case "opened":
+		return "alert.opened"
+	case "severity_escalation", "severity_deescalation":
+		return "alert.severity_changed"
+	case "state_change", "verifier_confirmed":
+		return "alert.state_changed"
+	case "verifier_cleared", "probe_cleared", "false_alarm",
+		"manual_override", "maintenance_swallowed", "superseded", "auto_timeout":
+		return "alert.closed"
+	default:
+		return ""
+	}
+}
+
+// buildPayload returns the JSON body stored on the delivery row. Frozen
+// at enqueue time. Includes both severity values so the renderer at
+// dispatch time can correctly distinguish escalation from recovery.
+func buildPayload(eventType string, transitionID, eventID, blogID int64, reason, state string, prev, next uint8, occurredAt time.Time) (json.RawMessage, error) {
+	body := map[string]any{
+		"type":            eventType,
+		"occurred_at":     occurredAt.UTC().Format(time.RFC3339Nano),
+		"transition_id":   transitionID,
+		"event_id":        eventID,
+		"site_id":         blogID,
+		"reason":          reason,
+		"state":           state,
+		"severity_before": prev,
+		"severity_after":  next,
+	}
+	return json.Marshal(body)
+}
+
+// loadProgress / saveProgress mirror the webhooks worker on the
+// jetmon_alert_dispatch_progress table.
+func (w *Worker) loadProgress(ctx context.Context) (int64, error) {
+	var lastID int64
+	err := w.cfg.DB.QueryRowContext(ctx,
+		`SELECT last_transition_id FROM jetmon_alert_dispatch_progress WHERE instance_id = ?`,
+		w.cfg.InstanceID,
+	).Scan(&lastID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return lastID, nil
+}
+
+func (w *Worker) saveProgress(ctx context.Context, lastID int64) error {
+	_, err := w.cfg.DB.ExecContext(ctx, `
+		INSERT INTO jetmon_alert_dispatch_progress (instance_id, last_transition_id)
+		VALUES (?, ?)
+		ON DUPLICATE KEY UPDATE last_transition_id = VALUES(last_transition_id)`,
+		w.cfg.InstanceID, lastID)
+	return err
+}
+
+// ─── Deliver loop ─────────────────────────────────────────────────────
+
+func (w *Worker) deliverLoop() {
+	ticker := time.NewTicker(w.cfg.PollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-w.stop:
+			return
+		case <-ticker.C:
+			if err := w.deliverTick(); err != nil {
+				log.Printf("alerting: deliverer tick error: %v", err)
+			}
+		}
+	}
+}
+
+func (w *Worker) deliverTick() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	deliveries, err := ClaimReady(ctx, w.cfg.DB, w.cfg.MaxConcurrent)
+	if err != nil {
+		return err
+	}
+	for i := range deliveries {
+		d := deliveries[i]
+		if !w.acquireSlot(d.AlertContactID) {
+			continue
+		}
+		go func(d Delivery) {
+			defer w.releaseSlot(d.AlertContactID)
+			w.deliver(d)
+		}(d)
+	}
+	return nil
+}
+
+func (w *Worker) acquireSlot(contactID int64) bool {
+	w.inFlightMu.Lock()
+	defer w.inFlightMu.Unlock()
+	if w.inFlight[contactID] >= w.cfg.PerContactCap {
+		return false
+	}
+	w.inFlight[contactID]++
+	return true
+}
+
+func (w *Worker) releaseSlot(contactID int64) {
+	w.inFlightMu.Lock()
+	defer w.inFlightMu.Unlock()
+	w.inFlight[contactID]--
+	if w.inFlight[contactID] <= 0 {
+		delete(w.inFlight, contactID)
+	}
+}
+
+// deliver runs one dispatch attempt for d. Loads the contact +
+// destination, applies the rate cap, builds a Notification, and calls
+// the configured Dispatcher. Updates the delivery row with the result.
+func (w *Worker) deliver(d Delivery) {
+	ctx, cancel := context.WithTimeout(context.Background(), w.cfg.DispatchTimeout+5*time.Second)
+	defer cancel()
+
+	contact, err := Get(ctx, w.cfg.DB, d.AlertContactID)
+	if err != nil {
+		w.handleResult(ctx, d, 0, fmt.Sprintf("contact lookup: %v", err), true)
+		return
+	}
+	if !contact.Active {
+		w.handleResult(ctx, d, 0, "contact is inactive", true)
+		return
+	}
+
+	// Per-contact rate cap. 0 = unlimited.
+	if contact.MaxPerHour > 0 && !w.rateLimit.tryConsume(contact.ID, contact.MaxPerHour, time.Now()) {
+		if err := MarkSuppressed(ctx, w.cfg.DB, d.ID,
+			fmt.Sprintf("rate-limited: contact %d exceeded max_per_hour=%d", contact.ID, contact.MaxPerHour),
+		); err != nil {
+			log.Printf("alerting: mark suppressed id=%d: %v", d.ID, err)
+		}
+		return
+	}
+
+	dispatcher, ok := w.cfg.Dispatchers[contact.Transport]
+	if !ok {
+		w.handleResult(ctx, d, 0,
+			fmt.Sprintf("transport %q not configured on this instance", contact.Transport), true)
+		return
+	}
+	dest, err := LoadDestination(ctx, w.cfg.DB, contact.ID)
+	if err != nil {
+		w.handleResult(ctx, d, 0, fmt.Sprintf("destination lookup: %v", err), true)
+		return
+	}
+
+	n, err := w.buildNotification(ctx, contact, d)
+	if err != nil {
+		w.handleResult(ctx, d, 0, fmt.Sprintf("build notification: %v", err), true)
+		return
+	}
+
+	sendCtx, sendCancel := context.WithTimeout(ctx, w.cfg.DispatchTimeout)
+	defer sendCancel()
+	statusCode, respBody, sendErr := dispatcher.Send(sendCtx, dest, n)
+	if sendErr != nil {
+		w.handleResult(ctx, d, statusCode, "transport error: "+sendErr.Error(), false)
+		return
+	}
+	if err := MarkDelivered(ctx, w.cfg.DB, d.ID, statusCode, respBody); err != nil {
+		log.Printf("alerting: mark delivered id=%d: %v", d.ID, err)
+	}
+}
+
+// buildNotification reconstructs the rendered Notification from the
+// delivery row's frozen payload. Looks up the site URL from
+// jetpack_monitor_sites if available so renderers have a useful
+// display string; falls back to "site:<id>" if the lookup fails.
+func (w *Worker) buildNotification(ctx context.Context, contact *AlertContact, d Delivery) (Notification, error) {
+	var p struct {
+		SiteID         int64     `json:"site_id"`
+		EventID        int64     `json:"event_id"`
+		EventType      string    `json:"type"`
+		Reason         string    `json:"reason"`
+		State          string    `json:"state"`
+		SeverityBefore uint8     `json:"severity_before"`
+		SeverityAfter  uint8     `json:"severity_after"`
+		OccurredAt     time.Time `json:"occurred_at"`
+	}
+	if err := json.Unmarshal(d.Payload, &p); err != nil {
+		return Notification{}, fmt.Errorf("decode payload: %w", err)
+	}
+
+	siteURL := lookupSiteURL(ctx, w.cfg.DB, p.SiteID)
+	if siteURL == "" {
+		siteURL = fmt.Sprintf("site:%d", p.SiteID)
+	}
+
+	recovery := p.SeverityBefore >= contact.MinSeverity && p.SeverityAfter == eventstore.SeverityUp
+	severity := p.SeverityAfter
+
+	return Notification{
+		SiteID:       p.SiteID,
+		SiteURL:      siteURL,
+		EventID:      p.EventID,
+		EventType:    p.EventType,
+		Severity:     severity,
+		SeverityName: SeverityName(severity),
+		State:        p.State,
+		Reason:       p.Reason,
+		Timestamp:    p.OccurredAt,
+		DedupKey:     fmt.Sprintf("jetmon-event-%d", p.EventID),
+		Recovery:     recovery,
+	}, nil
+}
+
+func lookupSiteURL(ctx context.Context, db *sql.DB, blogID int64) string {
+	var url sql.NullString
+	err := db.QueryRowContext(ctx,
+		`SELECT monitor_url FROM jetpack_monitor_sites WHERE blog_id = ? LIMIT 1`,
+		blogID,
+	).Scan(&url)
+	if err != nil || !url.Valid {
+		return ""
+	}
+	return url.String
+}
+
+func (w *Worker) handleResult(ctx context.Context, d Delivery, statusCode int, responseBody string, forceAbandon bool) {
+	currentAttempt := d.Attempt + 1
+	var (
+		next      time.Time
+		abandoned bool
+	)
+	if forceAbandon {
+		abandoned = true
+	} else {
+		delay, ab := nextRetryDelay(currentAttempt)
+		abandoned = ab
+		if !abandoned {
+			next = time.Now().Add(delay)
+		}
+	}
+	if err := ScheduleRetry(ctx, w.cfg.DB, d.ID, statusCode, responseBody, next, abandoned); err != nil {
+		log.Printf("alerting: schedule retry id=%d: %v", d.ID, err)
+	}
+}
+
+// ─── Rate limit window ────────────────────────────────────────────────
+
+// rateLimitWindow tracks recent dispatch timestamps per contact for
+// the per-hour rate cap. Sliding window via timestamp pruning.
+//
+// In-memory only; multi-instance deployments share state via the DB
+// today. For a single-instance deployment this is correct; for
+// multi-instance, each instance enforces its own slice of the cap and
+// the actual delivered rate per contact may exceed the configured
+// max_per_hour by the number of instances. Tracked alongside the
+// "multi-instance row claim" caveat in deliveries.go.
+type rateLimitWindow struct {
+	mu         sync.Mutex
+	perContact map[int64][]time.Time
+}
+
+func newRateLimitWindow() *rateLimitWindow {
+	return &rateLimitWindow{perContact: make(map[int64][]time.Time)}
+}
+
+// tryConsume attempts to allocate a delivery for the given contact at
+// the given timestamp. Returns true if the window is under capacity
+// (and records the timestamp); false if the window is at capacity.
+func (r *rateLimitWindow) tryConsume(contactID int64, capacity int, now time.Time) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	cutoff := now.Add(-1 * time.Hour)
+	stamps := r.perContact[contactID]
+	pruned := stamps[:0]
+	for _, t := range stamps {
+		if t.After(cutoff) {
+			pruned = append(pruned, t)
+		}
+	}
+	if len(pruned) >= capacity {
+		r.perContact[contactID] = pruned
+		return false
+	}
+	r.perContact[contactID] = append(pruned, now)
+	return true
+}

--- a/internal/alerting/worker_test.go
+++ b/internal/alerting/worker_test.go
@@ -1,0 +1,177 @@
+package alerting
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNextRetryDelayFollowsSchedule(t *testing.T) {
+	cases := []struct {
+		current   int
+		want      time.Duration
+		abandoned bool
+	}{
+		{1, 1 * time.Minute, false},
+		{2, 5 * time.Minute, false},
+		{3, 30 * time.Minute, false},
+		{4, 1 * time.Hour, false},
+		{5, 6 * time.Hour, false},
+		{6, 0, true},
+		{7, 0, true},
+	}
+	for _, c := range cases {
+		got, ab := nextRetryDelay(c.current)
+		if ab != c.abandoned {
+			t.Errorf("nextRetryDelay(%d).abandoned = %v, want %v", c.current, ab, c.abandoned)
+		}
+		if !c.abandoned && got != c.want {
+			t.Errorf("nextRetryDelay(%d).delay = %v, want %v", c.current, got, c.want)
+		}
+	}
+}
+
+func TestApplyDefaults(t *testing.T) {
+	c := WorkerConfig{}
+	c.applyDefaults()
+	if c.PollInterval != 1*time.Second {
+		t.Errorf("PollInterval = %v, want 1s", c.PollInterval)
+	}
+	if c.MaxConcurrent != 50 {
+		t.Errorf("MaxConcurrent = %d, want 50", c.MaxConcurrent)
+	}
+	if c.PerContactCap != 3 {
+		t.Errorf("PerContactCap = %d, want 3", c.PerContactCap)
+	}
+	if c.BatchSize != 200 {
+		t.Errorf("BatchSize = %d, want 200", c.BatchSize)
+	}
+	if c.DispatchTimeout != 30*time.Second {
+		t.Errorf("DispatchTimeout = %v, want 30s", c.DispatchTimeout)
+	}
+	if c.InstanceID != "default" {
+		t.Errorf("InstanceID = %q, want default", c.InstanceID)
+	}
+}
+
+func TestApplyDefaultsPreservesExplicit(t *testing.T) {
+	c := WorkerConfig{
+		PollInterval:  5 * time.Second,
+		PerContactCap: 7,
+		InstanceID:    "host-a",
+	}
+	c.applyDefaults()
+	if c.PollInterval != 5*time.Second {
+		t.Errorf("PollInterval = %v, want 5s (explicit)", c.PollInterval)
+	}
+	if c.PerContactCap != 7 {
+		t.Errorf("PerContactCap = %d, want 7 (explicit)", c.PerContactCap)
+	}
+	if c.InstanceID != "host-a" {
+		t.Errorf("InstanceID = %q, want host-a (explicit)", c.InstanceID)
+	}
+	// Unset fields still get defaults.
+	if c.MaxConcurrent != 50 {
+		t.Errorf("MaxConcurrent = %d, want 50 (default)", c.MaxConcurrent)
+	}
+}
+
+func TestAcquireSlotRespectsCap(t *testing.T) {
+	w := &Worker{
+		cfg:      WorkerConfig{PerContactCap: 2},
+		inFlight: make(map[int64]int),
+	}
+	if !w.acquireSlot(1) {
+		t.Fatal("first acquire should succeed")
+	}
+	if !w.acquireSlot(1) {
+		t.Fatal("second acquire should succeed (under cap)")
+	}
+	if w.acquireSlot(1) {
+		t.Fatal("third acquire should fail (cap=2)")
+	}
+	w.releaseSlot(1)
+	if !w.acquireSlot(1) {
+		t.Fatal("acquire after release should succeed")
+	}
+}
+
+func TestAcquireSlotIsolatesContacts(t *testing.T) {
+	w := &Worker{
+		cfg:      WorkerConfig{PerContactCap: 1},
+		inFlight: make(map[int64]int),
+	}
+	if !w.acquireSlot(1) {
+		t.Fatal("contact 1 first acquire failed")
+	}
+	if w.acquireSlot(1) {
+		t.Fatal("contact 1 second acquire should fail (cap=1)")
+	}
+	if !w.acquireSlot(2) {
+		t.Fatal("contact 2 should be unaffected by contact 1's cap")
+	}
+}
+
+func TestReleaseSlotCleansUpZeroCounts(t *testing.T) {
+	w := &Worker{
+		cfg:      WorkerConfig{PerContactCap: 5},
+		inFlight: make(map[int64]int),
+	}
+	w.acquireSlot(1)
+	w.releaseSlot(1)
+	if _, ok := w.inFlight[1]; ok {
+		t.Error("zero-count entry should be deleted from map")
+	}
+}
+
+// TestRateLimitWindowRespectsCapacity verifies the rate window admits up
+// to capacity dispatches in an hour, then refuses, then admits again
+// after a timestamp ages out.
+func TestRateLimitWindowRespectsCapacity(t *testing.T) {
+	r := newRateLimitWindow()
+	base := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+
+	for i := 0; i < 3; i++ {
+		if !r.tryConsume(42, 3, base.Add(time.Duration(i)*time.Second)) {
+			t.Fatalf("dispatch %d should be admitted (cap=3)", i)
+		}
+	}
+	if r.tryConsume(42, 3, base.Add(4*time.Second)) {
+		t.Fatal("4th dispatch should be refused (cap=3)")
+	}
+	// 1h+1s later, all three earlier timestamps age out.
+	later := base.Add(1*time.Hour + 1*time.Second)
+	if !r.tryConsume(42, 3, later) {
+		t.Fatal("dispatch should be admitted after window pruning")
+	}
+}
+
+func TestRateLimitWindowIsolatesContacts(t *testing.T) {
+	r := newRateLimitWindow()
+	now := time.Now()
+	for i := 0; i < 2; i++ {
+		_ = r.tryConsume(1, 2, now)
+	}
+	if !r.tryConsume(2, 2, now) {
+		t.Error("contact 2 should not be affected by contact 1's rate")
+	}
+}
+
+func TestEventTypeForReason(t *testing.T) {
+	cases := map[string]string{
+		"opened":                "alert.opened",
+		"severity_escalation":   "alert.severity_changed",
+		"severity_deescalation": "alert.severity_changed",
+		"state_change":          "alert.state_changed",
+		"verifier_confirmed":    "alert.state_changed",
+		"verifier_cleared":      "alert.closed",
+		"manual_override":       "alert.closed",
+		"superseded":            "alert.closed",
+		"unknown_reason":        "",
+	}
+	for reason, want := range cases {
+		got := eventTypeForReason(reason)
+		if got != want {
+			t.Errorf("eventTypeForReason(%q) = %q, want %q", reason, got, want)
+		}
+	}
+}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -179,7 +179,7 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("DELETE /api/v1/alert-contacts/{id}",
 		s.requireScope(scopeWrite, s.handleDeleteAlertContact))
 	mux.HandleFunc("POST /api/v1/alert-contacts/{id}/test",
-		s.requireScope(scopeWrite, s.handleAlertContactTest))
+		s.requireScope(scopeWrite, s.withIdempotency(s.handleAlertContactTest)))
 
 	// Alert deliveries — read history, manually retry abandoned rows.
 	mux.HandleFunc("GET /api/v1/alert-contacts/{id}/deliveries",

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -181,6 +181,12 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("POST /api/v1/alert-contacts/{id}/test",
 		s.requireScope(scopeWrite, s.handleAlertContactTest))
 
+	// Alert deliveries — read history, manually retry abandoned rows.
+	mux.HandleFunc("GET /api/v1/alert-contacts/{id}/deliveries",
+		s.requireScope(scopeRead, s.handleListAlertDeliveries))
+	mux.HandleFunc("POST /api/v1/alert-contacts/{id}/deliveries/{delivery_id}/retry",
+		s.requireScope(scopeWrite, s.withIdempotency(s.handleRetryAlertDelivery)))
+
 	// Catch-all → 404 with a useful message rather than the default empty body.
 	mux.HandleFunc("/", s.handleNotFound)
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -17,6 +17,8 @@ import (
 	"log"
 	"net/http"
 	"time"
+
+	"github.com/Automattic/jetmon/internal/alerting"
 )
 
 // Timeout defaults for the API HTTP server. These are generous compared to
@@ -38,6 +40,13 @@ type Server struct {
 	httpSrv     *http.Server
 	limiter     *rateLimiter
 	idempotency *idempotencyStore
+
+	// alertDispatchers is the per-transport dispatcher map used by the
+	// alert-contact send-test endpoint. The same map is shared with the
+	// alerting worker so a successful send-test is a true smoke test of
+	// the path real alerts will take. Wired by main.go via
+	// SetAlertDispatchers; nil if alerting is disabled.
+	alertDispatchers map[alerting.Transport]alerting.Dispatcher
 }
 
 // New constructs a Server. Caller is responsible for ensuring db is connected
@@ -77,6 +86,14 @@ func (s *Server) Shutdown(ctx context.Context) error {
 		return nil
 	}
 	return s.httpSrv.Shutdown(ctx)
+}
+
+// SetAlertDispatchers wires the per-transport dispatcher map for the
+// alert-contact send-test endpoint. Call this before Listen if
+// alerting is enabled. The worker should share the same map so a
+// successful send-test exercises the real production code path.
+func (s *Server) SetAlertDispatchers(d map[alerting.Transport]alerting.Dispatcher) {
+	s.alertDispatchers = d
 }
 
 // routes builds the request multiplexer. Uses Go 1.22's pattern-based routing
@@ -147,6 +164,22 @@ func (s *Server) routes() *http.ServeMux {
 		s.requireScope(scopeRead, s.handleListDeliveries))
 	mux.HandleFunc("POST /api/v1/webhooks/{id}/deliveries/{delivery_id}/retry",
 		s.requireScope(scopeWrite, s.withIdempotency(s.handleRetryDelivery)))
+
+	// Alert contacts — read.
+	mux.HandleFunc("GET /api/v1/alert-contacts",
+		s.requireScope(scopeRead, s.handleListAlertContacts))
+	mux.HandleFunc("GET /api/v1/alert-contacts/{id}",
+		s.requireScope(scopeRead, s.handleGetAlertContact))
+
+	// Alert contacts — write.
+	mux.HandleFunc("POST /api/v1/alert-contacts",
+		s.requireScope(scopeWrite, s.withIdempotency(s.handleCreateAlertContact)))
+	mux.HandleFunc("PATCH /api/v1/alert-contacts/{id}",
+		s.requireScope(scopeWrite, s.handleUpdateAlertContact))
+	mux.HandleFunc("DELETE /api/v1/alert-contacts/{id}",
+		s.requireScope(scopeWrite, s.handleDeleteAlertContact))
+	mux.HandleFunc("POST /api/v1/alert-contacts/{id}/test",
+		s.requireScope(scopeWrite, s.handleAlertContactTest))
 
 	// Catch-all → 404 with a useful message rather than the default empty body.
 	mux.HandleFunc("/", s.handleNotFound)

--- a/internal/api/handlers_alert_deliveries.go
+++ b/internal/api/handlers_alert_deliveries.go
@@ -1,0 +1,173 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/Automattic/jetmon/internal/alerting"
+)
+
+// alertDeliveryResponse is the JSON shape for an alert delivery row.
+// Same flat shape as deliveryResponse for webhooks — flat fields are
+// easier to filter and sort than a nested envelope.
+type alertDeliveryResponse struct {
+	ID             int64           `json:"id"`
+	AlertContactID int64           `json:"alert_contact_id"`
+	TransitionID   int64           `json:"transition_id"`
+	EventID        int64           `json:"event_id"`
+	EventType      string          `json:"event_type"`
+	Severity       string          `json:"severity"`
+	Payload        json.RawMessage `json:"payload"`
+	Status         string          `json:"status"`
+	Attempt        int             `json:"attempt"`
+	NextAttemptAt  *string         `json:"next_attempt_at"`
+	LastStatusCode *int            `json:"last_status_code"`
+	LastResponse   *string         `json:"last_response"`
+	LastAttemptAt  *string         `json:"last_attempt_at"`
+	DeliveredAt    *string         `json:"delivered_at"`
+	CreatedAt      string          `json:"created_at"`
+}
+
+func toAlertDeliveryResponse(d *alerting.Delivery) alertDeliveryResponse {
+	out := alertDeliveryResponse{
+		ID:             d.ID,
+		AlertContactID: d.AlertContactID,
+		TransitionID:   d.TransitionID,
+		EventID:        d.EventID,
+		EventType:      d.EventType,
+		Severity:       alerting.SeverityName(d.Severity),
+		Payload:        d.Payload,
+		Status:         string(d.Status),
+		Attempt:        d.Attempt,
+		LastStatusCode: d.LastStatusCode,
+		LastResponse:   d.LastResponse,
+		CreatedAt:      d.CreatedAt.UTC().Format(time.RFC3339),
+	}
+	if d.NextAttemptAt != nil {
+		v := d.NextAttemptAt.UTC().Format(time.RFC3339)
+		out.NextAttemptAt = &v
+	}
+	if d.LastAttemptAt != nil {
+		v := d.LastAttemptAt.UTC().Format(time.RFC3339)
+		out.LastAttemptAt = &v
+	}
+	if d.DeliveredAt != nil {
+		v := d.DeliveredAt.UTC().Format(time.RFC3339)
+		out.DeliveredAt = &v
+	}
+	return out
+}
+
+// handleListAlertDeliveries implements
+// GET /api/v1/alert-contacts/{id}/deliveries.
+func (s *Server) handleListAlertDeliveries(w http.ResponseWriter, r *http.Request) {
+	contactID, err := parseIDPath(r, "id")
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_alert_contact_id",
+			"alert contact id must be a positive integer")
+		return
+	}
+
+	q := r.URL.Query()
+	limit, err := parseLimit(q.Get("limit"), 50, 200)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_limit", err.Error())
+		return
+	}
+	cursor, err := decodeIDCursor(q.Get("cursor"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_cursor", err.Error())
+		return
+	}
+
+	var status alerting.Status
+	if v := q.Get("status"); v != "" {
+		switch alerting.Status(v) {
+		case alerting.StatusPending, alerting.StatusDelivered,
+			alerting.StatusFailed, alerting.StatusAbandoned:
+			status = alerting.Status(v)
+		default:
+			writeError(w, r, http.StatusBadRequest, "invalid_status",
+				"status must be one of: pending, delivered, failed, abandoned")
+			return
+		}
+	}
+
+	rows, err := alerting.ListDeliveries(r.Context(), s.db, contactID, status, cursor, limit+1)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"alert deliveries list failed: "+err.Error())
+		return
+	}
+
+	out := make([]alertDeliveryResponse, 0, len(rows))
+	for i := range rows {
+		out = append(out, toAlertDeliveryResponse(&rows[i]))
+	}
+	var nextCursor *string
+	if len(out) > limit {
+		out = out[:limit]
+		c := encodeIDCursor(out[len(out)-1].ID)
+		nextCursor = &c
+	}
+
+	writeJSON(w, http.StatusOK, ListEnvelope{
+		Data: out,
+		Page: Page{Next: nextCursor, Limit: limit},
+	})
+}
+
+// handleRetryAlertDelivery implements
+// POST /api/v1/alert-contacts/{id}/deliveries/{delivery_id}/retry.
+//
+// Resets an abandoned delivery row to pending so the worker picks it
+// up on the next tick. Same semantics as the webhook retry endpoint —
+// only abandoned deliveries can be retried; pending ones are already
+// queued and delivered ones don't need to fire again.
+func (s *Server) handleRetryAlertDelivery(w http.ResponseWriter, r *http.Request) {
+	contactID, err := parseIDPath(r, "id")
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_alert_contact_id",
+			"alert contact id must be a positive integer")
+		return
+	}
+	deliveryID, err := parseIDPath(r, "delivery_id")
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_delivery_id",
+			"delivery id must be a positive integer")
+		return
+	}
+
+	d, err := alerting.GetDelivery(r.Context(), s.db, deliveryID)
+	if err != nil {
+		if errors.Is(err, alerting.ErrDeliveryNotFound) {
+			writeError(w, r, http.StatusNotFound, "delivery_not_found",
+				fmt.Sprintf("Delivery %d does not exist", deliveryID))
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"delivery lookup failed: "+err.Error())
+		return
+	}
+	if d.AlertContactID != contactID {
+		writeError(w, r, http.StatusNotFound, "delivery_not_found",
+			fmt.Sprintf("Delivery %d does not belong to alert contact %d", deliveryID, contactID))
+		return
+	}
+
+	if err := alerting.RetryDelivery(r.Context(), s.db, deliveryID); err != nil {
+		writeError(w, r, http.StatusConflict, "delivery_not_retryable", err.Error())
+		return
+	}
+
+	d, err = alerting.GetDelivery(r.Context(), s.db, deliveryID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"read-back failed: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, toAlertDeliveryResponse(d))
+}

--- a/internal/api/handlers_alert_deliveries_test.go
+++ b/internal/api/handlers_alert_deliveries_test.go
@@ -1,0 +1,156 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+const selectAlertDeliveriesSQL = ` SELECT id, alert_contact_id, transition_id, event_id, event_type, severity, payload, status, attempt, next_attempt_at, last_status_code, last_response, last_attempt_at, delivered_at, created_at FROM jetmon_alert_deliveries WHERE alert_contact_id = ? ORDER BY id DESC LIMIT ?`
+
+const selectAlertDeliveryOneSQL = ` SELECT id, alert_contact_id, transition_id, event_id, event_type, severity, payload, status, attempt, next_attempt_at, last_status_code, last_response, last_attempt_at, delivered_at, created_at FROM jetmon_alert_deliveries WHERE id = ?`
+
+var columnsAlertDelivery = []string{
+	"id", "alert_contact_id", "transition_id", "event_id", "event_type", "severity",
+	"payload", "status", "attempt", "next_attempt_at", "last_status_code", "last_response",
+	"last_attempt_at", "delivered_at", "created_at",
+}
+
+func makeAlertDeliveryRow(id, contactID int64, status string) *sqlmock.Rows {
+	now := time.Now().UTC()
+	payload := []byte(`{"site_id":42,"event_id":777,"type":"alert.opened"}`)
+	return sqlmock.NewRows(columnsAlertDelivery).AddRow(
+		id, contactID, int64(1), int64(777), "alert.opened", uint8(4),
+		payload, status, 1, nil, nil, nil, nil, nil, now,
+	)
+}
+
+func TestListAlertDeliveriesHappyPath(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	// limit + 1 = 51 (default 50 + 1 for pagination probe).
+	mock.ExpectQuery(selectAlertDeliveriesSQL).
+		WithArgs(int64(11), 51).
+		WillReturnRows(makeAlertDeliveryRow(101, 11, "delivered"))
+
+	req := httptest.NewRequest("GET", "/api/v1/alert-contacts/11/deliveries", nil)
+	req.SetPathValue("id", "11")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleListAlertDeliveries)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var env struct {
+		Data []alertDeliveryResponse `json:"data"`
+		Page json.RawMessage         `json:"page"`
+	}
+	readJSON(t, rec.Body, &env)
+	if len(env.Data) != 1 {
+		t.Fatalf("len(data) = %d, want 1", len(env.Data))
+	}
+	if env.Data[0].Severity != "Down" {
+		t.Errorf("Severity = %q, want Down (uint8 4)", env.Data[0].Severity)
+	}
+}
+
+func TestListAlertDeliveriesRejectsBadStatus(t *testing.T) {
+	s, _, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	req := httptest.NewRequest("GET", "/api/v1/alert-contacts/11/deliveries?status=bogus", nil)
+	req.SetPathValue("id", "11")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleListAlertDeliveries)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if got := readErrorBody(t, rec.Body).Code; got != "invalid_status" {
+		t.Errorf("code = %q, want invalid_status", got)
+	}
+}
+
+func TestRetryAlertDeliveryHappyPath(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	// 1) Get delivery to verify it belongs to the contact.
+	mock.ExpectQuery(selectAlertDeliveryOneSQL).WithArgs(int64(101)).
+		WillReturnRows(makeAlertDeliveryRow(101, 11, "abandoned"))
+	// 2) RetryDelivery UPDATE.
+	mock.ExpectExec(`UPDATE jetmon_alert_deliveries SET status = 'pending', attempt = 0, next_attempt_at = CURRENT_TIMESTAMP, last_status_code = NULL, last_response = NULL, last_attempt_at = NULL WHERE id = ? AND status = 'abandoned'`).
+		WithArgs(int64(101)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	// 3) Read-back GetDelivery.
+	mock.ExpectQuery(selectAlertDeliveryOneSQL).WithArgs(int64(101)).
+		WillReturnRows(makeAlertDeliveryRow(101, 11, "pending"))
+
+	req := newPOSTWithBody("/api/v1/alert-contacts/11/deliveries/101/retry", nil)
+	req.SetPathValue("id", "11")
+	req.SetPathValue("delivery_id", "101")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleRetryAlertDelivery)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp alertDeliveryResponse
+	readJSON(t, rec.Body, &resp)
+	if resp.Status != "pending" {
+		t.Errorf("Status = %q, want pending", resp.Status)
+	}
+}
+
+func TestRetryAlertDeliveryWrongContact(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	// Delivery belongs to contact 99, not 11.
+	mock.ExpectQuery(selectAlertDeliveryOneSQL).WithArgs(int64(101)).
+		WillReturnRows(makeAlertDeliveryRow(101, 99, "abandoned"))
+
+	req := newPOSTWithBody("/api/v1/alert-contacts/11/deliveries/101/retry", nil)
+	req.SetPathValue("id", "11")
+	req.SetPathValue("delivery_id", "101")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleRetryAlertDelivery)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestRetryAlertDeliveryNotAbandoned(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	// Lookup succeeds; delivery is currently 'delivered' (not retryable).
+	mock.ExpectQuery(selectAlertDeliveryOneSQL).WithArgs(int64(101)).
+		WillReturnRows(makeAlertDeliveryRow(101, 11, "delivered"))
+	// RetryDelivery UPDATE returns 0 affected.
+	mock.ExpectExec(`UPDATE jetmon_alert_deliveries SET status = 'pending', attempt = 0, next_attempt_at = CURRENT_TIMESTAMP, last_status_code = NULL, last_response = NULL, last_attempt_at = NULL WHERE id = ? AND status = 'abandoned'`).
+		WithArgs(int64(101)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	// RetryDelivery's error path re-reads to get the current state for the message.
+	mock.ExpectQuery(selectAlertDeliveryOneSQL).WithArgs(int64(101)).
+		WillReturnRows(makeAlertDeliveryRow(101, 11, "delivered"))
+
+	req := newPOSTWithBody("/api/v1/alert-contacts/11/deliveries/101/retry", nil)
+	req.SetPathValue("id", "11")
+	req.SetPathValue("delivery_id", "101")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleRetryAlertDelivery)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", rec.Code)
+	}
+	if got := readErrorBody(t, rec.Body).Code; got != "delivery_not_retryable" {
+		t.Errorf("code = %q, want delivery_not_retryable", got)
+	}
+}

--- a/internal/api/handlers_alerts.go
+++ b/internal/api/handlers_alerts.go
@@ -1,0 +1,341 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/Automattic/jetmon/internal/alerting"
+)
+
+// alertContactResponse is the JSON shape for an alert contact in
+// list/single responses. The destination credential is never returned;
+// only DestinationPreview (last 4 chars) is exposed.
+type alertContactResponse struct {
+	ID                 int64               `json:"id"`
+	Label              string              `json:"label"`
+	Active             bool                `json:"active"`
+	Transport          string              `json:"transport"`
+	DestinationPreview string              `json:"destination_preview"`
+	SiteFilter         alerting.SiteFilter `json:"site_filter"`
+	MinSeverity        string              `json:"min_severity"`
+	MaxPerHour         int                 `json:"max_per_hour"`
+	CreatedBy          string              `json:"created_by"`
+	CreatedAt          string              `json:"created_at"`
+	UpdatedAt          string              `json:"updated_at"`
+}
+
+func toAlertContactResponse(c *alerting.AlertContact) alertContactResponse {
+	return alertContactResponse{
+		ID:                 c.ID,
+		Label:              c.Label,
+		Active:             c.Active,
+		Transport:          string(c.Transport),
+		DestinationPreview: c.DestinationPreview,
+		SiteFilter:         c.SiteFilter,
+		MinSeverity:        alerting.SeverityName(c.MinSeverity),
+		MaxPerHour:         c.MaxPerHour,
+		CreatedBy:          c.CreatedBy,
+		CreatedAt:          c.CreatedAt.UTC().Format(time.RFC3339),
+		UpdatedAt:          c.UpdatedAt.UTC().Format(time.RFC3339),
+	}
+}
+
+// createAlertContactRequest is the body shape for POST /api/v1/alert-contacts.
+// MinSeverity is a string ("Down", "Warning", etc.) on the wire — it's
+// translated to the internal uint8 before passing to the alerting
+// package.
+type createAlertContactRequest struct {
+	Label       string              `json:"label"`
+	Active      *bool               `json:"active"`
+	Transport   string              `json:"transport"`
+	Destination json.RawMessage     `json:"destination"`
+	SiteFilter  alerting.SiteFilter `json:"site_filter"`
+	MinSeverity *string             `json:"min_severity"`
+	MaxPerHour  *int                `json:"max_per_hour"`
+}
+
+// updateAlertContactRequest is the body shape for PATCH
+// /api/v1/alert-contacts/{id}. Pointer fields distinguish absent from
+// explicitly empty. Transport itself cannot be changed via PATCH —
+// see API.md "Family 5".
+type updateAlertContactRequest struct {
+	Label       *string              `json:"label"`
+	Active      *bool                `json:"active"`
+	Destination json.RawMessage      `json:"destination"`
+	SiteFilter  *alerting.SiteFilter `json:"site_filter"`
+	MinSeverity *string              `json:"min_severity"`
+	MaxPerHour  *int                 `json:"max_per_hour"`
+}
+
+// handleCreateAlertContact implements POST /api/v1/alert-contacts.
+func (s *Server) handleCreateAlertContact(w http.ResponseWriter, r *http.Request) {
+	var body createAlertContactRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_body",
+			"request body must be valid JSON: "+err.Error())
+		return
+	}
+	if !alerting.IsValidTransport(body.Transport) {
+		writeError(w, r, http.StatusBadRequest, "invalid_transport",
+			fmt.Sprintf("transport must be one of: email, pagerduty, slack, teams (got %q)", body.Transport))
+		return
+	}
+
+	in := alerting.CreateInput{
+		Label:       body.Label,
+		Active:      body.Active,
+		Transport:   alerting.Transport(body.Transport),
+		Destination: body.Destination,
+		SiteFilter:  body.SiteFilter,
+		MaxPerHour:  body.MaxPerHour,
+		CreatedBy:   consumerName(r),
+	}
+	if body.MinSeverity != nil {
+		sev, err := alerting.SeverityFromName(*body.MinSeverity)
+		if err != nil {
+			writeError(w, r, http.StatusBadRequest, "invalid_severity",
+				fmt.Sprintf("min_severity must be one of: %v", alerting.AllSeverityNames()))
+			return
+		}
+		in.MinSeverity = &sev
+	}
+
+	contact, err := alerting.Create(r.Context(), s.db, in)
+	if err != nil {
+		writeAlertingValidationError(w, r, err, "alert contact create failed")
+		return
+	}
+	writeJSON(w, http.StatusCreated, toAlertContactResponse(contact))
+}
+
+// handleListAlertContacts implements GET /api/v1/alert-contacts.
+func (s *Server) handleListAlertContacts(w http.ResponseWriter, r *http.Request) {
+	contacts, err := alerting.List(r.Context(), s.db)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"alert contact list failed: "+err.Error())
+		return
+	}
+	out := make([]alertContactResponse, 0, len(contacts))
+	for i := range contacts {
+		out = append(out, toAlertContactResponse(&contacts[i]))
+	}
+	writeJSON(w, http.StatusOK, ListEnvelope{
+		Data: out,
+		Page: Page{Next: nil, Limit: len(out)},
+	})
+}
+
+// handleGetAlertContact implements GET /api/v1/alert-contacts/{id}.
+func (s *Server) handleGetAlertContact(w http.ResponseWriter, r *http.Request) {
+	id, err := parseIDPath(r, "id")
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_alert_contact_id",
+			"alert contact id must be a positive integer")
+		return
+	}
+	contact, err := alerting.Get(r.Context(), s.db, id)
+	if err != nil {
+		if errors.Is(err, alerting.ErrContactNotFound) {
+			writeError(w, r, http.StatusNotFound, "alert_contact_not_found",
+				fmt.Sprintf("Alert contact %d does not exist", id))
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"alert contact lookup failed: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, toAlertContactResponse(contact))
+}
+
+// handleUpdateAlertContact implements PATCH /api/v1/alert-contacts/{id}.
+func (s *Server) handleUpdateAlertContact(w http.ResponseWriter, r *http.Request) {
+	id, err := parseIDPath(r, "id")
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_alert_contact_id",
+			"alert contact id must be a positive integer")
+		return
+	}
+	var body updateAlertContactRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_body",
+			"request body must be valid JSON: "+err.Error())
+		return
+	}
+
+	in := alerting.UpdateInput{
+		Label:       body.Label,
+		Active:      body.Active,
+		Destination: body.Destination,
+		SiteFilter:  body.SiteFilter,
+		MaxPerHour:  body.MaxPerHour,
+	}
+	if body.MinSeverity != nil {
+		sev, err := alerting.SeverityFromName(*body.MinSeverity)
+		if err != nil {
+			writeError(w, r, http.StatusBadRequest, "invalid_severity",
+				fmt.Sprintf("min_severity must be one of: %v", alerting.AllSeverityNames()))
+			return
+		}
+		in.MinSeverity = &sev
+	}
+
+	contact, err := alerting.Update(r.Context(), s.db, id, in)
+	if err != nil {
+		if errors.Is(err, alerting.ErrContactNotFound) {
+			writeError(w, r, http.StatusNotFound, "alert_contact_not_found",
+				fmt.Sprintf("Alert contact %d does not exist", id))
+			return
+		}
+		writeAlertingValidationError(w, r, err, "alert contact update failed")
+		return
+	}
+	writeJSON(w, http.StatusOK, toAlertContactResponse(contact))
+}
+
+// handleDeleteAlertContact implements DELETE /api/v1/alert-contacts/{id}.
+// Hard delete — see comment on handleDeleteWebhook for rationale.
+func (s *Server) handleDeleteAlertContact(w http.ResponseWriter, r *http.Request) {
+	id, err := parseIDPath(r, "id")
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_alert_contact_id",
+			"alert contact id must be a positive integer")
+		return
+	}
+	if err := alerting.Delete(r.Context(), s.db, id); err != nil {
+		if errors.Is(err, alerting.ErrContactNotFound) {
+			writeError(w, r, http.StatusNotFound, "alert_contact_not_found",
+				fmt.Sprintf("Alert contact %d does not exist", id))
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"alert contact delete failed: "+err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleAlertContactTest implements POST /api/v1/alert-contacts/{id}/test.
+//
+// Sends a synthetic notification through the contact's transport — same
+// rendering, same dispatch path, but with a test-flagged Notification.
+// Bypasses the severity gate and the per-hour rate cap; logged in
+// jetmon_audit_log via the API auth middleware.
+//
+// Returns the transport's status_code + truncated response body so
+// operators can verify connectivity. Transport-level errors are
+// surfaced as 502 (we successfully called the transport, but the
+// transport reported a failure).
+func (s *Server) handleAlertContactTest(w http.ResponseWriter, r *http.Request) {
+	id, err := parseIDPath(r, "id")
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_alert_contact_id",
+			"alert contact id must be a positive integer")
+		return
+	}
+	contact, err := alerting.Get(r.Context(), s.db, id)
+	if err != nil {
+		if errors.Is(err, alerting.ErrContactNotFound) {
+			writeError(w, r, http.StatusNotFound, "alert_contact_not_found",
+				fmt.Sprintf("Alert contact %d does not exist", id))
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"alert contact lookup failed: "+err.Error())
+		return
+	}
+
+	dispatcher, ok := s.alertDispatchers[contact.Transport]
+	if !ok {
+		writeError(w, r, http.StatusServiceUnavailable, "transport_not_configured",
+			fmt.Sprintf("transport %q is not configured on this server", contact.Transport))
+		return
+	}
+	dest, err := alerting.LoadDestination(r.Context(), s.db, id)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			"alert contact destination load failed: "+err.Error())
+		return
+	}
+
+	now := time.Now().UTC()
+	n := alerting.Notification{
+		SiteID:       0,
+		SiteURL:      "https://test.invalid/" + contact.Label,
+		EventID:      0,
+		EventType:    "event.test",
+		Severity:     contact.MinSeverity,
+		SeverityName: alerting.SeverityName(contact.MinSeverity),
+		State:        "Test",
+		Reason:       "test_send",
+		Timestamp:    now,
+		IsTest:       true,
+	}
+
+	// Bound the test send tightly so a wedged transport doesn't
+	// hang the API request indefinitely.
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+
+	statusCode, respBody, sendErr := dispatcher.Send(ctx, dest, n)
+
+	resp := struct {
+		ContactID    int64  `json:"contact_id"`
+		Transport    string `json:"transport"`
+		StatusCode   int    `json:"status_code"`
+		ResponseBody string `json:"response_body"`
+		Error        string `json:"error,omitempty"`
+		Delivered    bool   `json:"delivered"`
+	}{
+		ContactID:    contact.ID,
+		Transport:    string(contact.Transport),
+		StatusCode:   statusCode,
+		ResponseBody: respBody,
+	}
+	if sendErr != nil {
+		resp.Error = sendErr.Error()
+		writeJSON(w, http.StatusBadGateway, resp)
+		return
+	}
+	resp.Delivered = true
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// writeAlertingValidationError translates package-level validation
+// errors into the appropriate HTTP status. ErrInvalidTransport and
+// ErrInvalidSeverity are operator/client mistakes (4xx); everything
+// else is treated as a 500 db_error.
+func writeAlertingValidationError(w http.ResponseWriter, r *http.Request, err error, prefix string) {
+	switch {
+	case errors.Is(err, alerting.ErrInvalidTransport):
+		writeError(w, r, http.StatusBadRequest, "invalid_transport", err.Error())
+	case errors.Is(err, alerting.ErrInvalidSeverity):
+		writeError(w, r, http.StatusBadRequest, "invalid_severity", err.Error())
+	default:
+		// Treat all other errors as either client validation (string
+		// errors from validateCreateInput / validateDestination) or
+		// server-side DB errors. Validation strings start with
+		// "alerting:" — match that prefix to choose 422 vs 500.
+		msg := err.Error()
+		if len(msg) >= 9 && msg[:9] == "alerting:" {
+			writeError(w, r, http.StatusUnprocessableEntity, "invalid_alert_contact", msg)
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "db_error",
+			prefix+": "+msg)
+	}
+}
+
+// consumerName returns the API key consumer name from the request
+// context, or "" if no key is attached. Used to populate created_by
+// fields when a write endpoint creates a new resource.
+func consumerName(r *http.Request) string {
+	if k := keyFromRequest(r); k != nil {
+		return k.ConsumerName
+	}
+	return ""
+}

--- a/internal/api/handlers_alerts_test.go
+++ b/internal/api/handlers_alerts_test.go
@@ -1,0 +1,357 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Automattic/jetmon/internal/alerting"
+)
+
+const insertAlertContactSQL = ` INSERT INTO jetmon_alert_contacts (label, active, transport, destination, destination_preview, site_filter, min_severity, max_per_hour, created_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+
+const selectAlertContactOneSQL = ` SELECT id, label, active, transport, destination_preview, site_filter, min_severity, max_per_hour, created_by, created_at, updated_at FROM jetmon_alert_contacts WHERE id = ?`
+
+const loadAlertDestinationSQL = `SELECT destination FROM jetmon_alert_contacts WHERE id = ?`
+
+var columnsAlertContact = []string{
+	"id", "label", "active", "transport", "destination_preview",
+	"site_filter", "min_severity", "max_per_hour",
+	"created_by", "created_at", "updated_at",
+}
+
+func makeAlertContactRow(id int64, label string, transport string, active uint8, minSev uint8) *sqlmock.Rows {
+	now := time.Now().UTC()
+	return sqlmock.NewRows(columnsAlertContact).AddRow(
+		id, label, active, transport, "abcd",
+		[]byte(`{"site_ids":[]}`), minSev, 60,
+		"test-consumer", now, now,
+	)
+}
+
+// recordingDispatcher is a Dispatcher used by send-test tests. It
+// records every Send call and returns a configurable status/body/err.
+type recordingDispatcher struct {
+	calls    int
+	gotDest  json.RawMessage
+	gotN     alerting.Notification
+	respCode int
+	respBody string
+	respErr  error
+}
+
+func (d *recordingDispatcher) Send(_ context.Context, dest json.RawMessage, n alerting.Notification) (int, string, error) {
+	d.calls++
+	d.gotDest = dest
+	d.gotN = n
+	return d.respCode, d.respBody, d.respErr
+}
+
+// ─── Create ───────────────────────────────────────────────────────────
+
+func TestCreateAlertContactHappyPath(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectExec(insertAlertContactSQL).
+		WithArgs(
+			"oncall", 1, "pagerduty",
+			sqlmock.AnyArg(), sqlmock.AnyArg(),
+			sqlmock.AnyArg(), uint8(4), 60,
+			"test-consumer",
+		).
+		WillReturnResult(sqlmock.NewResult(11, 1))
+	mock.ExpectQuery(selectAlertContactOneSQL).WithArgs(int64(11)).
+		WillReturnRows(makeAlertContactRow(11, "oncall", "pagerduty", 1, 4))
+
+	body := []byte(`{
+		"label":"oncall",
+		"transport":"pagerduty",
+		"destination":{"integration_key":"PDKEY-12345"}
+	}`)
+	req := newPOSTWithBody("/api/v1/alert-contacts", body)
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleCreateAlertContact)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp alertContactResponse
+	readJSON(t, rec.Body, &resp)
+	if resp.ID != 11 {
+		t.Errorf("ID = %d, want 11", resp.ID)
+	}
+	if resp.Transport != "pagerduty" {
+		t.Errorf("Transport = %q, want pagerduty", resp.Transport)
+	}
+	if resp.MinSeverity != "Down" {
+		t.Errorf("MinSeverity = %q, want Down (default)", resp.MinSeverity)
+	}
+}
+
+func TestCreateAlertContactRejectsBadTransport(t *testing.T) {
+	s, _, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	body := []byte(`{"label":"x","transport":"sms","destination":{}}`)
+	req := newPOSTWithBody("/api/v1/alert-contacts", body)
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleCreateAlertContact)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if got := readErrorBody(t, rec.Body).Code; got != "invalid_transport" {
+		t.Errorf("code = %q, want invalid_transport", got)
+	}
+}
+
+func TestCreateAlertContactRejectsMissingDestinationFields(t *testing.T) {
+	s, _, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	cases := []struct {
+		body string
+		code string
+	}{
+		{`{"label":"x","transport":"email","destination":{}}`, "invalid_alert_contact"},
+		{`{"label":"x","transport":"slack","destination":{"webhook_url":""}}`, "invalid_alert_contact"},
+		{`{"label":"","transport":"slack","destination":{"webhook_url":"https://x"}}`, "invalid_alert_contact"},
+	}
+	for _, c := range cases {
+		req := newPOSTWithBody("/api/v1/alert-contacts", []byte(c.body))
+		req = setAuthCtx(req, key)
+		rec := invokeAuthed(s, req, s.handleCreateAlertContact)
+		if rec.Code != http.StatusUnprocessableEntity {
+			t.Errorf("body=%s status=%d, want 422", c.body, rec.Code)
+			continue
+		}
+		if got := readErrorBody(t, rec.Body).Code; got != c.code {
+			t.Errorf("body=%s code = %q, want %q", c.body, got, c.code)
+		}
+	}
+}
+
+func TestCreateAlertContactRejectsBadSeverity(t *testing.T) {
+	s, _, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	body := []byte(`{"label":"x","transport":"email","destination":{"address":"a@b"},"min_severity":"Critical"}`)
+	req := newPOSTWithBody("/api/v1/alert-contacts", body)
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleCreateAlertContact)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if got := readErrorBody(t, rec.Body).Code; got != "invalid_severity" {
+		t.Errorf("code = %q, want invalid_severity", got)
+	}
+}
+
+// ─── Get ──────────────────────────────────────────────────────────────
+
+func TestGetAlertContactHappyPath(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(selectAlertContactOneSQL).WithArgs(int64(11)).
+		WillReturnRows(makeAlertContactRow(11, "oncall", "pagerduty", 1, 4))
+
+	req := httptest.NewRequest("GET", "/api/v1/alert-contacts/11", nil)
+	req.SetPathValue("id", "11")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleGetAlertContact)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestGetAlertContactNotFound(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(selectAlertContactOneSQL).WithArgs(int64(999)).
+		WillReturnRows(sqlmock.NewRows(columnsAlertContact))
+
+	req := httptest.NewRequest("GET", "/api/v1/alert-contacts/999", nil)
+	req.SetPathValue("id", "999")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleGetAlertContact)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+// ─── Update ───────────────────────────────────────────────────────────
+
+func TestUpdateAlertContactHappyPath(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	// Update first reads the current row to know the transport.
+	mock.ExpectQuery(selectAlertContactOneSQL).WithArgs(int64(11)).
+		WillReturnRows(makeAlertContactRow(11, "oncall", "pagerduty", 1, 4))
+	mock.ExpectExec(`UPDATE jetmon_alert_contacts SET active = ? WHERE id = ?`).
+		WithArgs(0, int64(11)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(selectAlertContactOneSQL).WithArgs(int64(11)).
+		WillReturnRows(makeAlertContactRow(11, "oncall", "pagerduty", 0, 4))
+
+	body := []byte(`{"active": false}`)
+	req := newPATCHWithBody("/api/v1/alert-contacts/11", body)
+	req.SetPathValue("id", "11")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleUpdateAlertContact)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUpdateAlertContactNotFound(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(selectAlertContactOneSQL).WithArgs(int64(999)).
+		WillReturnRows(sqlmock.NewRows(columnsAlertContact))
+
+	body := []byte(`{"active": false}`)
+	req := newPATCHWithBody("/api/v1/alert-contacts/999", body)
+	req.SetPathValue("id", "999")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleUpdateAlertContact)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+// ─── Delete ───────────────────────────────────────────────────────────
+
+func TestDeleteAlertContactHappyPath(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectExec(`DELETE FROM jetmon_alert_contacts WHERE id = ?`).
+		WithArgs(int64(11)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	req := httptest.NewRequest("DELETE", "/api/v1/alert-contacts/11", nil)
+	req.SetPathValue("id", "11")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleDeleteAlertContact)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rec.Code)
+	}
+}
+
+func TestDeleteAlertContactNotFound(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectExec(`DELETE FROM jetmon_alert_contacts WHERE id = ?`).
+		WithArgs(int64(999)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	req := httptest.NewRequest("DELETE", "/api/v1/alert-contacts/999", nil)
+	req.SetPathValue("id", "999")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleDeleteAlertContact)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+// ─── Send-test ────────────────────────────────────────────────────────
+
+func TestAlertContactTestHappyPath(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	disp := &recordingDispatcher{respCode: 200, respBody: "ok"}
+	s.SetAlertDispatchers(map[alerting.Transport]alerting.Dispatcher{
+		alerting.TransportSlack: disp,
+	})
+
+	// The test endpoint loads the contact, then loads its destination.
+	mock.ExpectQuery(selectAlertContactOneSQL).WithArgs(int64(11)).
+		WillReturnRows(makeAlertContactRow(11, "oncall-slack", "slack", 1, 4))
+	mock.ExpectQuery(loadAlertDestinationSQL).WithArgs(int64(11)).
+		WillReturnRows(sqlmock.NewRows([]string{"destination"}).
+			AddRow([]byte(`{"webhook_url":"https://hooks.slack.com/x"}`)))
+
+	req := newPOSTWithBody("/api/v1/alert-contacts/11/test", nil)
+	req.SetPathValue("id", "11")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleAlertContactTest)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if disp.calls != 1 {
+		t.Errorf("dispatcher called %d times, want 1", disp.calls)
+	}
+	if !disp.gotN.IsTest {
+		t.Error("dispatched notification should have IsTest=true")
+	}
+}
+
+func TestAlertContactTestSurfacesTransportError(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	disp := &recordingDispatcher{respCode: 500, respBody: "internal", respErr: errBoom("upstream")}
+	s.SetAlertDispatchers(map[alerting.Transport]alerting.Dispatcher{
+		alerting.TransportSlack: disp,
+	})
+
+	mock.ExpectQuery(selectAlertContactOneSQL).WithArgs(int64(11)).
+		WillReturnRows(makeAlertContactRow(11, "oncall-slack", "slack", 1, 4))
+	mock.ExpectQuery(loadAlertDestinationSQL).WithArgs(int64(11)).
+		WillReturnRows(sqlmock.NewRows([]string{"destination"}).
+			AddRow([]byte(`{"webhook_url":"https://hooks.slack.com/x"}`)))
+
+	req := newPOSTWithBody("/api/v1/alert-contacts/11/test", nil)
+	req.SetPathValue("id", "11")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleAlertContactTest)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAlertContactTestNoDispatcherConfigured(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	// alertDispatchers is nil → 503 "transport_not_configured"
+	mock.ExpectQuery(selectAlertContactOneSQL).WithArgs(int64(11)).
+		WillReturnRows(makeAlertContactRow(11, "oncall-email", "email", 1, 4))
+
+	req := newPOSTWithBody("/api/v1/alert-contacts/11/test", nil)
+	req.SetPathValue("id", "11")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleAlertContactTest)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+	if got := readErrorBody(t, rec.Body).Code; got != "transport_not_configured" {
+		t.Errorf("code = %q, want transport_not_configured", got)
+	}
+}
+
+// errBoom is a tiny error helper for tests.
+type errBoom string
+
+func (e errBoom) Error() string { return string(e) }

--- a/internal/api/handlers_alerts_test.go
+++ b/internal/api/handlers_alerts_test.go
@@ -215,6 +215,49 @@ func TestUpdateAlertContactHappyPath(t *testing.T) {
 	}
 }
 
+// TestUpdateAlertContactRejectsEmptyLabel verifies an empty label
+// PATCH gets rejected at the package's input-validation layer
+// without hitting the DB. Mirrors Create's "label is required" rule.
+func TestUpdateAlertContactRejectsEmptyLabel(t *testing.T) {
+	s, _, key, cleanup := newTestServer(t)
+	defer cleanup()
+	// No DB expectations — validation should fail before any query.
+
+	body := []byte(`{"label": ""}`)
+	req := newPATCHWithBody("/api/v1/alert-contacts/11", body)
+	req.SetPathValue("id", "11")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleUpdateAlertContact)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := readErrorBody(t, rec.Body).Code; got != "invalid_alert_contact" {
+		t.Errorf("code = %q, want invalid_alert_contact", got)
+	}
+}
+
+// TestUpdateAlertContactRejectsNegativeMaxPerHour verifies that PATCH
+// catches max_per_hour < 0 at input-validation time rather than letting
+// MySQL reject the negative value as a generic 500.
+func TestUpdateAlertContactRejectsNegativeMaxPerHour(t *testing.T) {
+	s, _, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	body := []byte(`{"max_per_hour": -10}`)
+	req := newPATCHWithBody("/api/v1/alert-contacts/11", body)
+	req.SetPathValue("id", "11")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleUpdateAlertContact)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := readErrorBody(t, rec.Body).Code; got != "invalid_alert_contact" {
+		t.Errorf("code = %q, want invalid_alert_contact", got)
+	}
+}
+
 func TestUpdateAlertContactNotFound(t *testing.T) {
 	s, mock, key, cleanup := newTestServer(t)
 	defer cleanup()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,21 @@ type Config struct {
 	DebugPort     int    `json:"DEBUG_PORT"`
 	APIPort       int    `json:"API_PORT"` // 0 = API server disabled
 
+	// Email transport selection for alert contacts. "stub" = log only
+	// (default; safe for environments where email is not configured),
+	// "smtp" = direct SMTP send (dev / staging with MailHog or similar),
+	// "wpcom" = POST to a WPCOM-owned email API endpoint (production).
+	// See API.md "Family 5 → Email delivery".
+	EmailTransport      string `json:"EMAIL_TRANSPORT"`
+	EmailFrom           string `json:"EMAIL_FROM"`
+	WPCOMEmailEndpoint  string `json:"WPCOM_EMAIL_ENDPOINT"`
+	WPCOMEmailAuthToken string `json:"WPCOM_EMAIL_AUTH_TOKEN"`
+	SMTPHost            string `json:"SMTP_HOST"`
+	SMTPPort            int    `json:"SMTP_PORT"`
+	SMTPUsername        string `json:"SMTP_USERNAME"`
+	SMTPPassword        string `json:"SMTP_PASSWORD"`
+	SMTPUseTLS          bool   `json:"SMTP_USE_TLS"`
+
 	Verifiers []VerifierConfig `json:"VERIFIERS"`
 }
 
@@ -162,6 +177,8 @@ func defaults() *Config {
 		LogFormat:               "text",
 		DashboardPort:           8080,
 		DebugPort:               6060,
+		EmailTransport:          "stub",
+		EmailFrom:               "jetmon@noreply.invalid",
 	}
 }
 

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -253,6 +253,88 @@ var migrations = []migration{
 		last_transition_id   BIGINT UNSIGNED NOT NULL DEFAULT 0,
 		updated_at           TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
+
+	// Migration 16 creates the alert contacts registry. Same shape as the
+	// webhook registry but with a simpler filter model (site_filter +
+	// min_severity, no event-type / state filter — see API.md Family 5).
+	//
+	// destination is JSON because each transport has a different shape:
+	//   email     → {"address":"ops@example.com"}
+	//   pagerduty → {"integration_key":"<events-v2 routing key>"}
+	//   slack     → {"webhook_url":"https://hooks.slack.com/..."}
+	//   teams     → {"webhook_url":"https://outlook.office.com/webhook/..."}
+	// destination stores the credential in plaintext for the same reason
+	// jetmon_webhooks.secret does (see migration 13): outbound dispatch
+	// needs the raw value at every send. A hash is useless because we'd
+	// have to recover the original to call the transport. Threat model and
+	// future encryption-at-rest plan are identical.
+	//
+	// min_severity is a TINYINT matching internal/eventstore.Severity*
+	// (0=Up, 1=Warning, 2=Degraded, 3=SeemsDown, 4=Down). Default 4 (Down)
+	// avoids accidental noise from new contacts. The API serializes by
+	// string name; the column stores the underlying uint8.
+	//
+	// max_per_hour caps notification rate per contact (default 60, 0 =
+	// unlimited). Per-contact because different destinations have
+	// different tolerance — a Slack channel can take far more than a
+	// PagerDuty oncall can.
+	{16, `CREATE TABLE IF NOT EXISTS jetmon_alert_contacts (
+		id                   BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		label                VARCHAR(128) NOT NULL,
+		active               TINYINT UNSIGNED NOT NULL DEFAULT 1,
+		transport            ENUM('email','pagerduty','slack','teams') NOT NULL,
+		destination          JSON NOT NULL,
+		destination_preview  VARCHAR(8) NOT NULL DEFAULT '',
+		site_filter          JSON NULL,
+		min_severity         TINYINT UNSIGNED NOT NULL DEFAULT 4,
+		max_per_hour         INT UNSIGNED NOT NULL DEFAULT 60,
+		created_by           VARCHAR(128) NOT NULL DEFAULT '',
+		created_at           TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		updated_at           TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+		INDEX idx_active (active)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
+
+	// Migration 17 creates the per-fire alert delivery records. One row per
+	// (alert_contact, transition) match — same fan-in shape as
+	// jetmon_webhook_deliveries: one transition produces many deliveries
+	// (one per matching contact), one contact gets at most one delivery
+	// per transition (enforced by uk_alert_transition).
+	//
+	// payload is frozen at row creation: contact sees the event as it was
+	// when the alert fired, not as it is now.
+	//
+	// status lifecycle and 'failed' semantics are identical to
+	// jetmon_webhook_deliveries.
+	{17, `CREATE TABLE IF NOT EXISTS jetmon_alert_deliveries (
+		id                BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		alert_contact_id  BIGINT UNSIGNED NOT NULL,
+		transition_id     BIGINT UNSIGNED NOT NULL,
+		event_id          BIGINT UNSIGNED NOT NULL,
+		event_type        VARCHAR(64) NOT NULL,
+		severity          TINYINT UNSIGNED NOT NULL,
+		payload           JSON NOT NULL,
+		status            ENUM('pending','delivered','failed','abandoned') NOT NULL DEFAULT 'pending',
+		attempt           INT UNSIGNED NOT NULL DEFAULT 0,
+		next_attempt_at   TIMESTAMP NULL,
+		last_status_code  INT NULL,
+		last_response     VARCHAR(2048) NULL,
+		last_attempt_at   TIMESTAMP NULL,
+		delivered_at      TIMESTAMP NULL,
+		created_at        TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		UNIQUE KEY uk_alert_transition (alert_contact_id, transition_id),
+		INDEX idx_status_next_attempt (status, next_attempt_at),
+		INDEX idx_contact_id_created (alert_contact_id, created_at),
+		INDEX idx_event_id (event_id)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
+
+	// Migration 18 records the alert dispatcher's progress. Mirrors
+	// jetmon_webhook_dispatch_progress — one row per jetmon2 instance with
+	// the high-water mark for jetmon_event_transitions.id.
+	{18, `CREATE TABLE IF NOT EXISTS jetmon_alert_dispatch_progress (
+		instance_id          VARCHAR(255) NOT NULL PRIMARY KEY,
+		last_transition_id   BIGINT UNSIGNED NOT NULL DEFAULT 0,
+		updated_at           TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
 }
 
 // Migrate applies all pending migrations idempotently.

--- a/internal/webhooks/deliveries.go
+++ b/internal/webhooks/deliveries.go
@@ -75,17 +75,42 @@ func Enqueue(ctx context.Context, db *sql.DB, in EnqueueInput) (int64, error) {
 	return id, nil
 }
 
-// ClaimReady returns up to limit pending deliveries whose next_attempt_at
-// is in the past, ordered by next_attempt_at ASC (oldest first). The
-// worker should claim, attempt, and update each row.
+// claimLockDuration is how far ClaimReady pushes next_attempt_at out
+// when it claims a row. It must outlast the worker's per-delivery wall
+// clock so the in-flight goroutine has time to write its real result
+// (delivered → next_attempt_at NULL, failed → next_attempt_at = retry
+// time) before this soft lock would expire. The default worker
+// HTTPTimeout is 30s with a 5s buffer; 60s gives comfortable headroom.
 //
-// Multi-instance safety: this implementation does NOT lock claimed rows.
-// Two instances polling simultaneously could pick up the same row and
-// fire duplicate deliveries. For single-instance deployment that's fine;
-// for multi-instance we add row-level claim via SELECT … FOR UPDATE SKIP
-// LOCKED in a transaction. Tracked in ROADMAP.md notes — see Architectural
-// roadmap "multi-repo split" (the deliverer process is the natural place
-// to add the locking when we extract it).
+// If a goroutine crashes without updating the row (panic without
+// recovery, OOM kill, etc.), the soft lock expires naturally and the
+// row becomes claimable again — natural recovery without operator
+// intervention.
+const claimLockDuration = 60 * time.Second
+
+// ClaimReady returns up to limit pending deliveries whose next_attempt_at
+// is in the past, ordered by next_attempt_at ASC (oldest first). Each
+// claimed row is soft-locked by pushing next_attempt_at to NOW +
+// claimLockDuration so subsequent ticks don't re-claim a row whose
+// dispatch is still in-flight. The dispatch goroutine overwrites
+// next_attempt_at with its real value (NULL on success, retry time on
+// failure) when it finishes.
+//
+// Without the soft lock, the deliver loop's 1-second tick re-claims
+// any in-flight row up to the per-contact in-flight cap, producing
+// concurrent dispatches and inflating the attempt counter — three
+// concurrent claims followed by three failures end up at attempt=3
+// after a single round. The soft lock prevents that.
+//
+// Multi-instance safety: this implementation does NOT use row-level
+// locks (SELECT ... FOR UPDATE SKIP LOCKED). Two instances polling
+// simultaneously could pick up the same row in the SELECT phase. The
+// UPDATE that follows is per-row, so only one of them will actually
+// transition next_attempt_at — but both still see the original
+// pre-claim row in their result set. For single-instance deployment
+// that's fine; for multi-instance the claim-and-lock should move to
+// SELECT ... FOR UPDATE SKIP LOCKED within a transaction. Tracked
+// alongside the deliverer-binary extraction in ROADMAP.md.
 func ClaimReady(ctx context.Context, db *sql.DB, limit int) ([]Delivery, error) {
 	rows, err := db.QueryContext(ctx, `
 		SELECT id, webhook_id, transition_id, event_id, event_type, payload,
@@ -99,16 +124,37 @@ func ClaimReady(ctx context.Context, db *sql.DB, limit int) ([]Delivery, error) 
 	if err != nil {
 		return nil, fmt.Errorf("webhooks: claim ready: %w", err)
 	}
-	defer rows.Close()
-	var out []Delivery
+	var candidates []Delivery
 	for rows.Next() {
 		d, err := scanDeliveryRow(rows)
 		if err != nil {
+			rows.Close()
 			return nil, err
 		}
-		out = append(out, *d)
+		candidates = append(candidates, *d)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, err
+	}
+	rows.Close()
+
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	// Soft-lock each claimed row so the next tick won't re-pick it.
+	lockUntil := time.Now().Add(claimLockDuration).UTC()
+	for i := range candidates {
+		if _, err := db.ExecContext(ctx, `
+			UPDATE jetmon_webhook_deliveries
+			   SET next_attempt_at = ?
+			 WHERE id = ? AND status = 'pending'`,
+			lockUntil, candidates[i].ID); err != nil {
+			return nil, fmt.Errorf("webhooks: soft-lock row %d: %w", candidates[i].ID, err)
+		}
+	}
+	return candidates, nil
 }
 
 // MarkDelivered records a successful delivery with the response status.

--- a/internal/webhooks/deliveries_test.go
+++ b/internal/webhooks/deliveries_test.go
@@ -1,0 +1,83 @@
+package webhooks
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+const selectClaimReadySQL = ` SELECT id, webhook_id, transition_id, event_id, event_type, payload, status, attempt, next_attempt_at, last_status_code, last_response, last_attempt_at, delivered_at, created_at FROM jetmon_webhook_deliveries WHERE status = 'pending' AND (next_attempt_at IS NULL OR next_attempt_at <= CURRENT_TIMESTAMP) ORDER BY next_attempt_at ASC LIMIT ?`
+
+const softLockClaimedSQL = ` UPDATE jetmon_webhook_deliveries SET next_attempt_at = ? WHERE id = ? AND status = 'pending'`
+
+var columnsClaimedDelivery = []string{
+	"id", "webhook_id", "transition_id", "event_id", "event_type",
+	"payload", "status", "attempt", "next_attempt_at", "last_status_code", "last_response",
+	"last_attempt_at", "delivered_at", "created_at",
+}
+
+// TestClaimReadySoftLocksEachRow verifies the contract that ClaimReady
+// follows its SELECT with one UPDATE per claimed row, pushing
+// next_attempt_at out so subsequent ticks won't re-claim a still-in-
+// flight row. Without this, the deliver loop's 1s tick re-claims
+// pending rows and produces concurrent dispatches that inflate the
+// attempt counter.
+func TestClaimReadySoftLocksEachRow(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	now := time.Now().UTC()
+	rows := sqlmock.NewRows(columnsClaimedDelivery).
+		AddRow(int64(1), int64(7), int64(100), int64(900), "event.opened",
+			[]byte(`{}`), "pending", 0, now, nil, nil, nil, nil, now).
+		AddRow(int64(2), int64(7), int64(101), int64(901), "event.opened",
+			[]byte(`{}`), "pending", 0, now, nil, nil, nil, nil, now)
+
+	mock.ExpectQuery(selectClaimReadySQL).WithArgs(50).WillReturnRows(rows)
+	mock.ExpectExec(softLockClaimedSQL).
+		WithArgs(sqlmock.AnyArg(), int64(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(softLockClaimedSQL).
+		WithArgs(sqlmock.AnyArg(), int64(2)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	out, err := ClaimReady(context.Background(), db, 50)
+	if err != nil {
+		t.Fatalf("ClaimReady: %v", err)
+	}
+	if len(out) != 2 {
+		t.Errorf("got %d claimed, want 2", len(out))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("expectations: %v", err)
+	}
+}
+
+// TestClaimReadyNoCandidatesSkipsLockUpdates verifies that when the
+// SELECT returns nothing, ClaimReady issues no UPDATEs.
+func TestClaimReadyNoCandidatesSkipsLockUpdates(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(selectClaimReadySQL).WithArgs(50).
+		WillReturnRows(sqlmock.NewRows(columnsClaimedDelivery))
+
+	out, err := ClaimReady(context.Background(), db, 50)
+	if err != nil {
+		t.Fatalf("ClaimReady: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("got %d claimed, want 0", len(out))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
Stacked PR 3 of 9.

Base: `stack-02-webhooks`
Head: `stack-03-alert-contacts`
Previous PR: #74

Summary:
- Adds alert-contact schema migrations and the `internal/alerting` package.
- Adds email, PagerDuty, Slack, and Teams transports.
- Adds alert contact CRUD, send-test, delivery listing, retry endpoints, retry behavior, and rate caps.
- Wires the alert delivery worker into `jetmon2`.

Review notes:
This PR builds on the webhook delivery shape from #74 and applies the same transition-consumer pattern to managed alert contacts.