### PR TITLE
Add production rollout hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,7 @@ go run -race ./cmd/jetmon2/
 ./jetmon2 status
 ./jetmon2 audit --blog-id 12345 --since 2h
 ./jetmon2 rollout pinned-check
+./jetmon2 rollout dynamic-check
 ./jetmon2 site-tenants import --file site-tenants.csv --dry-run
 ./jetmon2 drain
 ./jetmon2 reload

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,7 @@ Copy `config/config-sample.json` to `config/config.json`. All keys from the orig
 - `BUCKET_TOTAL`: Total bucket range (e.g. 1000); replaces static `BUCKET_NO_MIN/MAX`
 - `BUCKET_TARGET`: Maximum buckets this host should own
 - `BUCKET_HEARTBEAT_GRACE_SEC`: Seconds before an unresponsive host's buckets are reclaimed (suggested: 2× round time)
+- `PINNED_BUCKET_MIN/MAX`: Migration-only static bucket range for replacing one v1 host with one v2 host; disables `jetmon_hosts` dynamic ownership while set. Legacy `BUCKET_NO_MIN/MAX` are accepted as aliases for this mode.
 - `ALERT_COOLDOWN_MINUTES`: Default cooldown between repeated alerts for the same site
 - `LEGACY_STATUS_PROJECTION_ENABLE`: Keep v1 `site_status` / `last_status_change` projection updated during shadow-v2-state migration
 - `LOG_FORMAT`: `text` (default, drop-in compatible) or `json` (structured logging)
@@ -249,7 +250,7 @@ New tables introduced by Jetmon 2:
 
 ## Multi-Host Bucket Coordination
 
