### PR TITLE
Refresh docs, tooling, and coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ You are an expert Go developer with extensive knowledge about WordPress, enterpr
 
 Jetmon is a parallel HTTP uptime monitoring service that checks Jetpack websites at scale. Jetmon 2 is a complete rewrite of the original Node.js + C++ native addon service into a single Go binary. It retains full drop-in compatibility with all external interfaces — MySQL schema, WPCOM API payload, StatsD metric names, and log file format — while dramatically increasing concurrency, reducing memory usage, and eliminating the native addon compilation dependency.
 
-The Veriflier is rewritten in Go as well, replacing the Qt C++ dependency. The protocol between Monitor and Verifliers is upgraded from custom HTTPS to gRPC.
+The Veriflier is rewritten in Go as well, replacing the Qt C++ dependency. The current protocol between Monitor and Verifliers is JSON-over-HTTP on the configured Veriflier port, with the proto contract retained for a future generated gRPC transport.
 
 See `PROJECT.md` for the full project description, feature list, and performance benefit estimates.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,8 +104,8 @@ docker compose up --build                 # Rebuild binary and start
 docker compose down                       # Stop services
 docker compose down -v                    # Stop and remove volumes (fresh start)
 
-# Build binary directly
-go build ./cmd/jetmon2/
+# Build binaries directly
+make all
 
 # Run tests
 go test ./...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,9 +107,13 @@ docker compose down -v                    # Stop and remove volumes (fresh start
 # Build binaries directly
 make all
 
+# Use a non-default Go binary when needed
+make GO=/path/to/go all
+
 # Run tests
-go test ./...
-go test -race ./...
+make test
+make test-race
+make lint
 
 # Run with race detector
 go run -race ./cmd/jetmon2/

--- a/API.md
+++ b/API.md
@@ -85,7 +85,7 @@ The CLI talks to the database directly (via `jetmon_api_keys`), prints the new t
 https://api.jetmon.example.com/api/v1
 ```
 
-Hosted in the `jetmon2` binary on a dedicated port (`API_PORT`), separate from the operator dashboard (`DASHBOARD_PORT`) and the verifier transport (`VERIFLIER_GRPC_PORT`).
+Hosted in the `jetmon2` binary on a dedicated port (`API_PORT`), separate from the operator dashboard (`DASHBOARD_PORT`) and the verifier transport port (`VERIFLIER_GRPC_PORT`).
 
 ### Content negotiation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,20 @@ because it is intentionally **not** drop-in with the Jetmon 1 wire format
   SKIP LOCKED) still tracked alongside the deliverer-binary extraction in
   ROADMAP.md.
 
+**Docs / tooling:**
+- `make all` now builds the currently implemented `jetmon2` and
+  `veriflier2` binaries without requiring `protoc`; generated Veriflier
+  gRPC stubs remain an explicit `make generate` step for the future
+  transport swap.
+- Developer docs now point at the Makefile build path and document why
+  code generation is separate from the default build.
+- Added a top-level docs index and a post-v2 probe-agent architecture
+  options document for revisiting the v3 direction after v2 is stable in
+  production.
+- Clarified that the current Veriflier transport is JSON-over-HTTP and
+  that the public API roadmap is about a future customer-facing contract,
+  not the already-implemented internal `/api/v1`.
+
 **Polish:**
 - `alerting.Update` now validates `label` (must be non-empty) and
   `max_per_hour` (must be ≥ 0) at input time, surfacing 422

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,9 @@ because it is intentionally **not** drop-in with the Jetmon 1 wire format
   gRPC stubs remain an explicit `make generate` step for the future
   transport swap.
 - Makefile targets now share a configurable `GO` command and fall back to
-  `/usr/local/go/bin/go` when `go` is not on `PATH`.
+  `/usr/local/go/bin/go` when `go` is not on `PATH`; they also use an
+  overrideable `/tmp` Go build cache so checks do not depend on a
+  writable home-directory cache.
 - Developer docs now point at the Makefile build path and document why
   code generation is separate from the default build.
 - Added a top-level docs index and a post-v2 probe-agent architecture

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,8 @@ because it is intentionally **not** drop-in with the Jetmon 1 wire format
   `veriflier2` binaries without requiring `protoc`; generated Veriflier
   gRPC stubs remain an explicit `make generate` step for the future
   transport swap.
+- Makefile targets now share a configurable `GO` command and fall back to
+  `/usr/local/go/bin/go` when `go` is not on `PATH`.
 - Developer docs now point at the Makefile build path and document why
   code generation is separate from the default build.
 - Added a top-level docs index and a post-v2 probe-agent architecture

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BUILD_FLAGS := -ldflags "-X main.version=$(shell git describe --tags --always --
 
 .PHONY: all build build-veriflier generate test test-race lint clean
 
-all: generate build build-veriflier
+all: build build-veriflier
 
 build:
 	mkdir -p bin

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 BINARY      := bin/jetmon2
 VERIFLIER   := bin/veriflier2
+GO          ?= $(shell if command -v go >/dev/null 2>&1; then command -v go; elif [ -x /usr/local/go/bin/go ]; then printf /usr/local/go/bin/go; else printf go; fi)
 BUILD_FLAGS := -ldflags "-X main.version=$(shell git describe --tags --always --dirty) \
                          -X main.buildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ) \
-                         -X main.goVersion=$(shell go version | awk '{print $$3}')"
+                         -X main.goVersion=$(shell $(GO) version | awk '{print $$3}')"
 
 .PHONY: all build build-veriflier generate test test-race lint clean
 
@@ -10,11 +11,11 @@ all: build build-veriflier
 
 build:
 	mkdir -p bin
-	CGO_ENABLED=0 go build $(BUILD_FLAGS) -o $(BINARY) ./cmd/jetmon2/
+	CGO_ENABLED=0 $(GO) build $(BUILD_FLAGS) -o $(BINARY) ./cmd/jetmon2/
 
 build-veriflier:
 	mkdir -p bin
-	CGO_ENABLED=0 go build $(BUILD_FLAGS) -o $(VERIFLIER) ./veriflier2/cmd/
+	CGO_ENABLED=0 $(GO) build $(BUILD_FLAGS) -o $(VERIFLIER) ./veriflier2/cmd/
 
 
 generate:
@@ -23,13 +24,13 @@ generate:
 	       proto/veriflier.proto
 
 test:
-	go test ./...
+	$(GO) test ./...
 
 test-race:
-	go test -race ./...
+	$(GO) test -race ./...
 
 lint:
-	go vet ./...
+	$(GO) vet ./...
 
 clean:
 	rm -f $(BINARY) $(VERIFLIER)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 BINARY      := bin/jetmon2
 VERIFLIER   := bin/veriflier2
 GO          ?= $(shell if command -v go >/dev/null 2>&1; then command -v go; elif [ -x /usr/local/go/bin/go ]; then printf /usr/local/go/bin/go; else printf go; fi)
+GOCACHE     ?= /tmp/jetmon-go-cache
+GO_ENV      := GOCACHE=$(GOCACHE)
 BUILD_FLAGS := -ldflags "-X main.version=$(shell git describe --tags --always --dirty) \
                          -X main.buildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ) \
                          -X main.goVersion=$(shell $(GO) version | awk '{print $$3}')"
@@ -11,11 +13,11 @@ all: build build-veriflier
 
 build:
 	mkdir -p bin
-	CGO_ENABLED=0 $(GO) build $(BUILD_FLAGS) -o $(BINARY) ./cmd/jetmon2/
+	$(GO_ENV) CGO_ENABLED=0 $(GO) build $(BUILD_FLAGS) -o $(BINARY) ./cmd/jetmon2/
 
 build-veriflier:
 	mkdir -p bin
-	CGO_ENABLED=0 $(GO) build $(BUILD_FLAGS) -o $(VERIFLIER) ./veriflier2/cmd/
+	$(GO_ENV) CGO_ENABLED=0 $(GO) build $(BUILD_FLAGS) -o $(VERIFLIER) ./veriflier2/cmd/
 
 
 generate:
@@ -24,13 +26,13 @@ generate:
 	       proto/veriflier.proto
 
 test:
-	$(GO) test ./...
+	$(GO_ENV) $(GO) test ./...
 
 test-race:
-	$(GO) test -race ./...
+	$(GO_ENV) $(GO) test -race ./...
 
 lint:
-	$(GO) vet ./...
+	$(GO_ENV) $(GO) vet ./...
 
 clean:
 	rm -f $(BINARY) $(VERIFLIER)

--- a/README.md
+++ b/README.md
@@ -4,34 +4,68 @@ jetmon2
 Overview
 --------
 
-Jetmon is a parallel HTTP uptime monitoring service that checks Jetpack websites at scale. Jetmon 2 is a complete rewrite of the original Node.js + C++ service as a single Go binary, delivering a large reduction in memory usage, a significant increase in concurrent checks per host, and a simpler deployment model with no native addon compilation.
+Jetmon is the parallel HTTP health monitoring service for Jetpack-connected sites at scale. Jetmon 2 turns it from a binary up/down status flipper into a full event-sourced health platform — the same low-false-positive Veriflier-confirmed detection core, now with a five-layer severity model, an internal REST API, HMAC-signed webhooks, managed alert contacts (email, PagerDuty, Slack, Teams), and a complete operational audit trail.
 
-Jetmon periodically loops over a list of Jetpack sites and performs HTTP checks. When a site appears down, local retries are attempted before geographically distributed Veriflier services are asked to confirm the outage. WPCOM is notified only after confirmation, keeping false positive rates low.
+The whole thing ships as a single static Go binary with embedded migrations. No `node_modules`, no native addons, no worker process tree. Every check, retry, Veriflier confirmation, and notification lands in `jetmon_audit_log`; every status transition lands in `jetmon_event_transitions`. An operator can replay any incident, end-to-end, from the database alone.
 
-Jetmon 2 is a drop-in replacement: the MySQL schema, WPCOM notification payload, StatsD metric names, log file format, and config file keys are all backwards-compatible. See `PROJECT.md` for the full feature specification and performance estimates.
+The Jetmon 1 detection pipeline is preserved verbatim — periodic check rounds, local retries before escalation, geo-distributed Veriflier confirmation before WPCOM is notified. v2 keeps WPCOM compatibility through a shadow-state migration: the v2 event tables are authoritative, and `jetpack_monitor_sites.site_status` / `last_status_change` continue to be projected transactionally for legacy consumers until they cut over (`LEGACY_STATUS_PROJECTION_ENABLE`).
+
+
+What's new in v2
+----------------
+
+v2 keeps the Jetmon 1 detection pipeline (local retries → geo-distributed Veriflier confirmation → notify) and rebuilds everything around it.
+
+| Capability | Jetmon 1 | Jetmon 2 |
+|---|---|---|
+| Status model | Binary `up` / `down` (`confirmed_down` for re-detections) | Five-layer severity ladder: `Up < Warning < Degraded < SeemsDown < Down`, paired with separate state vocabulary |
+| State storage | Single mutable `site_status` column | Event-sourced — `jetmon_events` (current authoritative state) + append-only `jetmon_event_transitions` (every mutation) |
+| Failure classifications | `down` | `server`, `client`, `blocked`, `https`, `intermittent`, `redirect`, `ssl_expiry`, `tls_deprecated`, `keyword_missing`, `success` |
+| Notification channels | WPCOM only | WPCOM + HMAC-signed webhooks + managed alert contacts (email, PagerDuty, Slack, Teams) |
+| API surface | None | Internal REST API at `/api/v1`: Bearer auth, three coarse scopes, per-key rate limit, Stripe-style idempotency, cursor pagination, full audit logging |
+| Per-site config | Bucket + check interval | + custom headers, timeout override, redirect policy, alert cooldown, maintenance windows, keyword content check, SSL-expiry alerts at 30 / 14 / 7 days |
+| Operational audit | Basic logging | Full audit trail (`jetmon_audit_log`) over every check, retry, Veriflier dispatch, alert suppression, API call, and config reload |
+| Process model | Node master + Node workers + C++ native addon + Qt C++ Veriflier | Single Go binary (`jetmon2`) + Go Veriflier (`veriflier2`) |
+| Worker scaling | Spawn / kill child processes | In-process goroutine pool that auto-scales by queue depth |
+| Deployment friction | `npm` + `node-gyp` + Qt | Static binary + `./jetmon2 migrate` + `./jetmon2 validate-config` |
+| Multi-host coordination | Manual `bucket_min` / `bucket_max` per host | MySQL-coordinated `jetmon_hosts` table with heartbeat-and-reclaim |
+| Observability | StatsD | StatsD + structured logs + audit trail + operator dashboard (SSE) + localhost pprof |
+| Hot reload | Restart | `SIGHUP` for config; `SIGINT` for graceful drain |
+
+A few specifics worth bragging about:
+
+- **Webhooks with Stripe-style HMAC signatures.** `t=<unix>,v1=<hex>` over `{ts}.{body}`, per-webhook in-flight cap, retry ladder 1m → 5m → 30m → 1h → 6h before abandon. Frozen-at-fire-time payload contract — consumers see the event as it was when the webhook fired, not as it is now.
+- **Idempotent write endpoints.** POSTs accept `Idempotency-Key`; replays return the original response, so a retried "click to test" through a network blip won't double-page the destination.
+- **Rotation grace windows on API keys.** `revoked_at` and `expires_at` are half-open cutoffs; setting `revoked_at` in the future keeps the old key valid until consumers deploy the replacement.
+- **Migrations embedded in the binary.** `./jetmon2 migrate` walks the schema forward; `./jetmon2 validate-config` checks config + DB connectivity + email transport mode + verifier list before deploy, and warns loudly when alert-contact email is set to the log-only stub.
+- **MySQL 5.7+ compatible.** No window functions, no JSON-path expressions in SELECT — the v2 schema and queries land cleanly on the legacy production database.
 
 
 Architecture
 ------------
 
 ```
-┌──────────────────────────────────────────────────────┐
-│                  jetmon2 (single binary)             │
-│                                                      │
-│  ┌─────────────┐  ┌─────────────┐  ┌──────────────┐  │
-│  │ Orchestrator│  │ Check Pool  │  │  Veriflier   │  │
-│  │  goroutine  │  │ (goroutines)│  │  transport   │  │
-│  └──────┬──────┘  └──────┬──────┘  └──────┬───────┘  │
-│         │                │                │          │
-│  ┌──────┴────────────────┴────────────────┴───────┐  │
-│  │                 Internal channels              │  │
-│  └────────────────────────────────────────────────┘  │
-└────────────┬──────────────────────────┬──────────────┘
-             │                          │
-          MySQL                    WPCOM API
-          StatsD                   (unchanged)
-          Log files
-          (all unchanged)
+┌──────────────────────────────────────────────────────────────┐
+│                 jetmon2 (single binary)                      │
+│                                                              │
+│  ┌────────────┐  ┌────────────┐  ┌────────────────────┐      │
+│  │Orchestrator│  │ Check pool │  │ Veriflier          │      │
+│  │ goroutine  │  │(goroutines)│  │ transport          │      │
+│  └─────┬──────┘  └─────┬──────┘  └────────┬───────────┘      │
+│        │               │                  │                  │
+│  ┌─────┴───────────────┴──────────────────┴────────────┐     │
+│  │  Eventstore + Audit log                             │     │
+│  └─────┬─────────────────┬──────────────────┬──────────┘     │
+│        │                 │                  │                │
+│  ┌─────┴──────┐  ┌───────┴────────┐  ┌──────┴──────────┐     │
+│  │  REST API  │  │ Webhook worker │  │  Alert-contact  │     │
+│  │  /api/v1/  │  │ (HMAC-signed)  │  │     worker      │     │
+│  └────────────┘  └────────────────┘  └─────────────────┘     │
+└────────┬─────────────────────────────────────────┬───────────┘
+         │                                         │
+       MySQL                              WPCOM · custom webhooks
+       StatsD                             · email · PagerDuty
+       Log files                          · Slack · Teams
 ```
 
 The **Orchestrator goroutine** fetches site batches from MySQL, dispatches work to the check pool, manages the local retry queue, coordinates Veriflier confirmation, and sends WPCOM notifications. It owns all database access and all outbound WPCOM calls.
@@ -42,13 +76,22 @@ The **Veriflier transport** sends confirmation batches to remote Veriflier insta
 
 The **Veriflier** is a standalone Go binary deployed at remote locations. It replaces the Qt C++ Veriflier, using the same JSON-over-HTTP transport as the Monitor-side client until the generated gRPC stubs are wired in.
 
-Status change flows:
+The v2 platform layer sits below the detection pipeline:
 
-| Previous Status | Current Status    | Action                                            |
-|-----------------|-------------------|---------------------------------------------------|
+- **Eventstore** is the sole writer for `jetmon_events` and `jetmon_event_transitions`. Every state change — open, escalate, close, recover, manual override — is an atomic transition with full history. Audit log writes share the same MySQL handle.
+- **REST API** exposes the v2 surface at `/api/v1/` (enable with `API_PORT`). Bearer-token auth, three coarse scopes (`read` / `write` / `admin`), per-key token-bucket rate limiting, Stripe-style idempotency keys on POSTs. Every authenticated request lands in `jetmon_audit_log` with the consumer name, status, latency, and request id.
+- **Webhook worker** delivers HMAC-signed `event.*` posts to registered consumers. Per-webhook in-flight cap, retry ladder 1m → 5m → 30m → 1h → 6h, frozen-at-fire-time payload.
+- **Alert-contact worker** delivers Jetmon-rendered notifications through Jetmon-owned transports (email, PagerDuty Events API v2, Slack Block Kit, Teams Adaptive Cards). Per-contact `max_per_hour` rate cap as pager-storm insurance.
+
+WPCOM notification flow (preserved from Jetmon 1, used during shadow-state migration):
+
+| Previous Status | Current Status    | Action                                                |
+|-----------------|-------------------|-------------------------------------------------------|
 | UP              | DOWN              | Local retries → Veriflier confirmation → notify WPCOM |
-| DOWN            | UP                | Notify WPCOM site recovered                       |
-| DOWN            | DOWN (confirmed)  | Notify WPCOM confirmed down                       |
+| DOWN            | UP                | Notify WPCOM site recovered                           |
+| DOWN            | DOWN (confirmed)  | Notify WPCOM confirmed down                           |
+
+v2 emits richer events to webhook and alert-contact subscribers (full event lifecycle including escalations and severity transitions) — the WPCOM table above describes only the legacy notification path.
 
 
 Installation

--- a/README.md
+++ b/README.md
@@ -198,7 +198,9 @@ For Developers
 
 If `go` is not on `PATH`, the Makefile falls back to
 `/usr/local/go/bin/go` when present. Override with `make GO=/path/to/go ...`
-for other local layouts.
+for other local layouts. Make targets use `GOCACHE=/tmp/jetmon-go-cache` by
+default so builds do not depend on a writable home-directory cache; override
+with `make GOCACHE=/path/to/cache ...` when needed.
 
 `make generate` is intentionally separate from `make all`. It requires
 `protoc` and the Go protobuf plugins, and is only needed when replacing the

--- a/README.md
+++ b/README.md
@@ -196,14 +196,19 @@ For Developers
 	make build            # Build only bin/jetmon2
 	make build-veriflier  # Build only bin/veriflier2
 
+If `go` is not on `PATH`, the Makefile falls back to
+`/usr/local/go/bin/go` when present. Override with `make GO=/path/to/go ...`
+for other local layouts.
+
 `make generate` is intentionally separate from `make all`. It requires
 `protoc` and the Go protobuf plugins, and is only needed when replacing the
 current JSON-over-HTTP Veriflier transport with generated gRPC stubs.
 
 ### Running Tests
 
-	go test ./...
-	go test -race ./...
+	make test
+	make test-race
+	make lint
 
 The current `go test ./...` suite runs standalone. Use the Docker Compose environment for manual end-to-end checks against MySQL, StatsD, and Veriflier services.
 

--- a/README.md
+++ b/README.md
@@ -192,9 +192,13 @@ For Developers
 
 ### Building
 
-	mkdir -p bin
-	go build -o bin/jetmon2 ./cmd/jetmon2/
-	go build -o bin/veriflier2 ./veriflier2/cmd/
+	make all              # Build bin/jetmon2 and bin/veriflier2
+	make build            # Build only bin/jetmon2
+	make build-veriflier  # Build only bin/veriflier2
+
+`make generate` is intentionally separate from `make all`. It requires
+`protoc` and the Go protobuf plugins, and is only needed when replacing the
+current JSON-over-HTTP Veriflier transport with generated gRPC stubs.
 
 ### Running Tests
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,13 +20,16 @@ recommendation.
 
 ## Public REST API
 
-**Status:** Not started. No existing API surface covers this scope.
+**Status:** Not started as a customer-facing surface. The v2 branch has an
+internal `/api/v1` behind a gateway (see ADR-0002); this item is about the
+public/customer contract and the gateway-facing semantics needed to expose it
+safely.
 
 ### What it is
 
-A versioned, authenticated REST API (`/api/v1/`) on competitive parity with established uptime monitoring services (Pingdom, UptimeRobot, Better Uptime, Datadog Synthetics). Users and integrations interact with Jetmon entirely through this API — reading current health state, pulling event history and SLA statistics, managing what gets monitored, configuring alerts, and triggering on-demand checks.
+A versioned, authenticated customer-facing REST API on competitive parity with established uptime monitoring services (Pingdom, UptimeRobot, Better Uptime, Datadog Synthetics). Users and integrations interact with Jetmon entirely through this API — reading current health state, pulling event history and SLA statistics, managing what gets monitored, configuring alerts, and triggering on-demand checks.
 
-Currently, Jetmon has no public API. The operator dashboard exposes real-time state via SSE for human consumption. Check configuration requires direct writes to `jetpack_monitor_sites`. Event and audit data requires direct DB queries or use of the `jetmon2 audit` CLI. There is no programmatic interface for users or external tooling to interact with Jetmon.
+Currently, Jetmon's API is internal-only: callers are known services, tenant isolation lives at the gateway, errors are intentionally verbose, and ownership checks are coarse. What is missing is a stable public contract with customer-scoped auth, tenant ownership, sanitized error semantics, public rate limits, and payloads safe to expose directly to customer tooling.
 
 ### Why it matters
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,6 +4,88 @@ Deferred features that are intentionally out of scope for the current implementa
 
 ---
 
+## Prioritized TODO
+
+This is the current implementation/refinement queue. Lower-priority items are
+not abandoned; they are intentionally sequenced behind the v2 production
+migration and the operating data needed to make larger architecture decisions.
+
+### P0 - v2 production hardening
+
+- **Keep the v2 deployment target conservative.** Ship and stabilize the
+  current main-server-plus-Veriflier design before moving toward a v3
+  probe-agent architecture. The v2 event tables remain authoritative while
+  `LEGACY_STATUS_PROJECTION_ENABLE` keeps legacy `site_status` /
+  `last_status_change` consumers working during migration.
+- **Operationally enforce single-owner delivery until row claiming lands.**
+  In the single-binary deployment, `API_PORT > 0` also starts webhook and
+  alert-contact delivery workers. Run that on only one active `jetmon2`
+  instance per database cluster until delivery claiming moves to transactional
+  `SELECT ... FOR UPDATE SKIP LOCKED` or the deliverer binary is extracted.
+- **Instrument the data needed for the v3 decision.** During v2 production,
+  measure first-failure-to-`Seems Down`, `Seems Down`-to-`Down`, false alarm
+  rate by failure class, Veriflier agreement/disagreement by region, Veriflier
+  latency/timeout rates, mixed-region outcomes, monitor-side `Unknown` cases,
+  primary-check vs confirmation cost, operator explanation gaps, and WPCOM
+  notification parity.
+- **Watch projection drift as a production bug.** While the legacy projection
+  is enabled, event mutations, transition rows, and the site-row projection
+  must remain transactionally consistent.
+- **Reconcile roadmap/API documentation drift.** `API.md` is the source for
+  the implemented internal `/api/v1` route surface. This roadmap should track
+  only the remaining public/customer API work, production hardening, and
+  deferred architecture choices.
+
+### P1 - post-v2 platform refinement
+
+- **Extract `jetmon-deliverer` when delivery scale or blast radius warrants
+  it.** Move webhook delivery, alert-contact delivery, and eventually WPCOM
+  notification dispatch behind one outbound-delivery binary.
+- **Replace soft delivery locks with transactional row claims.** As part of
+  the deliverer extraction, update the webhook and alert-contact `ClaimReady`
+  paths to use `SELECT ... FOR UPDATE SKIP LOCKED` so active-active delivery
+  workers are safe.
+- **Unify webhook and alerting dispatch plumbing after production evidence.**
+  Keep the packages separate until there are two proven implementations and a
+  third transport path via WPCOM migration, then factor the shared retry,
+  claim, dispatch, and circuit-breaker shape behind a transport interface.
+- **Migrate WPCOM notifications behind alert contacts/deliverer.** Do this
+  only after alert contacts have proven stable in production and recipient
+  parity has been verified.
+- **Decide the Veriflier transport endpoint.** Either wire the generated gRPC
+  stubs once the protoc toolchain is ready, or explicitly bless
+  JSON-over-HTTP as the v2 production transport and update the docs/naming to
+  match.
+- **Generate an OpenAPI 3.1 contract for the internal API.** The spec should
+  be generated from the route/handler contract so client codegen matches the
+  running server.
+- **Plan encryption-at-rest for outbound credentials before public/customer
+  secret management.** Plaintext webhook secrets and alert-contact
+  destination credentials are acceptable for the current internal threat
+  model, but KMS-style encryption should be revisited before exposing
+  customer-managed secrets more broadly.
+
+### P2 - v3 and product-driven extensions
+
+- **Revisit Candidate 3 after v2 has production data.** The current leading
+  v3 option is a central scheduler plus regional probe agents. The migration
+  should start with richer v2 probe metadata, then durable confirmation jobs,
+  generic probe agents, shadow-mode primary jobs, and gradual cutover.
+- **Add regional/per-vantage status only when the support story is ready.**
+  Regional classifications, per-vantage SLA, and richer `Unknown` handling
+  depend on probe-agent data and taxonomy work; they should not leak to
+  customers prematurely.
+- **Treat alert/webhook polish as demand-driven.** Grace-period webhook secret
+  rotation, `site.state_changed` webhooks, alert digest mode, quiet hours,
+  external acknowledgements, SMS, and OpsGenie are clean additions, but should
+  wait for customer demand or compliance pressure.
+- **Retire the legacy status projection after consumers migrate.** Once
+  downstream readers use the v2 API/event tables, disable
+  `LEGACY_STATUS_PROJECTION_ENABLE` and stop treating stale legacy status
+  values as meaningful.
+
+---
+
 ## v3 Probe-Agent Architecture
 
 **Status:** Parked until v2 has been deployed to production and stabilized.
@@ -29,7 +111,7 @@ safely.
 
 A versioned, authenticated customer-facing REST API on competitive parity with established uptime monitoring services (Pingdom, UptimeRobot, Better Uptime, Datadog Synthetics). Users and integrations interact with Jetmon entirely through this API — reading current health state, pulling event history and SLA statistics, managing what gets monitored, configuring alerts, and triggering on-demand checks.
 
-Currently, Jetmon's API is internal-only: callers are known services, tenant isolation lives at the gateway, errors are intentionally verbose, and ownership checks are coarse. What is missing is a stable public contract with customer-scoped auth, tenant ownership, sanitized error semantics, public rate limits, and payloads safe to expose directly to customer tooling.
+Currently, Jetmon's API is internal-only: callers are known services, tenant isolation lives at the gateway, errors are intentionally verbose, and ownership checks are coarse. What is missing is a stable public contract with customer-scoped auth, tenant ownership, sanitized error semantics, public rate limits, and payloads safe to expose directly to customer tooling. The capability list below describes the public/customer contract target; many internal equivalents already exist and are documented in `API.md`.
 
 ### Why it matters
 
@@ -111,38 +193,60 @@ Programmatic management of where alerts go. Competitors that omit this force use
 | `GET /api/v1/sites/{blog_id}/alert-contacts` | List which contacts are subscribed to a site |
 | `PUT /api/v1/sites/{blog_id}/alert-contacts` | Set the alert contact list for a site |
 
-**Alert contact types (v1):** email, webhook (generic HTTP POST with configurable payload template). Later: Slack, PagerDuty, OpsGenie, SMS.
+**Alert contact types:** the internal API currently supports email, PagerDuty, Slack, and Teams. Generic customer-owned HTTP POSTs should use the HMAC-signed webhooks API instead of duplicating that surface as an alert-contact transport. Later, direct SMS or OpsGenie can be added if customer demand justifies them.
 
 **Webhook contract.** Outbound webhook POSTs carry a standard envelope: `event_type`, `site_id`, `blog_id`, `timestamp`, `event` (the full event object). `event_type` values: `site.seems_down`, `site.down`, `site.recovered`, `site.degraded`, `maintenance.started`, `maintenance.ended`. The payload structure is versioned and must not break existing webhook consumers when new fields are added.
 
-### Design decisions to make before building
+### Public API decisions before direct exposure
 
-**Authentication.** API keys stored in a `jetmon_api_keys` table (hashed, scoped, with optional expiry). The `Authorization: Bearer <token>` pattern from the Veriflier transport is the reference. Scopes: `read` (Capabilities 1–3), `write` (Capabilities 4–5), `admin` (key management). OAuth is overkill for an internal service; API keys are sufficient and match what competitors use for programmatic access.
+The internal API decisions are implemented in `internal/api/` and documented in
+`API.md`. A public/customer API is a different contract and needs these
+decisions before direct exposure:
 
-**Key lifecycle CLI.** `jetmon2 apikey create [--scope read|write|admin] [--expires 90d] [--label "CI deploy script"]`, `jetmon2 apikey revoke <key-id>`, `jetmon2 apikey list`. Keys are never returned after creation; only the ID and label are stored.
+**Tenant and ownership model.** Decide whether the gateway remains the sole
+tenant boundary or Jetmon stores tenant ownership directly on sites, webhooks,
+alert contacts, idempotency keys, and audit rows. Direct customer exposure
+requires every read/write to be tenant-scoped.
 
-**Hosting.** API runs within the `jetmon2` binary on a dedicated port (separate from the operator dashboard port). Embedding keeps deployment to one artifact. The operator dashboard's existing HTTP server in `internal/dashboard/` is the starting point — the API mounts alongside it or on a configurable separate port.
+**Auth scopes.** The internal API uses coarse `read` / `write` / `admin`
+scopes. Public keys likely need granular scopes such as `sites:read`,
+`events:read`, `webhooks:write`, and `alerts:write` so customer integrations can
+be least-privilege.
 
-**Pagination.** Cursor-based pagination for all list endpoints, using `event_id` or `timestamp` as the cursor. Offset-based pagination is rejected for append-only log tables. `limit` defaults to 100, max 1000. Response includes `next_cursor` when more results exist.
+**Error and metadata redaction.** Internal responses can expose query stages,
+DB error classes, verifier names, and operational metadata. Public responses
+need sanitized errors and customer-safe event metadata, with detailed context
+remaining in server logs and operator-only surfaces.
 
-**Rate limiting.** Per API key. Default limits: 60 requests/minute for read, 20 requests/minute for write, 5 requests/minute for trigger. Configurable per key in the DB. The `trigger` endpoint has its own bucket separate from read/write to prevent it from being used as a DoS vector against the check pipeline. Rate limit headers (`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`) returned on every response.
+**Public rate limits and abuse controls.** Internal limits are service
+protection. Public limits need commerce/abuse semantics, likely per tenant plus
+per key, with separate controls for expensive operations such as trigger-now.
 
-**Schema versioning.** `/api/v1/`. Breaking changes require a new version prefix. Additive changes (new fields, new endpoints) are backwards-compatible within v1. The version prefix is in the URL, not a header, to make it unambiguous in logs.
+**Webhook ownership and signing posture.** Internal HMAC signing is acceptable
+today. Public customer-managed webhooks may need per-tenant ownership columns,
+public-key/asymmetric signing, or stronger secret storage before direct
+exposure.
 
-**Trigger-now semantics.** The trigger endpoint enqueues an immediate check for the endpoint; it does not wait for the result. The response returns a `request_id`. The caller polls `GET /api/v1/sites/{blog_id}/history?request_id=<id>` or waits for the event stream to observe the result. This avoids holding HTTP connections open for the duration of a check.
+**OpenAPI and compatibility policy.** The customer contract needs a generated
+OpenAPI 3.1 spec, client-codegen validation, explicit deprecation rules, and
+tests that fail when handler behavior drifts from the published schema.
 
-**Relationship to SLA Reporting.** The statistics capability (Capability 3) is a superset of the "Incident History and SLA Reporting" stretch goal from `PROJECT.md`. Building Capability 3 makes that stretch goal a subset of what's already available.
+### Public API work still to do
 
-### What needs to be built
-
-- API key management: `jetmon_api_keys` table, key generation/revocation CLI, request authentication middleware with scope enforcement.
-- Alert contacts: `jetmon_alert_contacts` table, `jetmon_site_alert_contacts` join table, outbound webhook dispatcher with retry queue.
-- Query handlers: thin layer over existing DB functions in `internal/db/`, with response serialisation and cursor pagination.
-- Statistics handlers: uptime/response-time aggregation queries; must be pre-aggregated or cached to avoid slow queries on large history tables.
-- Manage handlers: validated writes to endpoint and check tables, triggering orchestrator pickup.
-- Trigger handler: enqueue immediate check; return `request_id` for polling.
-- Rate limiting middleware: per-key token bucket, separate buckets for read/write/trigger, rate-limit headers.
-- Integration tests in the Docker Compose environment covering auth, pagination, state consistency, and webhook delivery.
+- Define the gateway-to-Jetmon tenant contract and decide which tenant checks
+  live in the gateway versus Jetmon itself.
+- Add tenant ownership fields and filtered queries where Jetmon must enforce
+  ownership directly.
+- Add customer-safe error and metadata redaction paths for every public route.
+- Generate and publish `GET /api/v1/openapi.json` from the running route
+  contract.
+- Add public-contract integration tests for auth, tenant isolation,
+  pagination, idempotency, redaction, webhook ownership, and trigger-now abuse
+  controls.
+- Revisit response-time/SLA pre-aggregation before exposing high-volume public
+  reporting queries.
+- Document the migration path for consumers that currently use direct MySQL or
+  bespoke internal integrations.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,6 +4,20 @@ Deferred features that are intentionally out of scope for the current implementa
 
 ---
 
+## v3 Probe-Agent Architecture
+
+**Status:** Parked until v2 has been deployed to production and stabilized.
+
+The current v2 production target keeps the main-server-plus-Veriflier
+confirmation model. After v2 has enough production data, revisit whether Jetmon
+should evolve into a central scheduler plus regional probe-agent architecture.
+
+See [`docs/v3-probe-agent-architecture-options.md`](docs/v3-probe-agent-architecture-options.md)
+for the candidate architectures, data to gather during v2, and the current
+recommendation.
+
+---
+
 ## Public REST API
 
 **Status:** Not started. No existing API surface covers this scope.

--- a/cmd/jetmon2/main_test.go
+++ b/cmd/jetmon2/main_test.go
@@ -171,6 +171,79 @@ func TestEmailTransportLabelAndDelivery(t *testing.T) {
 	}
 }
 
+func TestEnabledLabel(t *testing.T) {
+	if got := enabledLabel(true); got != "enabled" {
+		t.Fatalf("enabledLabel(true) = %q, want enabled", got)
+	}
+	if got := enabledLabel(false); got != "disabled" {
+		t.Fatalf("enabledLabel(false) = %q, want disabled", got)
+	}
+}
+
+func TestParseInt64(t *testing.T) {
+	got, err := parseInt64("12345")
+	if err != nil {
+		t.Fatalf("parseInt64(valid) error = %v", err)
+	}
+	if got != 12345 {
+		t.Fatalf("parseInt64(valid) = %d, want 12345", got)
+	}
+	if _, err := parseInt64("not-an-id"); err == nil {
+		t.Fatal("parseInt64(invalid) returned nil error")
+	}
+}
+
+func TestCurrentOperatorPrefersUserThenLogname(t *testing.T) {
+	t.Setenv("USER", "alice")
+	t.Setenv("LOGNAME", "bob")
+	if got := currentOperator(); got != "alice" {
+		t.Fatalf("currentOperator() = %q, want USER", got)
+	}
+
+	t.Setenv("USER", "")
+	if got := currentOperator(); got != "bob" {
+		t.Fatalf("currentOperator() = %q, want LOGNAME", got)
+	}
+
+	t.Setenv("LOGNAME", "")
+	if got := currentOperator(); got != "cli" {
+		t.Fatalf("currentOperator() = %q, want cli", got)
+	}
+}
+
+func TestReadPIDFileRejectsInvalidContent(t *testing.T) {
+	dir := t.TempDir()
+	pidPath := filepath.Join(dir, "test.pid")
+	if err := os.WriteFile(pidPath, []byte("0\n"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	t.Setenv("JETMON_PID_FILE", pidPath)
+
+	if os.Getenv("JETMON_TEST_READ_PID_INVALID") == "1" {
+		_ = readPIDFile()
+		return
+	}
+
+	cmd := os.Args[0]
+	proc, err := os.StartProcess(cmd, []string{cmd, "-test.run=TestReadPIDFileRejectsInvalidContent"}, &os.ProcAttr{
+		Env: append(os.Environ(),
+			"JETMON_TEST_READ_PID_INVALID=1",
+			"JETMON_PID_FILE="+pidPath,
+		),
+		Files: []*os.File{os.Stdin, os.Stdout, os.Stderr},
+	})
+	if err != nil {
+		t.Fatalf("StartProcess: %v", err)
+	}
+	state, err := proc.Wait()
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if state.Success() {
+		t.Fatal("readPIDFile accepted invalid PID content")
+	}
+}
+
 func TestBuildAlertDispatchersIncludesStubEmail(t *testing.T) {
 	dispatchers := buildAlertDispatchers(&config.Config{
 		EmailTransport: "stub",
@@ -216,5 +289,32 @@ func TestBuildAlertDispatchersIncludesStubEmail(t *testing.T) {
 	}
 	if response != "delivered" {
 		t.Fatalf("stub email dispatcher response = %q, want delivered", response)
+	}
+}
+
+func TestBuildAlertDispatchersSelectsConfiguredEmailSenders(t *testing.T) {
+	tests := []struct {
+		name      string
+		transport string
+		wantType  string
+	}{
+		{name: "smtp", transport: "smtp", wantType: "*alerting.emailDispatcher"},
+		{name: "wpcom", transport: "wpcom", wantType: "*alerting.emailDispatcher"},
+		{name: "unknown falls back", transport: "sendmail", wantType: "*alerting.emailDispatcher"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dispatchers := buildAlertDispatchers(&config.Config{
+				EmailTransport:     tt.transport,
+				EmailFrom:          "jetmon@example.com",
+				WPCOMEmailEndpoint: "https://wpcom.example/send",
+				SMTPHost:           "smtp.example",
+				SMTPPort:           25,
+			})
+			got := fmt.Sprintf("%T", dispatchers[alerting.TransportEmail])
+			if got != tt.wantType {
+				t.Fatalf("email dispatcher type = %s, want %s", got, tt.wantType)
+			}
+		})
 	}
 }

--- a/cmd/jetmon2/main_test.go
+++ b/cmd/jetmon2/main_test.go
@@ -208,6 +208,9 @@ func TestBuildAlertDispatchersIncludesStubEmail(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stub email dispatcher Send() error = %v", err)
 	}
+	// 250 mirrors the SMTP "Requested mail action okay, completed" reply
+	// code so the audit row reads the same shape regardless of which email
+	// transport actually fired.
 	if status != 250 {
 		t.Fatalf("stub email dispatcher status = %d, want 250", status)
 	}

--- a/config/config.readme
+++ b/config/config.readme
@@ -108,5 +108,5 @@ VERIFIERS
 Array of veriflier configuration objects. Each entry requires:
   name       - display name
   host       - hostname or IP of the veriflier
-  grpc_port  - gRPC/HTTP port (default 7803)
+  grpc_port  - Veriflier transport port; currently JSON-over-HTTP, reserved for future gRPC (default 7803)
   auth_token - shared secret for veriflier authentication

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,20 @@
+# Jetmon Docs
+
+This directory holds longer-form design material that does not belong in the
+main README.
+
+## Architecture Decisions
+
+Accepted decisions live in [`adr/`](adr/). These records are append-only and
+capture load-bearing choices that the current v2 implementation depends on.
+
+Start with [`adr/README.md`](adr/README.md) for the ADR format and index.
+
+## Planning Notes
+
+Planning notes capture future options and open design threads. They are not
+accepted architecture decisions.
+
+| Document | Purpose |
+|---|---|
+| [`v3-probe-agent-architecture-options.md`](v3-probe-agent-architecture-options.md) | Post-v2 architecture options for evolving from main servers plus Verifliers toward a probe-agent architecture. |

--- a/docs/v3-probe-agent-architecture-options.md
+++ b/docs/v3-probe-agent-architecture-options.md
@@ -1,0 +1,391 @@
+# Jetmon v3 Probe-Agent Architecture Options
+
+## Status
+
+Planning note. This is not an accepted architecture decision and should not
+block the v2 production migration.
+
+The intended migration order is:
+
+```text
+v1 production
+  -> v2 compatibility rewrite
+  -> v2 production hardening and measurement
+  -> v3 probe-agent architecture in shadow mode
+  -> v3 gradual production cutover
+```
+
+The v3 architecture should be revisited only after v2 has been deployed to
+production and has enough operating data to make the tradeoffs concrete.
+
+## Why Revisit This After v2?
+
+The currently implemented v2 shape keeps Jetmon close to the existing mental
+model: main monitor servers own bucketed primary checks, and Verifliers provide
+independent confirmation before a site moves from `Seems Down` to `Down`.
+
+That is the right near-term migration target because it limits product and
+operational change while the Go rewrite, eventstore, API, alerting, and
+delivery workers stabilize.
+
+After v2 is stable, the main question is whether Jetmon should keep the
+separate "main monitor" and "Veriflier" roles or evolve into a more general
+probe platform where regional agents execute both routine checks and
+confirmation jobs while a central decision layer owns incident state.
+
+## Data To Gather During v2
+
+The v3 decision should be based on production data from v2, especially:
+
+- Time from first local failure to `Seems Down`.
+- Time from `Seems Down` to confirmed `Down`.
+- False alarm rate by failure class.
+- Veriflier agreement and disagreement rates.
+- Veriflier latency and timeout rates by region/provider.
+- Number of incidents where local failure was not confirmed remotely.
+- Number of incidents where remote confirmation was mixed by region.
+- Number of monitor-side failures that should be modeled as `Unknown`.
+- Cost and capacity profile for primary checks versus confirmation checks.
+- Operator pain points around explaining why an incident was or was not
+  confirmed.
+- Customer-impacting notification parity against the legacy WPCOM path.
+
+Without this data, v3 risks optimizing for hypothetical problems instead of
+the production failure modes that actually matter.
+
+## Current v2 Baseline
+
+The v2 flow is:
+
+```text
+Up
+  -> Seems Down     local probe failed, retry/confirmation in progress
+  -> Down           enough independent Verifliers confirmed
+  -> Resolved       local or confirmed recovery
+```
+
+The v2 deployment shape is:
+
+- Main `jetmon2` servers claim site buckets and perform primary checks.
+- Failed local checks open or update eventstore incidents.
+- After enough local failures, the orchestrator asks Verifliers to confirm.
+- Veriflier agreement promotes the same event from `Seems Down` to `Down`.
+- Veriflier disagreement closes the event as a false alarm.
+- Legacy WPCOM notification behavior remains preserved around the confirmed
+  `Down` and recovery transitions.
+
+This is intentionally conservative and remains the correct v2 production
+target.
+
+## Question 1: Is There A Better Flow Than Seems Down To Confirmed Down?
+
+Externally, the `Seems Down -> Down -> Resolved` lifecycle is still a good
+operator and customer-facing model. It is simple, useful, and maps well to the
+current false-positive reduction goal.
+
+Internally, v3 may need a richer decision model:
+
+| Internal state | Meaning |
+|---|---|
+| `Suspected` | First failure observed, not enough evidence yet |
+| `Confirming` | Confirmation probes are in flight |
+| `ConfirmedGlobalDown` | Enough independent regions agree the site is down |
+| `RegionalFailure` | Some regions fail while others succeed |
+| `Unknown` | Monitor/probe infrastructure cannot produce trustworthy evidence |
+| `FalseAlarm` | The original failure was not confirmed |
+
+Those internal states do not need to leak directly to every consumer. They can
+still project to the v2 public states where compatibility matters:
+
+```text
+Suspected / Confirming -> Seems Down
+ConfirmedGlobalDown    -> Down
+RegionalFailure        -> Degraded or Regional Failure, depending on taxonomy
+Unknown                -> Unknown, not downtime
+FalseAlarm             -> Resolved with reason=false_alarm
+```
+
+## Question 2: Should Main Servers And Verifliers Remain Separate?
+
+For v2, yes. It keeps the migration safe.
+
+For v3, probably not as a permanent distinction. A better long-term shape is
+likely:
+
+- **Decision layer:** owns scheduling, quorum rules, eventstore writes, and
+  notification decisions.
+- **Probe agents:** execute check jobs from one or more regions/providers.
+- **Durable job bus:** stores check jobs, claims, results, retries, and agent
+  heartbeats.
+
+In that model, "primary check" and "confirmation check" are job types, not
+separate binary roles.
+
+## Question 3: What Does The Current Shape Leave On The Table?
+
+Compared with a probe-agent architecture, the current v2 shape gives up or
+delays:
+
+- Continuous regional baseline data.
+- First-class regional or partial-outage classification.
+- Durable confirmation jobs independent of orchestrator memory.
+- Cleaner backpressure and retry accounting for probe work.
+- Easier addition of new probe types, such as synthetic flows or TCP checks.
+- Per-vantage-point latency and SLA reporting.
+- Better explanations for mixed outcomes.
+- More flexible capacity planning, because every probe agent can execute any
+  supported check job.
+
+These are good v3 motivations, but they should not be bundled into the v2
+production cutover.
+
+## Candidate Architectures To Revisit
+
+### Candidate 1: v2 Plus Stronger Probe Metadata
+
+Keep the main-server-plus-Veriflier structure, but record richer evidence for
+every vote: probe identity, region, provider, timing, failure class, and
+decision inputs.
+
+Flow:
+
+```text
+main check fails -> Seems Down
+local retries fail -> Veriflier confirmation
+event transition stores each vote and decision input
+quorum -> Down, disagreement -> false_alarm
+```
+
+Pros:
+
+- Lowest risk after v2.
+- Improves support and operator explainability quickly.
+- Produces better data for future v3 decisions.
+- Minimal deployment changes.
+
+Cons:
+
+- Keeps the main/Veriflier split.
+- Remote perspective is still mostly gathered after suspicion.
+- Does not fully support regional baseline or synthetic-check expansion.
+
+When to choose:
+
+- v2 works well, but operators mainly need better evidence and dashboards.
+
+### Candidate 2: Peer Probe Mesh
+
+Every monitor host can perform both primary and confirmation probes. A host
+that detects a failure asks peer monitor hosts in other regions/providers for
+confirmation.
+
+Flow:
+
+```text
+bucket owner detects failure
+bucket owner requests peer probes
+peer votes return directly to owner
+owner writes event transition and notifications
+```
+
+Pros:
+
+- Removes a separate Veriflier fleet.
+- Uses monitor capacity more evenly.
+- Simpler than introducing a full scheduler and job bus.
+- Can become region-aware if monitor hosts are deployed across regions.
+
+Cons:
+
+- Monitor hosts become more coupled.
+- A monitor-host incident can affect both primary and confirmation capacity.
+- Harder to enforce anti-correlation rules unless host metadata is rigorous.
+- Still centers decisions on the bucket owner.
+
+When to choose:
+
+- The Veriflier fleet is operationally awkward, but a full scheduler is too
+  large a step.
+
+### Candidate 3: Central Scheduler Plus Regional Probe Agents
+
+This is the leading v3 candidate.
+
+A scheduler/decision service owns check plans and durable jobs. Regional probe
+agents claim jobs, execute checks, and write results. The decision layer
+evaluates evidence and writes eventstore transitions.
+
+Flow:
+
+```text
+scheduler creates routine probe jobs
+regional probe agents claim and execute jobs
+decision layer evaluates results
+first failure opens Suspected/Seems Down
+confirmation jobs are scheduled to independent agents
+quorum/classifier promotes to Down, RegionalFailure, Unknown, or false_alarm
+eventstore writes remain the source of truth
+delivery workers notify from event transitions
+```
+
+Pros:
+
+- Best long-term separation of concerns.
+- Durable jobs replace in-memory confirmation state.
+- Probe agents are simple and horizontally scalable.
+- Primary and confirmation checks use the same execution path.
+- Supports regional status, confidence scoring, per-vantage SLA, synthetic
+  checks, and richer diagnostics.
+- Lets Jetmon add new probe types without reshaping the decision layer.
+
+Cons:
+
+- Largest implementation effort.
+- Requires durable job claiming and result deduplication.
+- Requires careful shadow-mode comparison before becoming authoritative.
+- More operational components than the v2 single-binary shape.
+
+When to choose:
+
+- v2 production data shows confirmation latency, regional ambiguity, or
+  operator explainability are material problems.
+- Jetmon needs regional SLAs, synthetic checks, or more probe types.
+- The team is ready to invest in a platform-shaped monitoring architecture.
+
+### Candidate 4: Always-On Multi-Region Quorum
+
+Every monitored site is checked from multiple regions continuously or
+near-continuously. Incidents are classified from live quorum rather than a
+second-stage confirmation request.
+
+Flow:
+
+```text
+regional agents check every site on schedule
+decision layer continuously evaluates current regional evidence
+multi-region failure -> Down
+single-region failure -> RegionalFailure or Degraded
+probe infrastructure failure -> Unknown
+```
+
+Pros:
+
+- Fastest confirmation.
+- Best regional visibility.
+- Strong latency and SLA data by vantage point.
+- Removes most of the "wait for retries, then confirm" gap.
+
+Cons:
+
+- Much higher check volume.
+- More customer-site load.
+- Higher cost.
+- Needs careful aggregation to avoid noisy partial failures.
+- Probably too expensive for every site unless tiers or sampling are added.
+
+When to choose:
+
+- Product requirements demand regional SLA visibility or very fast
+  confirmation, and the cost profile is acceptable.
+
+### Candidate 5: External Probes Plus Site/WPCOM Signals
+
+Combine external probe evidence with internal or site-side signals such as
+Jetpack heartbeat, wp-admin reachability, cron heartbeat, or WPCOM-side
+activity.
+
+Flow:
+
+```text
+external probe failure opens Suspected/Seems Down
+decision layer checks corroborating Jetpack/WPCOM/site signals
+external + internal evidence agree -> Down
+external failure only -> Confirming, RegionalFailure, or Unknown
+internal signal missing only -> agent/heartbeat problem, not customer downtime
+```
+
+Pros:
+
+- Better distinction between site downtime, regional network issues, and
+  monitor-side failures.
+- Better support diagnostics.
+- Can reduce false positives.
+- Complements any probe-agent architecture.
+
+Cons:
+
+- Depends on signal quality from Jetpack/WPCOM/site-side systems.
+- Heartbeats can be delayed for reasons other than downtime.
+- More data contracts outside Jetmon.
+- Not a replacement for external probing.
+
+When to choose:
+
+- v2 data shows many false positives that external probes alone cannot
+  classify confidently, or support needs better causal diagnostics.
+
+## Current Recommendation
+
+Do not change the v2 production target.
+
+The recommended path is:
+
+1. Finish and deploy v2 with the current main-server-plus-Veriflier shape.
+2. Stabilize v2 in production.
+3. Gather the data listed above.
+4. Revisit these candidates with real evidence.
+5. If the evidence supports it, evolve toward Candidate 3.
+
+Candidate 3 is the current best long-term option because it turns Jetmon into a
+durable probe platform instead of a monitor-plus-confirmers system. It offers
+the best path to regional status, richer classification, synthetic checks, and
+more predictable scaling.
+
+Candidate 1 is the likely first step regardless of final v3 choice because
+better probe metadata makes every other option easier to evaluate.
+
+## Candidate 3 Migration Sketch After v2 Stabilizes
+
+The v2-to-v3 migration should be incremental:
+
+1. **Add probe metadata to v2 results.**
+   Record region, provider, probe identity, timing, failure class, and vote
+   details for local and Veriflier checks.
+
+2. **Introduce durable confirmation jobs.**
+   Keep primary checks in v2, but replace direct Veriflier fanout with jobs in
+   MySQL. Existing Verifliers or new probe agents claim jobs and write results.
+
+3. **Generalize Veriflier into probe-agent.**
+   Make confirmation an execution mode of a generic agent rather than a
+   special-purpose service.
+
+4. **Run primary probe jobs in shadow mode.**
+   Schedule routine check jobs for a small cohort but do not let them affect
+   customer-visible state.
+
+5. **Compare v2 decisions to v3 decisions.**
+   Measure detection latency, confirmation latency, false positives, missed
+   incidents, regional disagreement, and WPCOM notification parity.
+
+6. **Cut over confirmation decisions.**
+   Let the job-based confirmation path become authoritative for
+   `Seems Down -> Down` after it matches or beats v2 behavior in shadow mode.
+
+7. **Cut over primary checks gradually.**
+   Move bucket ranges or site cohorts from direct v2 primary checks to scheduled
+   probe jobs.
+
+8. **Retire the main/Veriflier distinction.**
+   The central decision layer owns scheduling and state; probe agents execute
+   jobs from any supported check type.
+
+## Non-Goals Until After v2 Is Stable
+
+- Do not skip directly from v1 to v3.
+- Do not change customer-visible notification semantics during the v2 cutover.
+- Do not replace eventstore as the source of truth.
+- Do not require a new queueing system before MySQL-backed job claiming has
+  been evaluated.
+- Do not make regional classifications customer-visible until the taxonomy and
+  support story are ready.

--- a/internal/alerting/repository_coverage_test.go
+++ b/internal/alerting/repository_coverage_test.go
@@ -1,0 +1,400 @@
+package alerting
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Automattic/jetmon/internal/eventstore"
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+var contactColumns = []string{
+	"id", "label", "active", "transport", "destination_preview",
+	"site_filter", "min_severity", "max_per_hour",
+	"created_by", "created_at", "updated_at",
+}
+
+func contactRow(id int64, label string, active uint8, transport Transport, now time.Time) *sqlmock.Rows {
+	return sqlmock.NewRows(contactColumns).AddRow(
+		id, label, active, string(transport), "mple",
+		`{"site_ids":[42]}`, uint8(eventstore.SeverityDown), 60,
+		"ops", now, now,
+	)
+}
+
+func TestCreateContactPersistsDefaultsAndFetchesRecord(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	now := time.Now().UTC()
+	destination := json.RawMessage(`{"address":"ops@example.com"}`)
+	mock.ExpectExec("INSERT INTO jetmon_alert_contacts").
+		WithArgs(
+			"Ops email", 1, string(TransportEmail), []byte(destination), ".com",
+			sqlmock.AnyArg(), uint8(eventstore.SeverityDown), 60, "ops",
+		).
+		WillReturnResult(sqlmock.NewResult(11, 1))
+	mock.ExpectQuery("SELECT id, label, active, transport").
+		WithArgs(int64(11)).
+		WillReturnRows(contactRow(11, "Ops email", 1, TransportEmail, now))
+
+	contact, err := Create(context.Background(), db, CreateInput{
+		Label:       "Ops email",
+		Transport:   TransportEmail,
+		Destination: destination,
+		SiteFilter:  SiteFilter{SiteIDs: []int64{42}},
+		CreatedBy:   "ops",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if contact.ID != 11 || !contact.Active || contact.SiteFilter.SiteIDs[0] != 42 {
+		t.Fatalf("contact = %+v", contact)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestCreateContactRejectsInvalidInputBeforeDB(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := Create(context.Background(), db, CreateInput{}); err == nil {
+		t.Fatal("Create accepted empty label and destination")
+	}
+	if _, err := Create(context.Background(), db, CreateInput{
+		Label:       "Ops",
+		Transport:   Transport("sms"),
+		Destination: json.RawMessage(`{"address":"ops@example.com"}`),
+	}); !errors.Is(err, ErrInvalidTransport) {
+		t.Fatalf("Create invalid transport error = %v, want ErrInvalidTransport", err)
+	}
+	sev := uint8(99)
+	if _, err := Create(context.Background(), db, CreateInput{
+		Label:       "Ops",
+		Transport:   TransportEmail,
+		Destination: json.RawMessage(`{"address":"ops@example.com"}`),
+		MinSeverity: &sev,
+	}); !errors.Is(err, ErrInvalidSeverity) {
+		t.Fatalf("Create invalid severity error = %v, want ErrInvalidSeverity", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unexpected sql calls: %v", err)
+	}
+}
+
+func TestDestinationPreviewByTransport(t *testing.T) {
+	cases := []struct {
+		transport Transport
+		dest      json.RawMessage
+		want      string
+	}{
+		{TransportEmail, json.RawMessage(`{"address":"ops@example.com"}`), ".com"},
+		{TransportPagerDuty, json.RawMessage(`{"integration_key":"abcd1234"}`), "1234"},
+		{TransportSlack, json.RawMessage(`{"webhook_url":"https://hooks.slack.test/XYZ"}`), "/XYZ"},
+		{TransportTeams, json.RawMessage(`{"webhook_url":"https://teams.test/ABCD"}`), "ABCD"},
+	}
+	for _, tc := range cases {
+		if err := validateDestination(tc.transport, tc.dest); err != nil {
+			t.Fatalf("validateDestination(%s): %v", tc.transport, err)
+		}
+		if got := destinationPreview(tc.transport, tc.dest); got != tc.want {
+			t.Fatalf("destinationPreview(%s) = %q, want %q", tc.transport, got, tc.want)
+		}
+	}
+}
+
+func TestGetContactNotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT id, label, active, transport").
+		WithArgs(int64(404)).
+		WillReturnError(sql.ErrNoRows)
+
+	_, err = Get(context.Background(), db, 404)
+	if !errors.Is(err, ErrContactNotFound) {
+		t.Fatalf("Get error = %v, want ErrContactNotFound", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestListContactsScansRows(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	now := time.Now().UTC()
+	rows := sqlmock.NewRows(contactColumns).
+		AddRow(int64(1), "Email", uint8(1), string(TransportEmail), "mple", `{}`, uint8(4), 60, "ops", now, now).
+		AddRow(int64(2), "Slack", uint8(0), string(TransportSlack), "hook", nil, uint8(3), 0, "ops", now, now)
+	mock.ExpectQuery("SELECT id, label, active, transport").
+		WillReturnRows(rows)
+
+	contacts, err := List(context.Background(), db)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(contacts) != 2 || !contacts[0].Active || contacts[1].Active {
+		t.Fatalf("contacts = %+v", contacts)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestListActiveContactsScansRows(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	now := time.Now().UTC()
+	mock.ExpectQuery("SELECT id, label, active, transport").
+		WillReturnRows(contactRow(3, "PagerDuty", 1, TransportPagerDuty, now))
+
+	contacts, err := ListActive(context.Background(), db)
+	if err != nil {
+		t.Fatalf("ListActive: %v", err)
+	}
+	if len(contacts) != 1 || contacts[0].Transport != TransportPagerDuty {
+		t.Fatalf("contacts = %+v", contacts)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestUpdateContactAppliesPatchAndFetchesRecord(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	now := time.Now().UTC()
+	label := "Escalation"
+	active := false
+	destination := json.RawMessage(`{"address":"new@example.com"}`)
+	siteFilter := SiteFilter{SiteIDs: []int64{7}}
+	minSeverity := uint8(eventstore.SeverityWarning)
+	maxPerHour := 5
+
+	mock.ExpectQuery("SELECT id, label, active, transport").
+		WithArgs(int64(5)).
+		WillReturnRows(contactRow(5, "Ops email", 1, TransportEmail, now))
+	mock.ExpectExec("UPDATE jetmon_alert_contacts SET").
+		WithArgs(label, 0, []byte(destination), ".com", sqlmock.AnyArg(), minSeverity, maxPerHour, int64(5)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("SELECT id, label, active, transport").
+		WithArgs(int64(5)).
+		WillReturnRows(sqlmock.NewRows(contactColumns).AddRow(
+			int64(5), label, uint8(0), string(TransportEmail), ".com",
+			`{"site_ids":[7]}`, minSeverity, maxPerHour, "ops", now, now,
+		))
+
+	contact, err := Update(context.Background(), db, 5, UpdateInput{
+		Label:       &label,
+		Active:      &active,
+		Destination: destination,
+		SiteFilter:  &siteFilter,
+		MinSeverity: &minSeverity,
+		MaxPerHour:  &maxPerHour,
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if contact.Active || contact.Label != label || contact.SiteFilter.SiteIDs[0] != 7 {
+		t.Fatalf("contact = %+v", contact)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestDeleteContactReportsMissingRows(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("DELETE FROM jetmon_alert_contacts").
+		WithArgs(int64(10)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	if err := Delete(context.Background(), db, 10); !errors.Is(err, ErrContactNotFound) {
+		t.Fatalf("Delete error = %v, want ErrContactNotFound", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestLoadDestination(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT destination FROM jetmon_alert_contacts").
+		WithArgs(int64(4)).
+		WillReturnRows(sqlmock.NewRows([]string{"destination"}).AddRow([]byte(`{"address":"ops@example.com"}`)))
+
+	dest, err := LoadDestination(context.Background(), db, 4)
+	if err != nil {
+		t.Fatalf("LoadDestination: %v", err)
+	}
+	if !strings.Contains(string(dest), "ops@example.com") {
+		t.Fatalf("destination = %s", dest)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+var alertDeliveryColumns = []string{
+	"id", "alert_contact_id", "transition_id", "event_id", "event_type", "severity",
+	"payload", "status", "attempt", "next_attempt_at", "last_status_code", "last_response",
+	"last_attempt_at", "delivered_at", "created_at",
+}
+
+func alertDeliveryRow(id int64, status Status, now time.Time) *sqlmock.Rows {
+	return sqlmock.NewRows(alertDeliveryColumns).AddRow(
+		id, int64(20), int64(30), int64(40), "alert.opened", uint8(4),
+		[]byte(`{"ok":true}`), string(status), 2, now, 503, "down", now, nil, now,
+	)
+}
+
+func TestEnqueueAlertDeliveryReturnsInsertedIDAndDuplicateZero(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	payload := json.RawMessage(`{"type":"alert.opened"}`)
+	mock.ExpectExec("INSERT IGNORE INTO jetmon_alert_deliveries").
+		WithArgs(int64(1), int64(2), int64(3), "alert.opened", uint8(4), []byte(payload)).
+		WillReturnResult(sqlmock.NewResult(9, 1))
+	mock.ExpectExec("INSERT IGNORE INTO jetmon_alert_deliveries").
+		WithArgs(int64(1), int64(2), int64(3), "alert.opened", uint8(4), []byte(payload)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	id, err := Enqueue(context.Background(), db, EnqueueInput{
+		AlertContactID: 1, TransitionID: 2, EventID: 3, EventType: "alert.opened",
+		Severity: 4, Payload: payload,
+	})
+	if err != nil || id != 9 {
+		t.Fatalf("Enqueue inserted = (%d, %v), want (9, nil)", id, err)
+	}
+	id, err = Enqueue(context.Background(), db, EnqueueInput{
+		AlertContactID: 1, TransitionID: 2, EventID: 3, EventType: "alert.opened",
+		Severity: 4, Payload: payload,
+	})
+	if err != nil || id != 0 {
+		t.Fatalf("Enqueue duplicate = (%d, %v), want (0, nil)", id, err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestAlertDeliveryStateUpdates(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	next := time.Now().UTC().Add(time.Minute)
+	mock.ExpectExec("UPDATE jetmon_alert_deliveries").
+		WithArgs(204, "ok", int64(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE jetmon_alert_deliveries").
+		WithArgs("quiet", int64(2)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE jetmon_alert_deliveries").
+		WithArgs(503, "retry", next, int64(3)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE jetmon_alert_deliveries").
+		WithArgs(410, "gone", int64(4)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := MarkDelivered(context.Background(), db, 1, 204, "ok"); err != nil {
+		t.Fatalf("MarkDelivered: %v", err)
+	}
+	if err := MarkSuppressed(context.Background(), db, 2, "quiet"); err != nil {
+		t.Fatalf("MarkSuppressed: %v", err)
+	}
+	if err := ScheduleRetry(context.Background(), db, 3, 503, "retry", next, false); err != nil {
+		t.Fatalf("ScheduleRetry retry: %v", err)
+	}
+	if err := ScheduleRetry(context.Background(), db, 4, 410, "gone", next, true); err != nil {
+		t.Fatalf("ScheduleRetry abandon: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestGetListAndRetryAlertDeliveries(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	now := time.Now().UTC()
+	mock.ExpectQuery("SELECT id, alert_contact_id, transition_id").
+		WithArgs(int64(1)).
+		WillReturnRows(alertDeliveryRow(1, StatusAbandoned, now))
+	mock.ExpectQuery("SELECT id, alert_contact_id, transition_id").
+		WithArgs(int64(20), string(StatusAbandoned), int64(50), 10).
+		WillReturnRows(alertDeliveryRow(2, StatusAbandoned, now))
+	mock.ExpectExec("UPDATE jetmon_alert_deliveries").
+		WithArgs(int64(2)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	d, err := GetDelivery(context.Background(), db, 1)
+	if err != nil {
+		t.Fatalf("GetDelivery: %v", err)
+	}
+	if d.LastStatusCode == nil || *d.LastStatusCode != 503 || d.LastResponse == nil || *d.LastResponse != "down" {
+		t.Fatalf("delivery did not scan nullable fields: %+v", d)
+	}
+	list, err := ListDeliveries(context.Background(), db, 20, StatusAbandoned, 50, 10)
+	if err != nil {
+		t.Fatalf("ListDeliveries: %v", err)
+	}
+	if len(list) != 1 || list[0].ID != 2 {
+		t.Fatalf("deliveries = %+v", list)
+	}
+	if err := RetryDelivery(context.Background(), db, 2); err != nil {
+		t.Fatalf("RetryDelivery: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}

--- a/internal/alerting/worker_test.go
+++ b/internal/alerting/worker_test.go
@@ -140,6 +140,12 @@ func TestNewWorkerInitializesRuntimeState(t *testing.T) {
 	}
 }
 
+func TestWorkerStartStop(t *testing.T) {
+	w := NewWorker(WorkerConfig{PollInterval: time.Hour})
+	w.Start()
+	w.Stop()
+}
+
 func TestDeliverTickNoReadyDeliveries(t *testing.T) {
 	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 	if err != nil {

--- a/internal/alerting/worker_test.go
+++ b/internal/alerting/worker_test.go
@@ -1,8 +1,14 @@
 package alerting
 
 import (
+	"context"
+	"database/sql"
+	"encoding/json"
 	"testing"
 	"time"
+
+	"github.com/Automattic/jetmon/internal/eventstore"
+	"github.com/DATA-DOG/go-sqlmock"
 )
 
 func TestNextRetryDelayFollowsSchedule(t *testing.T) {
@@ -123,6 +129,59 @@ func TestReleaseSlotCleansUpZeroCounts(t *testing.T) {
 	}
 }
 
+func TestNewWorkerInitializesRuntimeState(t *testing.T) {
+	dispatchers := map[Transport]Dispatcher{}
+	w := NewWorker(WorkerConfig{InstanceID: "host-a", Dispatchers: dispatchers})
+	if w.cfg.InstanceID != "host-a" {
+		t.Fatalf("InstanceID = %q, want host-a", w.cfg.InstanceID)
+	}
+	if w.cfg.Dispatchers == nil || w.inFlight == nil || w.rateLimit == nil || w.stop == nil || w.done == nil {
+		t.Fatalf("worker runtime state not initialized: %+v", w)
+	}
+}
+
+func TestDeliverTickNoReadyDeliveries(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(selectClaimReadySQL).WithArgs(50).
+		WillReturnRows(sqlmock.NewRows(columnsClaimedDelivery))
+
+	w := NewWorker(WorkerConfig{DB: db})
+	if err := w.deliverTick(); err != nil {
+		t.Fatalf("deliverTick: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestHandleResultSchedulesRetryAndForcedAbandon(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("UPDATE jetmon_alert_deliveries").
+		WithArgs(503, "retry", sqlmock.AnyArg(), int64(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE jetmon_alert_deliveries").
+		WithArgs(0, "gone", int64(2)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	w := NewWorker(WorkerConfig{DB: db})
+	w.handleResult(context.Background(), Delivery{ID: 1, Attempt: 0}, 503, "retry", false)
+	w.handleResult(context.Background(), Delivery{ID: 2, Attempt: 0}, 0, "gone", true)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
 // TestRateLimitWindowRespectsCapacity verifies the rate window admits up
 // to capacity dispatches in an hour, then refuses, then admits again
 // after a timestamp ages out.
@@ -173,5 +232,142 @@ func TestEventTypeForReason(t *testing.T) {
 		if got != want {
 			t.Errorf("eventTypeForReason(%q) = %q, want %q", reason, got, want)
 		}
+	}
+}
+
+func TestBuildPayload(t *testing.T) {
+	occurredAt := time.Date(2026, 4, 27, 12, 0, 0, 123, time.UTC)
+	payload, err := buildPayload("alert.opened", 10, 20, 30, "opened", "Seems Down", 1, 4, occurredAt)
+	if err != nil {
+		t.Fatalf("buildPayload: %v", err)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(payload, &body); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if body["type"] != "alert.opened" || body["reason"] != "opened" || body["state"] != "Seems Down" {
+		t.Fatalf("payload = %s", payload)
+	}
+	if body["severity_before"].(float64) != 1 || body["severity_after"].(float64) != 4 {
+		t.Fatalf("payload severities = %s", payload)
+	}
+	if body["occurred_at"] != occurredAt.Format(time.RFC3339Nano) {
+		t.Fatalf("occurred_at = %v", body["occurred_at"])
+	}
+}
+
+func TestProgressLoadSave(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	w := &Worker{cfg: WorkerConfig{DB: db, InstanceID: "host-a"}}
+	mock.ExpectQuery("SELECT last_transition_id FROM jetmon_alert_dispatch_progress").
+		WithArgs("host-a").
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectExec("INSERT INTO jetmon_alert_dispatch_progress").
+		WithArgs("host-a", int64(55)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("SELECT last_transition_id FROM jetmon_alert_dispatch_progress").
+		WithArgs("host-a").
+		WillReturnRows(sqlmock.NewRows([]string{"last_transition_id"}).AddRow(int64(55)))
+
+	last, err := w.loadProgress(context.Background())
+	if err != nil {
+		t.Fatalf("loadProgress empty: %v", err)
+	}
+	if last != 0 {
+		t.Fatalf("empty progress = %d, want 0", last)
+	}
+	if err := w.saveProgress(context.Background(), 55); err != nil {
+		t.Fatalf("saveProgress: %v", err)
+	}
+	last, err = w.loadProgress(context.Background())
+	if err != nil {
+		t.Fatalf("loadProgress stored: %v", err)
+	}
+	if last != 55 {
+		t.Fatalf("stored progress = %d, want 55", last)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestBuildNotificationUsesSiteURLAndRecoveryFlag(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	occurredAt := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	payload, err := buildPayload(
+		"alert.closed", 10, 20, 30, "verifier_cleared", "Resolved",
+		eventstore.SeverityDown, eventstore.SeverityUp, occurredAt,
+	)
+	if err != nil {
+		t.Fatalf("buildPayload: %v", err)
+	}
+	mock.ExpectQuery("SELECT monitor_url FROM jetpack_monitor_sites").
+		WithArgs(int64(30)).
+		WillReturnRows(sqlmock.NewRows([]string{"monitor_url"}).AddRow("https://site.example"))
+
+	w := &Worker{cfg: WorkerConfig{DB: db}}
+	notification, err := w.buildNotification(context.Background(), &AlertContact{
+		ID:          1,
+		MinSeverity: eventstore.SeverityDown,
+	}, Delivery{
+		ID:      99,
+		Payload: payload,
+	})
+	if err != nil {
+		t.Fatalf("buildNotification: %v", err)
+	}
+	if !notification.Recovery || notification.Severity != eventstore.SeverityUp {
+		t.Fatalf("notification recovery/severity = %+v", notification)
+	}
+	if notification.SiteURL != "https://site.example" || notification.DedupKey != "jetmon-event-20" {
+		t.Fatalf("notification = %+v", notification)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestBuildNotificationFallsBackToSiteID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	payload, err := buildPayload(
+		"alert.opened", 10, 20, 30, "opened", "Down",
+		eventstore.SeverityUp, eventstore.SeverityDown, time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatalf("buildPayload: %v", err)
+	}
+	mock.ExpectQuery("SELECT monitor_url FROM jetpack_monitor_sites").
+		WithArgs(int64(30)).
+		WillReturnError(sql.ErrNoRows)
+
+	w := &Worker{cfg: WorkerConfig{DB: db}}
+	notification, err := w.buildNotification(context.Background(), &AlertContact{
+		ID:          1,
+		MinSeverity: eventstore.SeverityDown,
+	}, Delivery{Payload: payload})
+	if err != nil {
+		t.Fatalf("buildNotification: %v", err)
+	}
+	if notification.SiteURL != "site:30" {
+		t.Fatalf("SiteURL = %q, want site:30", notification.SiteURL)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
 	}
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -136,5 +137,24 @@ func TestRoutesRegisterAllPaths(t *testing.T) {
 	mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("unknown route status = %d, want 404", rec.Code)
+	}
+}
+
+func TestShutdownWithoutListenIsNoop(t *testing.T) {
+	s := New(":0", nil, "test")
+	if err := s.Shutdown(t.Context()); err != nil {
+		t.Fatalf("Shutdown before Listen = %v, want nil", err)
+	}
+}
+
+func TestIsServerClosed(t *testing.T) {
+	if !IsServerClosed(http.ErrServerClosed) {
+		t.Fatal("IsServerClosed(http.ErrServerClosed) = false")
+	}
+	if !IsServerClosed(errors.Join(errors.New("wrapped"), http.ErrServerClosed)) {
+		t.Fatal("IsServerClosed(joined ErrServerClosed) = false")
+	}
+	if IsServerClosed(errors.New("listen failed")) {
+		t.Fatal("IsServerClosed(non-sentinel) = true")
 	}
 }

--- a/internal/api/handlers_alerts_test.go
+++ b/internal/api/handlers_alerts_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -15,6 +16,8 @@ import (
 const insertAlertContactSQL = ` INSERT INTO jetmon_alert_contacts (label, active, transport, destination, destination_preview, site_filter, min_severity, max_per_hour, created_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
 const selectAlertContactOneSQL = ` SELECT id, label, active, transport, destination_preview, site_filter, min_severity, max_per_hour, created_by, created_at, updated_at FROM jetmon_alert_contacts WHERE id = ?`
+
+const selectAlertContactListSQL = ` SELECT id, label, active, transport, destination_preview, site_filter, min_severity, max_per_hour, created_by, created_at, updated_at FROM jetmon_alert_contacts ORDER BY id ASC`
 
 const loadAlertDestinationSQL = `SELECT destination FROM jetmon_alert_contacts WHERE id = ?`
 
@@ -186,6 +189,62 @@ func TestGetAlertContactNotFound(t *testing.T) {
 
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestListAlertContactsHappyPath(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	now := time.Now().UTC()
+	rows := sqlmock.NewRows(columnsAlertContact).
+		AddRow(int64(1), "primary", uint8(1), "email", "mple",
+			[]byte(`{"site_ids":[42]}`), uint8(4), 60, "test-consumer", now, now).
+		AddRow(int64(2), "secondary", uint8(0), "slack", "hook",
+			nil, uint8(2), 0, "test-consumer", now, now)
+	mock.ExpectQuery(selectAlertContactListSQL).WillReturnRows(rows)
+
+	req := httptest.NewRequest("GET", "/api/v1/alert-contacts", nil)
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleListAlertContacts)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var env struct {
+		Data []alertContactResponse `json:"data"`
+		Page Page                   `json:"page"`
+	}
+	readJSON(t, rec.Body, &env)
+	if len(env.Data) != 2 {
+		t.Fatalf("len(data) = %d, want 2", len(env.Data))
+	}
+	if env.Page.Limit != 2 || env.Page.Next != nil {
+		t.Fatalf("page = %+v, want limit=2 next=nil", env.Page)
+	}
+	if env.Data[0].MinSeverity != "Down" || env.Data[0].SiteFilter.SiteIDs[0] != 42 {
+		t.Fatalf("first contact response = %+v", env.Data[0])
+	}
+	if env.Data[1].MinSeverity != "Degraded" {
+		t.Fatalf("second MinSeverity = %q, want Degraded", env.Data[1].MinSeverity)
+	}
+}
+
+func TestListAlertContactsDBError(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(selectAlertContactListSQL).WillReturnError(errors.New("query failed"))
+
+	req := httptest.NewRequest("GET", "/api/v1/alert-contacts", nil)
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleListAlertContacts)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	if got := readErrorBody(t, rec.Body).Code; got != "db_error" {
+		t.Fatalf("code = %q, want db_error", got)
 	}
 }
 