-Jetmon 2 replaces static `BUCKET_NO_MIN/MAX` config with runtime bucket ownership via the `jetmon_hosts` table. On startup, each instance claims unclaimed or expired bucket ranges using `SELECT ... FOR UPDATE` transactions. A heartbeat query runs each round; hosts with stale heartbeats (older than `BUCKET_HEARTBEAT_GRACE_SEC`) have their buckets absorbed by surviving peers. On SIGINT, the instance releases its buckets immediately.
+Jetmon 2 normally replaces static `BUCKET_NO_MIN/MAX` config with runtime bucket ownership via the `jetmon_hosts` table. On startup, each instance claims unclaimed or expired bucket ranges using `SELECT ... FOR UPDATE` transactions. A heartbeat query runs each round; hosts with stale heartbeats (older than `BUCKET_HEARTBEAT_GRACE_SEC`) have their buckets absorbed by surviving peers. On SIGINT, the instance releases its buckets immediately. During the initial v1-to-v2 migration only, `PINNED_BUCKET_MIN/MAX` (or legacy `BUCKET_NO_MIN/MAX`) can pin one v2 host to its v1 predecessor's exact bucket range and disables `jetmon_hosts` ownership for that host.
 
 This enables zero-config horizontal scaling (spin up a host, it claims buckets) and self-healing coverage (a failed host's buckets are absorbed within one grace period) without a cluster orchestrator.
 
@@ -304,7 +305,7 @@ Up → Seems Down → Down → Resolved
 
 **Retry Queue Persistence:** The local retry queue must persist between rounds. Do not flush it at round start — a site must accumulate `NUM_OF_CHECKS` failures before Veriflier escalation, and flushing resets that counter, preventing downtime confirmation.
 
-**Bucket Claiming Races:** The `SELECT ... FOR UPDATE` transaction on `jetmon_hosts` is the only safe way to claim buckets. Do not claim buckets outside a transaction — two hosts starting simultaneously will both see the same unclaimed range and must not both write it.
+**Bucket Claiming Races:** When dynamic ownership is active, the `SELECT ... FOR UPDATE` transaction on `jetmon_hosts` is the only safe way to claim buckets. Do not claim buckets outside a transaction — two hosts starting simultaneously will both see the same unclaimed range and must not both write it. Pinned v1-to-v2 migration hosts intentionally do not claim buckets in `jetmon_hosts`.
 
 **Circuit Breaker Floor:** The WPCOM API circuit breaker queue is bounded. If the queue fills, the oldest pending notifications are dropped with an error log. Monitor the circuit breaker state in the operator dashboard during any WPCOM API incident.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,7 @@ go run -race ./cmd/jetmon2/
 ./jetmon2 migrate
 ./jetmon2 status
 ./jetmon2 audit --blog-id 12345 --since 2h
+./jetmon2 rollout pinned-check
 ./jetmon2 site-tenants import --file site-tenants.csv --dry-run
 ./jetmon2 drain
 ./jetmon2 reload

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,7 @@ go run -race ./cmd/jetmon2/
 ./jetmon2 audit --blog-id 12345 --since 2h
 ./jetmon2 rollout pinned-check
 ./jetmon2 rollout dynamic-check
+./jetmon2 rollout projection-drift
 ./jetmon2 site-tenants import --file site-tenants.csv --dry-run
 ./jetmon2 drain
 ./jetmon2 reload

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -256,6 +256,7 @@ Queryable by `blog_id` and time range via a CLI tool (`jetmon2 audit --blog-id 1
 - `jetmon2 version` — prints binary version, build date, Go version, and git commit hash
 - `jetmon2 migrate` — applies pending DB schema migrations idempotently
 - `jetmon2 status` — connects to a running instance's internal API and prints a one-line health summary (equivalent to reading `stats/totals` but richer)
+- `jetmon2 rollout pinned-check` — validates a pinned v1-to-v2 cutover host before or during host replacement
 - `jetmon2 drain --worker N` — gracefully removes one worker pool slot, waiting for in-flight checks to complete before reducing concurrency
 - `jetmon2 reload` — sends SIGHUP to the running process (convenience wrapper)
 

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -258,6 +258,7 @@ Queryable by `blog_id` and time range via a CLI tool (`jetmon2 audit --blog-id 1
 - `jetmon2 status` — connects to a running instance's internal API and prints a one-line health summary (equivalent to reading `stats/totals` but richer)
 - `jetmon2 rollout pinned-check` — validates a pinned v1-to-v2 cutover host before or during host replacement
 - `jetmon2 rollout dynamic-check` — validates full `jetmon_hosts` coverage after the fleet transitions from pinned to dynamic ownership
+- `jetmon2 rollout projection-drift` — lists active sites whose legacy `site_status` projection disagrees with the authoritative event state
 - `jetmon2 drain --worker N` — gracefully removes one worker pool slot, waiting for in-flight checks to complete before reducing concurrency
 - `jetmon2 reload` — sends SIGHUP to the running process (convenience wrapper)
 

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -218,22 +218,28 @@ A lightweight web UI served by the binary itself (no separate process) on a conf
 - Round completion time
 - Local retry queue depth
 - Owned bucket range
+- Bucket ownership mode, legacy projection mode, delivery-worker ownership, and
+  rollout preflight / projection-drift commands
 - RSS memory usage
 - WPCOM circuit-breaker state and queued notification depth
+- Live dependency health for MySQL, configured Verifliers, WPCOM, StatsD, and
+  log/stats directory writes
 
-Updates via server-sent events — no WebSocket library needed, no JavaScript framework. A plain HTML page with `<EventSource>` is sufficient and has no build toolchain dependency.
+Updates via server-sent events and lightweight JSON polling — no WebSocket library needed, no JavaScript framework. A plain HTML page with `<EventSource>` and `fetch` is sufficient and has no build toolchain dependency.
 
-**Future System Health Map**
-A broader operator-dashboard health grid is still a natural follow-up:
+**System Health Map**
+The operator dashboard health grid publishes:
 
-- MySQL (primary + replicas): connection state, query latency, last successful batch
-- Each configured Veriflier: reachability, last response time, last batch sent/received
-- WPCOM API: last successful notification, current error rate
-- StatsD: last successful flush
-- Disk (log and stats files): free space, last write time
+- MySQL: connection state and ping latency
+- Each configured Veriflier: reachability and status latency
+- WPCOM API: circuit-breaker state and queued notification depth
+- StatsD: local client initialization state
+- Disk: writable `logs/` and `stats/` directories
 
-The current dashboard has an `/api/health` shape for this data, but the live
-publisher for those entries has not been wired yet.
+Future refinements can add primary/replica breakdowns, last successful
+orchestrator batch, WPCOM request error-rate windows, and disk free-space
+thresholds once production operating data shows which signals are worth paging
+on.
 
 **False Positive Tracker**
 Every time the system escalates a site to Veriflier confirmation and the Verifliers do NOT confirm it as down (i.e., the queue entry times out or all Verifliers report the site as up), the event is recorded in a `jetmon_false_positives` table with timestamp, site, HTTP code, error code, and RTT from the local check. A view in the operator dashboard surfaces sites with high false positive rates, helping operators tune per-site `NUM_OF_CHECKS` or `TIME_BETWEEN_CHECKS_SEC` settings.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -275,7 +275,7 @@ The worker pool monitors queue depth against a configurable high-water mark. Whe
 The binary ships with a systemd unit file. `Restart=on-failure` with a short `RestartSec` ensures the process is automatically restarted if it crashes or exits unexpectedly. `StartLimitIntervalSec` and `StartLimitBurst` prevent restart loops from hammering a broken dependency. The unit file also enforces resource limits (`MemoryMax`, `LimitNOFILE`) to keep the process within safe bounds on shared hosts. A watchdog integration via `sd_notify` lets systemd detect and restart a process that has stopped making progress without actually crashing.
 
 **MySQL-Coordinated Bucket Ownership**
-A `jetmon_hosts` table replaces the static `BUCKET_NO_MIN`/`BUCKET_NO_MAX` config values with runtime-negotiated bucket ownership. Hosts claim, hold, and release bucket ranges autonomously using MySQL transactions as the coordination mechanism — no cluster orchestrator required.
+A `jetmon_hosts` table replaces the static `BUCKET_NO_MIN`/`BUCKET_NO_MAX` config values with runtime-negotiated bucket ownership. Hosts claim, hold, and release bucket ranges autonomously using MySQL transactions as the coordination mechanism — no cluster orchestrator required. For the initial v1-to-v2 production migration, `PINNED_BUCKET_MIN`/`PINNED_BUCKET_MAX` (with `BUCKET_NO_MIN`/`BUCKET_NO_MAX` accepted as aliases) temporarily pins a v2 host to the exact static range of the v1 host it replaces; remove those keys after the fleet is on v2 to enable dynamic ownership.
 
 Table structure:
 ```sql
@@ -288,9 +288,9 @@ CREATE TABLE jetmon_hosts (
 );
 ```
 
-On startup, the instance upserts its own row, then scans for rows whose `last_heartbeat` is older than the grace period (suggested: 2× normal round time). Expired rows are presumed dead. The instance claims their uncovered bucket ranges by deleting the dead rows and inserting its own covering range inside a `SELECT ... FOR UPDATE` transaction, preventing two hosts from racing to claim the same range simultaneously. The instance derives its active range from what it successfully claimed — `BUCKET_NO_MIN`/`BUCKET_NO_MAX` are no longer needed in `config.json`.
+In dynamic ownership mode, on startup the instance upserts its own row, then scans for rows whose `last_heartbeat` is older than the grace period (suggested: 2× normal round time). Expired rows are presumed dead. The instance claims their uncovered bucket ranges by deleting the dead rows and inserting its own covering range inside a `SELECT ... FOR UPDATE` transaction, preventing two hosts from racing to claim the same range simultaneously. The instance derives its active range from what it successfully claimed — `BUCKET_NO_MIN`/`BUCKET_NO_MAX` are only needed as aliases for the temporary pinned migration mode.
 
-Each round, the orchestrator issues a single `UPDATE jetmon_hosts SET last_heartbeat = NOW() WHERE host_id = ?`. If a host stalls, is OOM-killed, or loses network, its heartbeat stops updating. Surviving hosts detect the stale row at the start of their next round and absorb its buckets up to their configured `BUCKET_TARGET` maximum.
+In dynamic ownership mode, each round the orchestrator issues a single `UPDATE jetmon_hosts SET last_heartbeat = NOW() WHERE host_id = ?`. If a host stalls, is OOM-killed, or loses network, its heartbeat stops updating. Surviving hosts detect the stale row at the start of their next round and absorb its buckets up to their configured `BUCKET_TARGET` maximum. In pinned migration mode, the host skips `jetmon_hosts` entirely and checks only its configured static range.
 
 On SIGINT, the instance sets `status = 'draining'`, completes in-flight checks, then deletes its own row. Surviving hosts can reclaim those buckets at the start of their next round without waiting for heartbeat expiry. A hard-killed host leaves its row in place; the grace period determines how long before its buckets are reclaimed.
 

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -201,6 +201,8 @@ A standalone binary (`jetmon2 validate-config`) that:
 - Validates value ranges and required per-mode settings
 - Attempts a test connection to MySQL
 - Reports legacy projection and email transport modes
+- Prints the matching rollout preflight and projection-drift investigation
+  commands for the configured bucket ownership mode
 - Warns when the email transport resolves to the log-only `stub` sender
 - Lists configured Verifliers as best-effort operator context
 - Outputs a pass/fail summary with specific error messages

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -257,6 +257,7 @@ Queryable by `blog_id` and time range via a CLI tool (`jetmon2 audit --blog-id 1
 - `jetmon2 migrate` — applies pending DB schema migrations idempotently
 - `jetmon2 status` — connects to a running instance's internal API and prints a one-line health summary (equivalent to reading `stats/totals` but richer)
 - `jetmon2 rollout pinned-check` — validates a pinned v1-to-v2 cutover host before or during host replacement
+- `jetmon2 rollout dynamic-check` — validates full `jetmon_hosts` coverage after the fleet transitions from pinned to dynamic ownership
 - `jetmon2 drain --worker N` — gracefully removes one worker pool slot, waiting for in-flight checks to complete before reducing concurrency
 - `jetmon2 reload` — sends SIGHUP to the running process (convenience wrapper)
 

--- a/README.md
+++ b/README.md
@@ -596,7 +596,8 @@ Metrics are emitted with prefix `com.jetpack.jetmon.<hostname>`. The Graphite/Gr
 - Free and active goroutines
 - Sites processed per second
 - Round completion time
-- WPCOM API success and error rates
+- WPCOM API attempt, delivered, retry, error, and failed rates, including
+  status-specific splits for `down`, `running`, and `confirmed_down`
 - Veriflier response times
 - Detection flow timing: first failure → Seems Down, first failure →
   Veriflier escalation, Seems Down → Down, Seems Down → false alarm, and

--- a/README.md
+++ b/README.md
@@ -514,6 +514,15 @@ bucket ownership and gives each host a simple rollback path.
    This verifies fresh, active, gap-free, overlap-free `jetmon_hosts` coverage
    before the fleet moves to normal v2 rolling updates.
 
+If either rollout check reports legacy projection drift, list the mismatched
+active site rows before continuing:
+
+		./jetmon2 rollout projection-drift
+
+For a specific range:
+
+		./jetmon2 rollout projection-drift --bucket-min=0 --bucket-max=99 --limit=100
+
 See [`docs/v1-to-v2-pinned-rollout.md`](docs/v1-to-v2-pinned-rollout.md) for
 the detailed rollout checklist.
 

--- a/README.md
+++ b/README.md
@@ -505,9 +505,14 @@ bucket ownership and gives each host a simple rollback path.
    projection remains enabled, legacy readers continue to see familiar status
    fields.
 
-6) Repeat for each v1 host. After the whole fleet is on v2 and stable, remove
-   `PINNED_BUCKET_*` from each host and transition to dynamic `jetmon_hosts`
-   ownership one controlled host at a time.
+6) Repeat for each v1 host. After the whole fleet is on v2 and stable, plan a
+   coordinated dynamic-ownership cutover, remove `PINNED_BUCKET_*` from the v2
+   monitor configs, restart the fleet in the approved window, then run:
+
+		./jetmon2 rollout dynamic-check
+
+   This verifies fresh, active, gap-free, overlap-free `jetmon_hosts` coverage
+   before the fleet moves to normal v2 rolling updates.
 
 See [`docs/v1-to-v2-pinned-rollout.md`](docs/v1-to-v2-pinned-rollout.md) for
 the detailed rollout checklist.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Key settings:
 | `BUCKET_TOTAL` | 1000 | Total bucket range across all hosts |
 | `BUCKET_TARGET` | 500 | Maximum buckets this host should own |
 | `BUCKET_HEARTBEAT_GRACE_SEC` | 600 | Seconds before a silent host's buckets are reclaimed |
+| `PINNED_BUCKET_MIN` / `PINNED_BUCKET_MAX` | unset | Migration-only static bucket range; disables `jetmon_hosts` ownership for v1-compatible host-by-host cutover |
 | `ALERT_COOLDOWN_MINUTES` | 30 | Default cooldown between repeated alerts per site |
 | `LEGACY_STATUS_PROJECTION_ENABLE` | true | Keep `jetpack_monitor_sites.site_status` / `last_status_change` updated for v1 consumers during migration |
 | `LOG_FORMAT` | `text` | `text` for plain-text logs or `json` for structured logs |
@@ -466,9 +467,48 @@ Jetmon runs on multiple production hosts managed by the Systems team. Each host 
 
 The new host will claim unclaimed buckets from the pool on first startup. No existing hosts need reconfiguration.
 
-### Rolling Updates (Zero Downtime)
+### v1 to v2 Pinned Rolling Migration
 
-Update one host at a time. Surviving hosts absorb the draining host's buckets during the update window:
+For the first production migration from v1, replace one v1 host at a time with
+a v2 host pinned to that same inclusive bucket range. This avoids mixed v1/v2
+bucket ownership and gives each host a simple rollback path.
+
+1) Pre-apply additive migrations during a quiet period:
+
+		./jetmon2 migrate
+
+2) On the host being replaced, copy the existing v1 bucket range into v2 config:
+
+		"PINNED_BUCKET_MIN": 0,
+		"PINNED_BUCKET_MAX": 99,
+		"LEGACY_STATUS_PROJECTION_ENABLE": true,
+		"API_PORT": 0
+
+   The v1 names `BUCKET_NO_MIN` / `BUCKET_NO_MAX` are accepted as aliases, but
+   `PINNED_BUCKET_*` makes the migration mode explicit. In pinned mode, v2 does
+   not claim or heartbeat `jetmon_hosts`; it checks only the configured range.
+
+3) Stop the v1 process for that range, start v2, and verify checks,
+   Veriflier confirmations, WPCOM notifications, audit rows, and legacy
+   `site_status` projection for that bucket range.
+
+4) If rollback is needed, stop v2 and restart the original v1 process with the
+   same bucket config. Because the v2 migrations are additive and the legacy
+   projection remains enabled, legacy readers continue to see familiar status
+   fields.
+
+5) Repeat for each v1 host. After the whole fleet is on v2 and stable, remove
+   `PINNED_BUCKET_*` from each host and transition to dynamic `jetmon_hosts`
+   ownership one controlled host at a time.
+
+See [`docs/v1-to-v2-pinned-rollout.md`](docs/v1-to-v2-pinned-rollout.md) for
+the detailed rollout checklist.
+
+### v2 Rolling Updates (Zero Downtime)
+
+After all monitor hosts are already on v2 dynamic bucket ownership, update one
+host at a time. Surviving hosts absorb the draining host's buckets during the
+update window:
 
 1) On the host being updated, drain in-flight checks and release buckets:
 

--- a/README.md
+++ b/README.md
@@ -592,8 +592,13 @@ Metrics are emitted with prefix `com.jetpack.jetmon.<hostname>`. The Graphite/Gr
 - Detection flow timing: first failure → Seems Down, first failure →
   Veriflier escalation, Seems Down → Down, Seems Down → false alarm, and
   Seems Down → probe-cleared recovery
+- Detection outcome counters split by local failure class (`server`, `client`,
+  `blocked`, `https`, `redirect`, `intermittent`) for false-alarm and
+  confirmed-down rate comparisons
 - Veriflier decision counters: escalations, RPC success/error, confirm/disagree
   votes, quorum-met confirmations, and false alarms
+- Per-Veriflier-host RPC and vote counters under `verifier.host.<host>.*` so
+  region/provider disagreement and latency can be compared during v2 production
 - Legacy projection drift: per-bucket count of active sites whose
   `site_status` no longer matches the authoritative open HTTP event
 - Memory usage

--- a/README.md
+++ b/README.md
@@ -430,7 +430,11 @@ Simulate a host failure by manually expiring a row in `jetmon_hosts`. Verify the
 
 ### Operator Dashboard
 
-The dashboard is available at http://localhost:8080 (configurable via `DASHBOARD_PORT`). It shows worker count, active checks, queue depth, retry queue depth, sites per second, round time, owned buckets, RSS, and WPCOM circuit-breaker state.
+The dashboard is available at http://localhost:8080 (configurable via
+`DASHBOARD_PORT`). It shows worker count, active checks, queue depth, retry
+queue depth, sites per second, round time, owned buckets, rollout guard state,
+RSS, WPCOM circuit-breaker state, and live dependency health for MySQL,
+configured Verifliers, WPCOM, StatsD, and log/stats directory writes.
 
 ### Internal API and Delivery Workers
 
@@ -459,11 +463,12 @@ Jetmon runs on multiple production hosts managed by the Systems team. Each host 
 1) Install the `jetmon2` binary to `/opt/jetmon2/`
 2) Install `systemd/jetmon2.service` to `/etc/systemd/system/` and run `systemctl daemon-reload`
 3) Install `systemd/jetmon2-logrotate` to `/etc/logrotate.d/jetmon2`
-4) Create `/opt/jetmon2/config/jetmon2.env` with the database credentials and auth tokens (see `config/db-config-sample.conf` for the required keys)
-5) Copy `config/config.json` from an existing host (or generate from `config-sample.json`)
-6) Set `BUCKET_TARGET` to the desired maximum bucket count for this host
-7) Run `./jetmon2 migrate` to apply any pending schema migrations
-8) Start the service: `systemctl enable --now jetmon2`
+4) Create `/opt/jetmon2/logs` and `/opt/jetmon2/stats`, owned by the `jetmon` service user
+5) Create `/opt/jetmon2/config/jetmon2.env` with the database credentials and auth tokens (see `config/db-config-sample.conf` for the required keys)
+6) Copy `config/config.json` from an existing host (or generate from `config-sample.json`)
+7) Set `BUCKET_TARGET` to the desired maximum bucket count for this host
+8) Run `./jetmon2 migrate` to apply any pending schema migrations
+9) Start the service: `systemctl enable --now jetmon2`
 
 The new host will claim unclaimed buckets from the pool on first startup. No existing hosts need reconfiguration.
 
@@ -488,7 +493,12 @@ bucket ownership and gives each host a simple rollback path.
    `PINNED_BUCKET_*` makes the migration mode explicit. In pinned mode, v2 does
    not claim or heartbeat `jetmon_hosts`; it checks only the configured range.
 
-3) Before starting the cutover, run the pinned rollout preflight:
+3) Before stopping v1, run config validation and confirm it prints the pinned
+   preflight plus projection-drift commands:
+
+		./jetmon2 validate-config
+
+4) Before starting the cutover, run the pinned rollout preflight:
 
 		./jetmon2 rollout pinned-check
 
@@ -496,16 +506,18 @@ bucket ownership and gives each host a simple rollback path.
    `jetmon_hosts` row for the host, active site count for the range, and zero
    legacy projection drift.
 
-4) Stop the v1 process for that range, start v2, and verify checks,
+5) Stop the v1 process for that range, start v2, and verify checks,
    Veriflier confirmations, WPCOM notifications, audit rows, and legacy
-   `site_status` projection for that bucket range.
+   `site_status` projection for that bucket range. If the operator dashboard is
+   enabled, also confirm rollout guard state and dependency health before
+   moving to the next host.
 
-5) If rollback is needed, stop v2 and restart the original v1 process with the
+6) If rollback is needed, stop v2 and restart the original v1 process with the
    same bucket config. Because the v2 migrations are additive and the legacy
    projection remains enabled, legacy readers continue to see familiar status
    fields.
 
-6) Repeat for each v1 host. After the whole fleet is on v2 and stable, plan a
+7) Repeat for each v1 host. After the whole fleet is on v2 and stable, plan a
    coordinated dynamic-ownership cutover, remove `PINNED_BUCKET_*` from the v2
    monitor configs, restart the fleet in the approved window, then run:
 
@@ -562,7 +574,11 @@ The service releases its buckets to the pool before exiting. Surviving hosts rec
 
 	./jetmon2 status
 
-Or check the operator dashboard at the configured `DASHBOARD_PORT` for check-pool, throughput, bucket, memory, and WPCOM circuit-breaker state.
+Or check the operator dashboard at the configured `DASHBOARD_PORT` for
+check-pool, throughput, bucket, rollout guard, memory, WPCOM circuit-breaker
+state, and live dependency health. The rollout section shows bucket ownership
+mode, legacy projection mode, delivery-worker ownership, and the matching
+rollout preflight and projection-drift commands for the active config.
 
 ### Config Reload Without Restart
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A few specifics worth bragging about:
 - **Webhooks with Stripe-style HMAC signatures.** `t=<unix>,v1=<hex>` over `{ts}.{body}`, per-webhook in-flight cap, retry ladder 1m → 5m → 30m → 1h → 6h before abandon. Frozen-at-fire-time payload contract — consumers see the event as it was when the webhook fired, not as it is now.
 - **Idempotent write endpoints.** POSTs accept `Idempotency-Key`; replays return the original response, so a retried "click to test" through a network blip won't double-page the destination.
 - **Rotation grace windows on API keys.** `revoked_at` and `expires_at` are half-open cutoffs; setting `revoked_at` in the future keeps the old key valid until consumers deploy the replacement.
-- **Migrations embedded in the binary.** `./jetmon2 migrate` walks the schema forward; `./jetmon2 validate-config` checks config + DB connectivity + email transport mode + verifier list before deploy, and warns loudly when alert-contact email is set to the log-only stub.
+- **Migrations embedded in the binary.** `./jetmon2 migrate` walks the schema forward; `./jetmon2 validate-config` checks config + DB connectivity + email transport mode + verifier list before deploy, prints the matching rollout preflight command, and warns loudly when alert-contact email is set to the log-only stub.
 - **MySQL 5.7+ compatible.** No window functions, no JSON-path expressions in SELECT — the v2 schema and queries land cleanly on the legacy production database.
 
 

--- a/README.md
+++ b/README.md
@@ -488,16 +488,24 @@ bucket ownership and gives each host a simple rollback path.
    `PINNED_BUCKET_*` makes the migration mode explicit. In pinned mode, v2 does
    not claim or heartbeat `jetmon_hosts`; it checks only the configured range.
 
-3) Stop the v1 process for that range, start v2, and verify checks,
+3) Before starting the cutover, run the pinned rollout preflight:
+
+		./jetmon2 rollout pinned-check
+
+   It verifies pinned mode, legacy projection writes, absence of a
+   `jetmon_hosts` row for the host, active site count for the range, and zero
+   legacy projection drift.
+
+4) Stop the v1 process for that range, start v2, and verify checks,
    Veriflier confirmations, WPCOM notifications, audit rows, and legacy
    `site_status` projection for that bucket range.
 
-4) If rollback is needed, stop v2 and restart the original v1 process with the
+5) If rollback is needed, stop v2 and restart the original v1 process with the
    same bucket config. Because the v2 migrations are additive and the legacy
    projection remains enabled, legacy readers continue to see familiar status
    fields.
 
-5) Repeat for each v1 host. After the whole fleet is on v2 and stable, remove
+6) Repeat for each v1 host. After the whole fleet is on v2 and stable, remove
    `PINNED_BUCKET_*` from each host and transition to dynamic `jetmon_hosts`
    ownership one controlled host at a time.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,7 +16,9 @@ migration and the operating data needed to make larger architecture decisions.
   current main-server-plus-Veriflier design before moving toward a v3
   probe-agent architecture. The v2 event tables remain authoritative while
   `LEGACY_STATUS_PROJECTION_ENABLE` keeps legacy `site_status` /
-  `last_status_change` consumers working during migration.
+  `last_status_change` consumers working during migration. Use the pinned
+  bucket rollout path for the first v1-to-v2 production migration, then remove
+  `PINNED_BUCKET_*` after every host is on v2 and stable.
 - **Use delivery ownership as a rollout guard.**
   In the single-binary deployment, `API_PORT > 0` also starts webhook and
   alert-contact delivery workers. A standalone `jetmon-deliverer` entry point

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,7 +30,10 @@ migration and the operating data needed to make larger architecture decisions.
   rate by failure class, Veriflier agreement/disagreement by region, Veriflier
   latency/timeout rates, mixed-region outcomes, monitor-side `Unknown` cases,
   primary-check vs confirmation cost, operator explanation gaps, and WPCOM
-  notification parity.
+  notification parity. StatsD now emits the core detection timings, outcome
+  counters split by local failure class, and per-Veriflier-host RPC/vote
+  counters; the remaining work is production dashboarding and any durable report
+  queries needed after v2 has real traffic.
 - **Watch projection drift as a production bug.** While the legacy projection
   is enabled, event mutations, transition rows, and the site-row projection
   must remain transactionally consistent.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,10 @@ migration and the operating data needed to make larger architecture decisions.
   queries needed after v2 has real traffic.
 - **Watch projection drift as a production bug.** While the legacy projection
   is enabled, event mutations, transition rows, and the site-row projection
-  must remain transactionally consistent.
+  must remain transactionally consistent. `jetmon2 rollout projection-drift`
+  lists the exact active sites whose legacy projection disagrees with the
+  authoritative HTTP event state, so rollout failures are actionable instead of
+  count-only.
 - **Keep roadmap/API documentation drift out of the branch.** `API.md` is the
   source for the implemented internal `/api/v1` route surface. This roadmap
   should track only the remaining public/customer API work, production

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,8 +32,9 @@ migration and the operating data needed to make larger architecture decisions.
   primary-check vs confirmation cost, operator explanation gaps, and WPCOM
   notification parity. StatsD now emits the core detection timings, outcome
   counters split by local failure class, and per-Veriflier-host RPC/vote
-  counters; the remaining work is production dashboarding and any durable report
-  queries needed after v2 has real traffic.
+  counters, plus legacy WPCOM notification attempt/delivered/retry/error/failed
+  counters split by status; the remaining work is production dashboarding and
+  any durable report queries needed after v2 has real traffic.
 - **Watch projection drift as a production bug.** While the legacy projection
   is enabled, event mutations, transition rows, and the site-row projection
   must remain transactionally consistent. `jetmon2 rollout projection-drift`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,12 +19,24 @@ migration and the operating data needed to make larger architecture decisions.
   `last_status_change` consumers working during migration. Use the pinned
   bucket rollout path for the first v1-to-v2 production migration, then remove
   `PINNED_BUCKET_*` after every host is on v2 and stable.
+- **Keep rollout health visible before cutover.** Operators should not have to
+  infer migration-critical state from logs or config while replacing v1 hosts.
+  The operator dashboard now shows bucket ownership mode, legacy projection
+  mode, delivery-worker ownership, rollout preflight commands, and live
+  dependency health for MySQL, Verifliers, WPCOM, StatsD, and log/stats disk
+  writes. Keep this visible and verified during rollout rehearsal because it
+  helps separate customer-site downtime from monitor-side impairment during
+  cutover.
 - **Use delivery ownership as a rollout guard.**
   In the single-binary deployment, `API_PORT > 0` also starts webhook and
   alert-contact delivery workers. A standalone `jetmon-deliverer` entry point
   and transactional `SELECT ... FOR UPDATE` row claims now exist; use
   `DELIVERY_OWNER_HOST` as a rollout guard when intentionally keeping delivery
   single-owner during migration from embedded to standalone delivery.
+- **Run a production rollout rehearsal pass.** Validate that README,
+  `docs/v1-to-v2-pinned-rollout.md`, config samples, systemd units,
+  `validate-config`, `rollout pinned-check`, `rollout projection-drift`, and
+  rollback steps line up exactly before the first production host replacement.
 - **Instrument the data needed for the v3 decision.** During v2 production,
   measure first-failure-to-`Seems Down`, `Seems Down`-to-`Down`, false alarm
   rate by failure class, Veriflier agreement/disagreement by region, Veriflier
@@ -33,8 +45,8 @@ migration and the operating data needed to make larger architecture decisions.
   notification parity. StatsD now emits the core detection timings, outcome
   counters split by local failure class, and per-Veriflier-host RPC/vote
   counters, plus legacy WPCOM notification attempt/delivered/retry/error/failed
-  counters split by status; the remaining work is production dashboarding and
-  any durable report queries needed after v2 has real traffic.
+  counters split by status. Durable report queries should wait until v2 has
+  enough real traffic to prove which questions operators actually need to ask.
 - **Watch projection drift as a production bug.** While the legacy projection
   is enabled, event mutations, transition rows, and the site-row projection
   must remain transactionally consistent. `jetmon2 rollout projection-drift`

--- a/cmd/jetmon2/main.go
+++ b/cmd/jetmon2/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Automattic/jetmon/internal/deliverer"
 	"github.com/Automattic/jetmon/internal/metrics"
 	"github.com/Automattic/jetmon/internal/orchestrator"
+	"github.com/Automattic/jetmon/internal/veriflier"
 	"github.com/Automattic/jetmon/internal/wpcom"
 )
 
@@ -171,22 +172,37 @@ func runServe() {
 
 	// Push dashboard state every stats interval.
 	if dash != nil {
+		publishDashboardHealth(dash, wp)
 		go func() {
 			ticker := time.NewTicker(time.Duration(cfg.StatsUpdateIntervalMS) * time.Millisecond)
 			defer ticker.Stop()
 			for range ticker.C {
 				bMin, bMax := orch.BucketRange()
+				currentCfg := config.Get()
 				dash.Update(dashboard.State{
-					WorkerCount:      orch.WorkerCount(),
-					ActiveChecks:     orch.ActiveChecks(),
-					QueueDepth:       orch.QueueDepth(),
-					RetryQueueSize:   orch.RetryQueueSize(),
-					SitesPerSec:      0,
-					WPCOMCircuitOpen: wp.IsCircuitOpen(),
-					WPCOMQueueDepth:  wp.QueueDepth(),
-					BucketMin:        bMin,
-					BucketMax:        bMax,
+					WorkerCount:                   orch.WorkerCount(),
+					ActiveChecks:                  orch.ActiveChecks(),
+					QueueDepth:                    orch.QueueDepth(),
+					RetryQueueSize:                orch.RetryQueueSize(),
+					SitesPerSec:                   0,
+					WPCOMCircuitOpen:              wp.IsCircuitOpen(),
+					WPCOMQueueDepth:               wp.QueueDepth(),
+					BucketMin:                     bMin,
+					BucketMax:                     bMax,
+					BucketOwnership:               bucketOwnershipLabel(currentCfg),
+					LegacyStatusProjectionEnabled: currentCfg.LegacyStatusProjectionEnable,
+					DeliveryWorkersEnabled:        deliveryWorkersEnabled,
+					DeliveryOwnerHost:             currentCfg.DeliveryOwnerHost,
+					RolloutPreflightCommand:       rolloutPreflightCommand(currentCfg),
+					ProjectionDriftCommand:        projectionDriftCommand(),
 				})
+			}
+		}()
+		go func() {
+			ticker := time.NewTicker(time.Duration(cfg.StatsUpdateIntervalMS) * time.Millisecond)
+			defer ticker.Stop()
+			for range ticker.C {
+				publishDashboardHealth(dash, wp)
 			}
 		}()
 	}
@@ -294,16 +310,176 @@ func bucketOwnershipLabel(cfg *config.Config) string {
 }
 
 func rolloutAdviceLines(cfg *config.Config) []string {
-	if _, _, ok := cfg.PinnedBucketRange(); ok {
-		return []string{
-			"INFO rollout_preflight=./jetmon2 rollout pinned-check",
-			"INFO rollout_drift_report=./jetmon2 rollout projection-drift",
-		}
-	}
 	return []string{
-		"INFO rollout_preflight=./jetmon2 rollout dynamic-check",
-		"INFO rollout_drift_report=./jetmon2 rollout projection-drift",
+		"INFO rollout_preflight=" + rolloutPreflightCommand(cfg),
+		"INFO rollout_drift_report=" + projectionDriftCommand(),
 	}
+}
+
+func rolloutPreflightCommand(cfg *config.Config) string {
+	if _, _, ok := cfg.PinnedBucketRange(); ok {
+		return "./jetmon2 rollout pinned-check"
+	}
+	return "./jetmon2 rollout dynamic-check"
+}
+
+func projectionDriftCommand() string {
+	return "./jetmon2 rollout projection-drift"
+}
+
+const dashboardHealthTimeout = 2 * time.Second
+
+func publishDashboardHealth(dash *dashboard.Server, wp *wpcom.Client) {
+	if dash == nil {
+		return
+	}
+	dash.UpdateHealth(dashboardHealthEntries(context.Background(), config.Get(), db.DB(), wp, metrics.Global() != nil, time.Now().UTC()))
+}
+
+func dashboardHealthEntries(ctx context.Context, cfg *config.Config, sqlDB *sql.DB, wp *wpcom.Client, statsdReady bool, checkedAt time.Time) []dashboard.HealthEntry {
+	entries := []dashboard.HealthEntry{
+		mysqlHealthEntry(ctx, sqlDB, checkedAt),
+		wpcomHealthEntry(wp, checkedAt),
+		statsdHealthEntry(statsdReady, checkedAt),
+		diskHealthEntry("logs", checkedAt),
+		diskHealthEntry("stats", checkedAt),
+	}
+	entries = append(entries, veriflierHealthEntries(ctx, cfg, checkedAt)...)
+	return entries
+}
+
+func mysqlHealthEntry(ctx context.Context, sqlDB *sql.DB, checkedAt time.Time) dashboard.HealthEntry {
+	entry := dashboard.HealthEntry{Name: "mysql", CheckedAt: checkedAt}
+	if sqlDB == nil {
+		entry.Status = "red"
+		entry.LastError = "database pool is not initialized"
+		return entry
+	}
+
+	pingCtx, cancel := context.WithTimeout(ctx, dashboardHealthTimeout)
+	defer cancel()
+
+	start := time.Now()
+	if err := sqlDB.PingContext(pingCtx); err != nil {
+		entry.Status = "red"
+		entry.Latency = time.Since(start).Milliseconds()
+		entry.LastError = err.Error()
+		return entry
+	}
+	entry.Status = "green"
+	entry.Latency = time.Since(start).Milliseconds()
+	return entry
+}
+
+func veriflierHealthEntries(ctx context.Context, cfg *config.Config, checkedAt time.Time) []dashboard.HealthEntry {
+	if cfg == nil || len(cfg.Verifiers) == 0 {
+		return []dashboard.HealthEntry{{
+			Name:      "verifliers",
+			Status:    "amber",
+			LastError: "no verifliers configured",
+			CheckedAt: checkedAt,
+		}}
+	}
+
+	entries := make([]dashboard.HealthEntry, 0, len(cfg.Verifiers))
+	for _, v := range cfg.Verifiers {
+		addr := fmt.Sprintf("%s:%s", v.Host, v.TransportPort())
+		name := "veriflier:" + v.Name
+		if v.Name == "" {
+			name = "veriflier:" + addr
+		}
+		entry := dashboard.HealthEntry{Name: name, CheckedAt: checkedAt}
+		if v.Host == "" || v.TransportPort() == "" {
+			entry.Status = "red"
+			entry.LastError = "host or port is not configured"
+			entries = append(entries, entry)
+			continue
+		}
+
+		pingCtx, cancel := context.WithTimeout(ctx, dashboardHealthTimeout)
+		start := time.Now()
+		version, err := veriflier.NewVeriflierClient(addr, v.AuthToken).Ping(pingCtx)
+		cancel()
+		entry.Latency = time.Since(start).Milliseconds()
+		if err != nil {
+			entry.Status = "red"
+			entry.LastError = err.Error()
+		} else {
+			entry.Status = "green"
+			if version != "" {
+				entry.Name = fmt.Sprintf("%s (%s)", entry.Name, version)
+			}
+		}
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+func wpcomHealthEntry(wp *wpcom.Client, checkedAt time.Time) dashboard.HealthEntry {
+	entry := dashboard.HealthEntry{Name: "wpcom", CheckedAt: checkedAt}
+	if wp == nil {
+		entry.Status = "red"
+		entry.LastError = "wpcom client is not initialized"
+		return entry
+	}
+	queueDepth := wp.QueueDepth()
+	if wp.IsCircuitOpen() {
+		entry.Status = "red"
+		entry.LastError = fmt.Sprintf("circuit open, queued notifications=%d", queueDepth)
+		return entry
+	}
+	if queueDepth > 0 {
+		entry.Status = "amber"
+		entry.LastError = fmt.Sprintf("queued notifications=%d", queueDepth)
+		return entry
+	}
+	entry.Status = "green"
+	return entry
+}
+
+func statsdHealthEntry(ready bool, checkedAt time.Time) dashboard.HealthEntry {
+	entry := dashboard.HealthEntry{Name: "statsd", CheckedAt: checkedAt}
+	if !ready {
+		entry.Status = "amber"
+		entry.LastError = "statsd client is not initialized"
+		return entry
+	}
+	entry.Status = "green"
+	return entry
+}
+
+func diskHealthEntry(dir string, checkedAt time.Time) dashboard.HealthEntry {
+	entry := dashboard.HealthEntry{Name: "disk:" + dir, CheckedAt: checkedAt}
+	if err := checkWritableDir(dir); err != nil {
+		entry.Status = "red"
+		entry.LastError = err.Error()
+		return entry
+	}
+	entry.Status = "green"
+	return entry
+}
+
+func checkWritableDir(dir string) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", dir)
+	}
+	f, err := os.CreateTemp(dir, ".jetmon-health-*")
+	if err != nil {
+		return err
+	}
+	name := f.Name()
+	if err := f.Close(); err != nil {
+		_ = os.Remove(name)
+		return err
+	}
+	if err := os.Remove(name); err != nil {
+		return err
+	}
+	return nil
 }
 
 // emailTransportLabel collapses an empty EMAIL_TRANSPORT to its compatibility

--- a/cmd/jetmon2/main.go
+++ b/cmd/jetmon2/main.go
@@ -260,6 +260,9 @@ func cmdValidateConfig() {
 	cfg := config.Get()
 	fmt.Printf("INFO legacy_status_projection=%s\n", enabledLabel(cfg.LegacyStatusProjectionEnable))
 	fmt.Printf("INFO bucket_ownership=%s\n", bucketOwnershipLabel(cfg))
+	for _, line := range rolloutAdviceLines(cfg) {
+		fmt.Println(line)
+	}
 	fmt.Printf("INFO email_transport=%s\n", emailTransportLabel(cfg))
 	if !emailTransportDelivers(cfg) {
 		fmt.Printf("WARN email_transport=%s — alert-contact emails will be logged but not delivered\n", emailTransportLabel(cfg))
@@ -268,7 +271,7 @@ func cmdValidateConfig() {
 		fmt.Printf("%s %s\n", level, msg)
 	}
 	for _, v := range cfg.Verifiers {
-		addr := fmt.Sprintf("%s:%s", v.Host, v.GRPCPort)
+		addr := fmt.Sprintf("%s:%s", v.Host, v.TransportPort())
 		// Listing configured Verifliers is operator context, not a reachability check.
 		fmt.Printf("INFO veriflier %q at %s\n", v.Name, addr)
 	}
@@ -288,6 +291,19 @@ func bucketOwnershipLabel(cfg *config.Config) string {
 		return fmt.Sprintf("pinned range=%d-%d", min, max)
 	}
 	return "dynamic jetmon_hosts"
+}
+
+func rolloutAdviceLines(cfg *config.Config) []string {
+	if _, _, ok := cfg.PinnedBucketRange(); ok {
+		return []string{
+			"INFO rollout_preflight=./jetmon2 rollout pinned-check",
+			"INFO rollout_drift_report=./jetmon2 rollout projection-drift",
+		}
+	}
+	return []string{
+		"INFO rollout_preflight=./jetmon2 rollout dynamic-check",
+		"INFO rollout_drift_report=./jetmon2 rollout projection-drift",
+	}
 }
 
 // emailTransportLabel collapses an empty EMAIL_TRANSPORT to its compatibility

--- a/cmd/jetmon2/main.go
+++ b/cmd/jetmon2/main.go
@@ -60,6 +60,8 @@ func main() {
 		cmdKeys(os.Args[2:])
 	case "site-tenants":
 		cmdSiteTenants(os.Args[2:])
+	case "rollout":
+		cmdRollout(os.Args[2:])
 	default:
 		runServe()
 	}

--- a/cmd/jetmon2/main.go
+++ b/cmd/jetmon2/main.go
@@ -74,6 +74,7 @@ func runServe() {
 	}
 	cfg := config.Get()
 	log.Printf("config: legacy_status_projection=%s", enabledLabel(cfg.LegacyStatusProjectionEnable))
+	log.Printf("config: bucket_ownership=%s", bucketOwnershipLabel(cfg))
 	log.Printf("config: email_transport=%s", emailTransportLabel(cfg))
 	if !emailTransportDelivers(cfg) {
 		log.Printf("WARN: email_transport=%s — alert-contact emails will be logged but not delivered", emailTransportLabel(cfg))
@@ -256,6 +257,7 @@ func cmdValidateConfig() {
 
 	cfg := config.Get()
 	fmt.Printf("INFO legacy_status_projection=%s\n", enabledLabel(cfg.LegacyStatusProjectionEnable))
+	fmt.Printf("INFO bucket_ownership=%s\n", bucketOwnershipLabel(cfg))
 	fmt.Printf("INFO email_transport=%s\n", emailTransportLabel(cfg))
 	if !emailTransportDelivers(cfg) {
 		fmt.Printf("WARN email_transport=%s — alert-contact emails will be logged but not delivered\n", emailTransportLabel(cfg))
@@ -277,6 +279,13 @@ func enabledLabel(b bool) string {
 		return "enabled"
 	}
 	return "disabled"
+}
+
+func bucketOwnershipLabel(cfg *config.Config) string {
+	if min, max, ok := cfg.PinnedBucketRange(); ok {
+		return fmt.Sprintf("pinned range=%d-%d", min, max)
+	}
+	return "dynamic jetmon_hosts"
 }
 
 // emailTransportLabel collapses an empty EMAIL_TRANSPORT to its compatibility

--- a/cmd/jetmon2/main_test.go
+++ b/cmd/jetmon2/main_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Automattic/jetmon/internal/alerting"
 	"github.com/Automattic/jetmon/internal/config"
 	"github.com/Automattic/jetmon/internal/deliverer"
+	"github.com/DATA-DOG/go-sqlmock"
 )
 
 func TestHTTPGet(t *testing.T) {
@@ -286,6 +287,83 @@ func TestRolloutAdviceLines(t *testing.T) {
 	}
 	if !strings.Contains(pinned[1], "rollout projection-drift") {
 		t.Fatalf("pinned drift advice = %q", pinned[1])
+	}
+}
+
+func TestRolloutCommandHelpers(t *testing.T) {
+	if got := rolloutPreflightCommand(&config.Config{}); got != "./jetmon2 rollout dynamic-check" {
+		t.Fatalf("rolloutPreflightCommand(dynamic) = %q", got)
+	}
+	min, max := 12, 34
+	cfg := &config.Config{PinnedBucketMin: &min, PinnedBucketMax: &max}
+	if got := rolloutPreflightCommand(cfg); got != "./jetmon2 rollout pinned-check" {
+		t.Fatalf("rolloutPreflightCommand(pinned) = %q", got)
+	}
+	if got := projectionDriftCommand(); got != "./jetmon2 rollout projection-drift" {
+		t.Fatalf("projectionDriftCommand() = %q", got)
+	}
+}
+
+func TestDashboardHealthEntriesReportsCoreDependencies(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "logs"), 0755); err != nil {
+		t.Fatalf("mkdir logs: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "stats"), 0755); err != nil {
+		t.Fatalf("mkdir stats: %v", err)
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(wd); err != nil {
+			t.Fatalf("restore working directory: %v", err)
+		}
+	}()
+
+	sqlDB, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqlDB.Close()
+	mock.ExpectPing()
+
+	checkedAt := time.Date(2026, 4, 28, 3, 0, 0, 0, time.UTC)
+	entries := dashboardHealthEntries(context.Background(), &config.Config{}, sqlDB, nil, false, checkedAt)
+	byName := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		byName[entry.Name] = entry.Status
+		if !entry.CheckedAt.Equal(checkedAt) {
+			t.Fatalf("%s CheckedAt = %s, want %s", entry.Name, entry.CheckedAt, checkedAt)
+		}
+	}
+
+	want := map[string]string{
+		"mysql":      "green",
+		"wpcom":      "red",
+		"statsd":     "amber",
+		"disk:logs":  "green",
+		"disk:stats": "green",
+		"verifliers": "amber",
+	}
+	for name, status := range want {
+		if byName[name] != status {
+			t.Fatalf("health[%s] = %q, want %q (entries=%v)", name, byName[name], status, entries)
+		}
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sql expectations: %v", err)
+	}
+}
+
+func TestCheckWritableDirReportsMissingDirectory(t *testing.T) {
+	err := checkWritableDir(filepath.Join(t.TempDir(), "missing"))
+	if err == nil {
+		t.Fatal("checkWritableDir() returned nil for missing directory")
 	}
 }
 

--- a/cmd/jetmon2/main_test.go
+++ b/cmd/jetmon2/main_test.go
@@ -253,6 +253,17 @@ func TestEnabledLabel(t *testing.T) {
 	}
 }
 
+func TestBucketOwnershipLabel(t *testing.T) {
+	if got := bucketOwnershipLabel(&config.Config{}); got != "dynamic jetmon_hosts" {
+		t.Fatalf("bucketOwnershipLabel(dynamic) = %q", got)
+	}
+	min, max := 12, 34
+	got := bucketOwnershipLabel(&config.Config{PinnedBucketMin: &min, PinnedBucketMax: &max})
+	if got != "pinned range=12-34" {
+		t.Fatalf("bucketOwnershipLabel(pinned) = %q", got)
+	}
+}
+
 func TestParseInt64(t *testing.T) {
 	got, err := parseInt64("12345")
 	if err != nil {

--- a/cmd/jetmon2/main_test.go
+++ b/cmd/jetmon2/main_test.go
@@ -264,6 +264,31 @@ func TestBucketOwnershipLabel(t *testing.T) {
 	}
 }
 
+func TestRolloutAdviceLines(t *testing.T) {
+	dynamic := rolloutAdviceLines(&config.Config{})
+	if len(dynamic) != 2 {
+		t.Fatalf("dynamic advice len = %d, want 2", len(dynamic))
+	}
+	if !strings.Contains(dynamic[0], "rollout dynamic-check") {
+		t.Fatalf("dynamic preflight advice = %q", dynamic[0])
+	}
+	if !strings.Contains(dynamic[1], "rollout projection-drift") {
+		t.Fatalf("dynamic drift advice = %q", dynamic[1])
+	}
+
+	min, max := 12, 34
+	pinned := rolloutAdviceLines(&config.Config{PinnedBucketMin: &min, PinnedBucketMax: &max})
+	if len(pinned) != 2 {
+		t.Fatalf("pinned advice len = %d, want 2", len(pinned))
+	}
+	if !strings.Contains(pinned[0], "rollout pinned-check") {
+		t.Fatalf("pinned preflight advice = %q", pinned[0])
+	}
+	if !strings.Contains(pinned[1], "rollout projection-drift") {
+		t.Fatalf("pinned drift advice = %q", pinned[1])
+	}
+}
+
 func TestParseInt64(t *testing.T) {
 	got, err := parseInt64("12345")
 	if err != nil {

--- a/cmd/jetmon2/rollout.go
+++ b/cmd/jetmon2/rollout.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/Automattic/jetmon/internal/config"
 	"github.com/Automattic/jetmon/internal/db"
@@ -20,17 +22,26 @@ type pinnedRolloutCheckDeps struct {
 	CountLegacyProjectionDrift     func(context.Context, int, int) (int, error)
 }
 
+type dynamicRolloutCheckDeps struct {
+	Now                            func() time.Time
+	GetAllHosts                    func() ([]db.HostRow, error)
+	CountActiveSitesForBucketRange func(context.Context, int, int) (int, error)
+	CountLegacyProjectionDrift     func(context.Context, int, int) (int, error)
+}
+
 func cmdRollout(args []string) {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout <pinned-check> [args]")
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout <pinned-check|dynamic-check> [args]")
 		os.Exit(1)
 	}
 
 	switch args[0] {
 	case "pinned-check":
 		cmdRolloutPinnedCheck(args[1:])
+	case "dynamic-check":
+		cmdRolloutDynamicCheck(args[1:])
 	default:
-		fmt.Fprintf(os.Stderr, "unknown rollout subcommand %q (want: pinned-check)\n", args[0])
+		fmt.Fprintf(os.Stderr, "unknown rollout subcommand %q (want: pinned-check, dynamic-check)\n", args[0])
 		os.Exit(1)
 	}
 }
@@ -65,6 +76,40 @@ func cmdRolloutPinnedCheck(args []string) {
 		CountLegacyProjectionDrift:     db.CountLegacyProjectionDrift,
 	}
 	if err := runPinnedRolloutCheck(context.Background(), os.Stdout, config.Get(), *host, deps); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func cmdRolloutDynamicCheck(args []string) {
+	fs := flag.NewFlagSet("rollout dynamic-check", flag.ExitOnError)
+	_ = fs.Parse(args)
+	if fs.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout dynamic-check")
+		os.Exit(1)
+	}
+
+	configPath := envOrDefault("JETMON_CONFIG", "config/config.json")
+	if err := config.Load(configPath); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL config parse: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("PASS config parse")
+
+	config.LoadDB()
+	if err := db.ConnectWithRetry(3); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL db connect: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("PASS db connect")
+
+	deps := dynamicRolloutCheckDeps{
+		Now:                            time.Now,
+		GetAllHosts:                    db.GetAllHosts,
+		CountActiveSitesForBucketRange: db.CountActiveSitesForBucketRange,
+		CountLegacyProjectionDrift:     db.CountLegacyProjectionDrift,
+	}
+	if err := runDynamicRolloutCheck(context.Background(), os.Stdout, config.Get(), deps); err != nil {
 		fmt.Fprintf(os.Stderr, "FAIL %v\n", err)
 		os.Exit(1)
 	}
@@ -135,5 +180,106 @@ func runPinnedRolloutCheck(ctx context.Context, out io.Writer, cfg *config.Confi
 	}
 	fmt.Fprintln(out, "PASS legacy_projection_drift=0")
 	fmt.Fprintln(out, "pinned rollout check passed")
+	return nil
+}
+
+func runDynamicRolloutCheck(ctx context.Context, out io.Writer, cfg *config.Config, deps dynamicRolloutCheckDeps) error {
+	if cfg == nil {
+		return errors.New("config is not loaded")
+	}
+	if minBucket, maxBucket, ok := cfg.PinnedBucketRange(); ok {
+		return fmt.Errorf("pinned bucket range %d-%d is still configured; remove PINNED_BUCKET_*/BUCKET_NO_* before dynamic ownership cutover", minBucket, maxBucket)
+	}
+	fmt.Fprintln(out, "PASS bucket_ownership=dynamic")
+
+	if !cfg.LegacyStatusProjectionEnable {
+		return errors.New("LEGACY_STATUS_PROJECTION_ENABLE must remain true until legacy readers have migrated")
+	}
+	fmt.Fprintln(out, "PASS legacy_status_projection=enabled")
+
+	if deps.GetAllHosts == nil {
+		return errors.New("host list query is not configured")
+	}
+	hosts, err := deps.GetAllHosts()
+	if err != nil {
+		return fmt.Errorf("query jetmon_hosts: %w", err)
+	}
+	fmt.Fprintf(out, "INFO jetmon_hosts_rows=%d\n", len(hosts))
+
+	now := time.Now()
+	if deps.Now != nil {
+		now = deps.Now()
+	}
+	if err := validateDynamicBucketCoverage(hosts, cfg.BucketTotal, time.Duration(cfg.BucketHeartbeatGraceSec)*time.Second, now); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "PASS dynamic_bucket_coverage=0-%d hosts=%d\n", cfg.BucketTotal-1, len(hosts))
+
+	if deps.CountActiveSitesForBucketRange == nil {
+		return errors.New("active site counter is not configured")
+	}
+	activeSites, err := deps.CountActiveSitesForBucketRange(ctx, 0, cfg.BucketTotal-1)
+	if err != nil {
+		return fmt.Errorf("count active sites in dynamic range 0-%d: %w", cfg.BucketTotal-1, err)
+	}
+	fmt.Fprintf(out, "INFO active_sites_dynamic_range=%d\n", activeSites)
+
+	if deps.CountLegacyProjectionDrift == nil {
+		return errors.New("projection drift counter is not configured")
+	}
+	drift, err := deps.CountLegacyProjectionDrift(ctx, 0, cfg.BucketTotal-1)
+	if err != nil {
+		return fmt.Errorf("count legacy projection drift in dynamic range 0-%d: %w", cfg.BucketTotal-1, err)
+	}
+	if drift > 0 {
+		return fmt.Errorf("legacy projection drift=%d in dynamic range 0-%d", drift, cfg.BucketTotal-1)
+	}
+	fmt.Fprintln(out, "PASS legacy_projection_drift=0")
+	fmt.Fprintln(out, "dynamic rollout check passed")
+	return nil
+}
+
+func validateDynamicBucketCoverage(hosts []db.HostRow, bucketTotal int, heartbeatGrace time.Duration, now time.Time) error {
+	if bucketTotal <= 0 {
+		return errors.New("BUCKET_TOTAL must be > 0")
+	}
+	if heartbeatGrace <= 0 {
+		return errors.New("BUCKET_HEARTBEAT_GRACE_SEC must be > 0")
+	}
+	if len(hosts) == 0 {
+		return errors.New("jetmon_hosts has no rows; dynamic ownership is not established")
+	}
+
+	sortedHosts := append([]db.HostRow(nil), hosts...)
+	sort.Slice(sortedHosts, func(i, j int) bool {
+		if sortedHosts[i].BucketMin == sortedHosts[j].BucketMin {
+			return sortedHosts[i].HostID < sortedHosts[j].HostID
+		}
+		return sortedHosts[i].BucketMin < sortedHosts[j].BucketMin
+	})
+
+	expectedMin := 0
+	for _, host := range sortedHosts {
+		if host.Status != "active" {
+			return fmt.Errorf("host %q has status=%q; all dynamic ownership rows must be active", host.HostID, host.Status)
+		}
+		if age := now.Sub(host.LastHeartbeat); age > heartbeatGrace {
+			return fmt.Errorf("host %q heartbeat is stale age=%s grace=%s", host.HostID, age.Round(time.Second), heartbeatGrace)
+		}
+		if host.BucketMin < 0 || host.BucketMax < host.BucketMin || host.BucketMax >= bucketTotal {
+			return fmt.Errorf("host %q has invalid bucket range %d-%d for BUCKET_TOTAL=%d", host.HostID, host.BucketMin, host.BucketMax, bucketTotal)
+		}
+		if host.BucketMin > expectedMin {
+			return fmt.Errorf("dynamic bucket coverage has gap %d-%d before host %q", expectedMin, host.BucketMin-1, host.HostID)
+		}
+		if host.BucketMin < expectedMin {
+			return fmt.Errorf("dynamic bucket coverage overlaps before host %q at bucket %d", host.HostID, host.BucketMin)
+		}
+		expectedMin = host.BucketMax + 1
+	}
+
+	if expectedMin < bucketTotal {
+		return fmt.Errorf("dynamic bucket coverage has trailing gap %d-%d", expectedMin, bucketTotal-1)
+	}
 	return nil
 }

--- a/cmd/jetmon2/rollout.go
+++ b/cmd/jetmon2/rollout.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/Automattic/jetmon/internal/config"
+	"github.com/Automattic/jetmon/internal/db"
+)
+
+type pinnedRolloutCheckDeps struct {
+	Hostname                       func() string
+	HostRowExists                  func(context.Context, string) (bool, error)
+	CountActiveSitesForBucketRange func(context.Context, int, int) (int, error)
+	CountLegacyProjectionDrift     func(context.Context, int, int) (int, error)
+}
+
+func cmdRollout(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout <pinned-check> [args]")
+		os.Exit(1)
+	}
+
+	switch args[0] {
+	case "pinned-check":
+		cmdRolloutPinnedCheck(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown rollout subcommand %q (want: pinned-check)\n", args[0])
+		os.Exit(1)
+	}
+}
+
+func cmdRolloutPinnedCheck(args []string) {
+	fs := flag.NewFlagSet("rollout pinned-check", flag.ExitOnError)
+	host := fs.String("host", "", "host id to check (default current hostname)")
+	_ = fs.Parse(args)
+	if fs.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout pinned-check [--host=<host_id>]")
+		os.Exit(1)
+	}
+
+	configPath := envOrDefault("JETMON_CONFIG", "config/config.json")
+	if err := config.Load(configPath); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL config parse: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("PASS config parse")
+
+	config.LoadDB()
+	if err := db.ConnectWithRetry(3); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL db connect: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("PASS db connect")
+
+	deps := pinnedRolloutCheckDeps{
+		Hostname:                       db.Hostname,
+		HostRowExists:                  db.HostRowExists,
+		CountActiveSitesForBucketRange: db.CountActiveSitesForBucketRange,
+		CountLegacyProjectionDrift:     db.CountLegacyProjectionDrift,
+	}
+	if err := runPinnedRolloutCheck(context.Background(), os.Stdout, config.Get(), *host, deps); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runPinnedRolloutCheck(ctx context.Context, out io.Writer, cfg *config.Config, hostOverride string, deps pinnedRolloutCheckDeps) error {
+	if cfg == nil {
+		return errors.New("config is not loaded")
+	}
+	minBucket, maxBucket, ok := cfg.PinnedBucketRange()
+	if !ok {
+		return errors.New("pinned bucket range is not configured; set PINNED_BUCKET_MIN/PINNED_BUCKET_MAX or BUCKET_NO_MIN/BUCKET_NO_MAX")
+	}
+	fmt.Fprintf(out, "PASS pinned_range=%d-%d\n", minBucket, maxBucket)
+
+	if !cfg.LegacyStatusProjectionEnable {
+		return errors.New("LEGACY_STATUS_PROJECTION_ENABLE must be true during pinned v1-to-v2 rollout")
+	}
+	fmt.Fprintln(out, "PASS legacy_status_projection=enabled")
+
+	if cfg.APIPort > 0 {
+		fmt.Fprintf(out, "WARN api_port=%d; confirm the API/delivery ownership plan before monitor cutover\n", cfg.APIPort)
+	} else {
+		fmt.Fprintln(out, "PASS api_port=disabled")
+	}
+
+	hostID := strings.TrimSpace(hostOverride)
+	if hostID == "" {
+		if deps.Hostname == nil {
+			return errors.New("hostname resolver is not configured")
+		}
+		hostID = strings.TrimSpace(deps.Hostname())
+	}
+	if hostID == "" {
+		return errors.New("host id is empty")
+	}
+
+	if deps.HostRowExists == nil {
+		return errors.New("host row checker is not configured")
+	}
+	hostRowExists, err := deps.HostRowExists(ctx, hostID)
+	if err != nil {
+		return fmt.Errorf("check jetmon_hosts row for %q: %w", hostID, err)
+	}
+	if hostRowExists {
+		return fmt.Errorf("host %q still has a jetmon_hosts row; pinned hosts must not participate in dynamic bucket ownership", hostID)
+	}
+	fmt.Fprintf(out, "PASS jetmon_hosts row absent host=%q\n", hostID)
+
+	if deps.CountActiveSitesForBucketRange == nil {
+		return errors.New("active site counter is not configured")
+	}
+	activeSites, err := deps.CountActiveSitesForBucketRange(ctx, minBucket, maxBucket)
+	if err != nil {
+		return fmt.Errorf("count active sites in pinned range %d-%d: %w", minBucket, maxBucket, err)
+	}
+	fmt.Fprintf(out, "INFO active_sites_in_pinned_range=%d\n", activeSites)
+
+	if deps.CountLegacyProjectionDrift == nil {
+		return errors.New("projection drift counter is not configured")
+	}
+	drift, err := deps.CountLegacyProjectionDrift(ctx, minBucket, maxBucket)
+	if err != nil {
+		return fmt.Errorf("count legacy projection drift in pinned range %d-%d: %w", minBucket, maxBucket, err)
+	}
+	if drift > 0 {
+		return fmt.Errorf("legacy projection drift=%d in pinned range %d-%d", drift, minBucket, maxBucket)
+	}
+	fmt.Fprintln(out, "PASS legacy_projection_drift=0")
+	fmt.Fprintln(out, "pinned rollout check passed")
+	return nil
+}

--- a/cmd/jetmon2/rollout.go
+++ b/cmd/jetmon2/rollout.go
@@ -29,9 +29,14 @@ type dynamicRolloutCheckDeps struct {
 	CountLegacyProjectionDrift     func(context.Context, int, int) (int, error)
 }
 
+type projectionDriftDeps struct {
+	CountLegacyProjectionDrift func(context.Context, int, int) (int, error)
+	ListLegacyProjectionDrift  func(context.Context, int, int, int) ([]db.ProjectionDriftRow, error)
+}
+
 func cmdRollout(args []string) {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout <pinned-check|dynamic-check> [args]")
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout <pinned-check|dynamic-check|projection-drift> [args]")
 		os.Exit(1)
 	}
 
@@ -40,8 +45,10 @@ func cmdRollout(args []string) {
 		cmdRolloutPinnedCheck(args[1:])
 	case "dynamic-check":
 		cmdRolloutDynamicCheck(args[1:])
+	case "projection-drift":
+		cmdRolloutProjectionDrift(args[1:])
 	default:
-		fmt.Fprintf(os.Stderr, "unknown rollout subcommand %q (want: pinned-check, dynamic-check)\n", args[0])
+		fmt.Fprintf(os.Stderr, "unknown rollout subcommand %q (want: pinned-check, dynamic-check, projection-drift)\n", args[0])
 		os.Exit(1)
 	}
 }
@@ -110,6 +117,41 @@ func cmdRolloutDynamicCheck(args []string) {
 		CountLegacyProjectionDrift:     db.CountLegacyProjectionDrift,
 	}
 	if err := runDynamicRolloutCheck(context.Background(), os.Stdout, config.Get(), deps); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func cmdRolloutProjectionDrift(args []string) {
+	fs := flag.NewFlagSet("rollout projection-drift", flag.ExitOnError)
+	bucketMin := fs.Int("bucket-min", -1, "inclusive bucket minimum (default pinned range or 0)")
+	bucketMax := fs.Int("bucket-max", -1, "inclusive bucket maximum (default pinned range or BUCKET_TOTAL-1)")
+	limit := fs.Int("limit", 50, "maximum drift rows to print")
+	_ = fs.Parse(args)
+	if fs.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout projection-drift [--bucket-min=N --bucket-max=N] [--limit=N]")
+		os.Exit(1)
+	}
+
+	configPath := envOrDefault("JETMON_CONFIG", "config/config.json")
+	if err := config.Load(configPath); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL config parse: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("PASS config parse")
+
+	config.LoadDB()
+	if err := db.ConnectWithRetry(3); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL db connect: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("PASS db connect")
+
+	deps := projectionDriftDeps{
+		CountLegacyProjectionDrift: db.CountLegacyProjectionDrift,
+		ListLegacyProjectionDrift:  db.ListLegacyProjectionDrift,
+	}
+	if err := runProjectionDriftReport(context.Background(), os.Stdout, config.Get(), *bucketMin, *bucketMax, *limit, deps); err != nil {
 		fmt.Fprintf(os.Stderr, "FAIL %v\n", err)
 		os.Exit(1)
 	}
@@ -282,4 +324,99 @@ func validateDynamicBucketCoverage(hosts []db.HostRow, bucketTotal int, heartbea
 		return fmt.Errorf("dynamic bucket coverage has trailing gap %d-%d", expectedMin, bucketTotal-1)
 	}
 	return nil
+}
+
+func runProjectionDriftReport(ctx context.Context, out io.Writer, cfg *config.Config, bucketMin, bucketMax, limit int, deps projectionDriftDeps) error {
+	if cfg == nil {
+		return errors.New("config is not loaded")
+	}
+	if limit <= 0 {
+		return errors.New("limit must be > 0")
+	}
+	minBucket, maxBucket, err := resolveProjectionDriftRange(cfg, bucketMin, bucketMax)
+	if err != nil {
+		return err
+	}
+
+	if deps.CountLegacyProjectionDrift == nil {
+		return errors.New("projection drift counter is not configured")
+	}
+	count, err := deps.CountLegacyProjectionDrift(ctx, minBucket, maxBucket)
+	if err != nil {
+		return fmt.Errorf("count legacy projection drift in range %d-%d: %w", minBucket, maxBucket, err)
+	}
+	fmt.Fprintf(out, "INFO projection_drift_range=%d-%d\n", minBucket, maxBucket)
+	fmt.Fprintf(out, "INFO legacy_projection_drift=%d\n", count)
+
+	if count == 0 {
+		fmt.Fprintln(out, "PASS legacy_projection_drift=0")
+		return nil
+	}
+
+	if deps.ListLegacyProjectionDrift == nil {
+		return errors.New("projection drift lister is not configured")
+	}
+	rows, err := deps.ListLegacyProjectionDrift(ctx, minBucket, maxBucket, limit)
+	if err != nil {
+		return fmt.Errorf("list legacy projection drift in range %d-%d: %w", minBucket, maxBucket, err)
+	}
+	printProjectionDriftRows(out, rows)
+	if count > len(rows) {
+		fmt.Fprintf(out, "INFO projection_drift_rows_truncated=%d\n", count-len(rows))
+	}
+	return fmt.Errorf("legacy projection drift=%d in range %d-%d", count, minBucket, maxBucket)
+}
+
+func resolveProjectionDriftRange(cfg *config.Config, bucketMin, bucketMax int) (int, int, error) {
+	if bucketMin < -1 || bucketMax < -1 {
+		return 0, 0, errors.New("bucket-min and bucket-max must be >= 0")
+	}
+	if (bucketMin == -1) != (bucketMax == -1) {
+		return 0, 0, errors.New("bucket-min and bucket-max must be set together")
+	}
+	if bucketMin >= 0 && bucketMax >= 0 {
+		if bucketMax < bucketMin {
+			return 0, 0, errors.New("bucket-max must be >= bucket-min")
+		}
+		if bucketMax >= cfg.BucketTotal {
+			return 0, 0, fmt.Errorf("bucket-max must be < BUCKET_TOTAL (%d)", cfg.BucketTotal)
+		}
+		return bucketMin, bucketMax, nil
+	}
+	if minBucket, maxBucket, ok := cfg.PinnedBucketRange(); ok {
+		return minBucket, maxBucket, nil
+	}
+	if cfg.BucketTotal <= 0 {
+		return 0, 0, errors.New("BUCKET_TOTAL must be > 0")
+	}
+	return 0, cfg.BucketTotal - 1, nil
+}
+
+func printProjectionDriftRows(out io.Writer, rows []db.ProjectionDriftRow) {
+	fmt.Fprintf(out, "%-12s %-8s %-11s %-9s %-10s %s\n",
+		"BLOG_ID", "BUCKET", "SITE_STATUS", "EXPECTED", "EVENT_ID", "EVENT_STATE")
+	for _, row := range rows {
+		fmt.Fprintf(out, "%-12d %-8d %-11d %-9d %-10s %s\n",
+			row.BlogID,
+			row.BucketNo,
+			row.SiteStatus,
+			row.ExpectedStatus,
+			formatOptionalInt(row.EventID),
+			formatOptionalString(row.EventState),
+		)
+	}
+}
+
+func formatOptionalInt(v *int64) string {
+	if v == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%d", *v)
+}
+
+func formatOptionalString(v *string) string {
+	if v == nil || *v == "" {
+		return "-"
+	}
+	return *v
 }

--- a/cmd/jetmon2/rollout_test.go
+++ b/cmd/jetmon2/rollout_test.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Automattic/jetmon/internal/config"
+)
+
+func TestRunPinnedRolloutCheckSuccess(t *testing.T) {
+	minBucket, maxBucket := 12, 34
+	cfg := &config.Config{
+		PinnedBucketMin:              &minBucket,
+		PinnedBucketMax:              &maxBucket,
+		LegacyStatusProjectionEnable: true,
+	}
+
+	var gotHost string
+	var gotMin, gotMax int
+	deps := pinnedRolloutCheckDeps{
+		Hostname: func() string { return "host-a" },
+		HostRowExists: func(_ context.Context, hostID string) (bool, error) {
+			gotHost = hostID
+			return false, nil
+		},
+		CountActiveSitesForBucketRange: func(_ context.Context, min, max int) (int, error) {
+			gotMin, gotMax = min, max
+			return 37, nil
+		},
+		CountLegacyProjectionDrift: func(_ context.Context, min, max int) (int, error) {
+			if min != minBucket || max != maxBucket {
+				t.Fatalf("CountLegacyProjectionDrift range = %d-%d, want %d-%d", min, max, minBucket, maxBucket)
+			}
+			return 0, nil
+		},
+	}
+
+	var out bytes.Buffer
+	if err := runPinnedRolloutCheck(context.Background(), &out, cfg, "", deps); err != nil {
+		t.Fatalf("runPinnedRolloutCheck: %v", err)
+	}
+	if gotHost != "host-a" {
+		t.Fatalf("host = %q, want host-a", gotHost)
+	}
+	if gotMin != minBucket || gotMax != maxBucket {
+		t.Fatalf("active site range = %d-%d, want %d-%d", gotMin, gotMax, minBucket, maxBucket)
+	}
+	for _, want := range []string{
+		"PASS pinned_range=12-34",
+		"PASS legacy_status_projection=enabled",
+		"PASS api_port=disabled",
+		"PASS jetmon_hosts row absent host=\"host-a\"",
+		"INFO active_sites_in_pinned_range=37",
+		"PASS legacy_projection_drift=0",
+		"pinned rollout check passed",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestRunPinnedRolloutCheckUsesHostOverride(t *testing.T) {
+	minBucket, maxBucket := 1, 2
+	cfg := &config.Config{
+		PinnedBucketMin:              &minBucket,
+		PinnedBucketMax:              &maxBucket,
+		LegacyStatusProjectionEnable: true,
+	}
+
+	var gotHost string
+	deps := pinnedRolloutCheckDeps{
+		Hostname: func() string { return "wrong-host" },
+		HostRowExists: func(_ context.Context, hostID string) (bool, error) {
+			gotHost = hostID
+			return false, nil
+		},
+		CountActiveSitesForBucketRange: func(context.Context, int, int) (int, error) {
+			return 1, nil
+		},
+		CountLegacyProjectionDrift: func(context.Context, int, int) (int, error) {
+			return 0, nil
+		},
+	}
+
+	var out bytes.Buffer
+	if err := runPinnedRolloutCheck(context.Background(), &out, cfg, " override-host ", deps); err != nil {
+		t.Fatalf("runPinnedRolloutCheck: %v", err)
+	}
+	if gotHost != "override-host" {
+		t.Fatalf("host = %q, want override-host", gotHost)
+	}
+}
+
+func TestRunPinnedRolloutCheckWarnsWhenAPIEnabled(t *testing.T) {
+	minBucket, maxBucket := 1, 2
+	cfg := &config.Config{
+		PinnedBucketMin:              &minBucket,
+		PinnedBucketMax:              &maxBucket,
+		LegacyStatusProjectionEnable: true,
+		APIPort:                      8090,
+	}
+	deps := successfulPinnedRolloutDeps()
+
+	var out bytes.Buffer
+	if err := runPinnedRolloutCheck(context.Background(), &out, cfg, "", deps); err != nil {
+		t.Fatalf("runPinnedRolloutCheck: %v", err)
+	}
+	if !strings.Contains(out.String(), "WARN api_port=8090") {
+		t.Fatalf("output missing API warning:\n%s", out.String())
+	}
+}
+
+func TestRunPinnedRolloutCheckFailures(t *testing.T) {
+	minBucket, maxBucket := 1, 2
+	tests := []struct {
+		name string
+		cfg  *config.Config
+		deps pinnedRolloutCheckDeps
+		want string
+	}{
+		{
+			name: "missing pinned range",
+			cfg:  &config.Config{LegacyStatusProjectionEnable: true},
+			deps: successfulPinnedRolloutDeps(),
+			want: "pinned bucket range is not configured",
+		},
+		{
+			name: "legacy projection disabled",
+			cfg: &config.Config{
+				PinnedBucketMin: &minBucket,
+				PinnedBucketMax: &maxBucket,
+			},
+			deps: successfulPinnedRolloutDeps(),
+			want: "LEGACY_STATUS_PROJECTION_ENABLE must be true",
+		},
+		{
+			name: "host row exists",
+			cfg:  pinnedRolloutTestConfig(minBucket, maxBucket),
+			deps: pinnedRolloutCheckDeps{
+				Hostname: func() string { return "host-a" },
+				HostRowExists: func(context.Context, string) (bool, error) {
+					return true, nil
+				},
+			},
+			want: "still has a jetmon_hosts row",
+		},
+		{
+			name: "host row query error",
+			cfg:  pinnedRolloutTestConfig(minBucket, maxBucket),
+			deps: pinnedRolloutCheckDeps{
+				Hostname: func() string { return "host-a" },
+				HostRowExists: func(context.Context, string) (bool, error) {
+					return false, errors.New("db unavailable")
+				},
+			},
+			want: "db unavailable",
+		},
+		{
+			name: "projection drift",
+			cfg:  pinnedRolloutTestConfig(minBucket, maxBucket),
+			deps: pinnedRolloutCheckDeps{
+				Hostname: func() string { return "host-a" },
+				HostRowExists: func(context.Context, string) (bool, error) {
+					return false, nil
+				},
+				CountActiveSitesForBucketRange: func(context.Context, int, int) (int, error) {
+					return 10, nil
+				},
+				CountLegacyProjectionDrift: func(context.Context, int, int) (int, error) {
+					return 2, nil
+				},
+			},
+			want: "legacy projection drift=2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			err := runPinnedRolloutCheck(context.Background(), &out, tt.cfg, "", tt.deps)
+			if err == nil {
+				t.Fatal("runPinnedRolloutCheck succeeded")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), tt.want)
+			}
+		})
+	}
+}
+
+func pinnedRolloutTestConfig(minBucket, maxBucket int) *config.Config {
+	return &config.Config{
+		PinnedBucketMin:              &minBucket,
+		PinnedBucketMax:              &maxBucket,
+		LegacyStatusProjectionEnable: true,
+	}
+}
+
+func successfulPinnedRolloutDeps() pinnedRolloutCheckDeps {
+	return pinnedRolloutCheckDeps{
+		Hostname: func() string { return "host-a" },
+		HostRowExists: func(context.Context, string) (bool, error) {
+			return false, nil
+		},
+		CountActiveSitesForBucketRange: func(context.Context, int, int) (int, error) {
+			return 1, nil
+		},
+		CountLegacyProjectionDrift: func(context.Context, int, int) (int, error) {
+			return 0, nil
+		},
+	}
+}

--- a/cmd/jetmon2/rollout_test.go
+++ b/cmd/jetmon2/rollout_test.go
@@ -420,6 +420,161 @@ func TestValidateDynamicBucketCoverageFailures(t *testing.T) {
 	}
 }
 
+func TestRunProjectionDriftReportNoDrift(t *testing.T) {
+	cfg := dynamicRolloutTestConfig()
+	deps := projectionDriftDeps{
+		CountLegacyProjectionDrift: func(_ context.Context, min, max int) (int, error) {
+			if min != 0 || max != 9 {
+				t.Fatalf("count range = %d-%d, want 0-9", min, max)
+			}
+			return 0, nil
+		},
+	}
+
+	var out bytes.Buffer
+	if err := runProjectionDriftReport(context.Background(), &out, cfg, -1, -1, 50, deps); err != nil {
+		t.Fatalf("runProjectionDriftReport: %v", err)
+	}
+	for _, want := range []string{
+		"INFO projection_drift_range=0-9",
+		"INFO legacy_projection_drift=0",
+		"PASS legacy_projection_drift=0",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestRunProjectionDriftReportListsRowsAndFails(t *testing.T) {
+	cfg := dynamicRolloutTestConfig()
+	eventID := int64(123)
+	eventState := "Down"
+	deps := projectionDriftDeps{
+		CountLegacyProjectionDrift: func(context.Context, int, int) (int, error) {
+			return 2, nil
+		},
+		ListLegacyProjectionDrift: func(_ context.Context, min, max, limit int) ([]db.ProjectionDriftRow, error) {
+			if min != 2 || max != 4 || limit != 1 {
+				t.Fatalf("list args = %d-%d limit=%d, want 2-4 limit=1", min, max, limit)
+			}
+			return []db.ProjectionDriftRow{
+				{BlogID: 42, BucketNo: 3, SiteStatus: 1, ExpectedStatus: 2, EventID: &eventID, EventState: &eventState},
+			}, nil
+		},
+	}
+
+	var out bytes.Buffer
+	err := runProjectionDriftReport(context.Background(), &out, cfg, 2, 4, 1, deps)
+	if err == nil {
+		t.Fatal("runProjectionDriftReport succeeded")
+	}
+	if !strings.Contains(err.Error(), "legacy projection drift=2") {
+		t.Fatalf("error = %q, want drift count", err.Error())
+	}
+	for _, want := range []string{
+		"BLOG_ID",
+		"42",
+		"Down",
+		"INFO projection_drift_rows_truncated=1",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestResolveProjectionDriftRange(t *testing.T) {
+	minBucket, maxBucket := 2, 4
+	tests := []struct {
+		name    string
+		cfg     *config.Config
+		inMin   int
+		inMax   int
+		wantMin int
+		wantMax int
+		wantErr string
+	}{
+		{
+			name:    "dynamic default",
+			cfg:     dynamicRolloutTestConfig(),
+			inMin:   -1,
+			inMax:   -1,
+			wantMin: 0,
+			wantMax: 9,
+		},
+		{
+			name: "pinned default",
+			cfg: &config.Config{
+				BucketTotal:     10,
+				PinnedBucketMin: &minBucket,
+				PinnedBucketMax: &maxBucket,
+			},
+			inMin:   -1,
+			inMax:   -1,
+			wantMin: 2,
+			wantMax: 4,
+		},
+		{
+			name:    "explicit range",
+			cfg:     dynamicRolloutTestConfig(),
+			inMin:   3,
+			inMax:   5,
+			wantMin: 3,
+			wantMax: 5,
+		},
+		{
+			name:    "one sided range",
+			cfg:     dynamicRolloutTestConfig(),
+			inMin:   3,
+			inMax:   -1,
+			wantErr: "must be set together",
+		},
+		{
+			name:    "negative range",
+			cfg:     dynamicRolloutTestConfig(),
+			inMin:   -2,
+			inMax:   -2,
+			wantErr: "must be >= 0",
+		},
+		{
+			name:    "inverted range",
+			cfg:     dynamicRolloutTestConfig(),
+			inMin:   7,
+			inMax:   3,
+			wantErr: "bucket-max must be >= bucket-min",
+		},
+		{
+			name:    "range outside total",
+			cfg:     dynamicRolloutTestConfig(),
+			inMin:   0,
+			inMax:   10,
+			wantErr: "bucket-max must be < BUCKET_TOTAL",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMin, gotMax, err := resolveProjectionDriftRange(tt.cfg, tt.inMin, tt.inMax)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatal("resolveProjectionDriftRange succeeded")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %q, want substring %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveProjectionDriftRange: %v", err)
+			}
+			if gotMin != tt.wantMin || gotMax != tt.wantMax {
+				t.Fatalf("range = %d-%d, want %d-%d", gotMin, gotMax, tt.wantMin, tt.wantMax)
+			}
+		})
+	}
+}
+
 func dynamicRolloutTestConfig() *config.Config {
 	return &config.Config{
 		BucketTotal:                  10,

--- a/cmd/jetmon2/rollout_test.go
+++ b/cmd/jetmon2/rollout_test.go
@@ -6,8 +6,10 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Automattic/jetmon/internal/config"
+	"github.com/Automattic/jetmon/internal/db"
 )
 
 func TestRunPinnedRolloutCheckSuccess(t *testing.T) {
@@ -205,6 +207,239 @@ func successfulPinnedRolloutDeps() pinnedRolloutCheckDeps {
 		Hostname: func() string { return "host-a" },
 		HostRowExists: func(context.Context, string) (bool, error) {
 			return false, nil
+		},
+		CountActiveSitesForBucketRange: func(context.Context, int, int) (int, error) {
+			return 1, nil
+		},
+		CountLegacyProjectionDrift: func(context.Context, int, int) (int, error) {
+			return 0, nil
+		},
+	}
+}
+
+func TestRunDynamicRolloutCheckSuccess(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	cfg := &config.Config{
+		BucketTotal:                  10,
+		BucketHeartbeatGraceSec:      60,
+		LegacyStatusProjectionEnable: true,
+	}
+
+	var gotMin, gotMax int
+	deps := dynamicRolloutCheckDeps{
+		Now: func() time.Time { return now },
+		GetAllHosts: func() ([]db.HostRow, error) {
+			return []db.HostRow{
+				{HostID: "host-b", BucketMin: 5, BucketMax: 9, LastHeartbeat: now.Add(-10 * time.Second), Status: "active"},
+				{HostID: "host-a", BucketMin: 0, BucketMax: 4, LastHeartbeat: now.Add(-10 * time.Second), Status: "active"},
+			}, nil
+		},
+		CountActiveSitesForBucketRange: func(_ context.Context, min, max int) (int, error) {
+			gotMin, gotMax = min, max
+			return 123, nil
+		},
+		CountLegacyProjectionDrift: func(_ context.Context, min, max int) (int, error) {
+			if min != 0 || max != 9 {
+				t.Fatalf("drift range = %d-%d, want 0-9", min, max)
+			}
+			return 0, nil
+		},
+	}
+
+	var out bytes.Buffer
+	if err := runDynamicRolloutCheck(context.Background(), &out, cfg, deps); err != nil {
+		t.Fatalf("runDynamicRolloutCheck: %v", err)
+	}
+	if gotMin != 0 || gotMax != 9 {
+		t.Fatalf("active site range = %d-%d, want 0-9", gotMin, gotMax)
+	}
+	for _, want := range []string{
+		"PASS bucket_ownership=dynamic",
+		"PASS legacy_status_projection=enabled",
+		"INFO jetmon_hosts_rows=2",
+		"PASS dynamic_bucket_coverage=0-9 hosts=2",
+		"INFO active_sites_dynamic_range=123",
+		"PASS legacy_projection_drift=0",
+		"dynamic rollout check passed",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestRunDynamicRolloutCheckFailures(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	minBucket, maxBucket := 1, 2
+
+	tests := []struct {
+		name string
+		cfg  *config.Config
+		deps dynamicRolloutCheckDeps
+		want string
+	}{
+		{
+			name: "pinned range still configured",
+			cfg: &config.Config{
+				BucketTotal:                  10,
+				BucketHeartbeatGraceSec:      60,
+				LegacyStatusProjectionEnable: true,
+				PinnedBucketMin:              &minBucket,
+				PinnedBucketMax:              &maxBucket,
+			},
+			deps: successfulDynamicRolloutDeps(now),
+			want: "pinned bucket range 1-2 is still configured",
+		},
+		{
+			name: "legacy projection disabled",
+			cfg: &config.Config{
+				BucketTotal:             10,
+				BucketHeartbeatGraceSec: 60,
+			},
+			deps: successfulDynamicRolloutDeps(now),
+			want: "LEGACY_STATUS_PROJECTION_ENABLE must remain true",
+		},
+		{
+			name: "host query error",
+			cfg:  dynamicRolloutTestConfig(),
+			deps: dynamicRolloutCheckDeps{
+				GetAllHosts: func() ([]db.HostRow, error) {
+					return nil, errors.New("db unavailable")
+				},
+			},
+			want: "db unavailable",
+		},
+		{
+			name: "projection drift",
+			cfg:  dynamicRolloutTestConfig(),
+			deps: dynamicRolloutCheckDeps{
+				Now: func() time.Time { return now },
+				GetAllHosts: func() ([]db.HostRow, error) {
+					return dynamicRolloutHosts(now), nil
+				},
+				CountActiveSitesForBucketRange: func(context.Context, int, int) (int, error) {
+					return 10, nil
+				},
+				CountLegacyProjectionDrift: func(context.Context, int, int) (int, error) {
+					return 3, nil
+				},
+			},
+			want: "legacy projection drift=3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			err := runDynamicRolloutCheck(context.Background(), &out, tt.cfg, tt.deps)
+			if err == nil {
+				t.Fatal("runDynamicRolloutCheck succeeded")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateDynamicBucketCoverageFailures(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name  string
+		hosts []db.HostRow
+		want  string
+	}{
+		{
+			name:  "no hosts",
+			hosts: nil,
+			want:  "jetmon_hosts has no rows",
+		},
+		{
+			name: "inactive host",
+			hosts: []db.HostRow{
+				{HostID: "host-a", BucketMin: 0, BucketMax: 9, LastHeartbeat: now, Status: "draining"},
+			},
+			want: "status=\"draining\"",
+		},
+		{
+			name: "stale heartbeat",
+			hosts: []db.HostRow{
+				{HostID: "host-a", BucketMin: 0, BucketMax: 9, LastHeartbeat: now.Add(-2 * time.Minute), Status: "active"},
+			},
+			want: "heartbeat is stale",
+		},
+		{
+			name: "invalid range",
+			hosts: []db.HostRow{
+				{HostID: "host-a", BucketMin: 0, BucketMax: 10, LastHeartbeat: now, Status: "active"},
+			},
+			want: "invalid bucket range",
+		},
+		{
+			name: "leading gap",
+			hosts: []db.HostRow{
+				{HostID: "host-a", BucketMin: 1, BucketMax: 9, LastHeartbeat: now, Status: "active"},
+			},
+			want: "gap 0-0",
+		},
+		{
+			name: "middle gap",
+			hosts: []db.HostRow{
+				{HostID: "host-a", BucketMin: 0, BucketMax: 3, LastHeartbeat: now, Status: "active"},
+				{HostID: "host-b", BucketMin: 5, BucketMax: 9, LastHeartbeat: now, Status: "active"},
+			},
+			want: "gap 4-4",
+		},
+		{
+			name: "overlap",
+			hosts: []db.HostRow{
+				{HostID: "host-a", BucketMin: 0, BucketMax: 5, LastHeartbeat: now, Status: "active"},
+				{HostID: "host-b", BucketMin: 5, BucketMax: 9, LastHeartbeat: now, Status: "active"},
+			},
+			want: "overlaps",
+		},
+		{
+			name: "trailing gap",
+			hosts: []db.HostRow{
+				{HostID: "host-a", BucketMin: 0, BucketMax: 8, LastHeartbeat: now, Status: "active"},
+			},
+			want: "trailing gap 9-9",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateDynamicBucketCoverage(tt.hosts, 10, time.Minute, now)
+			if err == nil {
+				t.Fatal("validateDynamicBucketCoverage succeeded")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), tt.want)
+			}
+		})
+	}
+}
+
+func dynamicRolloutTestConfig() *config.Config {
+	return &config.Config{
+		BucketTotal:                  10,
+		BucketHeartbeatGraceSec:      60,
+		LegacyStatusProjectionEnable: true,
+	}
+}
+
+func dynamicRolloutHosts(now time.Time) []db.HostRow {
+	return []db.HostRow{
+		{HostID: "host-a", BucketMin: 0, BucketMax: 4, LastHeartbeat: now, Status: "active"},
+		{HostID: "host-b", BucketMin: 5, BucketMax: 9, LastHeartbeat: now, Status: "active"},
+	}
+}
+
+func successfulDynamicRolloutDeps(now time.Time) dynamicRolloutCheckDeps {
+	return dynamicRolloutCheckDeps{
+		Now: func() time.Time { return now },
+		GetAllHosts: func() ([]db.HostRow, error) {
+			return dynamicRolloutHosts(now), nil
 		},
 		CountActiveSitesForBucketRange: func(context.Context, int, int) (int, error) {
 			return 1, nil

--- a/config/config.readme
+++ b/config/config.readme
@@ -25,6 +25,12 @@ Number of buckets this host should claim on startup. Used for initial distributi
 BUCKET_HEARTBEAT_GRACE_SEC
 Seconds after a host's last heartbeat before its buckets are considered available for reclaiming by another host. Default: 600.
 
+PINNED_BUCKET_MIN / PINNED_BUCKET_MAX
+Migration-only static bucket range for replacing one v1 host with one v2 host during the initial v1-to-v2 rollout. When both are set, jetmon2 checks only that inclusive bucket range and does not claim, heartbeat, or release rows in jetmon_hosts. Disable after the whole fleet is on v2 so dynamic bucket ownership can take over. Must satisfy 0 <= min <= max < BUCKET_TOTAL. Default: unset.
+
+BUCKET_NO_MIN / BUCKET_NO_MAX
+Deprecated v1 names accepted as aliases for PINNED_BUCKET_MIN / PINNED_BUCKET_MAX. They must be set together and must match PINNED_BUCKET_* if both forms are present.
+
 BATCH_SIZE
 Number of buckets fetched per database query when loading sites. Default: 32.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,4 +20,5 @@ accepted architecture decisions.
 | [`jetmon-deliverer-rollout.md`](jetmon-deliverer-rollout.md) | Operational rollout policy for moving outbound dispatch from embedded `jetmon2` workers to standalone `jetmon-deliverer`. |
 | [`outbound-credential-encryption-plan.md`](outbound-credential-encryption-plan.md) | Migration plan for encrypting webhook secrets and alert-contact destination credentials after the current plaintext v2 model. |
 | [`public-api-gateway-tenant-contract.md`](public-api-gateway-tenant-contract.md) | Gateway boundary contract, implemented Jetmon-side tenant ownership checks, and remaining public-exposure prerequisites. |
+| [`v1-to-v2-pinned-rollout.md`](v1-to-v2-pinned-rollout.md) | Initial production migration plan for replacing v1 static-bucket hosts with v2 hosts pinned to the same ranges before enabling dynamic ownership. |
 | [`v3-probe-agent-architecture-options.md`](v3-probe-agent-architecture-options.md) | Post-v2 architecture options for evolving from main servers plus Verifliers toward a probe-agent architecture. |

--- a/docs/v1-to-v2-pinned-rollout.md
+++ b/docs/v1-to-v2-pinned-rollout.md
@@ -56,7 +56,9 @@ While pinned:
    `jetpack_monitor_sites.site_status` and `last_status_change`.
 5. Keep `API_PORT=0` on monitor hosts during initial replacement unless the API
    and delivery owner plan has been explicitly approved.
-6. Verify Veriflier endpoints, WPCOM auth, StatsD, log paths, and config reload
+6. Run `./jetmon2 validate-config` with the prepared v2 config and confirm it
+   prints the pinned rollout preflight command plus the projection-drift command.
+7. Verify Veriflier endpoints, WPCOM auth, StatsD, log paths, and config reload
    behavior in staging.
 
 ## Per-Host Cutover
@@ -65,10 +67,13 @@ For each v1 host:
 
 1. Record the host name and v1 bucket range.
 2. Prepare the v2 config with the same pinned range.
-3. Stop the v1 process for that host.
-4. Start the v2 process.
-5. Run `./jetmon2 validate-config` and confirm it reports
-   `bucket_ownership=pinned range=<min>-<max>`.
+3. Before stopping v1, run `./jetmon2 validate-config` and confirm it reports:
+   - `legacy_status_projection=enabled`
+   - `bucket_ownership=pinned range=<min>-<max>`
+   - `rollout_preflight=./jetmon2 rollout pinned-check`
+   - `rollout_drift_report=./jetmon2 rollout projection-drift`
+4. Stop the v1 process for that host.
+5. Start the v2 process.
 6. Run the pinned rollout preflight:
 
    ```bash
@@ -96,8 +101,16 @@ For each v1 host:
    - `legacy_status_projection=enabled`
    - `bucket_ownership=pinned range=<min>-<max>`
    - `orchestrator: using pinned buckets <min>-<max>`
-8. Watch one full check round for that bucket range.
-9. Confirm:
+8. If `DASHBOARD_PORT` is enabled, open the operator dashboard and confirm:
+   - rollout ownership shows the pinned range
+   - legacy projection is enabled
+   - delivery workers are disabled unless the delivery owner plan explicitly
+     enables them on this host
+   - dependency health is green for MySQL, configured Verifliers, log/stats
+     directory writes, and StatsD initialization; WPCOM must not show an open
+     circuit
+9. Watch one full check round for that bucket range.
+10. Confirm:
    - checks are running only for the pinned range
    - Veriflier confirmation works
    - WPCOM notifications retain the v1 payload shape
@@ -129,7 +142,9 @@ After every monitor host is on v2 and stable in pinned mode:
 3. Remove `PINNED_BUCKET_MIN` / `PINNED_BUCKET_MAX` (and any legacy
    `BUCKET_NO_MIN` / `BUCKET_NO_MAX` aliases) from the v2 monitor configs.
 4. Restart the v2 monitor hosts in the approved deployment window.
-5. Run the dynamic ownership preflight:
+5. Run `./jetmon2 validate-config` and confirm it reports
+   `rollout_preflight=./jetmon2 rollout dynamic-check`.
+6. Run the dynamic ownership preflight:
 
    ```bash
    ./jetmon2 rollout dynamic-check
@@ -145,7 +160,7 @@ After every monitor host is on v2 and stable in pinned mode:
    ./jetmon2 rollout projection-drift --limit=100
    ```
 
-6. Continue using the normal v2 rolling-update process from `README.md`.
+7. Continue using the normal v2 rolling-update process from `README.md`.
 
 Do not run a mixed configuration where some v1 hosts still own static ranges
 while unpinned v2 hosts use dynamic `jetmon_hosts` ownership. Also avoid a

--- a/docs/v1-to-v2-pinned-rollout.md
+++ b/docs/v1-to-v2-pinned-rollout.md
@@ -115,12 +115,27 @@ not require schema rollback.
 
 After every monitor host is on v2 and stable in pinned mode:
 
-1. Pick one host and remove `PINNED_BUCKET_MIN` / `PINNED_BUCKET_MAX`.
-2. Restart it and verify it claims a `jetmon_hosts` row.
-3. Repeat host by host until all monitor hosts use dynamic ownership.
-4. Verify `jetmon_hosts` covers the full bucket range with current heartbeats.
-5. Continue using the normal v2 rolling-update process from `README.md`.
+1. Confirm no v1 monitor hosts remain active.
+2. Plan a coordinated dynamic-ownership cutover. Pinned hosts do not write
+   `jetmon_hosts`, so avoid leaving a long-lived mixed fleet where some v2
+   hosts are pinned and others use dynamic ownership.
+3. Remove `PINNED_BUCKET_MIN` / `PINNED_BUCKET_MAX` (and any legacy
+   `BUCKET_NO_MIN` / `BUCKET_NO_MAX` aliases) from the v2 monitor configs.
+4. Restart the v2 monitor hosts in the approved deployment window.
+5. Run the dynamic ownership preflight:
+
+   ```bash
+   ./jetmon2 rollout dynamic-check
+   ```
+
+   This check fails if pinned mode is still configured, legacy projection writes
+   are disabled, `jetmon_hosts` rows are missing, stale, inactive, overlapping,
+   or gapped, or the legacy projection has drifted.
+
+6. Continue using the normal v2 rolling-update process from `README.md`.
 
 Do not run a mixed configuration where some v1 hosts still own static ranges
-while unpinned v2 hosts use dynamic `jetmon_hosts` ownership. That is the state
-this migration mode is designed to avoid.
+while unpinned v2 hosts use dynamic `jetmon_hosts` ownership. Also avoid a
+long-lived pinned-v2/dynamic-v2 mix: dynamic hosts cannot see pinned hosts in
+`jetmon_hosts`, so the fleet can overlap checks even though it should not create
+coverage gaps.

--- a/docs/v1-to-v2-pinned-rollout.md
+++ b/docs/v1-to-v2-pinned-rollout.md
@@ -78,8 +78,15 @@ For each v1 host:
    This check fails if the host is not in pinned mode, legacy projection writes
    are disabled, the current host still has a `jetmon_hosts` ownership row, or
    the active sites in the pinned range have projection drift. It also prints the
-   active site count for the range. If checking a config before running on the
-   final hostname, pass the expected host id explicitly:
+   active site count for the range. If projection drift is reported, list the
+   mismatched rows before continuing:
+
+   ```bash
+   ./jetmon2 rollout projection-drift
+   ```
+
+   If checking a config before running on the final hostname, pass the expected
+   host id explicitly:
 
    ```bash
    ./jetmon2 rollout pinned-check --host=<v2-hostname>
@@ -131,6 +138,12 @@ After every monitor host is on v2 and stable in pinned mode:
    This check fails if pinned mode is still configured, legacy projection writes
    are disabled, `jetmon_hosts` rows are missing, stale, inactive, overlapping,
    or gapped, or the legacy projection has drifted.
+
+   To inspect projection drift details across the dynamic range:
+
+   ```bash
+   ./jetmon2 rollout projection-drift --limit=100
+   ```
 
 6. Continue using the normal v2 rolling-update process from `README.md`.
 

--- a/docs/v1-to-v2-pinned-rollout.md
+++ b/docs/v1-to-v2-pinned-rollout.md
@@ -1,0 +1,110 @@
+# v1 to v2 Pinned Bucket Rollout
+
+**Status:** Production migration runbook for the first v1-to-v2 cutover.
+
+This rollout replaces one v1 static-bucket host with one v2 host pinned to the
+same inclusive bucket range. It avoids mixed ownership between v1 static config
+and v2 `jetmon_hosts` dynamic ownership during the riskiest part of the
+migration.
+
+## Why Pinned Mode Exists
+
+v1 and v2 do not share a bucket ownership protocol:
+
+- v1 uses static `BUCKET_NO_MIN` / `BUCKET_NO_MAX` config per host.
+- v2 normally uses the `jetmon_hosts` table with heartbeat and reclaim.
+
+During a mixed fleet rollout, dynamic v2 ownership cannot know which buckets are
+still covered by v1. Pinned mode keeps each replacement host on the exact range
+its v1 predecessor owned and disables `jetmon_hosts` ownership for that v2 host.
+
+## Configuration
+
+Prefer explicit pinned keys in v2 config:
+
+```json
+{
+  "PINNED_BUCKET_MIN": 0,
+  "PINNED_BUCKET_MAX": 99,
+  "LEGACY_STATUS_PROJECTION_ENABLE": true,
+  "API_PORT": 0
+}
+```
+
+The legacy v1 names `BUCKET_NO_MIN` and `BUCKET_NO_MAX` are accepted as aliases
+for pinned mode. If both forms are present, they must describe the same range.
+
+While pinned:
+
+- the host checks only `PINNED_BUCKET_MIN <= bucket_no <= PINNED_BUCKET_MAX`
+- the host does not claim or heartbeat `jetmon_hosts`
+- shutdown does not release a `jetmon_hosts` row
+- `BUCKET_TOTAL`, `BUCKET_TARGET`, and `BUCKET_HEARTBEAT_GRACE_SEC` still
+  validate, but dynamic ownership does not use them on that host
+
+## Preflight
+
+1. Confirm the v1 fleet's static bucket ranges are complete and non-overlapping.
+2. Build all v2 binaries and run `make test`, `make test-race`, and `make all`.
+3. Apply additive migrations before the cutover:
+
+   ```bash
+   ./jetmon2 migrate
+   ```
+
+4. Keep `LEGACY_STATUS_PROJECTION_ENABLE=true` so legacy readers continue to see
+   `jetpack_monitor_sites.site_status` and `last_status_change`.
+5. Keep `API_PORT=0` on monitor hosts during initial replacement unless the API
+   and delivery owner plan has been explicitly approved.
+6. Verify Veriflier endpoints, WPCOM auth, StatsD, log paths, and config reload
+   behavior in staging.
+
+## Per-Host Cutover
+
+For each v1 host:
+
+1. Record the host name and v1 bucket range.
+2. Prepare the v2 config with the same pinned range.
+3. Stop the v1 process for that host.
+4. Start the v2 process.
+5. Run `./jetmon2 validate-config` and confirm it reports
+   `bucket_ownership=pinned range=<min>-<max>`.
+6. Verify the process logs:
+   - `legacy_status_projection=enabled`
+   - `bucket_ownership=pinned range=<min>-<max>`
+   - `orchestrator: using pinned buckets <min>-<max>`
+7. Watch one full check round for that bucket range.
+8. Confirm:
+   - checks are running only for the pinned range
+   - Veriflier confirmation works
+   - WPCOM notifications retain the v1 payload shape
+   - `jetmon_events` and `jetmon_event_transitions` receive event mutations
+   - `jetpack_monitor_sites.site_status` projection updates when enabled
+   - no unexpected rows are claimed in `jetmon_hosts` by the pinned host
+
+## Rollback
+
+Rollback is host-local:
+
+1. Stop the v2 process.
+2. Restart the original v1 process with the same `BUCKET_NO_MIN` /
+   `BUCKET_NO_MAX` config.
+3. Verify v1 checks the range again.
+
+The v2 migrations are additive, and legacy projection writes keep the old status
+fields meaningful while `LEGACY_STATUS_PROJECTION_ENABLE=true`, so rollback does
+not require schema rollback.
+
+## Transition to Dynamic v2 Ownership
+
+After every monitor host is on v2 and stable in pinned mode:
+
+1. Pick one host and remove `PINNED_BUCKET_MIN` / `PINNED_BUCKET_MAX`.
+2. Restart it and verify it claims a `jetmon_hosts` row.
+3. Repeat host by host until all monitor hosts use dynamic ownership.
+4. Verify `jetmon_hosts` covers the full bucket range with current heartbeats.
+5. Continue using the normal v2 rolling-update process from `README.md`.
+
+Do not run a mixed configuration where some v1 hosts still own static ranges
+while unpinned v2 hosts use dynamic `jetmon_hosts` ownership. That is the state
+this migration mode is designed to avoid.

--- a/docs/v1-to-v2-pinned-rollout.md
+++ b/docs/v1-to-v2-pinned-rollout.md
@@ -69,12 +69,28 @@ For each v1 host:
 4. Start the v2 process.
 5. Run `./jetmon2 validate-config` and confirm it reports
    `bucket_ownership=pinned range=<min>-<max>`.
-6. Verify the process logs:
+6. Run the pinned rollout preflight:
+
+   ```bash
+   ./jetmon2 rollout pinned-check
+   ```
+
+   This check fails if the host is not in pinned mode, legacy projection writes
+   are disabled, the current host still has a `jetmon_hosts` ownership row, or
+   the active sites in the pinned range have projection drift. It also prints the
+   active site count for the range. If checking a config before running on the
+   final hostname, pass the expected host id explicitly:
+
+   ```bash
+   ./jetmon2 rollout pinned-check --host=<v2-hostname>
+   ```
+
+7. Verify the process logs:
    - `legacy_status_projection=enabled`
    - `bucket_ownership=pinned range=<min>-<max>`
    - `orchestrator: using pinned buckets <min>-<max>`
-7. Watch one full check round for that bucket range.
-8. Confirm:
+8. Watch one full check round for that bucket range.
+9. Confirm:
    - checks are running only for the pinned range
    - Veriflier confirmation works
    - WPCOM notifications retain the v1 payload shape

--- a/docs/v3-probe-agent-architecture-options.md
+++ b/docs/v3-probe-agent-architecture-options.md
@@ -53,6 +53,14 @@ The v3 decision should be based on production data from v2, especially:
 Without this data, v3 risks optimizing for hypothetical problems instead of
 the production failure modes that actually matter.
 
+The v2 monitor emits the first production evidence slice through StatsD:
+`detection.*` timing metrics cover the local-failure to lifecycle-state path,
+class-specific `detection.*.<failure-class>.count` counters split confirmed,
+false-alarm, and probe-cleared outcomes, and `verifier.host.<host>.*` counters
+split RPC health and confirm/disagree votes by configured Veriflier host. Use
+the host naming convention to preserve region/provider information in those
+series.
+
 ## Current v2 Baseline
 
 The v2 flow is:

--- a/docs/v3-probe-agent-architecture-options.md
+++ b/docs/v3-probe-agent-architecture-options.md
@@ -59,7 +59,10 @@ class-specific `detection.*.<failure-class>.count` counters split confirmed,
 false-alarm, and probe-cleared outcomes, and `verifier.host.<host>.*` counters
 split RPC health and confirm/disagree votes by configured Veriflier host. Use
 the host naming convention to preserve region/provider information in those
-series.
+series. Legacy WPCOM notification parity is tracked through
+`wpcom.notification.*` counters for attempts, deliveries, retries, errors, and
+final failures, with status-specific splits for `down`, `running`, and
+`confirmed_down`.
 
 ## Current v2 Baseline
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,18 @@ type Config struct {
 	BucketTarget            int `json:"BUCKET_TARGET"`
 	BucketHeartbeatGraceSec int `json:"BUCKET_HEARTBEAT_GRACE_SEC"`
 
+	// PinnedBucketMin/Max let a v2 host temporarily use the exact static bucket
+	// range of the v1 host it replaces during host-by-host migration. While set,
+	// the orchestrator does not participate in jetmon_hosts dynamic ownership.
+	PinnedBucketMin *int `json:"PINNED_BUCKET_MIN"`
+	PinnedBucketMax *int `json:"PINNED_BUCKET_MAX"`
+
+	// BucketNoMin/Max are the legacy v1 config names. They are accepted as
+	// aliases for the pinned migration mode so operators can copy a v1 host's
+	// bucket range directly into v2 config during cutover.
+	BucketNoMin *int `json:"BUCKET_NO_MIN"`
+	BucketNoMax *int `json:"BUCKET_NO_MAX"`
+
 	BatchSize int    `json:"BATCH_SIZE"`
 	AuthToken string `json:"AUTH_TOKEN"`
 
@@ -231,6 +243,22 @@ func LegacyStatusProjectionEnabled() bool {
 	return cfg.LegacyStatusProjectionEnable
 }
 
+// PinnedBucketRange returns the migration-only static bucket range configured
+// on this host. Explicit PINNED_BUCKET_* keys take precedence over legacy
+// BUCKET_NO_* aliases after validation has checked for conflicts.
+func (cfg *Config) PinnedBucketRange() (int, int, bool) {
+	if cfg == nil {
+		return 0, 0, false
+	}
+	if cfg.PinnedBucketMin != nil && cfg.PinnedBucketMax != nil {
+		return *cfg.PinnedBucketMin, *cfg.PinnedBucketMax, true
+	}
+	if cfg.BucketNoMin != nil && cfg.BucketNoMax != nil {
+		return *cfg.BucketNoMin, *cfg.BucketNoMax, true
+	}
+	return 0, 0, false
+}
+
 func validate(cfg *Config) error {
 	if cfg.AuthToken == "" {
 		return fmt.Errorf("AUTH_TOKEN is required")
@@ -243,6 +271,9 @@ func validate(cfg *Config) error {
 	}
 	if cfg.BucketTarget <= 0 || cfg.BucketTarget > cfg.BucketTotal {
 		return fmt.Errorf("BUCKET_TARGET must be between 1 and BUCKET_TOTAL")
+	}
+	if err := validatePinnedBucketRange(cfg); err != nil {
+		return err
 	}
 	if cfg.NetCommsTimeout <= 0 {
 		return fmt.Errorf("NET_COMMS_TIMEOUT must be > 0")
@@ -278,6 +309,37 @@ func validate(cfg *Config) error {
 		if v.TransportPort() == "" {
 			return fmt.Errorf("VERIFIERS[%d] (%s): port is required", i, displayName(v, i))
 		}
+	}
+	return nil
+}
+
+func validatePinnedBucketRange(cfg *Config) error {
+	hasPinned := cfg.PinnedBucketMin != nil || cfg.PinnedBucketMax != nil
+	hasLegacy := cfg.BucketNoMin != nil || cfg.BucketNoMax != nil
+
+	if hasPinned && (cfg.PinnedBucketMin == nil || cfg.PinnedBucketMax == nil) {
+		return fmt.Errorf("PINNED_BUCKET_MIN and PINNED_BUCKET_MAX must be set together")
+	}
+	if hasLegacy && (cfg.BucketNoMin == nil || cfg.BucketNoMax == nil) {
+		return fmt.Errorf("BUCKET_NO_MIN and BUCKET_NO_MAX must be set together")
+	}
+	if hasPinned && hasLegacy &&
+		(*cfg.PinnedBucketMin != *cfg.BucketNoMin || *cfg.PinnedBucketMax != *cfg.BucketNoMax) {
+		return fmt.Errorf("PINNED_BUCKET_* conflicts with legacy BUCKET_NO_* range")
+	}
+
+	min, max, ok := cfg.PinnedBucketRange()
+	if !ok {
+		return nil
+	}
+	if min < 0 {
+		return fmt.Errorf("pinned bucket min must be >= 0")
+	}
+	if max < min {
+		return fmt.Errorf("pinned bucket max must be >= min")
+	}
+	if max >= cfg.BucketTotal {
+		return fmt.Errorf("pinned bucket max must be < BUCKET_TOTAL")
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -66,6 +66,68 @@ func TestValidate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "pinned bucket range is valid",
+			mutate: func(c *Config) {
+				min, max := 10, 19
+				c.PinnedBucketMin = &min
+				c.PinnedBucketMax = &max
+			},
+		},
+		{
+			name: "legacy bucket range alias is valid",
+			mutate: func(c *Config) {
+				min, max := 10, 19
+				c.BucketNoMin = &min
+				c.BucketNoMax = &max
+			},
+		},
+		{
+			name: "pinned bucket range requires min and max",
+			mutate: func(c *Config) {
+				min := 10
+				c.PinnedBucketMin = &min
+			},
+			wantErr: true,
+		},
+		{
+			name: "legacy bucket range requires min and max",
+			mutate: func(c *Config) {
+				max := 19
+				c.BucketNoMax = &max
+			},
+			wantErr: true,
+		},
+		{
+			name: "pinned bucket range rejects max before min",
+			mutate: func(c *Config) {
+				min, max := 20, 19
+				c.PinnedBucketMin = &min
+				c.PinnedBucketMax = &max
+			},
+			wantErr: true,
+		},
+		{
+			name: "pinned bucket range rejects max outside total",
+			mutate: func(c *Config) {
+				min, max := 90, 100
+				c.PinnedBucketMin = &min
+				c.PinnedBucketMax = &max
+			},
+			wantErr: true,
+		},
+		{
+			name: "pinned and legacy ranges must agree",
+			mutate: func(c *Config) {
+				pMin, pMax := 10, 19
+				lMin, lMax := 20, 29
+				c.PinnedBucketMin = &pMin
+				c.PinnedBucketMax = &pMax
+				c.BucketNoMin = &lMin
+				c.BucketNoMax = &lMax
+			},
+			wantErr: true,
+		},
+		{
 			name:    "net comms timeout zero",
 			mutate:  func(c *Config) { c.NetCommsTimeout = 0 },
 			wantErr: true,
@@ -146,6 +208,28 @@ func TestValidate(t *testing.T) {
 				t.Fatalf("validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestPinnedBucketRange(t *testing.T) {
+	pMin, pMax := 10, 19
+	lMin, lMax := 20, 29
+	cfg := &Config{
+		PinnedBucketMin: &pMin,
+		PinnedBucketMax: &pMax,
+		BucketNoMin:     &lMin,
+		BucketNoMax:     &lMax,
+	}
+	min, max, ok := cfg.PinnedBucketRange()
+	if !ok || min != 10 || max != 19 {
+		t.Fatalf("PinnedBucketRange explicit = %d-%d ok=%v, want 10-19 true", min, max, ok)
+	}
+
+	cfg.PinnedBucketMin = nil
+	cfg.PinnedBucketMax = nil
+	min, max, ok = cfg.PinnedBucketRange()
+	if !ok || min != 20 || max != 29 {
+		t.Fatalf("PinnedBucketRange legacy = %d-%d ok=%v, want 20-29 true", min, max, ok)
 	}
 }
 

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -13,19 +13,25 @@ import (
 
 // State holds the real-time metrics snapshot served by the dashboard.
 type State struct {
-	WorkerCount      int       `json:"worker_count"`
-	ActiveChecks     int       `json:"active_checks"`
-	QueueDepth       int       `json:"queue_depth"`
-	RetryQueueSize   int       `json:"retry_queue_size"`
-	SitesPerSec      int       `json:"sites_per_sec"`
-	RoundDurationMs  int64     `json:"round_duration_ms"`
-	WPCOMCircuitOpen bool      `json:"wpcom_circuit_open"`
-	WPCOMQueueDepth  int       `json:"wpcom_queue_depth"`
-	MemRSSMB         int       `json:"mem_rss_mb"`
-	BucketMin        int       `json:"bucket_min"`
-	BucketMax        int       `json:"bucket_max"`
-	Hostname         string    `json:"hostname"`
-	UpdatedAt        time.Time `json:"updated_at"`
+	WorkerCount                   int       `json:"worker_count"`
+	ActiveChecks                  int       `json:"active_checks"`
+	QueueDepth                    int       `json:"queue_depth"`
+	RetryQueueSize                int       `json:"retry_queue_size"`
+	SitesPerSec                   int       `json:"sites_per_sec"`
+	RoundDurationMs               int64     `json:"round_duration_ms"`
+	WPCOMCircuitOpen              bool      `json:"wpcom_circuit_open"`
+	WPCOMQueueDepth               int       `json:"wpcom_queue_depth"`
+	MemRSSMB                      int       `json:"mem_rss_mb"`
+	BucketMin                     int       `json:"bucket_min"`
+	BucketMax                     int       `json:"bucket_max"`
+	BucketOwnership               string    `json:"bucket_ownership"`
+	LegacyStatusProjectionEnabled bool      `json:"legacy_status_projection_enabled"`
+	DeliveryWorkersEnabled        bool      `json:"delivery_workers_enabled"`
+	DeliveryOwnerHost             string    `json:"delivery_owner_host"`
+	RolloutPreflightCommand       string    `json:"rollout_preflight_command"`
+	ProjectionDriftCommand        string    `json:"projection_drift_command"`
+	Hostname                      string    `json:"hostname"`
+	UpdatedAt                     time.Time `json:"updated_at"`
 }
 
 // HealthEntry represents one external dependency's status.
@@ -71,7 +77,7 @@ func (s *Server) Update(st State) {
 	s.broadcast(st)
 }
 
-// UpdateHealth replaces the health entries and pushes an SSE event.
+// UpdateHealth replaces the health entries served by /api/health.
 func (s *Server) UpdateHealth(entries []HealthEntry) {
 	s.mu.Lock()
 	s.health = entries
@@ -193,6 +199,7 @@ const dashboardHTML = `<!DOCTYPE html>
   .card { background: #2a2a2a; padding: 1rem; border-radius: 4px; }
   .card .label { font-size: 0.75rem; color: #888; }
   .card .value { font-size: 1.5rem; color: #7ec8e3; margin-top: 0.25rem; }
+  .card .value.command { font-size: 0.85rem; line-height: 1.35; overflow-wrap: anywhere; }
   .health-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 0.5rem; margin-top: 1rem; }
   .health-item { padding: 0.5rem 1rem; border-radius: 4px; font-size: 0.85rem; }
   .green  { background: #1a3a1a; border-left: 4px solid #4caf50; }
@@ -221,11 +228,22 @@ const dashboardHTML = `<!DOCTYPE html>
   <div class="card"><div class="label">RSS</div><div class="value" id="rss">—</div></div>
 </div>
 
+<h2>ROLLOUT</h2>
+<div class="grid">
+  <div class="card"><div class="label">OWNERSHIP</div><div class="value" id="ownership">—</div></div>
+  <div class="card"><div class="label">LEGACY PROJECTION</div><div class="value" id="projection">—</div></div>
+  <div class="card"><div class="label">DELIVERY WORKERS</div><div class="value" id="delivery">—</div></div>
+  <div class="card"><div class="label">DELIVERY OWNER</div><div class="value" id="delivery-owner">—</div></div>
+  <div class="card"><div class="label">PREFLIGHT</div><div class="value command" id="preflight">—</div></div>
+  <div class="card"><div class="label">DRIFT REPORT</div><div class="value command" id="drift">—</div></div>
+</div>
+
 <h2>EXTERNAL DEPENDENCIES</h2>
 <div class="grid">
   <div class="card"><div class="label">WPCOM CIRCUIT</div><div class="value" id="wpcom">—</div></div>
   <div class="card"><div class="label">WPCOM QUEUE</div><div class="value" id="wpcomq">—</div></div>
 </div>
+<div class="health-grid" id="health"></div>
 
 <div id="updated"></div>
 
@@ -242,10 +260,42 @@ src.onmessage = function(e) {
   document.getElementById('round').textContent   = (d.round_duration_ms / 1000).toFixed(1) + 's';
   document.getElementById('buckets').textContent = d.bucket_min + '–' + d.bucket_max;
   document.getElementById('rss').textContent     = d.mem_rss_mb + 'MB';
+  document.getElementById('ownership').textContent = d.bucket_ownership || '—';
+  document.getElementById('projection').textContent = d.legacy_status_projection_enabled ? 'enabled' : 'disabled';
+  document.getElementById('delivery').textContent = d.delivery_workers_enabled ? 'enabled' : 'disabled';
+  document.getElementById('delivery-owner').textContent = d.delivery_owner_host || 'unset';
+  document.getElementById('preflight').textContent = d.rollout_preflight_command || '—';
+  document.getElementById('drift').textContent = d.projection_drift_command || '—';
   document.getElementById('wpcom').textContent   = d.wpcom_circuit_open ? 'OPEN' : 'closed';
   document.getElementById('wpcomq').textContent  = d.wpcom_queue_depth;
   document.getElementById('updated').textContent = 'Updated: ' + new Date(d.updated_at).toLocaleTimeString();
 };
+
+async function refreshHealth() {
+  try {
+    const res = await fetch('/api/health', { cache: 'no-store' });
+    const entries = await res.json();
+    const box = document.getElementById('health');
+    box.textContent = '';
+    entries.forEach(function(entry) {
+      const item = document.createElement('div');
+      item.className = 'health-item ' + (entry.status || 'amber');
+      const latency = entry.latency_ms ? ' ' + entry.latency_ms + 'ms' : '';
+      const detail = entry.last_error ? ' — ' + entry.last_error : '';
+      item.textContent = entry.name + ': ' + entry.status + latency + detail;
+      box.appendChild(item);
+    });
+  } catch (err) {
+    const box = document.getElementById('health');
+    box.textContent = '';
+    const item = document.createElement('div');
+    item.className = 'health-item red';
+    item.textContent = 'dashboard health: red — ' + err;
+    box.appendChild(item);
+  }
+}
+refreshHealth();
+setInterval(refreshHealth, 10000);
 </script>
 </body>
 </html>`

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -12,7 +12,16 @@ import (
 
 func TestHandleState(t *testing.T) {
 	srv := New("test-host")
-	srv.Update(State{WorkerCount: 5, QueueDepth: 3})
+	srv.Update(State{
+		WorkerCount:                   5,
+		QueueDepth:                    3,
+		BucketOwnership:               "pinned range=0-99",
+		LegacyStatusProjectionEnabled: true,
+		DeliveryWorkersEnabled:        true,
+		DeliveryOwnerHost:             "api-1",
+		RolloutPreflightCommand:       "./jetmon2 rollout pinned-check",
+		ProjectionDriftCommand:        "./jetmon2 rollout projection-drift",
+	})
 
 	r := httptest.NewRequest(http.MethodGet, "/api/state", nil)
 	w := httptest.NewRecorder()
@@ -30,6 +39,24 @@ func TestHandleState(t *testing.T) {
 	}
 	if st.Hostname != "test-host" {
 		t.Fatalf("Hostname = %q, want test-host", st.Hostname)
+	}
+	if st.BucketOwnership != "pinned range=0-99" {
+		t.Fatalf("BucketOwnership = %q, want pinned range=0-99", st.BucketOwnership)
+	}
+	if !st.LegacyStatusProjectionEnabled {
+		t.Fatal("LegacyStatusProjectionEnabled = false, want true")
+	}
+	if !st.DeliveryWorkersEnabled {
+		t.Fatal("DeliveryWorkersEnabled = false, want true")
+	}
+	if st.DeliveryOwnerHost != "api-1" {
+		t.Fatalf("DeliveryOwnerHost = %q, want api-1", st.DeliveryOwnerHost)
+	}
+	if st.RolloutPreflightCommand != "./jetmon2 rollout pinned-check" {
+		t.Fatalf("RolloutPreflightCommand = %q", st.RolloutPreflightCommand)
+	}
+	if st.ProjectionDriftCommand != "./jetmon2 rollout projection-drift" {
+		t.Fatalf("ProjectionDriftCommand = %q", st.ProjectionDriftCommand)
 	}
 }
 
@@ -73,6 +100,15 @@ func TestHandleIndex(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "Jetmon") {
 		t.Fatal("body does not contain expected HTML content")
+	}
+	if !strings.Contains(w.Body.String(), "id=\"preflight\"") {
+		t.Fatal("body does not contain rollout preflight card")
+	}
+	if !strings.Contains(w.Body.String(), "id=\"delivery-owner\"") {
+		t.Fatal("body does not contain delivery owner card")
+	}
+	if !strings.Contains(w.Body.String(), "id=\"health\"") {
+		t.Fatal("body does not contain dependency health grid")
 	}
 }
 

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -125,6 +125,83 @@ func CountLegacyProjectionDrift(ctx context.Context, bucketMin, bucketMax int) (
 	return count, nil
 }
 
+// ProjectionDriftRow identifies one active site whose legacy site_status
+// projection disagrees with the authoritative open HTTP event, if any.
+type ProjectionDriftRow struct {
+	BlogID         int64
+	BucketNo       int
+	SiteStatus     int
+	ExpectedStatus int
+	EventID        *int64
+	EventState     *string
+}
+
+// ListLegacyProjectionDrift returns active sites in the bucket range whose v1
+// site_status projection disagrees with the authoritative open HTTP event.
+func ListLegacyProjectionDrift(ctx context.Context, bucketMin, bucketMax, limit int) ([]ProjectionDriftRow, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	rows, err := db.QueryContext(ctx, `
+		SELECT s.blog_id,
+		       s.bucket_no,
+		       s.site_status,
+		       CASE
+		         WHEN e.state = 'Down' THEN 2
+		         WHEN e.state = 'Seems Down' THEN 0
+		         ELSE 1
+		       END AS expected_status,
+		       e.id,
+		       e.state
+		  FROM jetpack_monitor_sites s
+		  LEFT JOIN jetmon_events e
+		    ON e.blog_id = s.blog_id
+		   AND e.check_type = 'http'
+		   AND e.ended_at IS NULL
+		 WHERE s.monitor_active = 1
+		   AND s.bucket_no BETWEEN ? AND ?
+		   AND s.site_status <> CASE
+		     WHEN e.state = 'Down' THEN 2
+		     WHEN e.state = 'Seems Down' THEN 0
+		     ELSE 1
+		   END
+		 ORDER BY s.bucket_no ASC, s.blog_id ASC
+		 LIMIT ?`,
+		bucketMin, bucketMax, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list projection drift: %w", err)
+	}
+	defer rows.Close()
+
+	var out []ProjectionDriftRow
+	for rows.Next() {
+		var row ProjectionDriftRow
+		var eventID sql.NullInt64
+		var eventState sql.NullString
+		if err := rows.Scan(
+			&row.BlogID,
+			&row.BucketNo,
+			&row.SiteStatus,
+			&row.ExpectedStatus,
+			&eventID,
+			&eventState,
+		); err != nil {
+			return nil, fmt.Errorf("scan projection drift: %w", err)
+		}
+		if eventID.Valid {
+			v := eventID.Int64
+			row.EventID = &v
+		}
+		if eventState.Valid {
+			v := eventState.String
+			row.EventState = &v
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
 // MarkSiteChecked records when a site was last checked.
 func MarkSiteChecked(ctx context.Context, blogID int64, checkedAt time.Time) error {
 	_, err := db.ExecContext(ctx,

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -59,6 +60,23 @@ func GetSitesForBucket(ctx context.Context, bucketMin, bucketMax, batchSize int,
 		sites = append(sites, s)
 	}
 	return sites, rows.Err()
+}
+
+// CountActiveSitesForBucketRange returns the number of active monitor rows in
+// the inclusive bucket range.
+func CountActiveSitesForBucketRange(ctx context.Context, bucketMin, bucketMax int) (int, error) {
+	var count int
+	err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		  FROM jetpack_monitor_sites
+		 WHERE monitor_active = 1
+		   AND bucket_no BETWEEN ? AND ?`,
+		bucketMin, bucketMax,
+	).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("count active sites: %w", err)
+	}
+	return count, nil
 }
 
 // UpdateSiteStatus updates site_status and last_status_change for a site.
@@ -239,6 +257,23 @@ func MarkHostDraining(ctx context.Context, hostID string) error {
 func ReleaseHost(ctx context.Context, hostID string) error {
 	_, err := db.ExecContext(ctx, `DELETE FROM jetmon_hosts WHERE host_id = ?`, hostID)
 	return err
+}
+
+// HostRowExists reports whether a host currently has a jetmon_hosts ownership
+// row.
+func HostRowExists(ctx context.Context, hostID string) (bool, error) {
+	var exists int
+	err := db.QueryRowContext(ctx,
+		`SELECT 1 FROM jetmon_hosts WHERE host_id = ? LIMIT 1`,
+		hostID,
+	).Scan(&exists)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("check host row: %w", err)
+	}
+	return true, nil
 }
 
 // GetAllHosts returns all rows from jetmon_hosts for operator visibility.

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -303,6 +303,42 @@ func TestCountLegacyProjectionDrift(t *testing.T) {
 	}
 }
 
+func TestListLegacyProjectionDrift(t *testing.T) {
+	mock, cleanup := withMockDB(t)
+	defer cleanup()
+
+	mock.ExpectQuery("SELECT s.blog_id").
+		WithArgs(0, 99, 50).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"blog_id", "bucket_no", "site_status", "expected_status", "id", "state",
+		}).
+			AddRow(int64(42), 7, 1, 2, int64(123), "Down").
+			AddRow(int64(43), 8, 0, 1, nil, nil))
+
+	rows, err := ListLegacyProjectionDrift(context.Background(), 0, 99, 0)
+	if err != nil {
+		t.Fatalf("ListLegacyProjectionDrift: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows len = %d, want 2", len(rows))
+	}
+	if rows[0].BlogID != 42 || rows[0].BucketNo != 7 || rows[0].SiteStatus != 1 || rows[0].ExpectedStatus != 2 {
+		t.Fatalf("row 0 = %+v", rows[0])
+	}
+	if rows[0].EventID == nil || *rows[0].EventID != 123 {
+		t.Fatalf("row 0 EventID = %v, want 123", rows[0].EventID)
+	}
+	if rows[0].EventState == nil || *rows[0].EventState != "Down" {
+		t.Fatalf("row 0 EventState = %v, want Down", rows[0].EventState)
+	}
+	if rows[1].EventID != nil || rows[1].EventState != nil {
+		t.Fatalf("row 1 event fields = %+v, want nil", rows[1])
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
 func TestGetAllHostsScansRows(t *testing.T) {
 	mock, cleanup := withMockDB(t)
 	defer cleanup()

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -140,6 +140,26 @@ func TestGetSitesForBucketScansRowsAndDefaultRedirectPolicy(t *testing.T) {
 	}
 }
 
+func TestCountActiveSitesForBucketRange(t *testing.T) {
+	mock, cleanup := withMockDB(t)
+	defer cleanup()
+
+	mock.ExpectQuery("SELECT COUNT").
+		WithArgs(10, 19).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(42))
+
+	count, err := CountActiveSitesForBucketRange(context.Background(), 10, 19)
+	if err != nil {
+		t.Fatalf("CountActiveSitesForBucketRange: %v", err)
+	}
+	if count != 42 {
+		t.Fatalf("CountActiveSitesForBucketRange = %d, want 42", count)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
 func TestSimpleMutationQueries(t *testing.T) {
 	mock, cleanup := withMockDB(t)
 	defer cleanup()
@@ -226,6 +246,38 @@ func TestUpdateSiteStatusTx(t *testing.T) {
 	if err := tx.Commit(); err != nil {
 		t.Fatalf("Commit: %v", err)
 	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestHostRowExists(t *testing.T) {
+	mock, cleanup := withMockDB(t)
+	defer cleanup()
+
+	mock.ExpectQuery("SELECT 1 FROM jetmon_hosts").
+		WithArgs("host-a").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(1))
+	mock.ExpectQuery("SELECT 1 FROM jetmon_hosts").
+		WithArgs("host-b").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}))
+
+	exists, err := HostRowExists(context.Background(), "host-a")
+	if err != nil {
+		t.Fatalf("HostRowExists(host-a): %v", err)
+	}
+	if !exists {
+		t.Fatal("HostRowExists(host-a) = false, want true")
+	}
+
+	exists, err = HostRowExists(context.Background(), "host-b")
+	if err != nil {
+		t.Fatalf("HostRowExists(host-b): %v", err)
+	}
+	if exists {
+		t.Fatal("HostRowExists(host-b) = true, want false")
+	}
+
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet sql expectations: %v", err)
 	}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	runtimemetrics "runtime/metrics"
+	"strings"
 	"sync"
 	"time"
 
@@ -375,6 +376,7 @@ func (o *Orchestrator) handleRecovery(site db.Site, res checker.Result) {
 		log.Printf("orchestrator: blog_id=%d recovered", site.BlogID)
 		if entry != nil && site.SiteStatus == statusDown {
 			emitCounter("detection.probe_cleared.count", 1)
+			emitCounter("detection.probe_cleared."+failureClass(entry.lastResult)+".count", 1)
 			emitTimingSince("detection.seems_down_to_probe_cleared.time", entry.firstFailAt, changeTime)
 		}
 
@@ -401,6 +403,8 @@ func (o *Orchestrator) handleRecovery(site db.Site, res checker.Result) {
 
 func (o *Orchestrator) handleFailure(site db.Site, res checker.Result) {
 	entry := o.retries.record(res)
+	class := failureClass(res)
+	emitCounter("detection.failure."+class+".count", 1)
 
 	// Open a Seems Down event on the first failure we don't already have an
 	// id for. The schema's idempotent dedup_key means re-detecting the same
@@ -414,6 +418,7 @@ func (o *Orchestrator) handleFailure(site db.Site, res checker.Result) {
 			entry.eventID = id
 			if entry.failCount == 1 {
 				emitCounter("detection.seems_down.open.count", 1)
+				emitCounter("detection.seems_down.open."+class+".count", 1)
 				emitTimingSince("detection.first_failure_to_seems_down.time", entry.firstFailAt, nowFunc().UTC())
 			}
 		}
@@ -508,12 +513,16 @@ func (o *Orchestrator) escalateToVerifliers(site db.Site, entry *retryEntry) {
 	for range clients {
 		vr := <-ch
 		emitTiming("verifier.rpc.duration", vr.duration)
+		hostSegment := metricSegment(vr.host)
+		emitTiming("verifier.host."+hostSegment+".rpc.duration", vr.duration)
 		if vr.err != nil {
 			emitCounter("verifier.rpc.error.count", 1)
+			emitCounter("verifier.host."+hostSegment+".rpc.error.count", 1)
 			log.Printf("orchestrator: veriflier %s error: %v", vr.host, vr.err)
 			continue
 		}
 		emitCounter("verifier.rpc.success.count", 1)
+		emitCounter("verifier.host."+hostSegment+".rpc.success.count", 1)
 		healthyVerifliers++
 		// Verifier reply is operational telemetry — recorded under
 		// EventVeriflierSent with the response in metadata. The site-state
@@ -536,9 +545,11 @@ func (o *Orchestrator) escalateToVerifliers(site db.Site, entry *retryEntry) {
 		vResults = append(vResults, *vr.res)
 		if !vr.res.Success {
 			emitCounter("verifier.vote.confirm_down.count", 1)
+			emitCounter("verifier.host."+hostSegment+".vote.confirm_down.count", 1)
 			confirmations++
 		} else {
 			emitCounter("verifier.vote.disagree.count", 1)
+			emitCounter("verifier.host."+hostSegment+".vote.disagree.count", 1)
 		}
 	}
 
@@ -562,6 +573,7 @@ func (o *Orchestrator) escalateToVerifliers(site db.Site, entry *retryEntry) {
 		// event with reason=false_alarm and reset site_status in the same tx.
 		log.Printf("orchestrator: blog_id=%d verifliers did not confirm down (%d/%d)", site.BlogID, confirmations, quorum)
 		emitCounter("detection.verifier.false_alarm.count", 1)
+		emitCounter("detection.verifier.false_alarm."+failureClass(entry.lastResult)+".count", 1)
 		emitTimingSince("detection.seems_down_to_false_alarm.time", entry.firstFailAt, nowFunc().UTC())
 		_ = dbRecordFalsePositive(site.BlogID, entry.lastResult.HTTPCode, entry.lastResult.ErrorCode,
 			entry.lastResult.RTT.Milliseconds())
@@ -587,6 +599,7 @@ func (o *Orchestrator) confirmDown(site db.Site, entry *retryEntry, vResults []v
 	newStatus := statusConfirmedDown
 	changeTime := nowFunc().UTC()
 	emitCounter("detection.down.confirmed.count", 1)
+	emitCounter("detection.down.confirmed."+failureClass(entry.lastResult)+".count", 1)
 	emitTimingSince("detection.seems_down_to_down.time", entry.firstFailAt, changeTime)
 
 	log.Printf("orchestrator: blog_id=%d confirmed down", site.BlogID)
@@ -887,6 +900,37 @@ func emitTimingSince(stat string, start, end time.Time) {
 		return
 	}
 	emitTiming(stat, end.Sub(start))
+}
+
+func failureClass(res checker.Result) string {
+	return metricSegment((&res).StatusType())
+}
+
+func metricSegment(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	if s == "" {
+		return "unknown"
+	}
+
+	var b strings.Builder
+	lastUnderscore := false
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			lastUnderscore = false
+			continue
+		}
+		if !lastUnderscore {
+			b.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+
+	out := strings.Trim(b.String(), "_")
+	if out == "" {
+		return "unknown"
+	}
+	return out
 }
 
 // openSeemsDown opens (or re-detects) a Seems Down event for an HTTP-failing

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -678,7 +678,13 @@ func (o *Orchestrator) sendNotification(site db.Site, res checker.Result, status
 		Detail:    fmt.Sprintf("status=%d type=%s", status, n.StatusType),
 	})
 
+	wpcomStatus := wpcomStatusMetricSegment(status)
+	emitCounter("wpcom.notification.attempt.count", 1)
+	emitCounter("wpcom.notification.status."+wpcomStatus+".attempt.count", 1)
 	if err := wpcomNotifyFunc(o.wpcom, n); err != nil {
+		emitCounter("wpcom.notification.error.count", 1)
+		emitCounter("wpcom.notification.status."+wpcomStatus+".error.count", 1)
+		emitCounter("wpcom.notification.retry.count", 1)
 		log.Printf("orchestrator: wpcom notify failed for blog_id=%d: %v", site.BlogID, err)
 		o.auditLog(audit.Entry{
 			BlogID:    site.BlogID,
@@ -689,10 +695,17 @@ func (o *Orchestrator) sendNotification(site db.Site, res checker.Result, status
 
 		// Single retry.
 		if retryErr := wpcomNotifyFunc(o.wpcom, n); retryErr != nil {
+			emitCounter("wpcom.notification.error.count", 1)
+			emitCounter("wpcom.notification.status."+wpcomStatus+".error.count", 1)
+			emitCounter("wpcom.notification.failed.count", 1)
+			emitCounter("wpcom.notification.status."+wpcomStatus+".failed.count", 1)
 			log.Printf("orchestrator: wpcom notify retry failed for blog_id=%d: %v", site.BlogID, retryErr)
 			return
 		}
+		emitCounter("wpcom.notification.retry.delivered.count", 1)
 	}
+	emitCounter("wpcom.notification.delivered.count", 1)
+	emitCounter("wpcom.notification.status."+wpcomStatus+".delivered.count", 1)
 	if err := dbUpdateLastAlertSent(o.ctx, site.BlogID, nowFunc().UTC()); err != nil {
 		log.Printf("orchestrator: update last alert sent blog_id=%d: %v", site.BlogID, err)
 	}
@@ -1114,6 +1127,19 @@ func statusFromBool(success bool) int {
 		return statusRunning
 	}
 	return 0
+}
+
+func wpcomStatusMetricSegment(status int) string {
+	switch status {
+	case statusDown:
+		return "down"
+	case statusRunning:
+		return "running"
+	case statusConfirmedDown:
+		return "confirmed_down"
+	default:
+		return "unknown"
+	}
 }
 
 func (o *Orchestrator) refreshVeriflierClients(cfg *config.Config) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -136,6 +136,14 @@ func (o *Orchestrator) ev() *eventstore.Store {
 // ClaimBuckets registers this host in jetmon_hosts and sets the bucket range.
 func (o *Orchestrator) ClaimBuckets() error {
 	cfg := config.Get()
+	if min, max, ok := cfg.PinnedBucketRange(); ok {
+		if o.bucketMin != min || o.bucketMax != max {
+			log.Printf("orchestrator: using pinned buckets %d-%d (dynamic bucket ownership disabled)", min, max)
+		}
+		o.bucketMin = min
+		o.bucketMax = max
+		return nil
+	}
 	min, max, err := dbClaimBuckets(
 		o.hostname,
 		cfg.BucketTotal,
@@ -158,11 +166,15 @@ func (o *Orchestrator) Run() {
 		select {
 		case <-o.ctx.Done():
 			log.Println("orchestrator: shutting down")
-			if err := dbMarkHostDraining(stdctx.Background(), o.hostname); err != nil {
-				log.Printf("orchestrator: mark draining: %v", err)
+			if !o.usesPinnedBuckets(config.Get()) {
+				if err := dbMarkHostDraining(stdctx.Background(), o.hostname); err != nil {
+					log.Printf("orchestrator: mark draining: %v", err)
+				}
 			}
 			o.pool.Drain()
-			if err := dbReleaseHost(stdctx.Background(), o.hostname); err != nil {
+			if o.usesPinnedBuckets(config.Get()) {
+				log.Println("orchestrator: pinned bucket mode active; no jetmon_hosts row to release")
+			} else if err := dbReleaseHost(stdctx.Background(), o.hostname); err != nil {
 				log.Printf("orchestrator: release host: %v", err)
 			}
 			return
@@ -195,14 +207,20 @@ func (o *Orchestrator) Stop() {
 func (o *Orchestrator) runRound() {
 	cfg := config.Get()
 
-	// Update heartbeat.
-	if err := dbHeartbeat(o.ctx, o.hostname); err != nil {
-		log.Printf("orchestrator: heartbeat failed: %v", err)
-	}
-	// Re-claim every round so bucket ranges rebalance automatically when hosts
-	// join or leave the cluster.
-	if err := o.ClaimBuckets(); err != nil {
-		log.Printf("orchestrator: bucket rebalance failed: %v", err)
+	if o.usesPinnedBuckets(cfg) {
+		if err := o.ClaimBuckets(); err != nil {
+			log.Printf("orchestrator: pinned bucket claim failed: %v", err)
+		}
+	} else {
+		// Update heartbeat.
+		if err := dbHeartbeat(o.ctx, o.hostname); err != nil {
+			log.Printf("orchestrator: heartbeat failed: %v", err)
+		}
+		// Re-claim every round so bucket ranges rebalance automatically when
+		// hosts join or leave the cluster.
+		if err := o.ClaimBuckets(); err != nil {
+			log.Printf("orchestrator: bucket rebalance failed: %v", err)
+		}
 	}
 	o.checkLegacyProjectionDrift(cfg)
 
@@ -815,6 +833,11 @@ func (o *Orchestrator) RetryQueueSize() int {
 // BucketRange returns the current bucket min/max for this host.
 func (o *Orchestrator) BucketRange() (int, int) {
 	return o.bucketMin, o.bucketMax
+}
+
+func (o *Orchestrator) usesPinnedBuckets(cfg *config.Config) bool {
+	_, _, ok := cfg.PinnedBucketRange()
+	return ok
 }
 
 // WorkerCount returns the live worker count.

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -329,6 +329,11 @@ func TestEscalateToVerifliersRecordsFalsePositiveWhenQuorumMissed(t *testing.T) 
 
 func stubOrchestratorDeps() func() {
 	origNow := nowFunc
+	origDBClaimBuckets := dbClaimBuckets
+	origDBHeartbeat := dbHeartbeat
+	origDBReleaseHost := dbReleaseHost
+	origDBMarkHostDraining := dbMarkHostDraining
+	origDBGetSites := dbGetSitesForBucket
 	origDBUpdateStatus := dbUpdateSiteStatus
 	origDBUpdateLastAlert := dbUpdateLastAlertSent
 	origDBRecordFalsePositive := dbRecordFalsePositive
@@ -341,6 +346,11 @@ func stubOrchestratorDeps() func() {
 	origMetricsClient := metricsClientFunc
 
 	nowFunc = time.Now
+	dbClaimBuckets = func(string, int, int, int) (int, int, error) { return 0, 0, nil }
+	dbHeartbeat = func(context.Context, string) error { return nil }
+	dbReleaseHost = func(context.Context, string) error { return nil }
+	dbMarkHostDraining = func(context.Context, string) error { return nil }
+	dbGetSitesForBucket = func(context.Context, int, int, int, bool) ([]db.Site, error) { return nil, nil }
 	dbUpdateSiteStatus = func(context.Context, int64, int, time.Time) error { return nil }
 	dbUpdateLastAlertSent = func(context.Context, int64, time.Time) error { return nil }
 	dbRecordFalsePositive = func(int64, int, int, int64) error { return nil }
@@ -355,6 +365,11 @@ func stubOrchestratorDeps() func() {
 
 	return func() {
 		nowFunc = origNow
+		dbClaimBuckets = origDBClaimBuckets
+		dbHeartbeat = origDBHeartbeat
+		dbReleaseHost = origDBReleaseHost
+		dbMarkHostDraining = origDBMarkHostDraining
+		dbGetSitesForBucket = origDBGetSites
 		dbUpdateSiteStatus = origDBUpdateStatus
 		dbUpdateLastAlertSent = origDBUpdateLastAlert
 		dbRecordFalsePositive = origDBRecordFalsePositive
@@ -710,6 +725,60 @@ func TestOrchestratorAccessors(t *testing.T) {
 	}
 	if o.QueueDepth() != 0 {
 		t.Fatalf("QueueDepth() = %d, want 0", o.QueueDepth())
+	}
+}
+
+func TestClaimBucketsUsesPinnedRangeWithoutHostTable(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	cfg := setTestConfig(t)
+	min, max := 12, 34
+	cfg.PinnedBucketMin = &min
+	cfg.PinnedBucketMax = &max
+
+	var dynamicClaimCalled bool
+	dbClaimBuckets = func(string, int, int, int) (int, int, error) {
+		dynamicClaimCalled = true
+		return 0, 0, nil
+	}
+
+	o := &Orchestrator{hostname: "host-a"}
+	if err := o.ClaimBuckets(); err != nil {
+		t.Fatalf("ClaimBuckets: %v", err)
+	}
+	if dynamicClaimCalled {
+		t.Fatal("ClaimBuckets called dynamic jetmon_hosts claim in pinned mode")
+	}
+	if o.bucketMin != 12 || o.bucketMax != 34 {
+		t.Fatalf("bucket range = %d-%d, want 12-34", o.bucketMin, o.bucketMax)
+	}
+}
+
+func TestRunRoundSkipsHeartbeatWhenPinned(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	cfg := setTestConfig(t)
+	min, max := 12, 34
+	cfg.PinnedBucketMin = &min
+	cfg.PinnedBucketMax = &max
+
+	var heartbeatCalled bool
+	dbHeartbeat = func(context.Context, string) error {
+		heartbeatCalled = true
+		return nil
+	}
+	dbGetSitesForBucket = func(_ context.Context, gotMin, gotMax, _ int, _ bool) ([]db.Site, error) {
+		if gotMin != 12 || gotMax != 34 {
+			t.Fatalf("fetch buckets = %d-%d, want 12-34", gotMin, gotMax)
+		}
+		return nil, nil
+	}
+
+	o := &Orchestrator{ctx: context.Background(), hostname: "host-a"}
+	o.runRound()
+
+	if heartbeatCalled {
+		t.Fatal("runRound updated jetmon_hosts heartbeat in pinned mode")
 	}
 }
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -156,6 +156,9 @@ func TestSendNotificationRetriesAndUpdatesAlertTimestamp(t *testing.T) {
 
 	setTestConfig(t)
 
+	rec := newRecordingMetrics()
+	metricsClientFunc = func() metricsClient { return rec }
+
 	var notifyCalls int
 	wpcomNotifyFunc = func(_ *wpcom.Client, _ wpcom.Notification) error {
 		notifyCalls++
@@ -185,6 +188,20 @@ func TestSendNotificationRetriesAndUpdatesAlertTimestamp(t *testing.T) {
 	}
 	if updatedBlogID != 123 {
 		t.Fatalf("updated blog_id = %d, want 123", updatedBlogID)
+	}
+	for stat, want := range map[string]int{
+		"wpcom.notification.attempt.count":                  1,
+		"wpcom.notification.status.running.attempt.count":   1,
+		"wpcom.notification.error.count":                    1,
+		"wpcom.notification.status.running.error.count":     1,
+		"wpcom.notification.retry.count":                    1,
+		"wpcom.notification.retry.delivered.count":          1,
+		"wpcom.notification.delivered.count":                1,
+		"wpcom.notification.status.running.delivered.count": 1,
+	} {
+		if got := rec.counter(stat); got != want {
+			t.Fatalf("%s = %d, want %d", stat, got, want)
+		}
 	}
 }
 
@@ -929,6 +946,9 @@ func TestSendNotificationBothRetriesFail(t *testing.T) {
 	defer restore()
 	setTestConfig(t)
 
+	rec := newRecordingMetrics()
+	metricsClientFunc = func() metricsClient { return rec }
+
 	calls := 0
 	wpcomNotifyFunc = func(_ *wpcom.Client, _ wpcom.Notification) error {
 		calls++
@@ -953,6 +973,21 @@ func TestSendNotificationBothRetriesFail(t *testing.T) {
 	}
 	if updateAlertCalled {
 		t.Fatal("dbUpdateLastAlertSent should not be called when both retries fail")
+	}
+	for stat, want := range map[string]int{
+		"wpcom.notification.attempt.count":                         1,
+		"wpcom.notification.status.confirmed_down.attempt.count":   1,
+		"wpcom.notification.error.count":                           2,
+		"wpcom.notification.status.confirmed_down.error.count":     2,
+		"wpcom.notification.retry.count":                           1,
+		"wpcom.notification.failed.count":                          1,
+		"wpcom.notification.status.confirmed_down.failed.count":    1,
+		"wpcom.notification.delivered.count":                       0,
+		"wpcom.notification.status.confirmed_down.delivered.count": 0,
+	} {
+		if got := rec.counter(stat); got != want {
+			t.Fatalf("%s = %d, want %d", stat, got, want)
+		}
 	}
 }
 
@@ -1291,6 +1326,26 @@ func TestMetricSegment(t *testing.T) {
 		t.Run(tt.in, func(t *testing.T) {
 			if got := metricSegment(tt.in); got != tt.want {
 				t.Fatalf("metricSegment(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWPCOMStatusMetricSegment(t *testing.T) {
+	tests := []struct {
+		status int
+		want   string
+	}{
+		{status: statusDown, want: "down"},
+		{status: statusRunning, want: "running"},
+		{status: statusConfirmedDown, want: "confirmed_down"},
+		{status: 99, want: "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := wpcomStatusMetricSegment(tt.status); got != tt.want {
+				t.Fatalf("wpcomStatusMetricSegment(%d) = %q, want %q", tt.status, got, tt.want)
 			}
 		})
 	}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -497,6 +497,35 @@ func TestHandleRecoveryClearsRetryEntryEvenWhenAlreadyRunning(t *testing.T) {
 	}
 }
 
+func TestHandleRecoveryEmitsProbeClearedClassMetric(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	setTestConfig(t)
+
+	rec := newRecordingMetrics()
+	metricsClientFunc = func() metricsClient { return rec }
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		hostname: "local",
+		ctx:      context.Background(),
+	}
+	o.retries.record(checkerResultFailure(42))
+
+	o.handleRecovery(db.Site{BlogID: 42, SiteStatus: statusDown}, checkerResultSuccess(42))
+
+	if got := rec.counter("detection.probe_cleared.count"); got != 1 {
+		t.Fatalf("probe-cleared counter = %d, want 1", got)
+	}
+	if got := rec.counter("detection.probe_cleared.server.count"); got != 1 {
+		t.Fatalf("probe-cleared server counter = %d, want 1", got)
+	}
+	if got := rec.timingCount("detection.seems_down_to_probe_cleared.time"); got != 1 {
+		t.Fatalf("probe-cleared timing count = %d, want 1", got)
+	}
+}
+
 func TestHandleFailureBelowThresholdDoesNotEscalate(t *testing.T) {
 	restore := stubOrchestratorDeps()
 	defer restore()
@@ -1114,6 +1143,12 @@ func TestHandleFailureEmitsSeemsDownMetrics(t *testing.T) {
 	if got := rec.counter("detection.seems_down.open.count"); got != 1 {
 		t.Fatalf("seems-down open counter = %d, want 1", got)
 	}
+	if got := rec.counter("detection.failure.server.count"); got != 1 {
+		t.Fatalf("failure class counter = %d, want 1", got)
+	}
+	if got := rec.counter("detection.seems_down.open.server.count"); got != 1 {
+		t.Fatalf("seems-down class counter = %d, want 1", got)
+	}
 	if got := rec.timingCount("detection.first_failure_to_seems_down.time"); got != 1 {
 		t.Fatalf("first failure timing count = %d, want 1", got)
 	}
@@ -1157,11 +1192,14 @@ func TestEscalateToVerifliersEmitsConfirmedMetrics(t *testing.T) {
 	o.escalateToVerifliers(db.Site{BlogID: 321, MonitorURL: "https://example.com", SiteStatus: statusRunning}, entry)
 
 	for stat, want := range map[string]int{
-		"detection.verifier.escalation.count": 1,
-		"verifier.rpc.success.count":          1,
-		"verifier.vote.confirm_down.count":    1,
-		"detection.verifier.quorum_met.count": 1,
-		"detection.down.confirmed.count":      1,
+		"detection.verifier.escalation.count":      1,
+		"verifier.rpc.success.count":               1,
+		"verifier.host.v1.rpc.success.count":       1,
+		"verifier.vote.confirm_down.count":         1,
+		"verifier.host.v1.vote.confirm_down.count": 1,
+		"detection.verifier.quorum_met.count":      1,
+		"detection.down.confirmed.count":           1,
+		"detection.down.confirmed.server.count":    1,
 	} {
 		if got := rec.counter(stat); got != want {
 			t.Fatalf("%s = %d, want %d", stat, got, want)
@@ -1170,6 +1208,7 @@ func TestEscalateToVerifliersEmitsConfirmedMetrics(t *testing.T) {
 	for _, stat := range []string{
 		"detection.first_failure_to_verification.time",
 		"verifier.rpc.duration",
+		"verifier.host.v1.rpc.duration",
 		"detection.seems_down_to_down.time",
 	} {
 		if got := rec.timingCount(stat); got != 1 {
@@ -1219,10 +1258,13 @@ func TestEscalateToVerifliersEmitsFalseAlarmMetrics(t *testing.T) {
 	o.escalateToVerifliers(db.Site{BlogID: 654, MonitorURL: "https://example.com", SiteStatus: statusRunning}, entry)
 
 	for stat, want := range map[string]int{
-		"detection.verifier.escalation.count":  1,
-		"verifier.rpc.success.count":           1,
-		"verifier.vote.disagree.count":         1,
-		"detection.verifier.false_alarm.count": 1,
+		"detection.verifier.escalation.count":         1,
+		"verifier.rpc.success.count":                  1,
+		"verifier.host.v1.rpc.success.count":          1,
+		"verifier.vote.disagree.count":                1,
+		"verifier.host.v1.vote.disagree.count":        1,
+		"detection.verifier.false_alarm.count":        1,
+		"detection.verifier.false_alarm.server.count": 1,
 	} {
 		if got := rec.counter(stat); got != want {
 			t.Fatalf("%s = %d, want %d", stat, got, want)
@@ -1230,6 +1272,27 @@ func TestEscalateToVerifliersEmitsFalseAlarmMetrics(t *testing.T) {
 	}
 	if got := rec.timingCount("detection.seems_down_to_false_alarm.time"); got != 1 {
 		t.Fatalf("false alarm timing count = %d, want 1", got)
+	}
+}
+
+func TestMetricSegment(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{in: "", want: "unknown"},
+		{in: "server", want: "server"},
+		{in: "US-West:7803", want: "us_west_7803"},
+		{in: "  eu.central-1  ", want: "eu_central_1"},
+		{in: "://", want: "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := metricSegment(tt.in); got != tt.want {
+				t.Fatalf("metricSegment(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -132,6 +132,9 @@ func (c *VeriflierClient) Ping(ctx context.Context) (string, error) {
 		return "", err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("veriflier status returned %d", resp.StatusCode)
+	}
 
 	var s struct {
 		Status  string `json:"status"`

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -178,6 +178,22 @@ func TestClientPing(t *testing.T) {
 	}
 }
 
+func TestClientPingRejectsErrorStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	defer ts.Close()
+
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
+	_, err := client.Ping(context.Background())
+	if err == nil {
+		t.Fatal("Ping() expected error")
+	}
+	if err.Error() != "veriflier status returned 503" {
+		t.Fatalf("Ping() error = %v", err)
+	}
+}
+
 func TestClientBatchRoundTrip(t *testing.T) {
 	_, ts := newTestServer(func(req CheckRequest) CheckResult {
 		return CheckResult{BlogID: req.BlogID, Success: true, HTTPCode: 200}


### PR DESCRIPTION
Stacked PR 8 of 9.

Base: `stack-07-gateway-tenant`
Head: `stack-08-rollout-hardening`
Previous PR: #79

Summary:
- Adds pinned bucket rollout mode and preflight command.
- Adds dynamic rollout ownership checks.
- Splits detection metrics by outcome source.
- Lists legacy projection drift details and tracks WPCOM notification parity metrics.
- Surfaces rollout checks in `validate-config` and rollout health in the dashboard.

Review notes:
This PR focuses on migration confidence and observability. It should be reviewed with the v1 to v2 rollout plan in mind.