--- a/internal/api/handlers_deliveries_test.go
+++ b/internal/api/handlers_deliveries_test.go
@@ -1,0 +1,148 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+const selectWebhookDeliveriesSQL = ` SELECT id, webhook_id, transition_id, event_id, event_type, payload, status, attempt, next_attempt_at, last_status_code, last_response, last_attempt_at, delivered_at, created_at FROM jetmon_webhook_deliveries WHERE webhook_id = ? ORDER BY id DESC LIMIT ?`
+
+const selectWebhookDeliveryOneSQL = ` SELECT id, webhook_id, transition_id, event_id, event_type, payload, status, attempt, next_attempt_at, last_status_code, last_response, last_attempt_at, delivered_at, created_at FROM jetmon_webhook_deliveries WHERE id = ?`
+
+var columnsWebhookDelivery = []string{
+	"id", "webhook_id", "transition_id", "event_id", "event_type",
+	"payload", "status", "attempt", "next_attempt_at", "last_status_code", "last_response",
+	"last_attempt_at", "delivered_at", "created_at",
+}
+
+func makeWebhookDeliveryRow(id, webhookID int64, status string) *sqlmock.Rows {
+	now := time.Now().UTC()
+	payload := []byte(`{"site_id":42,"event_id":777,"type":"event.opened"}`)
+	return sqlmock.NewRows(columnsWebhookDelivery).AddRow(
+		id, webhookID, int64(1), int64(777), "event.opened",
+		payload, status, 1, nil, nil, nil, nil, nil, now,
+	)
+}
+
+func TestListDeliveriesHappyPath(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(selectWebhookDeliveriesSQL).
+		WithArgs(int64(11), 51).
+		WillReturnRows(makeWebhookDeliveryRow(101, 11, "delivered"))
+
+	req := httptest.NewRequest("GET", "/api/v1/webhooks/11/deliveries", nil)
+	req.SetPathValue("id", "11")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleListDeliveries)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var env struct {
+		Data []deliveryResponse `json:"data"`
+		Page json.RawMessage    `json:"page"`
+	}
+	readJSON(t, rec.Body, &env)
+	if len(env.Data) != 1 {
+		t.Fatalf("len(data) = %d, want 1", len(env.Data))
+	}
+	if env.Data[0].Status != "delivered" || env.Data[0].Payload == nil {
+		t.Fatalf("delivery response = %+v", env.Data[0])
+	}
+}
+
+func TestListDeliveriesRejectsBadStatus(t *testing.T) {
+	s, _, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	req := httptest.NewRequest("GET", "/api/v1/webhooks/11/deliveries?status=bogus", nil)
+	req.SetPathValue("id", "11")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleListDeliveries)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if got := readErrorBody(t, rec.Body).Code; got != "invalid_status" {
+		t.Errorf("code = %q, want invalid_status", got)
+	}
+}
+
+func TestRetryDeliveryHappyPath(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(selectWebhookDeliveryOneSQL).WithArgs(int64(101)).
+		WillReturnRows(makeWebhookDeliveryRow(101, 11, "abandoned"))
+	mock.ExpectExec(`UPDATE jetmon_webhook_deliveries SET status = 'pending', attempt = 0, next_attempt_at = CURRENT_TIMESTAMP, last_status_code = NULL, last_response = NULL, last_attempt_at = NULL WHERE id = ? AND status = 'abandoned'`).
+		WithArgs(int64(101)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(selectWebhookDeliveryOneSQL).WithArgs(int64(101)).
+		WillReturnRows(makeWebhookDeliveryRow(101, 11, "pending"))
+
+	req := newPOSTWithBody("/api/v1/webhooks/11/deliveries/101/retry", nil)
+	req.SetPathValue("id", "11")
+	req.SetPathValue("delivery_id", "101")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleRetryDelivery)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp deliveryResponse
+	readJSON(t, rec.Body, &resp)
+	if resp.Status != "pending" {
+		t.Errorf("Status = %q, want pending", resp.Status)
+	}
+}
+
+func TestRetryDeliveryWrongWebhook(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(selectWebhookDeliveryOneSQL).WithArgs(int64(101)).
+		WillReturnRows(makeWebhookDeliveryRow(101, 99, "abandoned"))
+
+	req := newPOSTWithBody("/api/v1/webhooks/11/deliveries/101/retry", nil)
+	req.SetPathValue("id", "11")
+	req.SetPathValue("delivery_id", "101")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleRetryDelivery)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestRetryDeliveryNotAbandoned(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(selectWebhookDeliveryOneSQL).WithArgs(int64(101)).
+		WillReturnRows(makeWebhookDeliveryRow(101, 11, "delivered"))
+	mock.ExpectExec(`UPDATE jetmon_webhook_deliveries SET status = 'pending', attempt = 0, next_attempt_at = CURRENT_TIMESTAMP, last_status_code = NULL, last_response = NULL, last_attempt_at = NULL WHERE id = ? AND status = 'abandoned'`).
+		WithArgs(int64(101)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(selectWebhookDeliveryOneSQL).WithArgs(int64(101)).
+		WillReturnRows(makeWebhookDeliveryRow(101, 11, "delivered"))
+
+	req := newPOSTWithBody("/api/v1/webhooks/11/deliveries/101/retry", nil)
+	req.SetPathValue("id", "11")
+	req.SetPathValue("delivery_id", "101")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleRetryDelivery)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", rec.Code)
+	}
+	if got := readErrorBody(t, rec.Body).Code; got != "delivery_not_retryable" {
+		t.Errorf("code = %q, want delivery_not_retryable", got)
+	}
+}

--- a/internal/api/handlers_identity.go
+++ b/internal/api/handlers_identity.go
@@ -11,7 +11,7 @@ import (
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	if s.db == nil {
 		writeError(w, r, http.StatusServiceUnavailable, "db_unavailable",
-			"database handle is not configured")
+			"database not reachable")
 		return
 	}
 
@@ -19,7 +19,7 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	if err := s.db.PingContext(ctx); err != nil {
 		writeError(w, r, http.StatusServiceUnavailable, "db_unavailable",
-			"database ping failed: "+err.Error())
+			"database not reachable: "+err.Error())
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})

--- a/internal/api/handlers_sites.go
+++ b/internal/api/handlers_sites.go
@@ -141,6 +141,9 @@ func (s *Server) handleListSites(w http.ResponseWriter, r *http.Request) {
 		results = append(results, s)
 		lastID = s.ID
 	}
+	rawCount := len(results)
+	rawLastID := lastID
+	fetchedMore := rawCount > limit
 
 	if err := s.applyActiveEventRollups(ctx, results); err != nil {
 		writeError(w, r, http.StatusInternalServerError, "db_error",
@@ -159,6 +162,9 @@ func (s *Server) handleListSites(w http.ResponseWriter, r *http.Request) {
 		results = results[:limit]
 		lastID = results[len(results)-1].ID
 		c := encodeIDCursor(lastID)
+		nextCursor = &c
+	} else if fetchedMore {
+		c := encodeIDCursor(rawLastID)
 		nextCursor = &c
 	}
 

--- a/internal/api/handlers_sites_test.go
+++ b/internal/api/handlers_sites_test.go
@@ -232,6 +232,54 @@ func TestListSitesAppliesPaginationCursor(t *testing.T) {
 	}
 }
 
+func TestListSitesKeepsCursorWhenFilteredPageHasMoreRows(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	// Three raw rows; limit=2 means the third row is the sentinel proving
+	// there may be another page. The first two rows are filtered out, so
+	// pagination must advance past the sentinel row instead of reporting
+	// page.next=null.
+	rows := makeSiteRow(10, "a", 1)
+	rows.AddRow(20, 20, "b", 1, 1, nil, nil, nil, nil, "follow", nil, nil, nil)
+	rows.AddRow(30, 30, "c", 1, 2, nil, nil, nil, nil, "follow", nil, nil, nil)
+
+	mock.ExpectQuery(sitesListSQL).
+		WithArgs(int64(0), 3).
+		WillReturnRows(rows)
+	mock.ExpectQuery(activeEventRollupsSQL("?,?,?")).
+		WithArgs(int64(10), int64(20), int64(30)).
+		WillReturnRows(sqlmock.NewRows(activeEventRollupColumns))
+
+	req := requestWithKey("GET", "/api/v1/sites?limit=2&state=Down", key)
+	rec := invokeAuthed(s, req, s.handleListSites)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Data []siteResponse `json:"data"`
+		Page Page           `json:"page"`
+	}
+	readJSON(t, rec.Body, &resp)
+	if len(resp.Data) != 1 || resp.Data[0].ID != 30 {
+		t.Fatalf("data = %+v, want only site 30", resp.Data)
+	}
+	if resp.Page.Next == nil {
+		t.Fatal("expected a next cursor")
+	}
+	id, err := decodeIDCursor(*resp.Page.Next)
+	if err != nil {
+		t.Fatalf("decode cursor: %v", err)
+	}
+	if id != 30 {
+		t.Errorf("next cursor id = %d, want 30", id)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
 func TestListSitesFiltersByMonitorActive(t *testing.T) {
 	s, mock, key, cleanup := newTestServer(t)
 	defer cleanup()

--- a/internal/api/handlers_sites_write_test.go
+++ b/internal/api/handlers_sites_write_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 )
@@ -23,6 +24,25 @@ func newPATCHWithBody(target string, body []byte) *http.Request {
 	req := httptest.NewRequest("PATCH", target, bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	return req
+}
+
+func TestParseMaintenanceTime(t *testing.T) {
+	if got, err := parseMaintenanceTime("", "maintenance_start"); err != nil || got != nil {
+		t.Fatalf("parseMaintenanceTime(empty) = (%v, %v), want (nil, nil)", got, err)
+	}
+
+	got, err := parseMaintenanceTime("2026-04-27T12:00:00-05:00", "maintenance_start")
+	if err != nil {
+		t.Fatalf("parseMaintenanceTime(valid): %v", err)
+	}
+	want := time.Date(2026, 4, 27, 17, 0, 0, 0, time.UTC)
+	if got != want {
+		t.Fatalf("parseMaintenanceTime(valid) = %v, want %v", got, want)
+	}
+
+	if _, err := parseMaintenanceTime("April 27", "maintenance_start"); err == nil {
+		t.Fatal("parseMaintenanceTime(invalid) returned nil error")
+	}
 }
 
 func TestCreateSiteHappyPath(t *testing.T) {

--- a/internal/api/handlers_webhooks_test.go
+++ b/internal/api/handlers_webhooks_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -12,6 +13,8 @@ import (
 const insertWebhookSQL = ` INSERT INTO jetmon_webhooks (url, active, events, site_filter, state_filter, secret, secret_preview, created_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
 
 const selectWebhookOneSQL = ` SELECT id, url, active, events, site_filter, state_filter, secret_preview, created_by, created_at, updated_at FROM jetmon_webhooks WHERE id = ?`
+
+const selectWebhookListSQL = ` SELECT id, url, active, events, site_filter, state_filter, secret_preview, created_by, created_at, updated_at FROM jetmon_webhooks ORDER BY id ASC`
 
 // columnsWebhook is the column set returned by webhook SELECT queries.
 var columnsWebhook = []string{
@@ -127,6 +130,62 @@ func TestGetWebhookNotFound(t *testing.T) {
 
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestListWebhooksHappyPath(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	now := time.Now().UTC()
+	rows := sqlmock.NewRows(columnsWebhook).
+		AddRow(int64(1), "https://a.example/hook", uint8(1), []byte(`["event.opened"]`),
+			[]byte(`{"site_ids":[42]}`), []byte(`{"states":["Down"]}`), "aaaa", "test-consumer", now, now).
+		AddRow(int64(2), "https://b.example/hook", uint8(0), nil,
+			nil, nil, "bbbb", "test-consumer", now, now)
+	mock.ExpectQuery(selectWebhookListSQL).WillReturnRows(rows)
+
+	req := httptest.NewRequest("GET", "/api/v1/webhooks", nil)
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleListWebhooks)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var env struct {
+		Data []webhookResponse `json:"data"`
+		Page Page              `json:"page"`
+	}
+	readJSON(t, rec.Body, &env)
+	if len(env.Data) != 2 {
+		t.Fatalf("len(data) = %d, want 2", len(env.Data))
+	}
+	if env.Page.Limit != 2 || env.Page.Next != nil {
+		t.Fatalf("page = %+v, want limit=2 next=nil", env.Page)
+	}
+	if env.Data[0].Events[0] != "event.opened" || env.Data[0].SiteFilter.SiteIDs[0] != 42 {
+		t.Fatalf("first webhook response = %+v", env.Data[0])
+	}
+	if env.Data[1].Events == nil {
+		t.Fatal("nil events should serialize as an empty slice")
+	}
+}
+
+func TestListWebhooksDBError(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(selectWebhookListSQL).WillReturnError(errors.New("query failed"))
+
+	req := httptest.NewRequest("GET", "/api/v1/webhooks", nil)
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleListWebhooks)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	if got := readErrorBody(t, rec.Body).Code; got != "db_error" {
+		t.Fatalf("code = %q, want db_error", got)
 	}
 }
 

--- a/internal/api/idempotency_test.go
+++ b/internal/api/idempotency_test.go
@@ -58,6 +58,26 @@ func TestIdempotencyStoreExpires(t *testing.T) {
 	}
 }
 
+func TestIdempotencyStoreGCRemovesExpiredEntries(t *testing.T) {
+	store := newIdempotencyStore()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return now }
+
+	expired := idempotencyKey{keyID: 1, key: "expired"}
+	live := idempotencyKey{keyID: 1, key: "live"}
+	store.store(expired, &idempotencyEntry{expiresAt: now.Add(-time.Second)})
+	store.store(live, &idempotencyEntry{expiresAt: now.Add(time.Hour)})
+
+	store.gc()
+
+	if _, ok := store.entries[expired]; ok {
+		t.Fatal("expired entry survived gc")
+	}
+	if _, ok := store.entries[live]; !ok {
+		t.Fatal("live entry removed by gc")
+	}
+}
+
 // bodyReader wraps a byte slice as an http.Request.Body.
 func bodyReader(b []byte) io.ReadCloser {
 	return io.NopCloser(bytes.NewReader(b))

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -67,7 +67,7 @@ func (s *Server) requireScope(required apikeys.Scope, h http.HandlerFunc) http.H
 		if token == "" {
 			writeError(w, req, http.StatusUnauthorized, "missing_token",
 				"Authorization header with Bearer token is required")
-			s.audit(nil, req, http.StatusUnauthorized, time.Time{}, "missing token")
+			s.audit(reqID, nil, req, http.StatusUnauthorized, time.Time{}, "missing token")
 			return
 		}
 
@@ -75,7 +75,7 @@ func (s *Server) requireScope(required apikeys.Scope, h http.HandlerFunc) http.H
 		if err != nil {
 			status, code, msg := mapAuthError(err)
 			writeError(w, req, status, code, msg)
-			s.audit(nil, req, status, time.Time{}, code)
+			s.audit(reqID, nil, req, status, time.Time{}, code)
 			return
 		}
 
@@ -83,7 +83,7 @@ func (s *Server) requireScope(required apikeys.Scope, h http.HandlerFunc) http.H
 			writeError(w, req, http.StatusForbidden, "insufficient_scope",
 				"this endpoint requires scope "+string(required)+
 					"; your key has scope "+string(key.Scope))
-			s.audit(key, req, http.StatusForbidden, time.Time{}, "insufficient scope")
+			s.audit(reqID, key, req, http.StatusForbidden, time.Time{}, "insufficient scope")
 			return
 		}
 
@@ -92,7 +92,7 @@ func (s *Server) requireScope(required apikeys.Scope, h http.HandlerFunc) http.H
 		writeRateLimitHeaders(w, key.RateLimitPerMinute, remaining, resetAt)
 		if !allowed {
 			writeRateLimited(w, req, key.RateLimitPerMinute, remaining, resetAt)
-			s.audit(key, req, http.StatusTooManyRequests, time.Time{}, "rate limited")
+			s.audit(reqID, key, req, http.StatusTooManyRequests, time.Time{}, "rate limited")
 			return
 		}
 
@@ -106,7 +106,7 @@ func (s *Server) requireScope(required apikeys.Scope, h http.HandlerFunc) http.H
 		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 		h(rec, r.WithContext(ctx))
 
-		s.audit(key, r, rec.status, started, "")
+		s.audit(reqID, key, req, rec.status, started, "")
 	}
 }
 
@@ -164,7 +164,11 @@ func mapAuthError(err error) (status int, code, msg string) {
 // could be moved to a buffered channel if write latency becomes a concern.
 // Errors are logged but never returned to the consumer — audit is observability,
 // not gate.
-func (s *Server) audit(key *apikeys.Key, r *http.Request, status int, started time.Time, note string) {
+//
+// reqID is passed explicitly rather than pulled from r's context so callers
+// can't accidentally drop it by handing in a request whose context wasn't
+// extended with the middleware's request id.
+func (s *Server) audit(reqID string, key *apikeys.Key, r *http.Request, status int, started time.Time, note string) {
 	consumerName := "unknown"
 	var keyID int64
 	if key != nil {
@@ -184,7 +188,7 @@ func (s *Server) audit(key *apikeys.Key, r *http.Request, status int, started ti
 		"path":        r.URL.Path,
 		"status":      status,
 		"duration_ms": durationMs,
-		"request_id":  requestIDFromRequest(r),
+		"request_id":  reqID,
 		"remote_addr": r.RemoteAddr,
 		"note":        note,
 	})

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -60,29 +60,30 @@ func (s *Server) requireScope(required apikeys.Scope, h http.HandlerFunc) http.H
 	return func(w http.ResponseWriter, r *http.Request) {
 		reqID := newRequestID()
 		ctx := context.WithValue(r.Context(), ctxKeyRequestID, reqID)
+		req := r.WithContext(ctx)
 		w.Header().Set("X-Request-ID", reqID)
 
 		token := bearerToken(r)
 		if token == "" {
-			writeError(w, r.WithContext(ctx), http.StatusUnauthorized, "missing_token",
+			writeError(w, req, http.StatusUnauthorized, "missing_token",
 				"Authorization header with Bearer token is required")
-			s.audit(nil, r, http.StatusUnauthorized, time.Time{}, "missing token")
+			s.audit(nil, req, http.StatusUnauthorized, time.Time{}, "missing token")
 			return
 		}
 
 		key, err := apikeys.Lookup(ctx, s.db, token)
 		if err != nil {
 			status, code, msg := mapAuthError(err)
-			writeError(w, r.WithContext(ctx), status, code, msg)
-			s.audit(nil, r, status, time.Time{}, code)
+			writeError(w, req, status, code, msg)
+			s.audit(nil, req, status, time.Time{}, code)
 			return
 		}
 
 		if !key.Scope.Includes(required) {
-			writeError(w, r.WithContext(ctx), http.StatusForbidden, "insufficient_scope",
+			writeError(w, req, http.StatusForbidden, "insufficient_scope",
 				"this endpoint requires scope "+string(required)+
 					"; your key has scope "+string(key.Scope))
-			s.audit(key, r, http.StatusForbidden, time.Time{}, "insufficient scope")
+			s.audit(key, req, http.StatusForbidden, time.Time{}, "insufficient scope")
 			return
 		}
 
@@ -90,8 +91,8 @@ func (s *Server) requireScope(required apikeys.Scope, h http.HandlerFunc) http.H
 		allowed, remaining, resetAt := s.limiter.allow(key.ID, key.RateLimitPerMinute)
 		writeRateLimitHeaders(w, key.RateLimitPerMinute, remaining, resetAt)
 		if !allowed {
-			writeRateLimited(w, r.WithContext(ctx), key.RateLimitPerMinute, remaining, resetAt)
-			s.audit(key, r, http.StatusTooManyRequests, time.Time{}, "rate limited")
+			writeRateLimited(w, req, key.RateLimitPerMinute, remaining, resetAt)
+			s.audit(key, req, http.StatusTooManyRequests, time.Time{}, "rate limited")
 			return
 		}
 

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -193,7 +193,12 @@ func (s *Server) audit(reqID string, key *apikeys.Key, r *http.Request, status i
 		"note":        note,
 	})
 
-	if err := audit.Log(audit.Entry{
+	// Derive the audit context from Background, not r.Context(): a client
+	// disconnect must not silence the audit row, since audit is for the
+	// operator, not the caller. The timeout caps any wedged-DB hang.
+	ctx, cancel := context.WithTimeout(context.Background(), auditWriteTimeout)
+	defer cancel()
+	if err := audit.Log(ctx, audit.Entry{
 		EventType: audit.EventAPIAccess,
 		Source:    consumerName,
 		Detail:    r.Method + " " + r.URL.Path,
@@ -202,6 +207,11 @@ func (s *Server) audit(reqID string, key *apikeys.Key, r *http.Request, status i
 		log.Printf("api: audit log failed: %v", err)
 	}
 }
+
+// auditWriteTimeout caps a single audit insert so a wedged DB cannot block
+// the request goroutine indefinitely. Audit is observability, not gate; if
+// the write times out we log and move on.
+const auditWriteTimeout = 5 * time.Second
 
 // newRequestID returns a 16-byte random hex id (32 chars). Same shape as the
 // verifier's NewRequestID for consistency in operator log-greppage.

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -450,6 +450,24 @@ func TestStatusRecorderCapturesCode(t *testing.T) {
 	}
 }
 
+type flushRecorder struct {
+	*httptest.ResponseRecorder
+	flushed bool
+}
+
+func (r *flushRecorder) Flush() {
+	r.flushed = true
+}
+
+func TestStatusRecorderFlushPassThrough(t *testing.T) {
+	rec := &flushRecorder{ResponseRecorder: httptest.NewRecorder()}
+	sr := &statusRecorder{ResponseWriter: rec, status: http.StatusOK}
+	sr.Flush()
+	if !rec.flushed {
+		t.Fatal("Flush did not pass through to the wrapped writer")
+	}
+}
+
 func TestMapAuthError(t *testing.T) {
 	cases := []struct {
 		err        error

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -1,12 +1,15 @@
 package api
 
 import (
+	"database/sql/driver"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/Automattic/jetmon/internal/apikeys"
+	"github.com/Automattic/jetmon/internal/audit"
 	"github.com/DATA-DOG/go-sqlmock"
 )
 
@@ -15,10 +18,53 @@ const keyLookupSQL = ` SELECT id, consumer_name, scope, rate_limit_per_minute, e
 
 const keyTouchSQL = `UPDATE jetmon_api_keys SET last_used_at = CURRENT_TIMESTAMP WHERE id = ?`
 
+const auditInsertSQL = `
+		INSERT INTO jetmon_audit_log
+			(blog_id, event_id, event_type, source, detail, metadata)
+		VALUES (?, ?, ?, ?, ?, ?)`
+
 // columnsKey is the column set returned by getByHash.
 var columnsKey = []string{
 	"id", "consumer_name", "scope", "rate_limit_per_minute",
 	"expires_at", "revoked_at", "last_used_at", "created_at", "created_by",
+}
+
+type apiAuditMetadataWithRequestID struct {
+	t          *testing.T
+	wantStatus float64
+	wantNote   string
+}
+
+func (m apiAuditMetadataWithRequestID) Match(v driver.Value) bool {
+	m.t.Helper()
+	var raw []byte
+	switch got := v.(type) {
+	case []byte:
+		raw = got
+	case string:
+		raw = []byte(got)
+	default:
+		m.t.Errorf("metadata type = %T, want []byte or string", v)
+		return false
+	}
+	var meta map[string]any
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		m.t.Errorf("metadata is not JSON: %v", err)
+		return false
+	}
+	if meta["request_id"] == "" {
+		m.t.Errorf("metadata request_id is empty: %s", raw)
+		return false
+	}
+	if meta["status"] != m.wantStatus {
+		m.t.Errorf("metadata status = %v, want %.0f", meta["status"], m.wantStatus)
+		return false
+	}
+	if meta["note"] != m.wantNote {
+		m.t.Errorf("metadata note = %v, want %q", meta["note"], m.wantNote)
+		return false
+	}
+	return true
 }
 
 func makeKeyRow(id int64, scope string, rateLimit int, revokedAt, expiresAt *time.Time) *sqlmock.Rows {
@@ -59,6 +105,42 @@ func TestRequireScopeMissingToken(t *testing.T) {
 	}
 	if rec.Header().Get("X-Request-ID") == "" {
 		t.Error("X-Request-ID header should be set")
+	}
+}
+
+func TestRequireScopeAuditsRejectedRequestWithRequestID(t *testing.T) {
+	s, mock, _, cleanup := newTestServer(t)
+	defer cleanup()
+	audit.Init(s.db)
+	t.Cleanup(func() { audit.Init(nil) })
+
+	mock.ExpectExec(auditInsertSQL).WithArgs(
+		nil,
+		nil,
+		audit.EventAPIAccess,
+		"unknown",
+		"GET /api/v1/anything",
+		apiAuditMetadataWithRequestID{
+			t:          t,
+			wantStatus: float64(http.StatusUnauthorized),
+			wantNote:   "missing token",
+		},
+	).WillReturnResult(sqlmock.NewResult(0, 1))
+
+	wrapped := s.requireScope(scopeRead, func(w http.ResponseWriter, r *http.Request) {})
+
+	req := httptest.NewRequest("GET", "/api/v1/anything", nil)
+	rec := httptest.NewRecorder()
+	wrapped(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401; body=%s", rec.Code, rec.Body.String())
+	}
+	if rec.Header().Get("X-Request-ID") == "" {
+		t.Fatal("X-Request-ID header should be set")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("expectations: %v", err)
 	}
 }
 

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -109,38 +109,104 @@ func TestRequireScopeMissingToken(t *testing.T) {
 }
 
 func TestRequireScopeAuditsRejectedRequestWithRequestID(t *testing.T) {
-	s, mock, _, cleanup := newTestServer(t)
-	defer cleanup()
-	audit.Init(s.db)
-	t.Cleanup(func() { audit.Init(nil) })
-
-	mock.ExpectExec(auditInsertSQL).WithArgs(
-		nil,
-		nil,
-		audit.EventAPIAccess,
-		"unknown",
-		"GET /api/v1/anything",
-		apiAuditMetadataWithRequestID{
-			t:          t,
-			wantStatus: float64(http.StatusUnauthorized),
+	tests := []struct {
+		name       string
+		scope      apikeys.Scope
+		setupMock  func(sqlmock.Sqlmock)
+		setHeader  func(*http.Request)
+		wantStatus int
+		wantNote   string
+	}{
+		{
+			name:       "missing_token",
+			scope:      scopeRead,
+			setupMock:  func(_ sqlmock.Sqlmock) {},
+			setHeader:  func(_ *http.Request) {},
+			wantStatus: http.StatusUnauthorized,
 			wantNote:   "missing token",
 		},
-	).WillReturnResult(sqlmock.NewResult(0, 1))
-
-	wrapped := s.requireScope(scopeRead, func(w http.ResponseWriter, r *http.Request) {})
-
-	req := httptest.NewRequest("GET", "/api/v1/anything", nil)
-	rec := httptest.NewRecorder()
-	wrapped(rec, req)
-
-	if rec.Code != http.StatusUnauthorized {
-		t.Fatalf("status = %d, want 401; body=%s", rec.Code, rec.Body.String())
+		{
+			name:  "invalid_token",
+			scope: scopeRead,
+			setupMock: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery(keyLookupSQL).WillReturnRows(sqlmock.NewRows(columnsKey))
+			},
+			setHeader: func(r *http.Request) {
+				r.Header.Set("Authorization", "Bearer jm_INVALID-LOOKING-TOKEN-XXXXX")
+			},
+			wantStatus: http.StatusUnauthorized,
+			wantNote:   "invalid_token",
+		},
+		{
+			name:  "token_revoked",
+			scope: scopeRead,
+			setupMock: func(m sqlmock.Sqlmock) {
+				revokedAt := time.Now().UTC().Add(-time.Hour)
+				m.ExpectQuery(keyLookupSQL).WillReturnRows(makeKeyRow(1, "read", 60, &revokedAt, nil))
+			},
+			setHeader: func(r *http.Request) {
+				r.Header.Set("Authorization", "Bearer jm_ANYTOKENWILLDOFORTHISTESTXX")
+			},
+			wantStatus: http.StatusUnauthorized,
+			wantNote:   "token_revoked",
+		},
+		{
+			name:  "insufficient_scope",
+			scope: scopeWrite,
+			setupMock: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery(keyLookupSQL).WillReturnRows(makeKeyRow(1, "read", 60, nil, nil))
+				m.ExpectExec(keyTouchSQL).WithArgs(int64(1)).WillReturnResult(sqlmock.NewResult(0, 1))
+			},
+			setHeader: func(r *http.Request) {
+				r.Header.Set("Authorization", "Bearer jm_ANYTOKENWILLDOFORTHISTESTXX")
+			},
+			wantStatus: http.StatusForbidden,
+			wantNote:   "insufficient scope",
+		},
 	}
-	if rec.Header().Get("X-Request-ID") == "" {
-		t.Fatal("X-Request-ID header should be set")
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Errorf("expectations: %v", err)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, mock, _, cleanup := newTestServer(t)
+			defer cleanup()
+			audit.Init(s.db)
+			t.Cleanup(func() { audit.Init(nil) })
+
+			tt.setupMock(mock)
+
+			// consumer name varies (unknown vs test-consumer) and is also
+			// reflected in the metadata's consumer field, but the matcher
+			// only asserts request_id/status/note, so AnyArg is enough.
+			mock.ExpectExec(auditInsertSQL).WithArgs(
+				nil,
+				nil,
+				audit.EventAPIAccess,
+				sqlmock.AnyArg(),
+				"GET /api/v1/anything",
+				apiAuditMetadataWithRequestID{
+					t:          t,
+					wantStatus: float64(tt.wantStatus),
+					wantNote:   tt.wantNote,
+				},
+			).WillReturnResult(sqlmock.NewResult(0, 1))
+
+			wrapped := s.requireScope(tt.scope, func(w http.ResponseWriter, r *http.Request) {})
+
+			req := httptest.NewRequest("GET", "/api/v1/anything", nil)
+			tt.setHeader(req)
+			rec := httptest.NewRecorder()
+			wrapped(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d; body=%s", rec.Code, tt.wantStatus, rec.Body.String())
+			}
+			if rec.Header().Get("X-Request-ID") == "" {
+				t.Fatal("X-Request-ID header should be set")
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("expectations: %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -314,9 +314,23 @@ func TestRequireScopeInsufficientScope(t *testing.T) {
 func TestRequireScopeAllowsValidToken(t *testing.T) {
 	s, mock, _, cleanup := newTestServer(t)
 	defer cleanup()
+	audit.Init(s.db)
+	t.Cleanup(func() { audit.Init(nil) })
 
 	mock.ExpectQuery(keyLookupSQL).WillReturnRows(makeKeyRow(1, "read", 60, nil, nil))
 	mock.ExpectExec(keyTouchSQL).WithArgs(int64(1)).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(auditInsertSQL).WithArgs(
+		nil,
+		nil,
+		audit.EventAPIAccess,
+		"test-consumer",
+		"GET /",
+		apiAuditMetadataWithRequestID{
+			t:          t,
+			wantStatus: float64(http.StatusOK),
+			wantNote:   "",
+		},
+	).WillReturnResult(sqlmock.NewResult(0, 1))
 
 	called := false
 	wrapped := s.requireScope(scopeRead, func(w http.ResponseWriter, r *http.Request) {
@@ -345,11 +359,16 @@ func TestRequireScopeAllowsValidToken(t *testing.T) {
 	if got := rec.Header().Get("X-RateLimit-Remaining"); got == "" {
 		t.Errorf("X-RateLimit-Remaining missing")
 	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("expectations: %v", err)
+	}
 }
 
 func TestRequireScopeRateLimit429(t *testing.T) {
 	s, mock, _, cleanup := newTestServer(t)
 	defer cleanup()
+	audit.Init(s.db)
+	t.Cleanup(func() { audit.Init(nil) })
 
 	// Limit = 1/min — second request should 429. We have to set up two
 	// lookup expectations because the limiter check runs after auth.
@@ -358,6 +377,30 @@ func TestRequireScopeRateLimit429(t *testing.T) {
 	mock.ExpectExec(keyTouchSQL).WithArgs(int64(2)).WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectQuery(keyLookupSQL).WillReturnRows(makeKeyRow(2, "read", 1, nil, nil))
 	mock.ExpectExec(keyTouchSQL).WithArgs(int64(2)).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(auditInsertSQL).WithArgs(
+		nil,
+		nil,
+		audit.EventAPIAccess,
+		"test-consumer",
+		"GET /",
+		apiAuditMetadataWithRequestID{
+			t:          t,
+			wantStatus: float64(http.StatusOK),
+			wantNote:   "",
+		},
+	).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(auditInsertSQL).WithArgs(
+		nil,
+		nil,
+		audit.EventAPIAccess,
+		"test-consumer",
+		"GET /",
+		apiAuditMetadataWithRequestID{
+			t:          t,
+			wantStatus: float64(http.StatusTooManyRequests),
+			wantNote:   "rate limited",
+		},
+	).WillReturnResult(sqlmock.NewResult(0, 1))
 
 	wrapped := s.requireScope(scopeRead, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -387,6 +430,9 @@ func TestRequireScopeRateLimit429(t *testing.T) {
 	body := readErrorBody(t, rec2.Body)
 	if body.Code != "rate_limited" {
 		t.Errorf("error code = %q, want rate_limited", body.Code)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("expectations: %v", err)
 	}
 }
 

--- a/internal/apikeys/apikeys_test.go
+++ b/internal/apikeys/apikeys_test.go
@@ -2,6 +2,7 @@ package apikeys
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"strings"
 	"testing"
@@ -213,6 +214,179 @@ func TestLookupRejectsPastExpiresAt(t *testing.T) {
 	_, err = Lookup(context.Background(), db, raw)
 	if !errors.Is(err, ErrKeyExpired) {
 		t.Fatalf("Lookup error = %v, want ErrKeyExpired", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+var keyColumns = []string{
+	"id", "consumer_name", "scope", "rate_limit_per_minute",
+	"expires_at", "revoked_at", "last_used_at", "created_at", "created_by",
+}
+
+func keyRow(id int64, consumer string, scope Scope, rate int, createdAt time.Time, createdBy string) *sqlmock.Rows {
+	return sqlmock.NewRows(keyColumns).
+		AddRow(id, consumer, string(scope), rate, nil, nil, nil, createdAt, createdBy)
+}
+
+func TestCreateUsesDefaultsAndFetchesPersistedKey(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	now := time.Now().UTC()
+	mock.ExpectExec("INSERT INTO jetmon_api_keys").
+		WithArgs(sqlmock.AnyArg(), "gateway", string(ScopeWrite), 30, sqlmock.AnyArg(), "cli").
+		WillReturnResult(sqlmock.NewResult(7, 1))
+	mock.ExpectQuery("SELECT id, consumer_name, scope, rate_limit_per_minute").
+		WithArgs(int64(7)).
+		WillReturnRows(keyRow(7, "gateway", ScopeWrite, 30, now, "cli"))
+
+	raw, key, err := Create(context.Background(), db, CreateInput{
+		ConsumerName: "gateway",
+		Scope:        ScopeWrite,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if !strings.HasPrefix(raw, TokenPrefix) {
+		t.Fatalf("raw token = %q, want %s prefix", raw, TokenPrefix)
+	}
+	if key.ID != 7 || key.RateLimitPerMinute != 30 || key.CreatedBy != "cli" {
+		t.Fatalf("key = %+v", key)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestCreateRejectsInvalidInputBeforeDB(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	if _, _, err := Create(context.Background(), db, CreateInput{Scope: ScopeRead}); err == nil {
+		t.Fatal("Create accepted empty consumer_name")
+	}
+	if _, _, err := Create(context.Background(), db, CreateInput{ConsumerName: "gateway", Scope: Scope("root")}); err == nil {
+		t.Fatal("Create accepted invalid scope")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unexpected sql calls: %v", err)
+	}
+}
+
+func TestListScansKeys(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	now := time.Now().UTC()
+	expiresAt := now.Add(time.Hour)
+	revokedAt := now.Add(-time.Minute)
+	lastUsedAt := now.Add(-time.Second)
+	rows := sqlmock.NewRows(keyColumns).
+		AddRow(int64(1), "gateway", string(ScopeRead), 60, nil, nil, nil, now, "ops").
+		AddRow(int64(2), "admin", string(ScopeAdmin), 60, expiresAt, revokedAt, lastUsedAt, now, "ops")
+	mock.ExpectQuery("SELECT id, consumer_name, scope, rate_limit_per_minute").
+		WillReturnRows(rows)
+
+	keys, err := List(context.Background(), db)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(keys) != 2 {
+		t.Fatalf("List len = %d, want 2", len(keys))
+	}
+	if keys[1].ExpiresAt == nil || keys[1].RevokedAt == nil || keys[1].LastUsedAt == nil {
+		t.Fatalf("second key did not scan nullable timestamps: %+v", keys[1])
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestRevokeAlreadyRevokedIsSuccess(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	now := time.Now().UTC()
+	mock.ExpectExec("UPDATE jetmon_api_keys SET revoked_at").
+		WithArgs(int64(9)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SELECT id, consumer_name, scope, rate_limit_per_minute").
+		WithArgs(int64(9)).
+		WillReturnRows(sqlmock.NewRows(keyColumns).
+			AddRow(int64(9), "gateway", string(ScopeRead), 60, nil, now, nil, now, "ops"))
+
+	if err := Revoke(context.Background(), db, 9); err != nil {
+		t.Fatalf("Revoke already revoked: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestRevokeMissingKeyReturnsNotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("UPDATE jetmon_api_keys SET revoked_at").
+		WithArgs(int64(404)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SELECT id, consumer_name, scope, rate_limit_per_minute").
+		WithArgs(int64(404)).
+		WillReturnError(sql.ErrNoRows)
+
+	err = Revoke(context.Background(), db, 404)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("Revoke missing error = %v, want not found", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestRotateSchedulesOldKeyRevocation(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	now := time.Now().UTC()
+	mock.ExpectQuery("SELECT id, consumer_name, scope, rate_limit_per_minute").
+		WithArgs(int64(3)).
+		WillReturnRows(keyRow(3, "gateway", ScopeAdmin, 60, now, "ops"))
+	mock.ExpectExec("INSERT INTO jetmon_api_keys").
+		WithArgs(sqlmock.AnyArg(), "gateway", string(ScopeAdmin), 60, sqlmock.AnyArg(), "operator").
+		WillReturnResult(sqlmock.NewResult(4, 1))
+	mock.ExpectQuery("SELECT id, consumer_name, scope, rate_limit_per_minute").
+		WithArgs(int64(4)).
+		WillReturnRows(keyRow(4, "gateway", ScopeAdmin, 60, now, "operator"))
+	mock.ExpectExec("UPDATE jetmon_api_keys").
+		WithArgs(300, int64(3)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	raw, key, err := Rotate(context.Background(), db, 3, 5*time.Minute, "operator")
+	if err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+	if !strings.HasPrefix(raw, TokenPrefix) || key.ID != 4 {
+		t.Fatalf("Rotate returned raw=%q key=%+v", raw, key)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet sql expectations: %v", err)

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -10,6 +10,7 @@
 package audit
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -50,8 +51,12 @@ type Entry struct {
 	Metadata  json.RawMessage // optional structured context (e.g. retry attempt, region)
 }
 
-// Log writes an entry to jetmon_audit_log.
-func Log(e Entry) error {
+// Log writes an entry to jetmon_audit_log. ctx propagates cancellation and
+// deadlines into the underlying INSERT. Callers control the context lifetime:
+// the orchestrator passes its long-lived shutdown context; the API middleware
+// uses a short bounded timeout derived from context.Background so audits fire
+// regardless of client disconnect but cannot block on a wedged DB.
+func Log(ctx context.Context, e Entry) error {
 	if db == nil {
 		return nil
 	}
@@ -62,7 +67,7 @@ func Log(e Entry) error {
 	if source == "" {
 		source = "local"
 	}
-	_, err := db.Exec(`
+	_, err := db.ExecContext(ctx, `
 		INSERT INTO jetmon_audit_log
 			(blog_id, event_id, event_type, source, detail, metadata)
 		VALUES (?, ?, ?, ?, ?, ?)`,

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -1,6 +1,12 @@
 package audit
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
 
 func TestNullableInt64(t *testing.T) {
 	if nullableInt64(0) != nil {
@@ -35,7 +41,7 @@ func TestNullableJSON(t *testing.T) {
 
 func TestLogWithNilDB(t *testing.T) {
 	// db is nil in tests — Log must return nil, not panic.
-	if err := Log(Entry{
+	if err := Log(context.Background(), Entry{
 		BlogID:    1,
 		EventType: EventVeriflierSent,
 		Source:    "test",
@@ -48,11 +54,37 @@ func TestLogWithNilDB(t *testing.T) {
 func TestLogRequiresEventType(t *testing.T) {
 	// Set a non-nil db so the validation runs (we won't actually hit it because
 	// the validation is before the db.Exec call).
-	if err := Log(Entry{BlogID: 1}); err != nil {
+	if err := Log(context.Background(), Entry{BlogID: 1}); err != nil {
 		// nil db short-circuits before validation. That's fine — the
 		// production code path requires a real db, which the integration
 		// tests cover. Here we just confirm the call doesn't panic with an
 		// empty Entry.
+	}
+}
+
+func TestLogHonorsCanceledContext(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+
+	orig := db
+	t.Cleanup(func() { db = orig })
+	db = conn
+
+	mock.ExpectExec(`INSERT INTO jetmon_audit_log`).WillReturnError(context.Canceled)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = Log(ctx, Entry{
+		EventType: EventConfigChange,
+		Source:    "test",
+		Detail:    "ctx canceled",
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Log() with canceled ctx = %v, want context.Canceled", err)
 	}
 }
 

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 )
@@ -94,5 +95,35 @@ func TestInit(t *testing.T) {
 	Init(nil)
 	if db != nil {
 		t.Fatal("Init(nil) should set db to nil")
+	}
+}
+
+func TestQueryBuildsTimeRange(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+
+	now := time.Now().UTC()
+	mock.ExpectQuery("SELECT id, blog_id, event_id, event_type").
+		WithArgs(int64(42), "2026-04-27 00:00:00", "2026-04-28 00:00:00").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "blog_id", "event_id", "event_type", "source", "detail", "metadata", "created_at",
+		}).AddRow(int64(1), int64(42), nil, EventAPIAccess, "api", "ok", nil, now))
+
+	rows, err := Query(conn, 42, "2026-04-27 00:00:00", "2026-04-28 00:00:00")
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		t.Fatal("expected one audit row")
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -270,6 +270,15 @@ func TestLegacyStatusProjectionConfig(t *testing.T) {
 	}
 }
 
+func TestDisplayName(t *testing.T) {
+	if got := displayName(VerifierConfig{Name: "us-west"}, 2); got != "us-west" {
+		t.Fatalf("displayName(named) = %q, want us-west", got)
+	}
+	if got := displayName(VerifierConfig{}, 2); got != "verifier #2" {
+		t.Fatalf("displayName(unnamed) = %q, want verifier #2", got)
+	}
+}
+
 func TestLoadInvalidConfigReturnsError(t *testing.T) {
 	saveConfigState(t)
 

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -205,6 +205,32 @@ func TestSimpleMutationQueries(t *testing.T) {
 	}
 }
 
+func TestUpdateSiteStatusTx(t *testing.T) {
+	mock, cleanup := withMockDB(t)
+	defer cleanup()
+
+	now := time.Now().UTC()
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE jetpack_monitor_sites SET site_status").
+		WithArgs(2, now, int64(42)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	if err := UpdateSiteStatusTx(context.Background(), tx, 42, 2, now); err != nil {
+		t.Fatalf("UpdateSiteStatusTx: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
 func TestGetAllHostsScansRows(t *testing.T) {
 	mock, cleanup := withMockDB(t)
 	defer cleanup()

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -1,8 +1,12 @@
 package db
 
 import (
+	"context"
 	"reflect"
 	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
 )
 
 func TestAssignBucketRanges(t *testing.T) {
@@ -64,5 +68,229 @@ func TestAssignBucketRanges(t *testing.T) {
 				t.Fatalf("assignBucketRanges() = %#v, want %#v", got, tt.want)
 			}
 		})
+	}
+}
+
+func withMockDB(t *testing.T) (sqlmock.Sqlmock, func()) {
+	t.Helper()
+	mockDB, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	orig := db
+	db = mockDB
+	cleanup := func() {
+		db = orig
+		_ = mockDB.Close()
+	}
+	return mock, cleanup
+}
+
+func TestGlobalDBAccessors(t *testing.T) {
+	mock, cleanup := withMockDB(t)
+	defer cleanup()
+
+	mock.ExpectPing()
+	if DB() == nil {
+		t.Fatal("DB() = nil")
+	}
+	if err := Ping(); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+	if Hostname() == "" {
+		t.Fatal("Hostname() returned empty string")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestGetSitesForBucketScansRowsAndDefaultRedirectPolicy(t *testing.T) {
+	mock, cleanup := withMockDB(t)
+	defer cleanup()
+
+	now := time.Now().UTC()
+	rows := sqlmock.NewRows([]string{
+		"jetpack_monitor_site_id", "blog_id", "bucket_no", "monitor_url",
+		"monitor_active", "site_status", "last_status_change", "check_interval", "last_checked_at",
+		"ssl_expiry_date", "check_keyword", "maintenance_start", "maintenance_end",
+		"custom_headers", "timeout_seconds", "redirect_policy", "alert_cooldown_minutes", "last_alert_sent_at",
+	}).AddRow(
+		int64(1), int64(42), 7, "https://site.example",
+		true, 1, now, 5, now,
+		nil, nil, nil, nil,
+		nil, nil, nil, nil, nil,
+	)
+	mock.ExpectQuery("SELECT").
+		WithArgs(0, 99, 50).
+		WillReturnRows(rows)
+
+	sites, err := GetSitesForBucket(context.Background(), 0, 99, 50, false)
+	if err != nil {
+		t.Fatalf("GetSitesForBucket: %v", err)
+	}
+	if len(sites) != 1 {
+		t.Fatalf("sites len = %d, want 1", len(sites))
+	}
+	if sites[0].BlogID != 42 || sites[0].RedirectPolicy != "follow" {
+		t.Fatalf("site = %+v", sites[0])
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestSimpleMutationQueries(t *testing.T) {
+	mock, cleanup := withMockDB(t)
+	defer cleanup()
+
+	now := time.Now().UTC()
+	mock.ExpectExec("UPDATE jetpack_monitor_sites SET site_status").
+		WithArgs(2, now, int64(42)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE jetpack_monitor_sites SET last_checked_at").
+		WithArgs(now, int64(42)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE jetpack_monitor_sites SET last_alert_sent_at").
+		WithArgs(now, int64(42)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE jetpack_monitor_sites SET ssl_expiry_date").
+		WithArgs(now, int64(42)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE jetmon_hosts SET last_heartbeat").
+		WithArgs("host-a").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE jetmon_hosts SET status = 'draining'").
+		WithArgs("host-a").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("DELETE FROM jetmon_hosts").
+		WithArgs("host-a").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO jetmon_false_positives").
+		WithArgs(int64(42), 500, 1, int64(123)).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO jetmon_check_history").
+		WithArgs(int64(42), 200, 0, int64(100), int64(1), int64(2), int64(3), int64(4)).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	if err := UpdateSiteStatus(context.Background(), 42, 2, now); err != nil {
+		t.Fatalf("UpdateSiteStatus: %v", err)
+	}
+	if err := MarkSiteChecked(context.Background(), 42, now); err != nil {
+		t.Fatalf("MarkSiteChecked: %v", err)
+	}
+	if err := UpdateLastAlertSent(context.Background(), 42, now); err != nil {
+		t.Fatalf("UpdateLastAlertSent: %v", err)
+	}
+	if err := UpdateSSLExpiry(context.Background(), 42, now); err != nil {
+		t.Fatalf("UpdateSSLExpiry: %v", err)
+	}
+	if err := Heartbeat(context.Background(), "host-a"); err != nil {
+		t.Fatalf("Heartbeat: %v", err)
+	}
+	if err := MarkHostDraining(context.Background(), "host-a"); err != nil {
+		t.Fatalf("MarkHostDraining: %v", err)
+	}
+	if err := ReleaseHost(context.Background(), "host-a"); err != nil {
+		t.Fatalf("ReleaseHost: %v", err)
+	}
+	if err := RecordFalsePositive(42, 500, 1, 123); err != nil {
+		t.Fatalf("RecordFalsePositive: %v", err)
+	}
+	if err := RecordCheckHistory(42, 200, 0, 100, 1, 2, 3, 4); err != nil {
+		t.Fatalf("RecordCheckHistory: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestGetAllHostsScansRows(t *testing.T) {
+	mock, cleanup := withMockDB(t)
+	defer cleanup()
+
+	now := time.Now().UTC()
+	mock.ExpectQuery("SELECT host_id, bucket_min, bucket_max").
+		WillReturnRows(sqlmock.NewRows([]string{"host_id", "bucket_min", "bucket_max", "last_heartbeat", "status"}).
+			AddRow("host-a", 0, 49, now, "active").
+			AddRow("host-b", 50, 99, now, "draining"))
+
+	hosts, err := GetAllHosts()
+	if err != nil {
+		t.Fatalf("GetAllHosts: %v", err)
+	}
+	if len(hosts) != 2 || hosts[1].Status != "draining" {
+		t.Fatalf("hosts = %+v", hosts)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestClaimBucketsRebalancesKnownHosts(t *testing.T) {
+	mock, cleanup := withMockDB(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM jetmon_hosts").
+		WithArgs(60, "host-b").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SELECT host_id FROM jetmon_hosts").
+		WithArgs("host-b").
+		WillReturnRows(sqlmock.NewRows([]string{"host_id"}).AddRow("host-a"))
+	mock.ExpectExec("INSERT INTO jetmon_hosts").
+		WithArgs("host-a", 0, 4).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO jetmon_hosts").
+		WithArgs("host-b", 5, 9).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	minBucket, maxBucket, err := ClaimBuckets("host-b", 10, 10, 60)
+	if err != nil {
+		t.Fatalf("ClaimBuckets: %v", err)
+	}
+	if minBucket != 5 || maxBucket != 9 {
+		t.Fatalf("claimed range = %d..%d, want 5..9", minBucket, maxBucket)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestMigrateAppliesOnlyPendingMigrations(t *testing.T) {
+	mock, cleanup := withMockDB(t)
+	defer cleanup()
+
+	origMigrations := migrations
+	migrations = []migration{
+		{id: 1, sql: "CREATE TABLE jetmon_schema_migrations"},
+		{id: 2, sql: "ALTER TABLE already_done"},
+		{id: 3, sql: "ALTER TABLE pending_change"},
+	}
+	defer func() { migrations = origMigrations }()
+
+	mock.ExpectExec("CREATE TABLE jetmon_schema_migrations").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT IGNORE INTO jetmon_schema_migrations").
+		WithArgs(1).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("SELECT COUNT").
+		WithArgs(2).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectQuery("SELECT COUNT").
+		WithArgs(3).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectExec("ALTER TABLE pending_change").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT IGNORE INTO jetmon_schema_migrations").
+		WithArgs(3).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := Migrate(); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
 	}
 }

--- a/internal/eventstore/eventstore_test.go
+++ b/internal/eventstore/eventstore_test.go
@@ -2,8 +2,11 @@ package eventstore
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
 )
 
 func TestNewWithNilDB(t *testing.T) {
@@ -80,6 +83,12 @@ func TestNilDBTxIsNoOp(t *testing.T) {
 	if _, err := tx.Promote(ctx, 1, SeverityDown, StateDown, ReasonVerifierConfirmed, "local", nil); err != nil {
 		t.Fatalf("Tx.Promote: %v", err)
 	}
+	if _, err := tx.UpdateState(ctx, 1, StateDown, ReasonStateChange, "local", nil); err != nil {
+		t.Fatalf("Tx.UpdateState: %v", err)
+	}
+	if _, err := tx.LinkCause(ctx, 1, 2, "local"); err != nil {
+		t.Fatalf("Tx.LinkCause: %v", err)
+	}
 	if err := tx.Close(ctx, 1, ReasonVerifierCleared, "local", nil); err != nil {
 		t.Fatalf("Tx.Close: %v", err)
 	}
@@ -97,6 +106,269 @@ func TestNilDBTxIsNoOp(t *testing.T) {
 	// Rollback after Commit should also be a no-op.
 	if err := tx.Rollback(); err != nil {
 		t.Fatalf("Rollback after Commit: %v", err)
+	}
+}
+
+func TestSQLTxBeginCommitAndRollback(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	s := New(db)
+	ctx := context.Background()
+
+	mock.ExpectBegin()
+	tx, err := s.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin for commit: %v", err)
+	}
+	if tx.Tx() == nil {
+		t.Fatal("sql-backed Tx should expose *sql.Tx")
+	}
+	mock.ExpectCommit()
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	// Rollback after Commit should swallow sql.ErrTxDone so callers can defer it.
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback after Commit: %v", err)
+	}
+
+	mock.ExpectBegin()
+	tx, err = s.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin for rollback: %v", err)
+	}
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	// A second Rollback after the transaction is closed is also a no-op.
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("second Rollback: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+var eventSnapshotColumns = []string{"blog_id", "severity", "state", "ended_at", "cause_event_id"}
+
+func eventSnapshotRow(blogID int64, severity uint8, state string, cause any) *sqlmock.Rows {
+	return sqlmock.NewRows(eventSnapshotColumns).
+		AddRow(blogID, severity, state, nil, cause)
+}
+
+func TestStoreOpenInsertedEventWritesTransition(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO jetmon_events").
+		WithArgs(int64(42), nil, "http", nil, SeveritySeemsDown, StateSeemsDown, nil).
+		WillReturnResult(sqlmock.NewResult(99, 1))
+	mock.ExpectExec("INSERT INTO jetmon_event_transitions").
+		WithArgs(int64(99), int64(42), nil, SeveritySeemsDown, nil, StateSeemsDown, ReasonOpened, "local", nil).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	res, err := New(db).Open(context.Background(), OpenInput{
+		Identity: Identity{BlogID: 42, CheckType: "http"},
+		Severity: SeveritySeemsDown,
+		State:    StateSeemsDown,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if res.EventID != 99 || !res.Opened || res.CurrentSeverity != SeveritySeemsDown || res.CurrentState != StateSeemsDown {
+		t.Fatalf("Open result = %+v", res)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestStoreOpenExistingEventReadsCurrentState(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO jetmon_events").
+		WithArgs(int64(42), nil, "http", nil, SeveritySeemsDown, StateSeemsDown, nil).
+		WillReturnResult(sqlmock.NewResult(99, 2))
+	mock.ExpectQuery("SELECT severity, state FROM jetmon_events").
+		WithArgs(int64(99)).
+		WillReturnRows(sqlmock.NewRows([]string{"severity", "state"}).AddRow(SeverityDown, StateDown))
+	mock.ExpectCommit()
+
+	res, err := New(db).Open(context.Background(), OpenInput{
+		Identity: Identity{BlogID: 42, CheckType: "http"},
+		Severity: SeveritySeemsDown,
+		State:    StateSeemsDown,
+	})
+	if err != nil {
+		t.Fatalf("Open existing: %v", err)
+	}
+	if res.Opened || res.CurrentSeverity != SeverityDown || res.CurrentState != StateDown {
+		t.Fatalf("Open existing result = %+v", res)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestStoreUpdateSeverityNoopSkipsTransition(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT blog_id, severity, state, ended_at, cause_event_id").
+		WithArgs(int64(99)).
+		WillReturnRows(eventSnapshotRow(42, SeverityDown, StateDown, nil))
+	mock.ExpectCommit()
+
+	changed, err := New(db).UpdateSeverity(context.Background(), 99, SeverityDown, ReasonSeverityEscalation, "tester", nil)
+	if err != nil {
+		t.Fatalf("UpdateSeverity: %v", err)
+	}
+	if changed {
+		t.Fatal("UpdateSeverity reported change for same severity")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestStorePromoteWritesEventAndTransition(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT blog_id, severity, state, ended_at, cause_event_id").
+		WithArgs(int64(99)).
+		WillReturnRows(eventSnapshotRow(42, SeveritySeemsDown, StateSeemsDown, nil))
+	mock.ExpectExec("UPDATE jetmon_events SET severity").
+		WithArgs(SeverityDown, StateDown, int64(99)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO jetmon_event_transitions").
+		WithArgs(int64(99), int64(42), SeveritySeemsDown, SeverityDown, StateSeemsDown, StateDown, ReasonVerifierConfirmed, "tester", nil).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	changed, err := New(db).Promote(context.Background(), 99, SeverityDown, StateDown, ReasonVerifierConfirmed, "tester", nil)
+	if err != nil {
+		t.Fatalf("Promote: %v", err)
+	}
+	if !changed {
+		t.Fatal("Promote reported no change")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestStoreLinkCauseWritesMetadataTransition(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT blog_id, severity, state, ended_at, cause_event_id").
+		WithArgs(int64(99)).
+		WillReturnRows(eventSnapshotRow(42, SeverityDown, StateDown, nil))
+	mock.ExpectExec("UPDATE jetmon_events SET cause_event_id").
+		WithArgs(int64(123), int64(99)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO jetmon_event_transitions").
+		WithArgs(int64(99), int64(42), SeverityDown, SeverityDown, StateDown, StateDown, ReasonCauseLinked, "tester", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	changed, err := New(db).LinkCause(context.Background(), 99, 123, "tester")
+	if err != nil {
+		t.Fatalf("LinkCause: %v", err)
+	}
+	if !changed {
+		t.Fatal("LinkCause reported no change")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestStoreCloseWritesResolvedTransition(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT blog_id, severity, state, ended_at, cause_event_id").
+		WithArgs(int64(99)).
+		WillReturnRows(eventSnapshotRow(42, SeverityDown, StateDown, nil))
+	mock.ExpectExec("UPDATE jetmon_events").
+		WithArgs(ReasonVerifierCleared, int64(99)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO jetmon_event_transitions").
+		WithArgs(int64(99), int64(42), SeverityDown, nil, StateDown, StateResolved, ReasonVerifierCleared, "tester", nil).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	if err := New(db).Close(context.Background(), 99, ReasonVerifierCleared, "tester", nil); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestTxFindActiveByBlog(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT id, severity, state FROM jetmon_events").
+		WithArgs(int64(42), "http").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "severity", "state"}).AddRow(int64(99), SeverityDown, StateDown))
+	mock.ExpectRollback()
+
+	tx, err := New(db).Begin(context.Background())
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	active, err := tx.FindActiveByBlog(context.Background(), 42, "http")
+	if err != nil {
+		t.Fatalf("FindActiveByBlog: %v", err)
+	}
+	if active.ID != 99 || active.Severity != SeverityDown || active.State != StateDown {
+		t.Fatalf("active = %+v", active)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
 	}
 }
 
@@ -167,5 +439,19 @@ func TestNullableHelpers(t *testing.T) {
 	}
 	if nullableString("x") != "x" {
 		t.Fatal("nullableString(\"x\") should be \"x\"")
+	}
+
+	if nullableInt64(sql.NullInt64{}) != nil {
+		t.Fatal("nullableInt64(invalid) should be nil")
+	}
+	validInt := sql.NullInt64{Int64: 12, Valid: true}
+	if nullableInt64(validInt) != int64(12) {
+		t.Fatalf("nullableInt64(valid 12) = %v, want 12", nullableInt64(validInt))
+	}
+	if nullableInt64ToAny(sql.NullInt64{}) != nil {
+		t.Fatal("nullableInt64ToAny(invalid) should be nil")
+	}
+	if nullableInt64ToAny(validInt) != int64(12) {
+		t.Fatalf("nullableInt64ToAny(valid 12) = %v, want 12", nullableInt64ToAny(validInt))
 	}
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,6 +1,12 @@
 package metrics
 
-import "testing"
+import (
+	"bufio"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
 
 func TestSanitize(t *testing.T) {
 	tests := []struct {
@@ -33,4 +39,93 @@ func TestWriteStatsFilesDoesNotPanic(t *testing.T) {
 	// stats/ directory may not exist in test context; errors are silently
 	// ignored by design — just verify this does not panic.
 	WriteStatsFiles(10, 5, 1000)
+}
+
+func TestClientSendsStatsDMessages(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	c := &Client{
+		prefix: "com.jetpack.jetmon.host_name",
+		conn:   clientConn,
+	}
+
+	lines := make(chan string, 5)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		r := bufio.NewReader(serverConn)
+		for i := 0; i < 5; i++ {
+			line, err := r.ReadString('\n')
+			if err != nil {
+				return
+			}
+			lines <- strings.TrimSpace(line)
+		}
+	}()
+
+	c.Increment("checks.total", 2)
+	c.Gauge("queue.depth", 7)
+	c.Timing("request.rtt", 1500*time.Millisecond)
+	c.EmitMemStats()
+
+	got := make([]string, 0, 5)
+	for len(got) < 5 {
+		select {
+		case line := <-lines:
+			got = append(got, line)
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for metric lines; got %v", got)
+		}
+	}
+	_ = serverConn.Close()
+	<-done
+
+	wantPrefix := "com.jetpack.jetmon.host_name."
+	expected := map[string]bool{
+		wantPrefix + "checks.total:2|c":    false,
+		wantPrefix + "queue.depth:7|g":     false,
+		wantPrefix + "request.rtt:1500|ms": false,
+	}
+	for _, line := range got {
+		if _, ok := expected[line]; ok {
+			expected[line] = true
+			continue
+		}
+		if !strings.HasPrefix(line, wantPrefix+"process.") {
+			t.Fatalf("unexpected metric line %q in %v", line, got)
+		}
+	}
+	for line, seen := range expected {
+		if !seen {
+			t.Fatalf("missing metric line %q in %v", line, got)
+		}
+	}
+}
+
+func TestInitSetsGlobalClient(t *testing.T) {
+	pc, err := net.ListenPacket("udp4", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("udp listener unavailable: %v", err)
+	}
+	defer pc.Close()
+
+	orig := global
+	t.Cleanup(func() {
+		if global != nil && global.conn != nil {
+			_ = global.conn.Close()
+		}
+		global = orig
+	})
+
+	if err := Init(pc.LocalAddr().String(), "my-host.example"); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if Global() == nil {
+		t.Fatal("Global() = nil after Init")
+	}
+	if Global().prefix != "com.jetpack.jetmon.my_host_example" {
+		t.Fatalf("prefix = %q", Global().prefix)
+	}
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -774,7 +774,7 @@ func (o *Orchestrator) QueueDepth() int {
 }
 
 func (o *Orchestrator) auditLog(e audit.Entry) {
-	if err := audit.Log(e); err != nil {
+	if err := audit.Log(o.ctx, e); err != nil {
 		log.Printf("audit: blog_id=%d event=%s: %v", e.BlogID, e.EventType, err)
 	}
 }

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -75,6 +75,23 @@ func TestInMaintenance(t *testing.T) {
 	}
 }
 
+func TestSummarizeVerifierResults(t *testing.T) {
+	got := summarizeVerifierResults([]veriflier.CheckResult{
+		{Host: "us-west", Success: false, HTTPCode: 500, RTTMs: 123},
+		{Host: "eu", Success: true, HTTPCode: 200, RTTMs: 45},
+	})
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0]["host"] != "us-west" || got[0]["success"] != false ||
+		got[0]["http_code"] != int32(500) || got[0]["rtt_ms"] != int64(123) {
+		t.Fatalf("first summary = %+v", got[0])
+	}
+	if got[1]["host"] != "eu" || got[1]["success"] != true {
+		t.Fatalf("second summary = %+v", got[1])
+	}
+}
+
 func TestSlicesEqual(t *testing.T) {
 	if !slicesEqual(nil, nil) {
 		t.Fatal("nil slices should be equal")

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -12,11 +12,11 @@ import (
 	"time"
 )
 
-// VeriflierClient sends check batches to a remote Veriflier via gRPC.
-// Until protoc-generated stubs are in place this implementation uses a
-// lightweight JSON-over-HTTP transport on the same port, making it fully
-// functional without a protoc dependency. Swap in the generated gRPC client
-// by replacing the send() method after running `make generate`.
+// VeriflierClient sends check batches to a remote Veriflier over the verifier
+// transport. Until protoc-generated stubs are in place this implementation
+// uses lightweight JSON-over-HTTP on the configured port, making it fully
+// functional without a protoc dependency. Swap in the generated gRPC client by
+// replacing the send() method after running `make generate`.
 type VeriflierClient struct {
 	addr       string
 	authToken  string

--- a/internal/webhooks/repository_coverage_test.go
+++ b/internal/webhooks/repository_coverage_test.go
@@ -1,0 +1,391 @@
+package webhooks
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+var webhookColumns = []string{
+	"id", "url", "active", "events", "site_filter", "state_filter",
+	"secret_preview", "created_by", "created_at", "updated_at",
+}
+
+func webhookRow(id int64, url string, active uint8, createdAt time.Time) *sqlmock.Rows {
+	return sqlmock.NewRows(webhookColumns).AddRow(
+		id, url, active,
+		`["event.opened"]`,
+		`{"site_ids":[42]}`,
+		`{"states":["Down"]}`,
+		"_XYZ", "ops", createdAt, createdAt,
+	)
+}
+
+func TestCreateWebhookPersistsDefaultsAndFetchesRecord(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	now := time.Now().UTC()
+	mock.ExpectExec("INSERT INTO jetmon_webhooks").
+		WithArgs(
+			"https://consumer.example/hook",
+			1,
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+			"ops",
+		).
+		WillReturnResult(sqlmock.NewResult(12, 1))
+	mock.ExpectQuery("SELECT id, url, active, events").
+		WithArgs(int64(12)).
+		WillReturnRows(webhookRow(12, "https://consumer.example/hook", 1, now))
+
+	raw, hook, err := Create(context.Background(), db, CreateInput{
+		URL:         "https://consumer.example/hook",
+		Events:      []string{EventOpened},
+		SiteFilter:  SiteFilter{SiteIDs: []int64{42}},
+		StateFilter: StateFilter{States: []string{"Down"}},
+		CreatedBy:   "ops",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if !strings.HasPrefix(raw, SecretPrefix) {
+		t.Fatalf("raw secret = %q, want %s prefix", raw, SecretPrefix)
+	}
+	if hook.ID != 12 || !hook.Active || hook.SiteFilter.SiteIDs[0] != 42 || hook.StateFilter.States[0] != "Down" {
+		t.Fatalf("hook = %+v", hook)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestCreateWebhookRejectsInvalidInputBeforeDB(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	if _, _, err := Create(context.Background(), db, CreateInput{}); err == nil {
+		t.Fatal("Create accepted an empty URL")
+	}
+	if _, _, err := Create(context.Background(), db, CreateInput{
+		URL:    "https://consumer.example/hook",
+		Events: []string{"event.bogus"},
+	}); !errors.Is(err, ErrInvalidEvent) {
+		t.Fatalf("Create invalid event error = %v, want ErrInvalidEvent", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unexpected sql calls: %v", err)
+	}
+}
+
+func TestGetWebhookNotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT id, url, active, events").
+		WithArgs(int64(404)).
+		WillReturnError(sql.ErrNoRows)
+
+	_, err = Get(context.Background(), db, 404)
+	if !errors.Is(err, ErrWebhookNotFound) {
+		t.Fatalf("Get error = %v, want ErrWebhookNotFound", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestListWebhooksScansRows(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	now := time.Now().UTC()
+	rows := sqlmock.NewRows(webhookColumns).
+		AddRow(int64(1), "https://a.example", uint8(1), `[]`, `{}`, `{}`, "aaaa", "ops", now, now).
+		AddRow(int64(2), "https://b.example", uint8(0), nil, nil, nil, "bbbb", "ops", now, now)
+	mock.ExpectQuery("SELECT id, url, active, events").
+		WillReturnRows(rows)
+
+	hooks, err := List(context.Background(), db)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(hooks) != 2 || hooks[0].Active != true || hooks[1].Active != false {
+		t.Fatalf("hooks = %+v", hooks)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestListActiveWebhooksScansRows(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	now := time.Now().UTC()
+	mock.ExpectQuery("SELECT id, url, active, events").
+		WillReturnRows(webhookRow(3, "https://active.example", 1, now))
+
+	hooks, err := ListActive(context.Background(), db)
+	if err != nil {
+		t.Fatalf("ListActive: %v", err)
+	}
+	if len(hooks) != 1 || hooks[0].ID != 3 {
+		t.Fatalf("hooks = %+v", hooks)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestUpdateWebhookAppliesPatchAndFetchesRecord(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	url := "https://consumer.example/new"
+	active := false
+	events := []string{EventClosed}
+	siteFilter := SiteFilter{SiteIDs: []int64{7}}
+	stateFilter := StateFilter{States: []string{"Up"}}
+	now := time.Now().UTC()
+
+	mock.ExpectExec("UPDATE jetmon_webhooks SET").
+		WithArgs(url, 0, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), int64(5)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("SELECT id, url, active, events").
+		WithArgs(int64(5)).
+		WillReturnRows(sqlmock.NewRows(webhookColumns).AddRow(
+			int64(5), url, uint8(0), `["event.closed"]`,
+			`{"site_ids":[7]}`, `{"states":["Up"]}`, "_NEW", "ops", now, now,
+		))
+
+	hook, err := Update(context.Background(), db, 5, UpdateInput{
+		URL:         &url,
+		Active:      &active,
+		Events:      &events,
+		SiteFilter:  &siteFilter,
+		StateFilter: &stateFilter,
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if hook.Active || hook.Events[0] != EventClosed || hook.SiteFilter.SiteIDs[0] != 7 {
+		t.Fatalf("hook = %+v", hook)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestDeleteWebhookReportsMissingRows(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("DELETE FROM jetmon_webhooks").
+		WithArgs(int64(10)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	if err := Delete(context.Background(), db, 10); !errors.Is(err, ErrWebhookNotFound) {
+		t.Fatalf("Delete error = %v, want ErrWebhookNotFound", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestRotateSecretUpdatesStoredSecret(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	now := time.Now().UTC()
+	mock.ExpectExec("UPDATE jetmon_webhooks SET secret").
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), int64(8)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("SELECT id, url, active, events").
+		WithArgs(int64(8)).
+		WillReturnRows(webhookRow(8, "https://consumer.example/hook", 1, now))
+
+	raw, hook, err := RotateSecret(context.Background(), db, 8)
+	if err != nil {
+		t.Fatalf("RotateSecret: %v", err)
+	}
+	if !strings.HasPrefix(raw, SecretPrefix) || hook.ID != 8 {
+		t.Fatalf("RotateSecret returned raw=%q hook=%+v", raw, hook)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestLoadSecret(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT secret FROM jetmon_webhooks").
+		WithArgs(int64(4)).
+		WillReturnRows(sqlmock.NewRows([]string{"secret"}).AddRow("whsec_secret"))
+
+	secret, err := LoadSecret(context.Background(), db, 4)
+	if err != nil {
+		t.Fatalf("LoadSecret: %v", err)
+	}
+	if secret != "whsec_secret" {
+		t.Fatalf("secret = %q", secret)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+var webhookDeliveryColumns = []string{
+	"id", "webhook_id", "transition_id", "event_id", "event_type",
+	"payload", "status", "attempt", "next_attempt_at", "last_status_code", "last_response",
+	"last_attempt_at", "delivered_at", "created_at",
+}
+
+func webhookDeliveryRow(id int64, status Status, now time.Time) *sqlmock.Rows {
+	return sqlmock.NewRows(webhookDeliveryColumns).AddRow(
+		id, int64(20), int64(30), int64(40), EventOpened,
+		[]byte(`{"ok":true}`), string(status), 2, now, 503, "down", now, nil, now,
+	)
+}
+
+func TestEnqueueWebhookDeliveryReturnsInsertedIDAndDuplicateZero(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	payload := json.RawMessage(`{"type":"event.opened"}`)
+	mock.ExpectExec("INSERT IGNORE INTO jetmon_webhook_deliveries").
+		WithArgs(int64(1), int64(2), int64(3), EventOpened, []byte(payload)).
+		WillReturnResult(sqlmock.NewResult(9, 1))
+	mock.ExpectExec("INSERT IGNORE INTO jetmon_webhook_deliveries").
+		WithArgs(int64(1), int64(2), int64(3), EventOpened, []byte(payload)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	id, err := Enqueue(context.Background(), db, EnqueueInput{
+		WebhookID: 1, TransitionID: 2, EventID: 3, EventType: EventOpened, Payload: payload,
+	})
+	if err != nil || id != 9 {
+		t.Fatalf("Enqueue inserted = (%d, %v), want (9, nil)", id, err)
+	}
+	id, err = Enqueue(context.Background(), db, EnqueueInput{
+		WebhookID: 1, TransitionID: 2, EventID: 3, EventType: EventOpened, Payload: payload,
+	})
+	if err != nil || id != 0 {
+		t.Fatalf("Enqueue duplicate = (%d, %v), want (0, nil)", id, err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestWebhookDeliveryStateUpdates(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	next := time.Now().UTC().Add(time.Minute)
+	mock.ExpectExec("UPDATE jetmon_webhook_deliveries").
+		WithArgs(204, "ok", int64(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE jetmon_webhook_deliveries").
+		WithArgs(503, "retry", next, int64(2)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE jetmon_webhook_deliveries").
+		WithArgs(410, "gone", int64(3)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := MarkDelivered(context.Background(), db, 1, 204, "ok"); err != nil {
+		t.Fatalf("MarkDelivered: %v", err)
+	}
+	if err := ScheduleRetry(context.Background(), db, 2, 503, "retry", next, false); err != nil {
+		t.Fatalf("ScheduleRetry retry: %v", err)
+	}
+	if err := ScheduleRetry(context.Background(), db, 3, 410, "gone", next, true); err != nil {
+		t.Fatalf("ScheduleRetry abandon: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestGetListAndRetryWebhookDeliveries(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	now := time.Now().UTC()
+	mock.ExpectQuery("SELECT id, webhook_id, transition_id").
+		WithArgs(int64(1)).
+		WillReturnRows(webhookDeliveryRow(1, StatusAbandoned, now))
+	mock.ExpectQuery("SELECT id, webhook_id, transition_id").
+		WithArgs(int64(20), string(StatusAbandoned), int64(50), 10).
+		WillReturnRows(webhookDeliveryRow(2, StatusAbandoned, now))
+	mock.ExpectExec("UPDATE jetmon_webhook_deliveries").
+		WithArgs(int64(2)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	d, err := GetDelivery(context.Background(), db, 1)
+	if err != nil {
+		t.Fatalf("GetDelivery: %v", err)
+	}
+	if d.LastStatusCode == nil || *d.LastStatusCode != 503 || d.LastResponse == nil || *d.LastResponse != "down" {
+		t.Fatalf("delivery did not scan nullable fields: %+v", d)
+	}
+	list, err := ListDeliveries(context.Background(), db, 20, StatusAbandoned, 50, 10)
+	if err != nil {
+		t.Fatalf("ListDeliveries: %v", err)
+	}
+	if len(list) != 1 || list[0].ID != 2 {
+		t.Fatalf("deliveries = %+v", list)
+	}
+	if err := RetryDelivery(context.Background(), db, 2); err != nil {
+		t.Fatalf("RetryDelivery: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}

--- a/internal/webhooks/worker_test.go
+++ b/internal/webhooks/worker_test.go
@@ -192,6 +192,12 @@ func TestNewWorkerInitializesRuntimeState(t *testing.T) {
 	}
 }
 
+func TestWorkerStartStop(t *testing.T) {
+	w := NewWorker(WorkerConfig{PollInterval: time.Hour})
+	w.Start()
+	w.Stop()
+}
+
 func TestDeliverTickNoReadyDeliveries(t *testing.T) {
 	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 	if err != nil {

--- a/internal/webhooks/worker_test.go
+++ b/internal/webhooks/worker_test.go
@@ -1,13 +1,18 @@
 package webhooks
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
+	"encoding/json"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
 )
 
 func TestNextRetryDelayFollowsSchedule(t *testing.T) {
@@ -171,5 +176,123 @@ func TestReleaseSlotCleansUpZeroCounts(t *testing.T) {
 	w.releaseSlot(1)
 	if _, ok := w.inFlight[1]; ok {
 		t.Error("zero-count entry should be deleted from map")
+	}
+}
+
+func TestNewWorkerInitializesRuntimeState(t *testing.T) {
+	w := NewWorker(WorkerConfig{InstanceID: "host-a", HTTPTimeout: 2 * time.Second})
+	if w.cfg.InstanceID != "host-a" {
+		t.Fatalf("InstanceID = %q, want host-a", w.cfg.InstanceID)
+	}
+	if w.httpClient == nil || w.httpClient.Timeout != 2*time.Second {
+		t.Fatalf("httpClient = %+v", w.httpClient)
+	}
+	if w.inFlight == nil || w.stop == nil || w.done == nil {
+		t.Fatalf("worker runtime state not initialized: %+v", w)
+	}
+}
+
+func TestDeliverTickNoReadyDeliveries(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(selectClaimReadySQL).WithArgs(50).
+		WillReturnRows(sqlmock.NewRows(columnsClaimedDelivery))
+
+	w := NewWorker(WorkerConfig{DB: db})
+	if err := w.deliverTick(); err != nil {
+		t.Fatalf("deliverTick: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestHandleResultSchedulesRetryAndForcedAbandon(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("UPDATE jetmon_webhook_deliveries").
+		WithArgs(503, "retry", sqlmock.AnyArg(), int64(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE jetmon_webhook_deliveries").
+		WithArgs(0, "gone", int64(2)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	w := NewWorker(WorkerConfig{DB: db})
+	w.handleResult(context.Background(), Delivery{ID: 1, Attempt: 0}, 503, "retry", false)
+	w.handleResult(context.Background(), Delivery{ID: 2, Attempt: 0}, 0, "gone", true)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestBuildPayload(t *testing.T) {
+	occurredAt := time.Date(2026, 4, 27, 12, 0, 0, 123, time.UTC)
+	w := &Worker{}
+	payload, err := w.buildPayload(EventOpened, 10, 20, 30, "opened", "Seems Down", occurredAt)
+	if err != nil {
+		t.Fatalf("buildPayload: %v", err)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(payload, &body); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if body["type"] != EventOpened || body["reason"] != "opened" || body["state"] != "Seems Down" {
+		t.Fatalf("payload = %s", payload)
+	}
+	if body["transition_id"].(float64) != 10 || body["event_id"].(float64) != 20 || body["site_id"].(float64) != 30 {
+		t.Fatalf("payload ids = %s", payload)
+	}
+	if body["occurred_at"] != occurredAt.Format(time.RFC3339Nano) {
+		t.Fatalf("occurred_at = %v", body["occurred_at"])
+	}
+}
+
+func TestProgressLoadSave(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	w := &Worker{cfg: WorkerConfig{DB: db, InstanceID: "host-a"}}
+	mock.ExpectQuery("SELECT last_transition_id FROM jetmon_webhook_dispatch_progress").
+		WithArgs("host-a").
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectExec("INSERT INTO jetmon_webhook_dispatch_progress").
+		WithArgs("host-a", int64(55)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("SELECT last_transition_id FROM jetmon_webhook_dispatch_progress").
+		WithArgs("host-a").
+		WillReturnRows(sqlmock.NewRows([]string{"last_transition_id"}).AddRow(int64(55)))
+
+	last, err := w.loadProgress(context.Background())
+	if err != nil {
+		t.Fatalf("loadProgress empty: %v", err)
+	}
+	if last != 0 {
+		t.Fatalf("empty progress = %d, want 0", last)
+	}
+	if err := w.saveProgress(context.Background(), 55); err != nil {
+		t.Fatalf("saveProgress: %v", err)
+	}
+	last, err = w.loadProgress(context.Background())
+	if err != nil {
+		t.Fatalf("loadProgress stored: %v", err)
+	}
+	if last != 55 {
+		t.Fatalf("stored progress = %d, want 55", last)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
 	}
 }

--- a/veriflier2/cmd/main_test.go
+++ b/veriflier2/cmd/main_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Automattic/jetmon/internal/checker"
+	"github.com/Automattic/jetmon/internal/veriflier"
+)
+
+func TestEnvOrDefault(t *testing.T) {
+	const key = "VERIFLIER_TEST_ENV_OR_DEFAULT"
+	t.Setenv(key, "")
+	if got := envOrDefault(key, "fallback"); got != "fallback" {
+		t.Fatalf("envOrDefault(empty) = %q, want fallback", got)
+	}
+
+	t.Setenv(key, "configured")
+	if got := envOrDefault(key, "fallback"); got != "configured" {
+		t.Fatalf("envOrDefault(set) = %q, want configured", got)
+	}
+}
+
+func TestStringPtr(t *testing.T) {
+	if got := stringPtr(""); got != nil {
+		t.Fatalf("stringPtr(empty) = %v, want nil", got)
+	}
+	got := stringPtr("needle")
+	if got == nil || *got != "needle" {
+		t.Fatalf("stringPtr(non-empty) = %v, want pointer to needle", got)
+	}
+}
+
+func TestLoadConfigFromFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "veriflier.json")
+	if err := os.WriteFile(path, []byte(`{"auth_token":"secret","grpc_port":"7804"}`), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg, err := loadConfig(path)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.AuthToken != "secret" || cfg.GRPCPort != "7804" {
+		t.Fatalf("config = %+v", cfg)
+	}
+}
+
+func TestLoadConfigFallsBackToEnvironment(t *testing.T) {
+	t.Setenv("VERIFLIER_AUTH_TOKEN", "env-secret")
+	t.Setenv("VERIFLIER_GRPC_PORT", "7900")
+
+	cfg, err := loadConfig(filepath.Join(t.TempDir(), "missing.json"))
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.AuthToken != "env-secret" || cfg.GRPCPort != "7900" {
+		t.Fatalf("config = %+v", cfg)
+	}
+}
+
+func TestLoadConfigRejectsMalformedJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "veriflier.json")
+	if err := os.WriteFile(path, []byte(`{"auth_token":`), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if _, err := loadConfig(path); err == nil {
+		t.Fatal("loadConfig accepted malformed JSON")
+	}
+}
+
+func TestPerformCheckSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Test"); got != "present" {
+			t.Fatalf("X-Test header = %q, want present", got)
+		}
+		_, _ = w.Write([]byte("needle"))
+	}))
+	defer srv.Close()
+
+	res := performCheck(veriflier.CheckRequest{
+		BlogID:         42,
+		URL:            srv.URL,
+		TimeoutSeconds: 2,
+		Keyword:        "needle",
+		CustomHeaders:  map[string]string{"X-Test": "present"},
+		RedirectPolicy: string(checker.RedirectFollow),
+	})
+	if !res.Success {
+		t.Fatalf("performCheck success = false; result=%+v", res)
+	}
+	if res.BlogID != 42 || res.HTTPCode != http.StatusOK {
+		t.Fatalf("performCheck result = %+v", res)
+	}
+}
+
+func TestPerformCheckKeywordFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("different"))
+	}))
+	defer srv.Close()
+
+	res := performCheck(veriflier.CheckRequest{
+		BlogID:         43,
+		URL:            srv.URL,
+		TimeoutSeconds: 2,
+		Keyword:        "needle",
+		RedirectPolicy: string(checker.RedirectFollow),
+	})
+	if res.Success {
+		t.Fatalf("performCheck success = true; result=%+v", res)
+	}
+	if res.ErrorCode != int32(checker.ErrorKeyword) {
+		t.Fatalf("error code = %d, want %d", res.ErrorCode, checker.ErrorKeyword)
+	}
+}


### PR DESCRIPTION
Stacked PR 5 of 9.

Base: `stack-04-shadow-projection-hardening`
Head: `stack-05-docs-tooling-coverage`
Previous PR: #76

Summary:
- Adds the top-level docs index and refreshes README/project docs for the v2 health-platform story.
- Clarifies public API, Veriflier transport, Makefile, dashboard, and probe-agent architecture notes.
- Makes Go resolution and writable build cache behavior explicit in build targets.
- Expands coverage across core packages and tightens API/audit tests.
- Prioritizes remaining roadmap work.

Review notes:
This PR is a documentation, tooling, and test-coverage layer after the main API and delivery behavior has landed.