### PR TITLE
Add API CLI for Jetmon internal API

### DIFF
--- a/API.md
+++ b/API.md
@@ -71,7 +71,7 @@ We deliberately did not split into `sites:read` / `events:read` / `webhooks:read
 **Key management is ops-only.** No `/api/v1/keys` endpoints. Keys are created and revoked via the `./jetmon2` CLI:
 
 ```
-./jetmon2 keys create --consumer gateway --scope read [--expires 90d]
+./jetmon2 keys create --consumer gateway --scope read [--ttl 2160h]
 ./jetmon2 keys list
 ./jetmon2 keys revoke <key_id>
 ./jetmon2 keys rotate <key_id>     # creates a new key for the same consumer; revokes old after grace
@@ -86,6 +86,37 @@ The CLI talks to the database directly (via `jetmon_api_keys`), prints the new t
 **Why not mTLS / IP allowlists alone?** Either could replace Bearer tokens for service-to-service auth, but tokens make per-consumer identity trivial to log and revoke. mTLS rotation is heavier; IP allowlists don't survive containerized deployments cleanly. Bearer tokens are the lowest-friction option that gives us per-consumer accountability.
 
 **Why not OAuth?** Same reasoning as before, now stronger: there are no user delegations to model. Every caller is a server.
+
+## API CLI helper
+
+`jetmon2 api` is the local developer/operator helper for this API. It defaults
+to the Docker-local API listener and reads the Bearer token from the
+environment:
+
+```bash
+export JETMON_API_URL=http://localhost:8090
+export JETMON_API_TOKEN=jm_replace_with_a_local_key
+
+./bin/jetmon2 api health --pretty
+./bin/jetmon2 api me --pretty
+./bin/jetmon2 api sites list --output table
+./bin/jetmon2 api sites get --pretty 12345
+```
+
+Typed commands cover sites, events, webhooks, alert contacts, local smoke runs,
+and failure simulation. Use `api request` as the escape hatch for new API routes
+before a typed command exists:
+
+```bash
+./bin/jetmon2 api request --output table GET '/api/v1/sites?limit=5'
+./bin/jetmon2 api sites bulk-add --count 3 --batch local-smoke --dry-run --pretty
+./bin/jetmon2 api smoke --batch local-smoke --pretty
+./bin/jetmon2 api sites simulate-failure --batch local-smoke --mode http-500 --wait 15s --pretty
+```
+
+JSON is the default output for scripts. Add `--pretty` for readable JSON or
+`--output table` for stable human-readable tables on list and workflow summary
+commands.
 
 ## Common patterns
 

--- a/API.md
+++ b/API.md
@@ -99,6 +99,7 @@ export JETMON_API_TOKEN=jm_replace_with_a_local_key
 
 ./bin/jetmon2 api health --pretty
 ./bin/jetmon2 api me --pretty
+./bin/jetmon2 api commands --output table
 ./bin/jetmon2 api sites list --output table
 ./bin/jetmon2 api sites get --pretty 12345
 ```

--- a/API.md
+++ b/API.md
@@ -112,6 +112,7 @@ before a typed command exists:
 ./bin/jetmon2 api sites bulk-add --count 3 --batch local-smoke --dry-run --pretty
 ./bin/jetmon2 api smoke --batch local-smoke --pretty
 ./bin/jetmon2 api sites simulate-failure --batch local-smoke --mode http-500 --wait 15s --pretty
+./bin/jetmon2 api sites cleanup --batch local-smoke --count 3 --output table
 ```
 
 JSON is the default output for scripts. Add `--pretty` for readable JSON or

--- a/API.md
+++ b/API.md
@@ -112,12 +112,26 @@ before a typed command exists:
 ./bin/jetmon2 api sites bulk-add --count 3 --batch local-smoke --dry-run --pretty
 ./bin/jetmon2 api smoke --batch local-smoke --pretty
 ./bin/jetmon2 api sites simulate-failure --batch local-smoke --mode http-500 --wait 15s --pretty
+./bin/jetmon2 api sites simulate-failure --batch local-smoke --mode http-500 --wait 30s --expect-event-state 'Seems Down' --expect-transition-reason opened --pretty
 ./bin/jetmon2 api sites cleanup --batch local-smoke --count 3 --output table
 ```
 
 JSON is the default output for scripts. Add `--pretty` for readable JSON or
 `--output table` for stable human-readable tables on list and workflow summary
 commands.
+
+When Docker Compose is running, `sites simulate-failure` probes
+`http://localhost:18091/health` and uses the Docker-internal fixture URL
+`http://api-fixture:8091` for deterministic HTTP 500, HTTP 403, redirect,
+keyword, timeout, and TLS scenarios. Use `--fixture-url=off` to force the
+public endpoint fallback, or set `JETMON_API_FIXTURE_URL` /
+`JETMON_API_FIXTURE_PROBE_URL` for custom local fixtures.
+
+For strict rehearsal or CI checks, add `--expect-event-state`,
+`--expect-event-severity`, `--require-transition`, or
+`--expect-transition-reason`. When an expectation is set, the command keeps
+polling until the expectation matches or `--wait` expires, then returns non-zero
+with the last observed events/transitions in the summary.
 
 ## Common patterns
 

--- a/API.md
+++ b/API.md
@@ -105,7 +105,8 @@ export JETMON_API_TOKEN=jm_replace_with_a_local_key
 
 Typed commands cover sites, events, webhooks, alert contacts, local smoke runs,
 and failure simulation. Use `api request` as the escape hatch for new API routes
-before a typed command exists:
+before a typed command exists. See [`docs/api-cli-guide.md`](docs/api-cli-guide.md)
+for a fuller feature guide and workflow examples:
 
 ```bash
 ./bin/jetmon2 api request --output table GET '/api/v1/sites?limit=5'

--- a/API.md
+++ b/API.md
@@ -103,6 +103,11 @@ export JETMON_API_TOKEN=jm_replace_with_a_local_key
 ./bin/jetmon2 api sites get --pretty 12345
 ```
 
+For Docker-local rehearsals, `make api-cli-token-create`,
+`make api-cli-token-list`, and
+`API_CLI_TOKEN_ID=<id> make api-cli-token-revoke` wrap the in-container
+`jetmon2 keys` commands from the repository root.
+
 Typed commands cover sites, events, webhooks, alert contacts, local smoke runs,
 and failure simulation. Use `api request` as the escape hatch for new API routes
 before a typed command exists. See [`docs/api-cli-guide.md`](docs/api-cli-guide.md)

--- a/API.md
+++ b/API.md
@@ -121,6 +121,10 @@ JSON is the default output for scripts. Add `--pretty` for readable JSON or
 `--output table` for stable human-readable tables on list and workflow summary
 commands.
 
+Use `make api-cli-validate` with `JETMON_API_URL` and `JETMON_API_TOKEN` set for
+a live Docker-local validation pass covering the guide's core examples, the
+smoke workflow, and a deterministic failure-simulation assertion.
+
 When Docker Compose is running, `sites simulate-failure` probes
 `http://localhost:18091/health` and uses the Docker-internal fixture URL
 `http://api-fixture:8091` for deterministic HTTP 500, HTTP 403, redirect,

--- a/API.md
+++ b/API.md
@@ -368,7 +368,8 @@ see rows mapped to `X-Jetmon-Tenant-ID` in `jetmon_site_tenants`.
       "redirect_policy": "follow",
       "maintenance_start": null,
       "maintenance_end": null,
-      "alert_cooldown_minutes": null
+      "alert_cooldown_minutes": null,
+      "cli_batch": "local-smoke"
     }
   ],
   "page": { "next": "eyJ...", "limit": 50 }
@@ -376,6 +377,10 @@ see rows mapped to `X-Jetmon-Tenant-ID` in `jetmon_site_tenants`.
 ```
 
 `id` and `blog_id` are the same value for now; `id` is the public field name (`blog_id` is the historical column name). Consumers should rely on `id`.
+
+`cli_batch` is a derived local-tooling field. It is present only when the
+site's `custom_headers` include `X-Jetmon-CLI-Batch`; the API does not expose
+the rest of `custom_headers`.
 
 `current_state`, `current_severity`, and `active_event_id` are derived from
 open rows in `jetmon_events`. During shadow-v2-state migration the legacy

--- a/API.md
+++ b/API.md
@@ -345,6 +345,7 @@ see rows mapped to `X-Jetmon-Tenant-ID` in `jetmon_site_tenants`.
 | `severity__gte` | int | Minimum severity |
 | `monitor_active` | bool | Filter active vs paused |
 | `q` | string | URL substring search |
+| `include_cli_metadata` | bool | Optional local-tooling projection; when true, includes `cli_batch` if the site carries the CLI batch marker |
 
 **Response 200:**
 
@@ -368,8 +369,7 @@ see rows mapped to `X-Jetmon-Tenant-ID` in `jetmon_site_tenants`.
       "redirect_policy": "follow",
       "maintenance_start": null,
       "maintenance_end": null,
-      "alert_cooldown_minutes": null,
-      "cli_batch": "local-smoke"
+      "alert_cooldown_minutes": null
     }
   ],
   "page": { "next": "eyJ...", "limit": 50 }
@@ -378,9 +378,9 @@ see rows mapped to `X-Jetmon-Tenant-ID` in `jetmon_site_tenants`.
 
 `id` and `blog_id` are the same value for now; `id` is the public field name (`blog_id` is the historical column name). Consumers should rely on `id`.
 
-`cli_batch` is a derived local-tooling field. It is present only when the
-site's `custom_headers` include `X-Jetmon-CLI-Batch`; the API does not expose
-the rest of `custom_headers`.
+`cli_batch` is an opt-in local-tooling projection. It is present only when
+`include_cli_metadata=true` and the site's `custom_headers` include
+`X-Jetmon-CLI-Batch`; the API does not expose the rest of `custom_headers`.
 
 `current_state`, `current_severity`, and `active_event_id` are derived from
 open rows in `jetmon_events`. During the
@@ -393,6 +393,9 @@ status values.
 #### `GET /api/v1/sites/{id}`
 
 Single site, same shape as a list entry plus an `active_events` array for any open events:
+
+Accepts `include_cli_metadata=true` with the same `cli_batch` behavior as
+`GET /api/v1/sites`.
 
 ```json
 {

--- a/API.md
+++ b/API.md
@@ -383,8 +383,9 @@ site's `custom_headers` include `X-Jetmon-CLI-Batch`; the API does not expose
 the rest of `custom_headers`.
 
 `current_state`, `current_severity`, and `active_event_id` are derived from
-open rows in `jetmon_events`. During shadow-v2-state migration the legacy
-`site_status` column is only a fallback for sites with no active v2 event while
+open rows in `jetmon_events`. During the
+[v1-to-v2 migration](docs/v1-to-v2-migration.md), the legacy `site_status`
+column is only a fallback for sites with no active v2 event while
 `LEGACY_STATUS_PROJECTION_ENABLE` is true; once the projection is disabled, a
 site with no active v2 event is reported as `Up` regardless of stale legacy
 status values.

--- a/EVENTS.md
+++ b/EVENTS.md
@@ -138,9 +138,9 @@ Condition has cleared. `ended_at` is set, `resolution_reason` is recorded, and a
 
 ## The site row projection
 
-During the v2 migration, `jetpack_monitor_sites` remains the legacy site/config
-table and compatibility projection. The authoritative incident state is the
-v2 event model:
+During the [v1-to-v2 migration](docs/v1-to-v2-migration.md),
+`jetpack_monitor_sites` remains the legacy site/config table and compatibility
+projection. The authoritative incident state is the v2 event model:
 
 - `jetmon_events` stores the current incident row.
 - `jetmon_event_transitions` stores every mutation.

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,12 @@ API_VALIDATE_COUNT ?= 1
 API_VALIDATE_MODE  ?= http-500
 API_VALIDATE_WAIT  ?= 30s
 API_VALIDATE_SKIP_FAILURE ?= 0
+DOCKER_COMPOSE ?= docker compose -f docker/docker-compose.yml
+API_CLI_TOKEN_CONSUMER ?= api-cli
+API_CLI_TOKEN_SCOPE ?= admin
+API_CLI_TOKEN_CREATED_BY ?= docker-local
+API_CLI_TOKEN_TTL ?= 0
+API_CLI_TOKEN_ID ?=
 GO          ?= $(shell if command -v go >/dev/null 2>&1; then command -v go; elif [ -x /usr/local/go/bin/go ]; then printf /usr/local/go/bin/go; else printf go; fi)
 GOCACHE     ?= /tmp/jetmon-go-cache
 GO_ENV      := GOCACHE=$(GOCACHE)
@@ -15,7 +21,7 @@ BUILD_FLAGS := -ldflags "-X main.version=$(shell git describe --tags --always --
                          -X main.buildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ) \
                          -X main.goVersion=$(shell $(GO) version | awk '{print $$3}')"
 
-.PHONY: all build build-deliverer build-veriflier generate test test-race lint api-cli-smoke api-cli-validate clean
+.PHONY: all build build-deliverer build-veriflier generate test test-race lint api-cli-smoke api-cli-validate api-cli-token-create api-cli-token-list api-cli-token-revoke clean
 
 all: build build-deliverer build-veriflier
 
@@ -61,6 +67,16 @@ api-cli-validate: build
 	API_VALIDATE_WAIT=$(API_VALIDATE_WAIT) \
 	API_VALIDATE_SKIP_FAILURE=$(API_VALIDATE_SKIP_FAILURE) \
 	scripts/api-cli-validate.sh
+
+api-cli-token-create:
+	$(DOCKER_COMPOSE) exec jetmon ./jetmon2 keys create --consumer $(API_CLI_TOKEN_CONSUMER) --scope $(API_CLI_TOKEN_SCOPE) --ttl $(API_CLI_TOKEN_TTL) --created-by $(API_CLI_TOKEN_CREATED_BY)
+
+api-cli-token-list:
+	$(DOCKER_COMPOSE) exec jetmon ./jetmon2 keys list
+
+api-cli-token-revoke:
+	@test -n "$(API_CLI_TOKEN_ID)" || { echo "API_CLI_TOKEN_ID is required"; exit 1; }
+	$(DOCKER_COMPOSE) exec jetmon ./jetmon2 keys revoke $(API_CLI_TOKEN_ID)
 
 clean:
 	rm -f $(BINARY) $(DELIVERER) $(VERIFLIER)

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@ DELIVERER   := bin/jetmon-deliverer
 VERIFLIER   := bin/veriflier2
 API_SMOKE_BATCH ?= local-smoke
 API_SMOKE_ARGS  ?=
+API_VALIDATE_BATCH ?= api-cli-validate
+API_VALIDATE_COUNT ?= 1
+API_VALIDATE_MODE  ?= http-500
+API_VALIDATE_WAIT  ?= 30s
+API_VALIDATE_SKIP_FAILURE ?= 0
 GO          ?= $(shell if command -v go >/dev/null 2>&1; then command -v go; elif [ -x /usr/local/go/bin/go ]; then printf /usr/local/go/bin/go; else printf go; fi)
 GOCACHE     ?= /tmp/jetmon-go-cache
 GO_ENV      := GOCACHE=$(GOCACHE)
@@ -10,7 +15,7 @@ BUILD_FLAGS := -ldflags "-X main.version=$(shell git describe --tags --always --
                          -X main.buildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ) \
                          -X main.goVersion=$(shell $(GO) version | awk '{print $$3}')"
 
-.PHONY: all build build-deliverer build-veriflier generate test test-race lint api-cli-smoke clean
+.PHONY: all build build-deliverer build-veriflier generate test test-race lint api-cli-smoke api-cli-validate clean
 
 all: build build-deliverer build-veriflier
 
@@ -47,6 +52,15 @@ api-cli-smoke: build
 	$(BINARY) api me --pretty
 	$(BINARY) api sites bulk-add --count 3 --batch $(API_SMOKE_BATCH) --dry-run --pretty
 	$(BINARY) api smoke --batch $(API_SMOKE_BATCH) --pretty $(API_SMOKE_ARGS)
+
+api-cli-validate: build
+	API_CLI_BINARY=$(BINARY) \
+	API_VALIDATE_BATCH=$(API_VALIDATE_BATCH) \
+	API_VALIDATE_COUNT=$(API_VALIDATE_COUNT) \
+	API_VALIDATE_MODE=$(API_VALIDATE_MODE) \
+	API_VALIDATE_WAIT=$(API_VALIDATE_WAIT) \
+	API_VALIDATE_SKIP_FAILURE=$(API_VALIDATE_SKIP_FAILURE) \
+	scripts/api-cli-validate.sh
 
 clean:
 	rm -f $(BINARY) $(DELIVERER) $(VERIFLIER)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 BINARY      := bin/jetmon2
 DELIVERER   := bin/jetmon-deliverer
 VERIFLIER   := bin/veriflier2
+API_SMOKE_BATCH ?= local-smoke
+API_SMOKE_ARGS  ?=
 GO          ?= $(shell if command -v go >/dev/null 2>&1; then command -v go; elif [ -x /usr/local/go/bin/go ]; then printf /usr/local/go/bin/go; else printf go; fi)
 GOCACHE     ?= /tmp/jetmon-go-cache
 GO_ENV      := GOCACHE=$(GOCACHE)
@@ -8,7 +10,7 @@ BUILD_FLAGS := -ldflags "-X main.version=$(shell git describe --tags --always --
                          -X main.buildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ) \
                          -X main.goVersion=$(shell $(GO) version | awk '{print $$3}')"
 
-.PHONY: all build build-deliverer build-veriflier generate test test-race lint clean
+.PHONY: all build build-deliverer build-veriflier generate test test-race lint api-cli-smoke clean
 
 all: build build-deliverer build-veriflier
 
@@ -38,6 +40,13 @@ test-race:
 
 lint:
 	$(GO_ENV) $(GO) vet ./...
+
+api-cli-smoke: build
+	@test -n "$$JETMON_API_TOKEN" || { echo "JETMON_API_TOKEN is required"; exit 1; }
+	$(BINARY) api health --pretty
+	$(BINARY) api me --pretty
+	$(BINARY) api sites bulk-add --count 3 --batch $(API_SMOKE_BATCH) --dry-run --pretty
+	$(BINARY) api smoke --batch $(API_SMOKE_BATCH) --pretty $(API_SMOKE_ARGS)
 
 clean:
 	rm -f $(BINARY) $(DELIVERER) $(VERIFLIER)

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -117,8 +117,11 @@ These features address the most significant gaps against competing solutions and
 **SSL Certificate Expiry Monitoring**
 During each HTTPS check, inspect the peer certificate chain via Go's `tls.ConnectionState`. Extract `NotAfter` from the leaf certificate and store it in a new `ssl_expiry_date` column on `jetpack_monitor_sites`. Emit alerts at configurable thresholds (30, 14, and 7 days before expiry) through the same WPCOM notification path as downtime alerts. Zero additional network requests — the data is present in every existing HTTPS connection.
 
+**GET-Based Site Checks**
+Jetmon 1's HEAD-only verification was a major source of customer-visible false positives and false negatives because many production stacks block, special-case, or incorrectly implement HEAD. Jetmon 2 uses GET requests for local monitor checks and Veriflier checks so uptime decisions are based on the same class of request a browser and customer-facing uptime product normally make.
+
 **Keyword / Content Checking**
-For sites with a `check_keyword` value set in the database, perform a GET request and search the response body for the configured string. A missing keyword on an otherwise-200 response counts as a failure and enters the same retry and confirmation pipeline as an HTTP error. Builds directly on the GET request mode introduced in the current branch.
+For sites with a `check_keyword` value set in the database, perform a GET request and search the response body for the configured string. A missing keyword on an otherwise-200 response counts as a failure and enters the same retry and confirmation pipeline as an HTTP error. Builds directly on the GET request mode used by v2 checks.
 
 **Maintenance Windows**
 Add `maintenance_start` and `maintenance_end` (nullable `DATETIME`) columns to `jetpack_monitor_sites`. During a maintenance window, checks continue and RTT data is collected, but status-change notifications are suppressed. The check result is logged internally so the audit trail is complete, but no alert fires. Configurable via the WPCOM API or direct DB write.
@@ -269,6 +272,9 @@ Queryable by `blog_id` and time range via a CLI tool (`jetmon2 audit --blog-id 1
 - `jetmon2 rollout projection-drift` — lists active sites whose legacy `site_status` projection disagrees with the authoritative event state
 - `jetmon2 drain --worker N` — gracefully removes one worker pool slot, waiting for in-flight checks to complete before reducing concurrency
 - `jetmon2 reload` — sends SIGHUP to the running process (convenience wrapper)
+
+The complete v1-to-v2 production process is documented in
+[`docs/v1-to-v2-migration.md`](docs/v1-to-v2-migration.md).
 
 **Zero-Downtime Rolling Updates**
 Because bucket ownership is coordinated via MySQL, a multi-host deployment can be updated one host at a time with no coverage gap. The procedure for each host: send SIGINT to release its buckets, wait for the drain to complete, deploy the new binary, start the new process. Surviving hosts absorb the draining host's buckets during the update window and release them back once the updated host rejoins and reclaims its range. No simultaneous restart of all hosts is required, and no sites are left unchecked during the update.

--- a/README.md
+++ b/README.md
@@ -10,17 +10,19 @@ The core detection story stays familiar:
 local checks -> local retries -> geo Veriflier confirmation -> notify
 ```
 
-The difference is what happens around that flow. Jetmon 2 records what it saw,
-why it believed a site was down, which Verifliers agreed, which notifications
-were sent, and how every incident changed over time. It turns "up or down" into
-an auditable health platform.
+The first difference is correctness: v2 checks sites with `GET`, not the
+`HEAD`-only probes that made v1 disagree with real visitor behavior on too many
+VIP and Agency sites. Around that more realistic probe, Jetmon 2 records what
+it saw, why it believed a site was down, which Verifliers agreed, which
+notifications were sent, and how every incident changed over time. It turns "up
+or down" into an auditable health platform.
 
 ## Why This Matters
 
 | Audience | What Gets Better |
 |---|---|
 | Systems teams | Static Go binaries, no `npm`, `node-gyp`, Qt, or worker process tree. Bucket ownership is coordinated in MySQL, hosts drain cleanly, and memory pressure is handled inside the goroutine pool. |
-| VIP and Agency teams | Fewer noisy pages and fewer missed incidents through local retries, Veriflier quorum, maintenance windows, keyword checks, redirect policy, SSL/TLS checks, and clearer failure classes. |
+| VIP and Agency teams | GET-based checks that match customer-visible behavior better than v1's HEAD probes, plus fewer noisy pages and fewer missed incidents through local retries, Veriflier quorum, maintenance windows, keyword checks, redirect policy, SSL/TLS checks, and clearer failure classes. |
 | Leadership | A foundation for differentiated uptime monitoring: internal API, webhooks, managed alert contacts, tenant-aware gateway paths, and future Jetpack/WPCOM integrations. |
 | Happiness Engineers | Incident answers with evidence: audit logs, event transitions, check timing, Veriflier votes, WPCOM payloads, and suppression reasons are all queryable. |
 | Jetpack contributors | A monitor that can grow into a product surface, not just a backend notification hook. |
@@ -30,6 +32,7 @@ an auditable health platform.
 | Area | Jetmon 1 | Jetmon 2 |
 |---|---|---|
 | Runtime | Node master, Node workers, C++ native addon, Qt Veriflier | Go monitor, Go Veriflier, optional Go deliverer |
+| Probe method | `HEAD` requests that could disagree with real page loads | `GET` requests for local checks and Veriflier checks |
 | State | Mutable `site_status` projection | `jetmon_events` plus append-only `jetmon_event_transitions` |
 | Detection | Binary status changes | `Seems Down`, `Down`, recovery, false-alarm, and severity transitions |
 | Evidence | Basic logs | Audit log, check history, timing breakdown, verifier outcomes, API request logs |
@@ -43,7 +46,7 @@ Jetmon 2 keeps the compatibility surfaces that matter during rollout:
 - StatsD metric naming remains `com.jetpack.jetmon.<hostname>`.
 - Legacy log and stats file paths remain available.
 - `jetpack_monitor_sites.site_status` can be projected from v2 events during
-  the shadow-state migration.
+  the [v1-to-v2 migration](docs/v1-to-v2-migration.md).
 
 ## How Incidents Flow
 
@@ -106,7 +109,7 @@ See [docs/getting-started.md](docs/getting-started.md) for the full local loop.
 | [docs/data-model.md](docs/data-model.md) | Tables, migrations, event projection, tenant mapping |
 | [docs/support-guide.md](docs/support-guide.md) | HE workflows for explaining alerts and missed alerts |
 | [docs/api-cli-guide.md](docs/api-cli-guide.md) | API CLI examples and automation patterns |
-| [docs/v1-to-v2-pinned-rollout.md](docs/v1-to-v2-pinned-rollout.md) | First production migration from v1 static buckets |
+| [docs/v1-to-v2-migration.md](docs/v1-to-v2-migration.md) | Full v1-to-v2 production migration and rollback runbook |
 | [docs/jetmon-deliverer-rollout.md](docs/jetmon-deliverer-rollout.md) | Moving outbound delivery to `jetmon-deliverer` |
 | [ROADMAP.md](ROADMAP.md) | Broader v2 and v3 planning |
 
@@ -114,7 +117,8 @@ Longer design decisions live in [docs/adr/](docs/adr/).
 
 ## Production Posture
 
-Jetmon 2 is designed for a cautious host-by-host rollout:
+Jetmon 2 is designed for a cautious host-by-host rollout. The complete process
+is in [docs/v1-to-v2-migration.md](docs/v1-to-v2-migration.md):
 
 - Run `./jetmon2 migrate` before first start. Migrations are embedded and
   additive.

--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ The same CLI can create bounded test batches and run a Docker-local smoke pass:
 	./bin/jetmon2 api sites bulk-add --count 3 --batch local-smoke --dry-run --pretty
 	./bin/jetmon2 api smoke --batch local-smoke --pretty
 	./bin/jetmon2 api sites simulate-failure --batch local-smoke --mode http-500 --wait 15s --pretty
+	./bin/jetmon2 api sites simulate-failure --batch local-smoke --mode http-500 --wait 30s --expect-event-state 'Seems Down' --expect-transition-reason opened --pretty
 	./bin/jetmon2 api sites cleanup --batch local-smoke --count 3 --output table
 
 Or run the standard CLI smoke sequence with:
@@ -341,9 +342,17 @@ legacy consumers. After all consumers read from the v2 API/event tables, set
 
 ### Simulated Site Server
 
-The Docker Compose environment does not yet include the planned simulated site
-server. Use external test endpoints or local ad-hoc services for response-code,
-timeout, redirect, keyword, and TLS scenarios until that service is added.
+The Docker Compose environment includes `api-fixture`, a deterministic local
+site fixture for API CLI failure simulation. Jetmon containers reach it at
+`http://api-fixture:8091` and `https://api-fixture:8443`; the host can inspect
+it at `http://localhost:18091` and `https://localhost:18443` by default. The
+fixture exposes `/status/403`, `/status/500`, `/redirect`, `/keyword`, `/slow`,
+and `/tls` endpoints. `jetmon2 api sites simulate-failure` automatically uses
+the fixture when `http://localhost:18091/health` is reachable; set
+`--fixture-url=off` to force the public endpoint fallback. Add
+`--expect-event-state`, `--expect-event-severity`, `--require-transition`, or
+`--expect-transition-reason` when a rehearsal should fail unless the API reports
+the expected event/transition state before `--wait` expires.
 
 ### Config Validation
 

--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ point the API CLI at the exposed API port:
 	export JETMON_API_TOKEN=jm_replace_with_the_printed_token
 	./bin/jetmon2 api health --pretty
 	./bin/jetmon2 api me --pretty
+	./bin/jetmon2 api commands --output table
 	./bin/jetmon2 api sites list --output table
 
 The same CLI can create bounded test batches and run a Docker-local smoke pass:

--- a/README.md
+++ b/README.md
@@ -313,6 +313,11 @@ Or run the standard CLI smoke sequence with:
 
 	JETMON_API_URL=http://localhost:${API_HOST_PORT:-8090} JETMON_API_TOKEN=jm_replace_with_the_printed_token make api-cli-smoke
 
+For a fuller live validation pass against the API CLI guide examples and the
+Docker-local failure fixture, run:
+
+	JETMON_API_URL=http://localhost:${API_HOST_PORT:-8090} JETMON_API_TOKEN=jm_replace_with_the_printed_token make api-cli-validate
+
 ### Adding Test Sites
 
 Connect to the test database:

--- a/README.md
+++ b/README.md
@@ -1,829 +1,156 @@
-jetmon2
-=======
+# Jetmon 2
 
-Overview
---------
+Jetmon 2 is the Go rewrite of Jetpack's uptime monitor: the same production
+contract v1 consumers depend on, with a cleaner runtime, an event-sourced health
+model, richer diagnostics, and API-first automation.
 
-Jetmon is the parallel HTTP health monitoring service for Jetpack-connected sites at scale. Jetmon 2 turns it from a binary up/down status flipper into a full event-sourced health platform — the same low-false-positive Veriflier-confirmed detection core, now with a five-layer severity model, an internal REST API, HMAC-signed webhooks, managed alert contacts (email, PagerDuty, Slack, Teams), and a complete operational audit trail.
+The core detection story stays familiar:
 
-The whole thing ships as a single static Go binary with embedded migrations. No `node_modules`, no native addons, no worker process tree. Every check, retry, Veriflier confirmation, and notification lands in `jetmon_audit_log`; every status transition lands in `jetmon_event_transitions`. An operator can replay any incident, end-to-end, from the database alone.
+```text
+local checks -> local retries -> geo Veriflier confirmation -> notify
+```
 
-The Jetmon 1 detection pipeline is preserved verbatim — periodic check rounds, local retries before escalation, geo-distributed Veriflier confirmation before WPCOM is notified. v2 keeps WPCOM compatibility through a shadow-state migration: the v2 event tables are authoritative, and `jetpack_monitor_sites.site_status` / `last_status_change` continue to be projected transactionally for legacy consumers until they cut over (`LEGACY_STATUS_PROJECTION_ENABLE`).
+The difference is what happens around that flow. Jetmon 2 records what it saw,
+why it believed a site was down, which Verifliers agreed, which notifications
+were sent, and how every incident changed over time. It turns "up or down" into
+an auditable health platform.
 
+## Why This Matters
 
-What's new in v2
-----------------
+| Audience | What Gets Better |
+|---|---|
+| Systems teams | Static Go binaries, no `npm`, `node-gyp`, Qt, or worker process tree. Bucket ownership is coordinated in MySQL, hosts drain cleanly, and memory pressure is handled inside the goroutine pool. |
+| VIP and Agency teams | Fewer noisy pages and fewer missed incidents through local retries, Veriflier quorum, maintenance windows, keyword checks, redirect policy, SSL/TLS checks, and clearer failure classes. |
+| Leadership | A foundation for differentiated uptime monitoring: internal API, webhooks, managed alert contacts, tenant-aware gateway paths, and future Jetpack/WPCOM integrations. |
+| Happiness Engineers | Incident answers with evidence: audit logs, event transitions, check timing, Veriflier votes, WPCOM payloads, and suppression reasons are all queryable. |
+| Jetpack contributors | A monitor that can grow into a product surface, not just a backend notification hook. |
 
-v2 keeps the Jetmon 1 detection pipeline (local retries → geo-distributed Veriflier confirmation → notify) and rebuilds everything around it.
+## What Changed
 
-| Capability | Jetmon 1 | Jetmon 2 |
+| Area | Jetmon 1 | Jetmon 2 |
 |---|---|---|
-| Status model | Binary `up` / `down` (`confirmed_down` for re-detections) | Five-layer severity ladder: `Up < Warning < Degraded < SeemsDown < Down`, paired with separate state vocabulary |
-| State storage | Single mutable `site_status` column | Event-sourced — `jetmon_events` (current authoritative state) + append-only `jetmon_event_transitions` (every mutation) |
-| Failure classifications | `down` | `server`, `client`, `blocked`, `https`, `intermittent`, `redirect`, `ssl_expiry`, `tls_deprecated`, `keyword_missing`, `success` |
-| Notification channels | WPCOM only | WPCOM + HMAC-signed webhooks + managed alert contacts (email, PagerDuty, Slack, Teams) |
-| API surface | None | Internal REST API at `/api/v1`: Bearer auth, three coarse scopes, per-key rate limit, Stripe-style idempotency, cursor pagination, full audit logging |
-| Per-site config | Bucket + check interval | + custom headers, timeout override, redirect policy, alert cooldown, maintenance windows, keyword content check, SSL-expiry alerts at 30 / 14 / 7 days |
-| Operational audit | Basic logging | Full audit trail (`jetmon_audit_log`) over every check, retry, Veriflier dispatch, alert suppression, API call, and config reload |
-| Process model | Node master + Node workers + C++ native addon + Qt C++ Veriflier | Go monitor (`jetmon2`) + optional outbound deliverer (`jetmon-deliverer`) + Go Veriflier (`veriflier2`) |
-| Worker scaling | Spawn / kill child processes | In-process goroutine pool that auto-scales by queue depth |
-| Deployment friction | `npm` + `node-gyp` + Qt | Static binary + `./jetmon2 migrate` + `./jetmon2 validate-config` |
-| Multi-host coordination | Manual `bucket_min` / `bucket_max` per host | MySQL-coordinated `jetmon_hosts` table with heartbeat-and-reclaim |
-| Observability | StatsD | StatsD + structured logs + audit trail + operator dashboard (SSE) + localhost pprof |
-| Hot reload | Restart | `SIGHUP` for config; `SIGINT` for graceful drain |
+| Runtime | Node master, Node workers, C++ native addon, Qt Veriflier | Go monitor, Go Veriflier, optional Go deliverer |
+| State | Mutable `site_status` projection | `jetmon_events` plus append-only `jetmon_event_transitions` |
+| Detection | Binary status changes | `Seems Down`, `Down`, recovery, false-alarm, and severity transitions |
+| Evidence | Basic logs | Audit log, check history, timing breakdown, verifier outcomes, API request logs |
+| Integrations | WPCOM notification path | WPCOM, REST API, HMAC webhooks, email, PagerDuty, Slack, Teams |
+| Operations | Static bucket config and process recycling | Dynamic bucket ownership, graceful drain, hot reload, dashboard, pprof |
 
-A few specifics worth bragging about:
+Jetmon 2 keeps the compatibility surfaces that matter during rollout:
 
-- **Webhooks with Stripe-style HMAC signatures.** `t=<unix>,v1=<hex>` over `{ts}.{body}`, per-webhook in-flight cap, retry ladder 1m → 5m → 30m → 1h → 6h before abandon. Frozen-at-fire-time payload contract — consumers see the event as it was when the webhook fired, not as it is now.
-- **Idempotent write endpoints.** POSTs accept `Idempotency-Key`; replays return the original response, so a retried "click to test" through a network blip won't double-page the destination.
-- **Rotation grace windows on API keys.** `revoked_at` and `expires_at` are half-open cutoffs; setting `revoked_at` in the future keeps the old key valid until consumers deploy the replacement.
-- **Migrations embedded in the binary.** `./jetmon2 migrate` walks the schema forward; `./jetmon2 validate-config` checks config + DB connectivity + email transport mode + verifier list before deploy, prints the matching rollout preflight command, and warns loudly when alert-contact email is set to the log-only stub.
-- **MySQL 5.7+ compatible.** No window functions, no JSON-path expressions in SELECT — the v2 schema and queries land cleanly on the legacy production database.
+- MySQL changes are additive.
+- WPCOM notification payloads stay compatible.
+- StatsD metric naming remains `com.jetpack.jetmon.<hostname>`.
+- Legacy log and stats file paths remain available.
+- `jetpack_monitor_sites.site_status` can be projected from v2 events during
+  the shadow-state migration.
 
+## How Incidents Flow
 
-Architecture
-------------
+1. The monitor checks active sites with a bounded Go worker pool.
+2. A first local failure opens a `Seems Down` event so the incident start time is
+   honest.
+3. Local retries absorb one-off network blips before customer notification.
+4. Geo-distributed Verifliers confirm or reject the outage.
+5. Confirmed outages become `Down`; rejected outages close as false alarms.
+6. WPCOM, webhooks, alert contacts, the dashboard, and the API all read from the
+   same event and transition history.
 
-```
-┌──────────────────────────────────────────────────────────────┐
-│                           jetmon2                            │
-│                                                              │
-│  ┌────────────┐  ┌────────────┐  ┌────────────────────┐      │
-│  │Orchestrator│  │ Check pool │  │ Veriflier          │      │
-│  │ goroutine  │  │(goroutines)│  │ transport          │      │
-│  └─────┬──────┘  └─────┬──────┘  └────────┬───────────┘      │
-│        │               │                  │                  │
-│  ┌─────┴───────────────┴──────────────────┴────────────┐     │
-│  │  Eventstore + Audit log                             │     │
-│  └─────┬─────────────────┬──────────────────┬──────────┘     │
-│        │                 │                  │                │
-│  ┌─────┴──────┐  ┌───────┴────────┐  ┌──────┴──────────┐     │
-│  │  REST API  │  │ Webhook worker │  │  Alert-contact  │     │
-│  │  /api/v1/  │  │ embedded or    │  │ worker embedded │     │
-│  │            │  │ deliverer      │  │ or deliverer    │     │
-│  └────────────┘  └────────────────┘  └─────────────────┘     │
-└────────┬─────────────────────────────────────────┬───────────┘
-         │                                         │
-       MySQL                              WPCOM · custom webhooks
-       StatsD                             · email · PagerDuty
-       Log files                          · Slack · Teams
+That model gives operators and support teams the part v1 could not: a coherent
+timeline for every incident, not just the final status bit.
+
+## Try It Locally
+
+Docker Compose is the fastest path for local development:
+
+```bash
+cd docker
+cp .env-sample .env
+docker compose up --build -d
 ```
 
-The **Orchestrator goroutine** fetches site batches from MySQL, dispatches work to the check pool, manages the local retry queue, coordinates Veriflier confirmation, and sends WPCOM notifications. It owns all database access and all outbound WPCOM calls.
-
-The **Check Pool** is a bounded goroutine pool that performs HTTP checks using Go's `net/http` and `net/http/httptrace`. It records DNS, TCP, TLS, and TTFB timings on every check and auto-scales against queue depth without spawning new processes.
-
-The **Veriflier transport** sends confirmation batches to remote Veriflier instances. JSON-over-HTTP on the configured Veriflier port is the v2 production transport; the proto definition in `proto/` is retained only as a schema reference for a possible future transport.
-
-The **Veriflier** is a standalone Go binary deployed at remote locations. It replaces the Qt C++ Veriflier and uses the same JSON-over-HTTP transport as the Monitor-side client.
-
-The v2 platform layer sits below the detection pipeline:
-
-- **Eventstore** is the sole writer for `jetmon_events` and `jetmon_event_transitions`. Every state change — open, escalate, close, recover, manual override — is an atomic transition with full history. Audit log writes share the same MySQL handle.
-- **REST API** exposes the v2 surface at `/api/v1/` (enable with `API_PORT`). Bearer-token auth, three coarse scopes (`read` / `write` / `admin`), per-key token-bucket rate limiting, Stripe-style idempotency keys on POSTs. Every authenticated request lands in `jetmon_audit_log` with the consumer name, status, latency, and request id.
-- **Webhook worker** delivers HMAC-signed `event.*` posts to registered consumers. Per-webhook in-flight cap, retry ladder 1m → 5m → 30m → 1h → 6h, frozen-at-fire-time payload.
-- **Alert-contact worker** delivers Jetmon-rendered notifications through Jetmon-owned transports (email, PagerDuty Events API v2, Slack Block Kit, Teams Adaptive Cards). Per-contact `max_per_hour` rate cap as pager-storm insurance.
-
-WPCOM notification flow (preserved from Jetmon 1, used during shadow-state migration):
-
-| Previous Status | Current Status    | Action                                                |
-|-----------------|-------------------|-------------------------------------------------------|
-| UP              | DOWN              | Local retries → Veriflier confirmation → notify WPCOM |
-| DOWN            | UP                | Notify WPCOM site recovered                           |
-| DOWN            | DOWN (confirmed)  | Notify WPCOM confirmed down                           |
-
-v2 emits richer events to webhook and alert-contact subscribers (full event lifecycle including escalations and severity transitions) — the WPCOM table above describes only the legacy notification path.
-
-
-Installation
-------------
-
-1) Install [Docker](https://docs.docker.com/get-docker/) and [docker-compose](https://docs.docker.com/compose/install/)
-
-2) Clone the repository
-
-3) Copy the environment file:
-
-		cd docker && cp .env-sample .env
-
-4) Edit `docker/.env` for your local environment. The file is only for local
-   host-side bind address / `*_HOST_PORT` overrides, credentials, and user ids.
-   `BIND_ADDR` keeps non-API services local by default; `API_BIND_ADDR` controls
-   whether the REST API is reachable by other systems. Container-side service
-   ports are hardcoded in `docker-compose.yml`.
-   `MYSQL_ROOT_PASSWORD` is used only for local container setup; Jetmon connects
-   with the non-root `MYSQL_USER` / `MYSQL_PASSWORD` credentials.
-   New Docker-generated Jetmon configs use `EMAIL_TRANSPORT=smtp` through
-   Mailpit so alert-contact emails can be inspected locally.
-
-5) Build and start all services:
-
-		docker compose up --build -d
-
-
-Configuration
--------------
-
-Jetmon configuration lives in `config/config.json`. Copy `config/config-sample.json` to get started. The file is generated automatically from `config-sample.json` and `docker/.env` if not present.
-
-Send `SIGHUP` to the running process to reload configuration without restarting.
-
-Key settings:
-
-| Key | Default | Description |
-|-----|---------|-------------|
-| `NUM_WORKERS` | 60 | Goroutine pool size |
-| `NUM_TO_PROCESS` | 40 | Parallel checks per pool slot |
-| `MIN_TIME_BETWEEN_ROUNDS_SEC` | 300 | Minimum seconds between check rounds |
-| `NET_COMMS_TIMEOUT` | 10 | Default per-check HTTP timeout (seconds) |
-| `PEER_OFFLINE_LIMIT` | 3 | Veriflier agreements required to confirm downtime |
-| `WORKER_MAX_MEM_MB` | 53 | RSS threshold that triggers goroutine pool drain |
-| `BUCKET_TOTAL` | 1000 | Total bucket range across all hosts |
-| `BUCKET_TARGET` | 500 | Maximum buckets this host should own |
-| `BUCKET_HEARTBEAT_GRACE_SEC` | 600 | Seconds before a silent host's buckets are reclaimed |
-| `PINNED_BUCKET_MIN` / `PINNED_BUCKET_MAX` | unset | Migration-only static bucket range; disables `jetmon_hosts` ownership for v1-compatible host-by-host cutover |
-| `ALERT_COOLDOWN_MINUTES` | 30 | Default cooldown between repeated alerts per site |
-| `LEGACY_STATUS_PROJECTION_ENABLE` | true | Keep `jetpack_monitor_sites.site_status` / `last_status_change` updated for v1 consumers during migration |
-| `LOG_FORMAT` | `text` | `text` for plain-text logs or `json` for structured logs |
-| `DASHBOARD_PORT` | 8080 | Internal port for the operator dashboard (0 to disable) |
-| `API_PORT` | 0 | Internal REST API port (0 to disable). Also makes webhook and alert-contact delivery workers eligible to run. |
-| `DELIVERY_OWNER_HOST` | empty | Optional hostname allowed to run delivery workers when `API_PORT` is enabled; set this on shared production configs so only one API-enabled host dispatches outbound deliveries. |
-| `DEBUG_PORT` | 6060 | localhost-only pprof port (`127.0.0.1:PORT`); 0 to disable |
-| `EMAIL_TRANSPORT` | `stub` | Alert-contact email sender: `stub` (log only), `smtp`, or `wpcom` |
-
-See `config/config.readme` for the full option reference.
-
-The Veriflier configuration lives in `veriflier2/config/veriflier.json`, generated from `veriflier-sample.json` and `docker/.env`.
-
-
-Running
--------
-
-	cd docker && docker compose up -d
-
-To rebuild the binary after code changes:
-
-	docker compose up --build -d
-
-To follow logs:
-
-	docker compose logs -f jetmon
-
-To stop:
-
-	docker compose down
-
-After pulling Docker service or volume changes, clear stale stopped containers
-before restarting:
-
-	docker compose down --remove-orphans
-
-
-Database
---------
-
-Main table (unchanged from Jetmon 1):
-
-	CREATE TABLE `jetpack_monitor_sites` (
-	    `jetpack_monitor_site_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT PRIMARY KEY,
-	    `blog_id` bigint(20) unsigned NOT NULL,
-	    `bucket_no` smallint(2) unsigned NOT NULL,
-	    `monitor_url` varchar(300) NOT NULL,
-	    `monitor_active` tinyint(1) unsigned NOT NULL DEFAULT 1,
-	    `site_status` tinyint(1) unsigned NOT NULL DEFAULT 1,
-	    `last_status_change` timestamp NULL DEFAULT current_timestamp(),
-	    `check_interval` tinyint(1) unsigned NOT NULL DEFAULT 5,
-	    INDEX `blog_id_monitor_url` (`blog_id`, `monitor_url`),
-	    INDEX `bucket_no_monitor_active_check_interval` (`bucket_no`, `monitor_active`, `check_interval`)
-	);
-
-New columns added by Jetmon 2 (applied via `jetmon2 migrate`):
-
-| Column | Type | Purpose |
-|--------|------|---------|
-| `ssl_expiry_date` | DATE NULL | Updated each HTTPS check |
-| `check_keyword` | VARCHAR(500) NULL | String to verify in response body |
-| `maintenance_start` | DATETIME NULL | Maintenance window start |
-| `maintenance_end` | DATETIME NULL | Maintenance window end |
-| `custom_headers` | JSON NULL | Per-site request headers |
-| `timeout_seconds` | TINYINT NULL | Per-site timeout override |
-| `redirect_policy` | ENUM NULL | `follow`, `alert`, or `fail` |
-| `alert_cooldown_minutes` | SMALLINT NULL | Per-site cooldown override |
-
-Jetmon 2 uses a shadow-v2-state migration model. Incident state is authoritative
-in the v2 event tables, while `jetpack_monitor_sites` remains the legacy site
-configuration table and compatibility projection during migration. With
-`LEGACY_STATUS_PROJECTION_ENABLE: true`, every v2 incident mutation also updates
-the v1 `site_status` / `last_status_change` fields in the same transaction. Once
-legacy readers have moved to the v2 API/event tables, disable that projection.
-
-New tables added by Jetmon 2:
-
-| Table | Purpose |
-|-------|---------|
-| `jetmon_hosts` | MySQL-coordinated bucket ownership and heartbeat |
-| `jetmon_events` | Authoritative current state of each v2 incident |
-| `jetmon_event_transitions` | Append-only history of every mutation to `jetmon_events` |
-| `jetmon_audit_log` | Operational trail for checks, retries, WPCOM calls, suppression, API access, and config reloads |
-| `jetmon_check_history` | RTT and timing samples for trending |
-| `jetmon_false_positives` | Veriflier non-confirmation events |
-| `jetmon_api_keys` | Internal REST API Bearer-token registry |
-| `jetmon_webhooks` | Webhook registrations and HMAC signing secrets |
-| `jetmon_webhook_deliveries` | Outbound webhook delivery attempts and retry state |
-| `jetmon_webhook_dispatch_progress` | Webhook worker high-water marks over event transitions |
-| `jetmon_alert_contacts` | Managed alert destinations such as email, PagerDuty, Slack, and Teams |
-| `jetmon_alert_deliveries` | Outbound alert-contact delivery attempts and retry state |
-| `jetmon_alert_dispatch_progress` | Alert worker high-water marks over event transitions |
-
-Apply migrations before starting for the first time:
-
-	./jetmon2 migrate
-
-
-For Developers
---------------
-
-### Prerequisites
-
-- Go 1.22 or later
-- Docker and docker-compose (for integration testing)
-- Access to a MySQL instance (provided by Docker Compose)
-
-### Building
-
-	make all              # Build bin/jetmon2, bin/jetmon-deliverer, and bin/veriflier2
-	make build            # Build only bin/jetmon2
-	make build-deliverer  # Build only bin/jetmon-deliverer
-	make build-veriflier  # Build only bin/veriflier2
-
-If `go` is not on `PATH`, the Makefile falls back to
-`/usr/local/go/bin/go` when present. Override with `make GO=/path/to/go ...`
-for other local layouts. Make targets use `GOCACHE=/tmp/jetmon-go-cache` by
-default so builds do not depend on a writable home-directory cache; override
-with `make GOCACHE=/path/to/cache ...` when needed.
-
-`make generate` is intentionally separate from `make all`. It requires
-`protoc` and the Go protobuf plugins, and is reserved for experimental proto
-stub generation; generated stubs are not part of the v2 production transport.
-
-### Running Tests
-
-	make test
-	make test-race
-	make lint
-
-The current `go test ./...` suite runs standalone. Use the Docker Compose environment for manual end-to-end checks against MySQL, StatsD, and Veriflier services.
-
-### Docker Development Loop
-
-	cd docker
-	docker compose up --build -d          # Build binary and start all services
-	docker compose logs -f jetmon          # Follow logs
-	docker compose exec jetmon bash        # Shell into the container
-
-Mailpit captures Docker-local alert-contact emails. Open the web UI at
-`http://localhost:8025` by default, or at the `BIND_ADDR` /
-`MAILPIT_HOST_PORT` values from `docker/.env`. Jetmon sends SMTP to the
-internal `mailpit:1025` address; that SMTP port is not published to the host.
-Existing `config/config.json` files are not rewritten automatically, so remove
-or update a stale local config if you want it to use Mailpit.
-
-For local API checks, build `bin/jetmon2`, create a Docker-local API key, then
-point the API CLI at the exposed API port:
-
-	make build
-	cd docker
-	docker compose up --build -d
-	cd ..
-	make api-cli-token-create
-	export JETMON_API_URL=http://localhost:${API_HOST_PORT:-8090}
-	export JETMON_API_TOKEN=jm_replace_with_the_printed_token
-	./bin/jetmon2 api health --pretty
-	./bin/jetmon2 api me --pretty
-	./bin/jetmon2 api commands --output table
-	./bin/jetmon2 api sites list --output table
-
-The same CLI can create bounded test batches and run a Docker-local smoke pass:
-
-	./bin/jetmon2 api sites bulk-add --count 3 --batch local-smoke --dry-run --pretty
-	./bin/jetmon2 api smoke --batch local-smoke --pretty
-	./bin/jetmon2 api sites simulate-failure --batch local-smoke --mode http-500 --wait 15s --pretty
-	./bin/jetmon2 api sites simulate-failure --batch local-smoke --mode http-500 --wait 30s --expect-event-state 'Seems Down' --expect-transition-reason opened --pretty
-	./bin/jetmon2 api sites cleanup --batch local-smoke --count 3 --output table
-
-Or run the standard CLI smoke sequence with:
-
-	JETMON_API_URL=http://localhost:${API_HOST_PORT:-8090} JETMON_API_TOKEN=jm_replace_with_the_printed_token make api-cli-smoke
-
-For a fuller live validation pass against the API CLI guide examples and the
-Docker-local failure fixture, run:
-
-	JETMON_API_URL=http://localhost:${API_HOST_PORT:-8090} JETMON_API_TOKEN=jm_replace_with_the_printed_token make api-cli-validate
-
-Use `make api-cli-token-list` to inspect Docker-local API keys and
-`API_CLI_TOKEN_ID=<id> make api-cli-token-revoke` to revoke a rehearsal token.
-
-### Adding Test Sites
-
-Connect to the test database:
-
-	docker compose exec mysqldb mysql -u jetmon -pjetmon_dev_password jetmon_db
-
-Insert sites to check:
-
-	INSERT INTO jetpack_monitor_sites (blog_id, bucket_no, monitor_url, monitor_active, site_status)
-	VALUES
-	    (1, 0, 'https://wordpress.com', 1, 1),
-	    (2, 0, 'https://httpstat.us/200', 1, 1),
-	    (3, 0, 'https://httpstat.us/500', 1, 1),
-	    (4, 0, 'https://httpstat.us/200?sleep=15000', 1, 1);
-
-### Legacy Status Projection
-
-During migration, keep the legacy v1 status fields updated:
-
-	{ "LEGACY_STATUS_PROJECTION_ENABLE": true }
-
-This does not make the legacy row the source of truth. Jetmon v2 writes
-`jetmon_events` and `jetmon_event_transitions` first, then projects
-`site_status` and `last_status_change` back to `jetpack_monitor_sites` for
-legacy consumers. After all consumers read from the v2 API/event tables, set
-`LEGACY_STATUS_PROJECTION_ENABLE` to `false`.
-
-### Simulated Site Server
-
-The Docker Compose environment includes `api-fixture`, a deterministic local
-site fixture for API CLI failure simulation. Jetmon containers reach it at
-`http://api-fixture:8091` and `https://api-fixture:8443`; the host can inspect
-it at `http://localhost:18091` and `https://localhost:18443` by default. The
-fixture exposes `/status/403`, `/status/500`, `/redirect`, `/keyword`, `/slow`,
-and `/tls` endpoints. `jetmon2 api sites simulate-failure` automatically uses
-the fixture when `http://localhost:18091/health` is reachable; set
-`--fixture-url=off` to force the public endpoint fallback. Add
-`--expect-event-state`, `--expect-event-severity`, `--require-transition`, or
-`--expect-transition-reason` when a rehearsal should fail unless the API reports
-the expected event/transition state before `--wait` expires.
-
-### Config Validation
-
-	./jetmon2 validate-config
-
-Checks all required keys, validates value ranges, tests MySQL connectivity,
-reports legacy projection and email transport modes, warns when alert-contact
-email uses the log-only `stub` sender, and lists configured Verifliers.
-Veriflier reachability is informational here rather than a validation failure.
-
-### Tenant Mapping Backfill
-
-Gateway-routed site reads and writes are scoped through
-`jetmon_site_tenants`. Before customer traffic depends on Jetmon-side tenant
-enforcement, import the gateway/customer source of truth as CSV:
-
-	./jetmon2 site-tenants import --file site-tenants.csv --dry-run
-	./jetmon2 site-tenants import --file site-tenants.csv --source gateway
-
-The CSV format is `tenant_id,blog_id` with an optional header row. The import
-upserts mappings and skips duplicate rows in the input; it does not delete
-missing mappings, because pruning requires a source-specific reconciliation
-policy.
-
-### Debugging
-
-Enable debug logging in `config/config.json`:
-
-	{ "DEBUG": true }
-
-Or switch to structured JSON logs for easier filtering:
-
-	{ "LOG_FORMAT": "json" }
-
-Attach the Go pprof profiler (localhost only, never exposed remotely):
-
-	curl http://localhost:6060/debug/pprof/
-
-The debug port is configurable via `DEBUG_PORT` (default 6060). Set to 0 to disable.
-
-### Project Layout
-
-| Path | Purpose |
-|------|---------|
-| `cmd/jetmon2/` | Binary entry point |
-| `cmd/jetmon-deliverer/` | Standalone outbound delivery worker entry point |
-| `internal/orchestrator/` | Round scheduling, DB fetch, WPCOM notifications |
-| `internal/checker/` | HTTP check goroutine pool |
-| `internal/veriflier/` | JSON-over-HTTP Veriflier transport |
-| `internal/db/` | MySQL access, bucket heartbeat |
-| `internal/config/` | Config loading and hot-reload |
-| `internal/metrics/` | StatsD client, stats file writer |
-| `internal/wpcom/` | WPCOM API client and circuit breaker |
-| `internal/audit/` | Audit log |
-| `internal/eventstore/` | Authoritative event and transition writer |
-| `internal/api/` | Internal REST API server |
-| `internal/deliverer/` | Shared outbound delivery worker wiring |
-| `internal/webhooks/` | HMAC-signed webhook registry and delivery worker |
-| `internal/alerting/` | Managed alert-contact registry and delivery worker |
-| `internal/dashboard/` | Operator dashboard and SSE handler |
-| `veriflier2/` | Go Veriflier binary |
-
-
-For Testers
------------
-
-### Starting the Test Environment
-
-	cd docker
-	docker compose up --build -d
-	docker compose logs -f jetmon
-
-### Verifying Basic Operation
-
-Check that sites are being processed:
-
-	docker compose exec jetmon cat stats/sitespersec
-	docker compose exec jetmon cat stats/sitesqueue
-	docker compose exec jetmon ps aux
-
-Check the StatsD dashboard at `http://localhost:8088` by default, or at the
-`BIND_ADDR` / `GRAPHITE_HOST_PORT` values from `docker/.env`, under:
-`Metrics > stats > com > jetpack > jetmon > docker > jetmon`
-
-### Key Test Scenarios
-
-**Downtime detection and confirmation:**
-Insert a site pointing to `https://httpstat.us/500`. With `LEGACY_STATUS_PROJECTION_ENABLE: true`, Jetmon should detect the failure, retry locally, escalate to the Veriflier, confirm down, write the v2 event transition, and project `site_status` to `2`.
-
-**SSL certificate expiry:**
-Insert an HTTPS site. After a check round, verify `ssl_expiry_date` is populated in the database.
-
-**Keyword check:**
-Insert a site with `check_keyword` set to a string that appears (or does not appear) in the response body. Verify the check result matches the keyword presence.
-
-**Maintenance window suppression:**
-Set `maintenance_start` and `maintenance_end` to bracket the current time. Verify no alert fires even when the site returns errors. Verify the event appears in `jetmon_audit_log`.
-
-**Timeout handling:**
-Insert `https://httpstat.us/200?sleep=15000` (15-second delay). Verify it is classified as `intermittent` after the timeout expires.
-
-**Redirect policy:**
-Insert a site returning 301. Test `follow`, `alert`, and `fail` values in the `redirect_policy` column.
-
-**Alert cooldown:**
-Set `alert_cooldown_minutes` to a low value. Trigger repeated failures and verify subsequent alerts are suppressed and recorded in the audit log.
-
-**Graceful shutdown:**
-Drain in-flight checks and exit cleanly:
-
-	docker compose exec jetmon ./jetmon2 drain
-
-**Config reload:**
-Modify `config/config.json` and reload without a restart:
-
-	docker compose exec jetmon ./jetmon2 reload
-
-**Worker pool auto-scaling:**
-Set `NUM_WORKERS` to a low value with many sites in the database. Observe queue depth rising and the pool scaling up in the operator dashboard.
-
-**Bucket ownership failover:**
-Simulate a host failure by manually expiring a row in `jetmon_hosts`. Verify the surviving instance absorbs the abandoned buckets within one grace period.
-
-### Operator Dashboard
-
-The dashboard is available at http://localhost:8080 (configurable via
-`DASHBOARD_PORT`). It shows worker count, active checks, queue depth, retry
-queue depth, sites per second, round time, owned buckets, rollout guard state,
-RSS, WPCOM circuit-breaker state, and live dependency health for MySQL,
-configured Verifliers, WPCOM, StatsD, and log/stats directory writes.
-
-### Internal API and Delivery Workers
-
-The internal API is disabled by default. Set `API_PORT` to a non-zero port to enable `/api/v1/...`.
-
-In the embedded v2 deployment, `API_PORT` also makes the webhook and alert-contact delivery workers eligible to run inside `jetmon2`. Set `DELIVERY_OWNER_HOST` to exactly one hostname per database cluster when you want additional API-enabled hosts to serve API traffic without owning delivery during a staged rollout. If `DELIVERY_OWNER_HOST` is empty, the host keeps the legacy behavior and starts delivery workers whenever `API_PORT` is enabled; startup and `validate-config` warn about that fallback.
-
-`bin/jetmon-deliverer` is the first standalone process boundary for outbound delivery. It starts the same webhook and alert-contact workers without starting the monitor, API, dashboard, or bucket ownership loop. Delivery rows are claimed transactionally, so multiple active delivery workers do not claim the same pending row; use `DELIVERY_OWNER_HOST` when you want an explicit single-owner rollout during the transition from embedded to standalone delivery.
-
-### Cleanup
-
-	docker compose down -v
-	rm -f config/config.json
-	rm -rf logs/*.log stats/*
-
-
-For Admins
-----------
-
-### Production Overview
-
-Jetmon runs on multiple production hosts managed by the Systems team. Each host owns a non-overlapping range of site buckets. Bucket ownership is coordinated automatically via the `jetmon_hosts` MySQL table — no manual bucket range configuration is required.
-
-### Deploying a New Host
-
-1) Install the `jetmon2` binary to `/opt/jetmon2/`
-2) Install `systemd/jetmon2.service` to `/etc/systemd/system/` and run `systemctl daemon-reload`
-3) Install `systemd/jetmon2-logrotate` to `/etc/logrotate.d/jetmon2`
-4) Create `/opt/jetmon2/logs` and `/opt/jetmon2/stats`, owned by the `jetmon` service user
-5) Create `/opt/jetmon2/config/jetmon2.env` with the database credentials and auth tokens (see `config/db-config-sample.conf` for the required keys)
-6) Copy `config/config.json` from an existing host (or generate from `config-sample.json`)
-7) Set `BUCKET_TARGET` to the desired maximum bucket count for this host
-8) Run `./jetmon2 migrate` to apply any pending schema migrations
-9) Start the service: `systemctl enable --now jetmon2`
-
-The new host will claim unclaimed buckets from the pool on first startup. No existing hosts need reconfiguration.
-
-Manual CLI commands such as `migrate`, `validate-config`, and `rollout` need
-the same `DB_*` environment that systemd reads from
-`/opt/jetmon2/config/jetmon2.env`; systemd's `EnvironmentFile` is not loaded
-automatically for commands run directly from a shell.
-
-### Deploying Standalone Delivery Workers
-
-Standalone delivery is optional during the initial v2 rollout. Use it when
-outbound webhook and alert-contact dispatch should run outside API-enabled
-`jetmon2` processes.
-
-1) Install `bin/jetmon-deliverer` to `/opt/jetmon2/bin/jetmon-deliverer`
-2) Install `systemd/jetmon-deliverer.service` to `/etc/systemd/system/` and run `systemctl daemon-reload`
-3) Create `/opt/jetmon2/config/deliverer.json` from the same schema as `config/config.json`
-4) Set `DELIVERY_OWNER_HOST` in process-specific configs so only the intended process class delivers during cutover
-5) Run `JETMON_CONFIG=/opt/jetmon2/config/deliverer.json /opt/jetmon2/bin/jetmon-deliverer validate-config` with the same `DB_*` environment used by the service
-6) Start the service: `systemctl enable --now jetmon-deliverer`
-
-See `docs/jetmon-deliverer-rollout.md` for the full embedded-to-standalone
-delivery migration runbook and rollback path.
-
-### v1 to v2 Pinned Rolling Migration
-
-For the first production migration from v1, replace one v1 host at a time with
-a v2 host pinned to that same inclusive bucket range. This avoids mixed v1/v2
-bucket ownership and gives each host a simple rollback path.
-
-1) Pre-apply additive migrations during a quiet period:
-
-		./jetmon2 migrate
-
-2) On the host being replaced, copy the existing v1 bucket range into v2 config:
-
-		"PINNED_BUCKET_MIN": 0,
-		"PINNED_BUCKET_MAX": 99,
-		"LEGACY_STATUS_PROJECTION_ENABLE": true,
-		"API_PORT": 0
-
-   The v1 names `BUCKET_NO_MIN` / `BUCKET_NO_MAX` are accepted as aliases, but
-   `PINNED_BUCKET_*` makes the migration mode explicit. In pinned mode, v2 does
-   not claim or heartbeat `jetmon_hosts`; it checks only the configured range.
-
-3) Before stopping v1, run config validation and confirm it prints the pinned
-   preflight plus projection-drift commands:
-
-		./jetmon2 validate-config
-
-4) Before starting the cutover, run the pinned rollout preflight:
-
-		./jetmon2 rollout pinned-check
-
-   It verifies pinned mode, legacy projection writes, absence of a
-   `jetmon_hosts` row for the host, active site count for the range, and zero
-   legacy projection drift.
-
-5) Stop the v1 process for that range, start v2, and verify checks,
-   Veriflier confirmations, WPCOM notifications, audit rows, and legacy
-   `site_status` projection for that bucket range. If the operator dashboard is
-   enabled, also confirm rollout guard state and dependency health before
-   moving to the next host.
-
-6) If rollback is needed, stop v2 and restart the original v1 process with the
-   same bucket config. Because the v2 migrations are additive and the legacy
-   projection remains enabled, legacy readers continue to see familiar status
-   fields.
-
-7) Repeat for each v1 host. After the whole fleet is on v2 and stable, plan a
-   coordinated dynamic-ownership cutover, remove `PINNED_BUCKET_*` from the v2
-   monitor configs, restart the fleet in the approved window, then run:
-
-		./jetmon2 rollout dynamic-check
-
-   This verifies fresh, active, gap-free, overlap-free `jetmon_hosts` coverage
-   before the fleet moves to normal v2 rolling updates.
-
-If either rollout check reports legacy projection drift, list the mismatched
-active site rows before continuing:
-
-		./jetmon2 rollout projection-drift
-
-For a specific range:
-
-		./jetmon2 rollout projection-drift --bucket-min=0 --bucket-max=99 --limit=100
-
-See [`docs/v1-to-v2-pinned-rollout.md`](docs/v1-to-v2-pinned-rollout.md) for
-the detailed rollout checklist.
-
-### v2 Rolling Updates (Zero Downtime)
-
-After all monitor hosts are already on v2 dynamic bucket ownership, update one
-host at a time. Surviving hosts absorb the draining host's buckets during the
-update window:
-
-1) On the host being updated, drain in-flight checks and release buckets:
-
-		systemctl stop jetmon2
-
-2) Deploy the new binary and run migrations:
-
-		./jetmon2 migrate
-
-3) Restart the service:
-
-		systemctl start jetmon2
-
-4) Verify the host has reclaimed its buckets:
-
-		./jetmon2 status
-
-5) Repeat for the next host.
-
-### Decommissioning a Host
-
-Send SIGINT to release buckets immediately:
-
-	systemctl stop jetmon2
-
-The service releases its buckets to the pool before exiting. Surviving hosts reclaim them at the start of their next round.
-
-### Checking Service Health
-
-	./jetmon2 status
-
-Or check the operator dashboard at the configured `DASHBOARD_PORT` for
-check-pool, throughput, bucket, rollout guard, memory, WPCOM circuit-breaker
-state, and live dependency health. The rollout section shows bucket ownership
-mode, legacy projection mode, delivery-worker ownership, and the matching
-rollout preflight and projection-drift commands for the active config.
-
-### Config Reload Without Restart
-
-	./jetmon2 reload
-
-Or directly:
-
-	kill -HUP $(pgrep jetmon2)
-
-### Monitoring Bucket Coverage
-
-Query the `jetmon_hosts` table to verify all buckets are covered and heartbeats are current:
-
-	SELECT host_id, bucket_min, bucket_max, last_heartbeat, status
-	FROM jetmon_hosts
-	ORDER BY bucket_min;
-
-A host whose `last_heartbeat` is older than `BUCKET_HEARTBEAT_GRACE_SEC` will have its buckets reclaimed by peers on their next round.
-
-### Memory Pressure
-
-If RSS exceeds `WORKER_MAX_MEM_MB`, the goroutine pool shrinks by 10% via graceful drain. If memory pressure is sustained, use the pprof endpoint to investigate before raising the threshold:
-
-	curl http://localhost:6060/debug/pprof/heap > heap.prof
-	go tool pprof heap.prof
-
-### StatsD Metrics
-
-Metrics are emitted with prefix `com.jetpack.jetmon.<hostname>`. The Graphite/Grafana dashboard tracks:
-
-- Free and active goroutines
-- Sites processed per second
-- Round completion time
-- WPCOM API attempt, delivered, retry, error, and failed rates, including
-  status-specific splits for `down`, `running`, and `confirmed_down`
-- Veriflier response times
-- Detection flow timing: first failure → Seems Down, first failure →
-  Veriflier escalation, Seems Down → Down, Seems Down → false alarm, and
-  Seems Down → probe-cleared recovery
-- Detection outcome counters split by local failure class (`server`, `client`,
-  `blocked`, `https`, `redirect`, `intermittent`) for false-alarm and
-  confirmed-down rate comparisons
-- Veriflier decision counters: escalations, RPC success/error, confirm/disagree
-  votes, quorum-met confirmations, and false alarms
-- Per-Veriflier-host RPC and vote counters under `verifier.host.<host>.*` so
-  region/provider disagreement and latency can be compared during v2 production
-- Legacy projection drift: per-bucket count of active sites whose
-  `site_status` no longer matches the authoritative open HTTP event
-- Memory usage
-
-StatsD is the primary metrics transport. For integration with external systems, expose the Graphite/StatsD data via your existing metrics pipeline.
-
-### Veriflier Health
-
-Verifliers that fail to respond are automatically excluded from confirmation requests. If the number of healthy Verifliers drops below `PEER_OFFLINE_LIMIT`, no further downtime confirmations can be issued — monitor Veriflier health closely.
-
-Verify Veriflier connectivity manually:
-
-	curl http://<veriflier-host>:7803/status
-
-
-For Happiness Engineers
------------------------
-
-### Looking Up a Site's Check History
-
-Use the audit CLI to see a complete timeline for any site by `blog_id`:
-
-	./jetmon2 audit --blog-id 12345 --since 24h
-
-This outputs a human-readable timeline of every event: checks performed, local retries, Veriflier requests and results, WPCOM notifications sent, status transitions, and any maintenance windows that were active.
-
-The same data is queryable in the operator dashboard under the site's detail view.
-
-### Replaying an Alert Sequence
-
-To reconstruct exactly what happened during a reported incident — useful for "why did I get an alert?" or "why didn't I get an alert?" investigations:
-
-	./jetmon2 audit --blog-id 12345 --since 2026-04-01T10:00:00 --until 2026-04-01T11:00:00
-
-The output shows the sequence of local checks, which Verifliers were asked to confirm and what they returned, and what was sent to WPCOM including the full payload.
-
-### Understanding Alert Types
-
-| Type | Meaning |
-|------|---------|
-| `server` | Site returned a 5xx response |
-| `blocked` | Site returned 403 (monitoring blocked) |
-| `client` | Site returned a 4xx other than 403 (auth or DNS issue) |
-| `https` | SSL/TLS problem detected |
-| `intermittent` | Request timed out (site may still be loading slowly) |
-| `redirect` | Redirect policy failure (too many redirects or unexpected redirect) |
-| `ssl_expiry` | SSL certificate expires within the configured threshold |
-| `tls_deprecated` | Site is serving TLS 1.0 or 1.1 |
-| `keyword_missing` | Response body did not contain the expected keyword |
-| `success` | Site recovered (used in "site is back up" notifications) |
-
-### Checking SSL Certificate Status
-
-Query the database for a site's last recorded certificate expiry:
-
-	SELECT blog_id, monitor_url, ssl_expiry_date
-	FROM jetpack_monitor_sites
-	WHERE blog_id = 12345;
-
-`ssl_expiry_date` is updated on every HTTPS check. Alerts fire automatically at 30, 14, and 7 days before expiry via the same WPCOM notification path as downtime alerts.
-
-### Checking for False Positives
-
-If a customer reports an alert they believe was incorrect, check the false positives table:
-
-	SELECT *
-	FROM jetmon_false_positives
-	WHERE blog_id = 12345
-	ORDER BY created_at DESC
-	LIMIT 20;
-
-A false positive is recorded whenever Jetmon escalated a site to Veriflier confirmation but the Verifliers did not confirm it as down. High false positive rates for a site suggest its `NUM_OF_CHECKS` or `TIME_BETWEEN_CHECKS_SEC` per-site overrides should be tuned.
-
-### Setting a Maintenance Window
-
-To suppress alerts for a site during planned maintenance, set `maintenance_start` and `maintenance_end` directly in the database:
-
-	UPDATE jetpack_monitor_sites
-	SET maintenance_start = '2026-04-20 02:00:00',
-	    maintenance_end   = '2026-04-20 04:00:00'
-	WHERE blog_id = 12345;
-
-Checks continue and results are recorded in the audit log during the window, but no WPCOM notifications are sent. Clear the window after maintenance is complete by setting both columns to NULL.
-
-**Important:** An open-ended maintenance window (NULL `maintenance_end`) silently suppresses all alerts indefinitely. Always set an explicit end time.
-
-### Tuning Alert Sensitivity Per Site
-
-To reduce false positives for a site that flaps frequently:
-
-	UPDATE jetpack_monitor_sites
-	SET alert_cooldown_minutes = 60
-	WHERE blog_id = 12345;
-
-To require more local confirmations before escalating to Verifliers (increases confidence but slows detection):
-
-	UPDATE jetpack_monitor_sites
-	SET check_count_override = 5,
-	    check_interval_override_sec = 30
-	WHERE blog_id = 12345;
-
-### WPCOM Notification Data
-
-Every status change notification sent to WPCOM includes:
-
-| Field | Description |
-|-------|-------------|
-| `blog_id` | The site's WPCOM ID |
-| `monitor_url` | The URL that was checked |
-| `status_id` | `0` = down, `1` = running, `2` = confirmed down |
-| `last_check` | Datetime of the last check |
-| `last_status_change` | Datetime of the last status change |
-| `checks` | Array of check results from Jetmon and Verifliers |
-
-Each entry in `checks` includes:
-
-| Field | Description |
-|-------|-------------|
-| `type` | `1` = Jetmon local check, `2` = Veriflier check |
-| `host` | Hostname of the checking server |
-| `status` | `0` = down, `1` = running, `2` = confirmed down |
-| `rtt` | Round-trip time in milliseconds |
-| `code` | HTTP response code |
+Build and test from the repository root:
+
+```bash
+make all
+make test
+make test-race
+```
+
+The API CLI can exercise the internal REST API and local failure fixture:
+
+```bash
+make build
+make api-cli-token-create
+
+export JETMON_API_URL=http://localhost:${API_HOST_PORT:-8090}
+export JETMON_API_TOKEN=jm_replace_with_the_printed_token
+
+./bin/jetmon2 api health --pretty
+./bin/jetmon2 api commands --output table
+make api-cli-smoke
+```
+
+See [docs/getting-started.md](docs/getting-started.md) for the full local loop.
+
+## Documentation
+
+| Document | Start Here For |
+|---|---|
+| [PROJECT.md](PROJECT.md) | Full product and implementation specification |
+| [API.md](API.md) | Internal REST API reference |
+| [EVENTS.md](EVENTS.md) | Event lifecycle and transition semantics |
+| [TAXONOMY.md](TAXONOMY.md) | Severity, state, cause, and rollup taxonomy |
+| [docs/getting-started.md](docs/getting-started.md) | Docker setup, builds, tests, API CLI smoke runs |
+| [docs/operations-guide.md](docs/operations-guide.md) | Production config, rollout, delivery workers, metrics, debugging |
+| [docs/data-model.md](docs/data-model.md) | Tables, migrations, event projection, tenant mapping |
+| [docs/support-guide.md](docs/support-guide.md) | HE workflows for explaining alerts and missed alerts |
+| [docs/api-cli-guide.md](docs/api-cli-guide.md) | API CLI examples and automation patterns |
+| [docs/v1-to-v2-pinned-rollout.md](docs/v1-to-v2-pinned-rollout.md) | First production migration from v1 static buckets |
+| [docs/jetmon-deliverer-rollout.md](docs/jetmon-deliverer-rollout.md) | Moving outbound delivery to `jetmon-deliverer` |
+| [ROADMAP.md](ROADMAP.md) | Broader v2 and v3 planning |
+
+Longer design decisions live in [docs/adr/](docs/adr/).
+
+## Production Posture
+
+Jetmon 2 is designed for a cautious host-by-host rollout:
+
+- Run `./jetmon2 migrate` before first start. Migrations are embedded and
+  additive.
+- Run `./jetmon2 validate-config` before deploy to check config shape,
+  database connectivity, email transport mode, verifier config, and rollout
+  hints.
+- Use pinned bucket mode for the first v1-to-v2 migration so one v1 host can be
+  replaced by one v2 host with the same bucket range.
+- Keep `LEGACY_STATUS_PROJECTION_ENABLE` on until legacy readers have moved to
+  the v2 API or event tables.
+- Use `SIGINT` or `./jetmon2 drain` for graceful shutdown.
+- Use `SIGHUP` or `./jetmon2 reload` for config reload without restart.
+
+After the fleet is fully on v2, dynamic bucket ownership lets surviving hosts
+absorb work during rolling updates.
+
+## Main Binaries
+
+| Binary | Purpose |
+|---|---|
+| `bin/jetmon2` | Monitor, orchestrator, REST API, dashboard, embedded delivery workers |
+| `bin/veriflier2` | Remote confirmation worker used by the monitor |
+| `bin/jetmon-deliverer` | Standalone webhook and alert-contact delivery worker |
+
+## Development Commands
+
+```bash
+make all              # Build jetmon2, jetmon-deliverer, and veriflier2
+make build            # Build only jetmon2
+make build-deliverer  # Build only jetmon-deliverer
+make build-veriflier  # Build only veriflier2
+make test             # Run the Go test suite
+make test-race        # Run tests with the race detector
+make lint             # Run lint checks
+```
+
+`make generate` is intentionally separate. It requires `protoc` and Go protobuf
+plugins, and the generated stubs are not part of the production JSON-over-HTTP
+Veriflier transport.

--- a/README.md
+++ b/README.md
@@ -306,6 +306,11 @@ The same CLI can create bounded test batches and run a Docker-local smoke pass:
 	./bin/jetmon2 api sites bulk-add --count 3 --batch local-smoke --dry-run --pretty
 	./bin/jetmon2 api smoke --batch local-smoke --pretty
 	./bin/jetmon2 api sites simulate-failure --batch local-smoke --mode http-500 --wait 15s --pretty
+	./bin/jetmon2 api sites cleanup --batch local-smoke --count 3 --output table
+
+Or run the standard CLI smoke sequence with:
+
+	JETMON_API_URL=http://localhost:${API_HOST_PORT:-8090} JETMON_API_TOKEN=jm_replace_with_the_printed_token make api-cli-smoke
 
 ### Adding Test Sites
 

--- a/README.md
+++ b/README.md
@@ -293,8 +293,9 @@ point the API CLI at the exposed API port:
 
 	make build
 	cd docker
-	docker compose exec jetmon ./jetmon2 keys create --consumer api-cli --scope admin --created-by docker-local
+	docker compose up --build -d
 	cd ..
+	make api-cli-token-create
 	export JETMON_API_URL=http://localhost:${API_HOST_PORT:-8090}
 	export JETMON_API_TOKEN=jm_replace_with_the_printed_token
 	./bin/jetmon2 api health --pretty
@@ -317,6 +318,9 @@ For a fuller live validation pass against the API CLI guide examples and the
 Docker-local failure fixture, run:
 
 	JETMON_API_URL=http://localhost:${API_HOST_PORT:-8090} JETMON_API_TOKEN=jm_replace_with_the_printed_token make api-cli-validate
+
+Use `make api-cli-token-list` to inspect Docker-local API keys and
+`API_CLI_TOKEN_ID=<id> make api-cli-token-revoke` to revoke a rehearsal token.
 
 ### Adding Test Sites
 

--- a/README.md
+++ b/README.md
@@ -288,6 +288,25 @@ internal `mailpit:1025` address; that SMTP port is not published to the host.
 Existing `config/config.json` files are not rewritten automatically, so remove
 or update a stale local config if you want it to use Mailpit.
 
+For local API checks, build `bin/jetmon2`, create a Docker-local API key, then
+point the API CLI at the exposed API port:
+
+	make build
+	cd docker
+	docker compose exec jetmon ./jetmon2 keys create --consumer api-cli --scope admin --created-by docker-local
+	cd ..
+	export JETMON_API_URL=http://localhost:${API_HOST_PORT:-8090}
+	export JETMON_API_TOKEN=jm_replace_with_the_printed_token
+	./bin/jetmon2 api health --pretty
+	./bin/jetmon2 api me --pretty
+	./bin/jetmon2 api sites list --output table
+
+The same CLI can create bounded test batches and run a Docker-local smoke pass:
+
+	./bin/jetmon2 api sites bulk-add --count 3 --batch local-smoke --dry-run --pretty
+	./bin/jetmon2 api smoke --batch local-smoke --pretty
+	./bin/jetmon2 api sites simulate-failure --batch local-smoke --mode http-500 --wait 15s --pretty
+
 ### Adding Test Sites
 
 Connect to the test database:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -57,6 +57,12 @@ migration and the operating data needed to make larger architecture decisions.
   source for the implemented internal `/api/v1` route surface. This roadmap
   should track only the remaining public/customer API work, production
   hardening, and deferred architecture choices.
+- **Build a local API testing CLI.** Add a focused `jetmon2 api` helper so
+  local Docker/API testing does not depend on remembered curl commands,
+  handwritten auth headers, or stale payload examples. Start with health/auth
+  checks, an escape-hatch request command, Docker-local defaults, and verbose
+  request/response header logging. Then add typed resource commands and a smoke
+  workflow. See [`docs/api-cli-roadmap.md`](docs/api-cli-roadmap.md).
 
 ### P1 - post-v2 platform refinement
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,8 +16,9 @@ migration and the operating data needed to make larger architecture decisions.
   current main-server-plus-Veriflier design before moving toward a v3
   probe-agent architecture. The v2 event tables remain authoritative while
   `LEGACY_STATUS_PROJECTION_ENABLE` keeps legacy `site_status` /
-  `last_status_change` consumers working during migration. Use the pinned
-  bucket rollout path for the first v1-to-v2 production migration, then remove
+  `last_status_change` consumers working during migration. Use the
+  [`docs/v1-to-v2-migration.md`](docs/v1-to-v2-migration.md) pinned bucket
+  path for the first v1-to-v2 production migration, then remove
   `PINNED_BUCKET_*` after every host is on v2 and stable.
 - **Keep rollout health visible before cutover.** Operators should not have to
   infer migration-critical state from logs or config while replacing v1 hosts.
@@ -34,7 +35,7 @@ migration and the operating data needed to make larger architecture decisions.
   `DELIVERY_OWNER_HOST` as a rollout guard when intentionally keeping delivery
   single-owner during migration from embedded to standalone delivery.
 - **Run a production rollout rehearsal pass.** Validate that README,
-  `docs/v1-to-v2-pinned-rollout.md`, config samples, systemd units,
+  `docs/v1-to-v2-migration.md`, config samples, systemd units,
   `validate-config`, `rollout pinned-check`, `rollout projection-drift`, and
   rollback steps line up exactly before the first production host replacement.
 - **Instrument the data needed for the v3 decision.** During v2 production,

--- a/cmd/jetmon-testsite/main.go
+++ b/cmd/jetmon-testsite/main.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const (
+	defaultHTTPAddr  = ":8091"
+	defaultHTTPSAddr = ":8443"
+)
+
+func main() {
+	if len(os.Args) > 1 && os.Args[1] == "healthcheck" {
+		if err := healthcheck(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	httpAddr := envOrDefault("FIXTURE_HTTP_ADDR", defaultHTTPAddr)
+	httpsAddr := envOrDefault("FIXTURE_HTTPS_ADDR", defaultHTTPSAddr)
+	handler := newFixtureHandler()
+
+	servers := []*http.Server{{
+		Addr:    httpAddr,
+		Handler: handler,
+	}}
+	if httpsAddr != "" {
+		cert, err := selfSignedCert()
+		if err != nil {
+			log.Fatalf("generate tls cert: %v", err)
+		}
+		servers = append(servers, &http.Server{
+			Addr:      httpsAddr,
+			Handler:   handler,
+			TLSConfig: &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12},
+		})
+	}
+
+	errCh := make(chan error, len(servers))
+	for _, srv := range servers {
+		srv := srv
+		go func() {
+			log.Printf("jetmon-testsite: listening on %s", srv.Addr)
+			var err error
+			if srv.TLSConfig != nil {
+				err = srv.ListenAndServeTLS("", "")
+			} else {
+				err = srv.ListenAndServe()
+			}
+			if err != nil && !errors.Is(err, http.ErrServerClosed) {
+				errCh <- err
+			}
+		}()
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	select {
+	case sig := <-sigCh:
+		log.Printf("jetmon-testsite: shutdown signal=%s", sig)
+	case err := <-errCh:
+		log.Printf("jetmon-testsite: server error: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	for _, srv := range servers {
+		if err := srv.Shutdown(ctx); err != nil {
+			log.Printf("jetmon-testsite: shutdown %s: %v", srv.Addr, err)
+		}
+	}
+}
+
+func newFixtureHandler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, _ = io.WriteString(w, "ok\n")
+	})
+	mux.HandleFunc("/ok", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, _ = io.WriteString(w, "jetmon fixture ok\n")
+	})
+	mux.HandleFunc("/tls", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, _ = io.WriteString(w, "jetmon fixture tls endpoint\n")
+	})
+	mux.HandleFunc("/keyword", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, _ = io.WriteString(w, "jetmon fixture keyword present\n")
+	})
+	mux.HandleFunc("/redirect", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/ok", http.StatusFound)
+	})
+	mux.HandleFunc("/slow", func(w http.ResponseWriter, r *http.Request) {
+		delay := fixtureDelay(r.URL.Query().Get("delay"), 5*time.Second)
+		time.Sleep(delay)
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		fmt.Fprintf(w, "slow response after %s\n", delay)
+	})
+	mux.HandleFunc("/status/", func(w http.ResponseWriter, r *http.Request) {
+		raw := strings.TrimPrefix(r.URL.Path, "/status/")
+		code, err := strconv.Atoi(raw)
+		if err != nil || code < 100 || code > 599 {
+			http.Error(w, "status must be 100-599", http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(code)
+		if code != http.StatusNoContent && code != http.StatusNotModified {
+			fmt.Fprintf(w, "status %d\n", code)
+		}
+	})
+	return mux
+}
+
+func fixtureDelay(raw string, fallback time.Duration) time.Duration {
+	if raw == "" {
+		return fallback
+	}
+	delay, err := time.ParseDuration(raw)
+	if err != nil || delay < 0 {
+		return fallback
+	}
+	if delay > 30*time.Second {
+		return 30 * time.Second
+	}
+	return delay
+}
+
+func selfSignedCert() (tls.Certificate, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	tmpl := x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: "jetmon-testsite"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost", "api-fixture", "jetmon-testsite"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	keyDER := x509.MarshalPKCS1PrivateKey(key)
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: keyDER})
+	return tls.X509KeyPair(certPEM, keyPEM)
+}
+
+func healthcheck() error {
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get("http://127.0.0.1" + envOrDefault("FIXTURE_HEALTH_PORT", ":8091") + "/health")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("health returned %s", resp.Status)
+	}
+	return nil
+}
+
+func envOrDefault(name, fallback string) string {
+	if v := os.Getenv(name); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/cmd/jetmon-testsite/main.go
+++ b/cmd/jetmon-testsite/main.go
@@ -2,11 +2,15 @@ package main
 
 import (
 	"context"
+	"crypto/hmac"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -19,6 +23,7 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 )
@@ -94,10 +99,13 @@ func main() {
 
 func newFixtureHandler() http.Handler {
 	mux := http.NewServeMux()
+	webhooks := &fixtureWebhookReceiver{}
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		_, _ = io.WriteString(w, "ok\n")
 	})
+	mux.HandleFunc("/webhook", webhooks.handleWebhook)
+	mux.HandleFunc("/webhook/requests", webhooks.handleRequests)
 	mux.HandleFunc("/ok", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		_, _ = io.WriteString(w, "jetmon fixture ok\n")
@@ -132,6 +140,109 @@ func newFixtureHandler() http.Handler {
 		}
 	})
 	return mux
+}
+
+type fixtureWebhookReceiver struct {
+	mu       sync.Mutex
+	nextID   int
+	requests []fixtureWebhookRequest
+}
+
+type fixtureWebhookRequest struct {
+	ID             int    `json:"id"`
+	ReceivedAt     string `json:"received_at"`
+	Event          string `json:"event,omitempty"`
+	Delivery       string `json:"delivery,omitempty"`
+	Signature      string `json:"signature,omitempty"`
+	SignatureValid *bool  `json:"signature_valid,omitempty"`
+	Body           string `json:"body"`
+}
+
+func (f *fixtureWebhookReceiver) handleWebhook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 1<<20))
+	if err != nil {
+		http.Error(w, "read body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	signature := r.Header.Get("X-Jetmon-Signature")
+	var signatureValid *bool
+	if secret := r.URL.Query().Get("secret"); secret != "" {
+		valid := verifyJetmonSignature(signature, body, secret)
+		signatureValid = &valid
+	}
+
+	f.mu.Lock()
+	f.nextID++
+	f.requests = append(f.requests, fixtureWebhookRequest{
+		ID:             f.nextID,
+		ReceivedAt:     time.Now().UTC().Format(time.RFC3339Nano),
+		Event:          r.Header.Get("X-Jetmon-Event"),
+		Delivery:       r.Header.Get("X-Jetmon-Delivery"),
+		Signature:      signature,
+		SignatureValid: signatureValid,
+		Body:           string(body),
+	})
+	f.mu.Unlock()
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (f *fixtureWebhookReceiver) handleRequests(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		f.mu.Lock()
+		requests := append([]fixtureWebhookRequest(nil), f.requests...)
+		f.mu.Unlock()
+		writeFixtureJSON(w, map[string]any{
+			"count":    len(requests),
+			"requests": requests,
+		})
+	case http.MethodDelete:
+		f.mu.Lock()
+		f.nextID = 0
+		f.requests = nil
+		f.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func verifyJetmonSignature(signature string, body []byte, secret string) bool {
+	var timestamp string
+	var got string
+	for _, part := range strings.Split(signature, ",") {
+		k, v, ok := strings.Cut(part, "=")
+		if !ok {
+			continue
+		}
+		switch k {
+		case "t":
+			timestamp = v
+		case "v1":
+			got = v
+		}
+	}
+	if timestamp == "" || got == "" {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(timestamp))
+	_, _ = mac.Write([]byte("."))
+	_, _ = mac.Write(body)
+	want := hex.EncodeToString(mac.Sum(nil))
+	return hmac.Equal([]byte(got), []byte(want))
+}
+
+func writeFixtureJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		log.Printf("jetmon-testsite: encode json: %v", err)
+	}
 }
 
 func fixtureDelay(raw string, fallback time.Duration) time.Duration {

--- a/cmd/jetmon-testsite/main_test.go
+++ b/cmd/jetmon-testsite/main_test.go
@@ -1,6 +1,12 @@
 package main
 
 import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -67,4 +73,77 @@ func TestFixtureRedirectAndDelay(t *testing.T) {
 	if elapsed := time.Since(start); elapsed < 10*time.Millisecond {
 		t.Fatalf("slow endpoint returned too quickly: %s", elapsed)
 	}
+}
+
+func TestFixtureWebhookReceiverRecordsAndVerifiesSignature(t *testing.T) {
+	srv := httptest.NewServer(newFixtureHandler())
+	defer srv.Close()
+
+	secret := "whsec_test_secret"
+	body := []byte(`{"type":"event.opened"}`)
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/webhook?secret="+secret, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("X-Jetmon-Event", "event.opened")
+	req.Header.Set("X-Jetmon-Delivery", "123")
+	req.Header.Set("X-Jetmon-Signature", fixtureTestSignature(1700000000, body, secret))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST webhook: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("POST status = %d, want 204", resp.StatusCode)
+	}
+
+	resp, err = http.Get(srv.URL + "/webhook/requests")
+	if err != nil {
+		t.Fatalf("GET webhook requests: %v", err)
+	}
+	defer resp.Body.Close()
+	var got struct {
+		Count    int `json:"count"`
+		Requests []struct {
+			Event          string `json:"event"`
+			Delivery       string `json:"delivery"`
+			SignatureValid *bool  `json:"signature_valid"`
+			Body           string `json:"body"`
+		} `json:"requests"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode webhook requests: %v", err)
+	}
+	if got.Count != 1 || len(got.Requests) != 1 {
+		t.Fatalf("requests = %+v, want one", got)
+	}
+	if got.Requests[0].Event != "event.opened" || got.Requests[0].Delivery != "123" {
+		t.Fatalf("request headers = %+v", got.Requests[0])
+	}
+	if got.Requests[0].SignatureValid == nil || !*got.Requests[0].SignatureValid {
+		t.Fatalf("signature_valid = %v, want true", got.Requests[0].SignatureValid)
+	}
+	if got.Requests[0].Body != string(body) {
+		t.Fatalf("body = %q, want %q", got.Requests[0].Body, string(body))
+	}
+
+	req, err = http.NewRequest(http.MethodDelete, srv.URL+"/webhook/requests", nil)
+	if err != nil {
+		t.Fatalf("new delete request: %v", err)
+	}
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE webhook requests: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("DELETE status = %d, want 204", resp.StatusCode)
+	}
+}
+
+func fixtureTestSignature(ts int64, body []byte, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(fmt.Sprintf("%d.", ts)))
+	_, _ = mac.Write(body)
+	return fmt.Sprintf("t=%d,v1=%s", ts, hex.EncodeToString(mac.Sum(nil)))
 }

--- a/cmd/jetmon-testsite/main_test.go
+++ b/cmd/jetmon-testsite/main_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFixtureHandlerEndpoints(t *testing.T) {
+	srv := httptest.NewServer(newFixtureHandler())
+	defer srv.Close()
+
+	tests := []struct {
+		path string
+		code int
+		body string
+	}{
+		{path: "/health", code: http.StatusOK, body: "ok"},
+		{path: "/ok", code: http.StatusOK, body: "fixture ok"},
+		{path: "/keyword", code: http.StatusOK, body: "keyword present"},
+		{path: "/status/403", code: http.StatusForbidden, body: "status 403"},
+		{path: "/status/500", code: http.StatusInternalServerError, body: "status 500"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			resp, err := http.Get(srv.URL + tt.path)
+			if err != nil {
+				t.Fatalf("GET %s: %v", tt.path, err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != tt.code {
+				t.Fatalf("status = %d, want %d", resp.StatusCode, tt.code)
+			}
+			buf := make([]byte, 256)
+			n, _ := resp.Body.Read(buf)
+			if !strings.Contains(string(buf[:n]), tt.body) {
+				t.Fatalf("body = %q, want substring %q", string(buf[:n]), tt.body)
+			}
+		})
+	}
+}
+
+func TestFixtureRedirectAndDelay(t *testing.T) {
+	srv := httptest.NewServer(newFixtureHandler())
+	defer srv.Close()
+
+	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	resp, err := client.Get(srv.URL + "/redirect")
+	if err != nil {
+		t.Fatalf("GET redirect: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusFound || resp.Header.Get("Location") != "/ok" {
+		t.Fatalf("redirect status=%d location=%q", resp.StatusCode, resp.Header.Get("Location"))
+	}
+
+	start := time.Now()
+	resp, err = http.Get(srv.URL + "/slow?delay=10ms")
+	if err != nil {
+		t.Fatalf("GET slow: %v", err)
+	}
+	resp.Body.Close()
+	if elapsed := time.Since(start); elapsed < 10*time.Millisecond {
+		t.Fatalf("slow endpoint returned too quickly: %s", elapsed)
+	}
+}

--- a/cmd/jetmon2/api_cli.go
+++ b/cmd/jetmon2/api_cli.go
@@ -26,6 +26,7 @@ type apiCLIOptions struct {
 	baseURL        string
 	token          string
 	authPolicy     string
+	allowRemote    bool
 	verbose        bool
 	pretty         bool
 	output         string
@@ -37,6 +38,7 @@ type apiCLIOptions struct {
 	out            io.Writer
 	errOut         io.Writer
 	in             io.Reader
+	commandName    string
 }
 
 type apiHeaderFlags []string
@@ -219,6 +221,7 @@ func defaultAPIOptions() apiCLIOptions {
 }
 
 func newAPIFlagSet(name string, opts *apiCLIOptions) *flag.FlagSet {
+	opts.commandName = name
 	fs := flag.NewFlagSet(name, flag.ContinueOnError)
 	fs.SetOutput(opts.errOut)
 	fs.StringVar(&opts.baseURL, "base-url", opts.baseURL, "API base URL")
@@ -227,6 +230,7 @@ func newAPIFlagSet(name string, opts *apiCLIOptions) *flag.FlagSet {
 		tokenFlag.DefValue = ""
 	}
 	fs.StringVar(&opts.authPolicy, "auth-policy", opts.authPolicy, "automatic auth policy: same-origin or any-origin")
+	fs.BoolVar(&opts.allowRemote, "allow-remote", opts.allowRemote, "allow writes to a non-local API base URL")
 	fs.BoolVar(&opts.verbose, "v", false, "print request and response headers to stderr")
 	fs.BoolVar(&opts.verbose, "verbose", false, "print request and response headers to stderr")
 	fs.BoolVar(&opts.pretty, "pretty", false, "pretty-print JSON response bodies")
@@ -396,6 +400,11 @@ func doAPIRequest(ctx context.Context, client *http.Client, opts apiCLIOptions, 
 	if err != nil {
 		return apiHTTPResponse{}, err
 	}
+	if apiMethodRequiresRemoteWriteGuard(method) {
+		if _, err := requireAPILocalURLOrAllowRemote(requestURL, opts.allowRemote, apiRemoteGuardCommand(opts)); err != nil {
+			return apiHTTPResponse{}, err
+		}
+	}
 
 	var bodyReader io.Reader
 	if len(body) > 0 {
@@ -491,8 +500,28 @@ func sameAPIOrigin(a, b *url.URL) bool {
 	return strings.EqualFold(a.Scheme, b.Scheme) && strings.EqualFold(a.Host, b.Host)
 }
 
+func apiMethodRequiresRemoteWriteGuard(method string) bool {
+	switch strings.ToUpper(strings.TrimSpace(method)) {
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		return true
+	default:
+		return false
+	}
+}
+
+func apiRemoteGuardCommand(opts apiCLIOptions) string {
+	if strings.TrimSpace(opts.commandName) != "" {
+		return strings.TrimSpace(opts.commandName)
+	}
+	return "api"
+}
+
 func requireAPILocalOrAllowRemote(opts apiCLIOptions, allowRemote bool, command string) (bool, error) {
-	local, err := isLocalAPIBaseURL(opts.baseURL)
+	return requireAPILocalURLOrAllowRemote(opts.baseURL, allowRemote, command)
+}
+
+func requireAPILocalURLOrAllowRemote(rawURL string, allowRemote bool, command string) (bool, error) {
+	local, err := isLocalAPIURL(rawURL)
 	if err != nil {
 		return false, err
 	}
@@ -502,16 +531,16 @@ func requireAPILocalOrAllowRemote(opts apiCLIOptions, allowRemote bool, command 
 	if allowRemote {
 		return true, nil
 	}
-	return true, fmt.Errorf("%s refuses to modify non-local API base URL %q without --allow-remote (local means localhost or loopback IP)", command, opts.baseURL)
+	return true, fmt.Errorf("%s refuses to modify non-local API URL %q without --allow-remote (local means localhost or loopback IP)", command, rawURL)
 }
 
-func isLocalAPIBaseURL(baseURL string) (bool, error) {
-	u, err := url.Parse(strings.TrimSpace(baseURL))
+func isLocalAPIURL(rawURL string) (bool, error) {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
 	if err != nil {
-		return false, fmt.Errorf("invalid API base URL %q: %w", baseURL, err)
+		return false, fmt.Errorf("invalid API URL %q: %w", rawURL, err)
 	}
 	if !u.IsAbs() || u.Host == "" {
-		return false, fmt.Errorf("invalid API base URL %q: must include scheme and host", baseURL)
+		return false, fmt.Errorf("invalid API URL %q: must include scheme and host", rawURL)
 	}
 	host := strings.ToLower(strings.TrimSuffix(u.Hostname(), "."))
 	if host == "localhost" || strings.HasSuffix(host, ".localhost") {

--- a/cmd/jetmon2/api_cli.go
+++ b/cmd/jetmon2/api_cli.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -159,13 +160,61 @@ func newAPIFlagSet(name string, opts *apiCLIOptions) *flag.FlagSet {
 	fs.SetOutput(opts.errOut)
 	fs.StringVar(&opts.baseURL, "base-url", opts.baseURL, "API base URL")
 	fs.StringVar(&opts.token, "token", opts.token, "Bearer token")
+	if tokenFlag := fs.Lookup("token"); tokenFlag != nil {
+		tokenFlag.DefValue = ""
+	}
 	fs.BoolVar(&opts.verbose, "v", false, "print request and response headers to stderr")
 	fs.BoolVar(&opts.verbose, "verbose", false, "print request and response headers to stderr")
 	fs.BoolVar(&opts.pretty, "pretty", false, "pretty-print JSON response bodies")
 	fs.StringVar(&opts.output, "output", "json", "response output format: json or table")
 	fs.DurationVar(&opts.timeout, "timeout", opts.timeout, "request timeout")
 	fs.Var(&opts.headers, "header", "additional request header in Name: Value form (repeatable)")
+	fs.Usage = func() {
+		printAPIFlagUsage(fs.Output(), fs)
+	}
 	return fs
+}
+
+func printAPIFlagUsage(w io.Writer, fs *flag.FlagSet) {
+	fmt.Fprintf(w, "Usage of %s:\n", fs.Name())
+	printAPIFlagDefaults(w, fs)
+}
+
+func printAPIFlagDefaults(w io.Writer, fs *flag.FlagSet) {
+	flags := []*flag.Flag{}
+	fs.VisitAll(func(f *flag.Flag) {
+		flags = append(flags, f)
+	})
+	sort.Slice(flags, func(i, j int) bool {
+		return flags[i].Name < flags[j].Name
+	})
+
+	for _, f := range flags {
+		valueName, usage := flag.UnquoteUsage(f)
+		prefix := "--"
+		if len(f.Name) == 1 {
+			prefix = "-"
+		}
+		fmt.Fprintf(w, "  %s%s", prefix, f.Name)
+		if valueName != "" {
+			fmt.Fprintf(w, " %s", valueName)
+		}
+		fmt.Fprintf(w, "\n    \t%s", usage)
+		if defaultValue := apiFlagDefaultValue(f, valueName); defaultValue != "" {
+			fmt.Fprintf(w, " (default %s)", defaultValue)
+		}
+		fmt.Fprintln(w)
+	}
+}
+
+func apiFlagDefaultValue(f *flag.Flag, valueName string) string {
+	if f.DefValue == "" || f.DefValue == "0" || f.DefValue == "0s" || f.DefValue == "false" {
+		return ""
+	}
+	if valueName == "string" {
+		return strconv.Quote(f.DefValue)
+	}
+	return f.DefValue
 }
 
 func readAPIRequestBody(opts apiCLIOptions) ([]byte, error) {
@@ -525,6 +574,9 @@ func apiTableValue(v any) string {
 }
 
 func logAPIErrorAndExit(err error) {
+	if errors.Is(err, flag.ErrHelp) {
+		os.Exit(0)
+	}
 	fmt.Fprintf(os.Stderr, "api: %v\n", err)
 	os.Exit(1)
 }

--- a/cmd/jetmon2/api_cli.go
+++ b/cmd/jetmon2/api_cli.go
@@ -69,8 +69,10 @@ func cmdAPI(args []string) {
 		err = cmdAPIEvents(rest)
 	case "webhooks":
 		err = cmdAPIWebhooks(rest)
+	case "alert-contacts":
+		err = cmdAPIAlertContacts(rest)
 	default:
-		fmt.Fprintf(os.Stderr, "unknown api subcommand %q (want: health, me, request, sites, events, webhooks)\n", sub)
+		fmt.Fprintf(os.Stderr, "unknown api subcommand %q (want: health, me, request, sites, events, webhooks, alert-contacts)\n", sub)
 		printAPIUsage(os.Stderr)
 		os.Exit(1)
 	}
@@ -80,7 +82,7 @@ func cmdAPI(args []string) {
 }
 
 func printAPIUsage(w io.Writer) {
-	fmt.Fprintln(w, "usage: jetmon2 api <health|me|request|sites|events|webhooks> [flags]")
+	fmt.Fprintln(w, "usage: jetmon2 api <health|me|request|sites|events|webhooks|alert-contacts> [flags]")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Environment:")
 	fmt.Fprintln(w, "  JETMON_API_URL     API base URL (default: http://localhost:8090)")

--- a/cmd/jetmon2/api_cli.go
+++ b/cmd/jetmon2/api_cli.go
@@ -44,6 +44,43 @@ type apiHTTPResponse struct {
 	Body       []byte
 }
 
+type apiCommandInfo struct {
+	Command     string `json:"command"`
+	Description string `json:"description"`
+	Example     string `json:"example"`
+}
+
+var apiCommandCatalog = []apiCommandInfo{
+	{Command: "health", Description: "check API and database health", Example: "jetmon2 api health --pretty"},
+	{Command: "me", Description: "show the authenticated API key identity", Example: "jetmon2 api me --pretty"},
+	{Command: "request", Description: "send an arbitrary request to an API path", Example: "jetmon2 api request --output table GET /api/v1/sites"},
+	{Command: "sites list", Description: "list monitored sites with filters", Example: "jetmon2 api sites list --limit 20 --output table"},
+	{Command: "sites get", Description: "show one monitored site", Example: "jetmon2 api sites get 12345 --pretty"},
+	{Command: "sites create", Description: "create or upsert a monitored site", Example: "jetmon2 api sites create --blog-id 12345 --url https://example.com --pretty"},
+	{Command: "sites update", Description: "update check settings for a site", Example: "jetmon2 api sites update 12345 --url https://example.com/health --pretty"},
+	{Command: "sites delete", Description: "delete a monitored site", Example: "jetmon2 api sites delete 12345"},
+	{Command: "sites pause", Description: "pause monitoring for a site", Example: "jetmon2 api sites pause 12345 --idempotency-key site-12345-pause"},
+	{Command: "sites resume", Description: "resume monitoring for a site", Example: "jetmon2 api sites resume 12345 --idempotency-key site-12345-resume"},
+	{Command: "sites trigger-now", Description: "run an immediate check", Example: "jetmon2 api sites trigger-now 12345 --pretty"},
+	{Command: "sites bulk-add", Description: "create bounded local test-site batches", Example: "jetmon2 api sites bulk-add --count 3 --batch local-smoke --dry-run --pretty"},
+	{Command: "sites cleanup", Description: "delete deterministic CLI-created site batches", Example: "jetmon2 api sites cleanup --batch local-smoke --count 3 --output table"},
+	{Command: "sites simulate-failure", Description: "mutate test sites into known failure modes", Example: "jetmon2 api sites simulate-failure --batch local-smoke --mode http-500 --wait 30s --output table"},
+	{Command: "events list", Description: "list events for a site", Example: "jetmon2 api events list 12345 --active=true --output table"},
+	{Command: "events get", Description: "show one event", Example: "jetmon2 api events get --site-id 12345 98765 --pretty"},
+	{Command: "events transitions", Description: "list event transition history", Example: "jetmon2 api events transitions 12345 98765 --output table"},
+	{Command: "events close", Description: "manually close an event", Example: "jetmon2 api events close 12345 98765 --reason manual_override --pretty"},
+	{Command: "webhooks list", Description: "list webhook registrations", Example: "jetmon2 api webhooks list --output table"},
+	{Command: "webhooks create", Description: "create a webhook registration", Example: "jetmon2 api webhooks create --url https://receiver.example.test/jetmon --event event.opened --pretty"},
+	{Command: "webhooks deliveries", Description: "list webhook delivery rows", Example: "jetmon2 api webhooks deliveries 77 --status failed --output table"},
+	{Command: "webhooks retry", Description: "retry an abandoned webhook delivery", Example: "jetmon2 api webhooks retry 77 555 --idempotency-key webhook-77-555-retry --pretty"},
+	{Command: "alert-contacts list", Description: "list managed alert contacts", Example: "jetmon2 api alert-contacts list --output table"},
+	{Command: "alert-contacts create", Description: "create an email, PagerDuty, Slack, or Teams contact", Example: "jetmon2 api alert-contacts create --label Local --transport email --address alerts@example.test --pretty"},
+	{Command: "alert-contacts test", Description: "send a managed alert-contact test", Example: "jetmon2 api alert-contacts test 12 --idempotency-key alert-12-test --pretty"},
+	{Command: "alert-contacts deliveries", Description: "list managed alert delivery rows", Example: "jetmon2 api alert-contacts deliveries 12 --status failed --output table"},
+	{Command: "smoke", Description: "run the Docker-local API smoke workflow", Example: "jetmon2 api smoke --batch local-smoke --pretty"},
+	{Command: "commands", Description: "list API CLI commands and examples", Example: "jetmon2 api commands --output table"},
+}
+
 func (h *apiHeaderFlags) String() string {
 	return strings.Join(*h, ",")
 }
@@ -72,6 +109,8 @@ func cmdAPI(args []string) {
 		err = cmdAPIMe(rest)
 	case "request":
 		err = cmdAPIRequest(rest)
+	case "commands":
+		err = cmdAPICommands(rest)
 	case "sites":
 		err = cmdAPISites(rest)
 	case "events":
@@ -83,7 +122,7 @@ func cmdAPI(args []string) {
 	case "smoke":
 		err = cmdAPISmoke(rest)
 	default:
-		fmt.Fprintf(os.Stderr, "unknown api subcommand %q (want: health, me, request, sites, events, webhooks, alert-contacts, smoke)\n", sub)
+		fmt.Fprintf(os.Stderr, "unknown api subcommand %q (want: health, me, request, commands, sites, events, webhooks, alert-contacts, smoke)\n", sub)
 		printAPIUsage(os.Stderr)
 		os.Exit(1)
 	}
@@ -93,7 +132,9 @@ func cmdAPI(args []string) {
 }
 
 func printAPIUsage(w io.Writer) {
-	fmt.Fprintln(w, "usage: jetmon2 api <health|me|request|sites|events|webhooks|alert-contacts|smoke> [flags]")
+	fmt.Fprintln(w, "usage: jetmon2 api <health|me|request|commands|sites|events|webhooks|alert-contacts|smoke> [flags]")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Run `jetmon2 api commands --output table` for the command catalog.")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Environment:")
 	fmt.Fprintln(w, "  JETMON_API_URL     API base URL (default: http://localhost:8090)")
@@ -144,6 +185,23 @@ func cmdAPIRequest(args []string) error {
 	return executeAPIRequest(context.Background(), nil, opts, fs.Arg(0), fs.Arg(1), body)
 }
 
+func cmdAPICommands(args []string) error {
+	opts := defaultAPIOptions()
+	opts.output = "table"
+	fs := newAPIFlagSet("api commands", &opts)
+	if err := parseAPIFlags(fs, args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("usage: jetmon2 api commands [flags]")
+	}
+	return writeAPICommands(opts)
+}
+
+func writeAPICommands(opts apiCLIOptions) error {
+	return writeAPIValueOutput(opts.out, map[string]any{"commands": apiCommandCatalog}, opts)
+}
+
 func defaultAPIOptions() apiCLIOptions {
 	return apiCLIOptions{
 		baseURL: envOrDefault("JETMON_API_URL", defaultAPIBaseURL),
@@ -166,7 +224,11 @@ func newAPIFlagSet(name string, opts *apiCLIOptions) *flag.FlagSet {
 	fs.BoolVar(&opts.verbose, "v", false, "print request and response headers to stderr")
 	fs.BoolVar(&opts.verbose, "verbose", false, "print request and response headers to stderr")
 	fs.BoolVar(&opts.pretty, "pretty", false, "pretty-print JSON response bodies")
-	fs.StringVar(&opts.output, "output", "json", "response output format: json or table")
+	defaultOutput := opts.output
+	if defaultOutput == "" {
+		defaultOutput = "json"
+	}
+	fs.StringVar(&opts.output, "output", defaultOutput, "response output format: json or table")
 	fs.DurationVar(&opts.timeout, "timeout", opts.timeout, "request timeout")
 	fs.Var(&opts.headers, "header", "additional request header in Name: Value form (repeatable)")
 	fs.Usage = func() {
@@ -535,7 +597,7 @@ func apiTableRows(value any) []map[string]any {
 		if rows := apiWorkflowTableRows(v); len(rows) > 0 {
 			return rows
 		}
-		for _, key := range []string{"data", "created", "sites", "steps"} {
+		for _, key := range []string{"data", "created", "sites", "steps", "commands"} {
 			if data, ok := v[key].([]any); ok {
 				return apiRowsFromArray(data)
 			}
@@ -610,6 +672,7 @@ func apiTableColumns(rows []map[string]any) []string {
 		{"site_id", "action", "trigger_status", "event_ids", "event_states", "event_severities", "transition_count", "note", "error"},
 		{"site_id", "action", "note", "error"},
 		{"kind", "name", "id", "status", "detail"},
+		{"command", "description", "example"},
 		{"name", "status", "detail"},
 	} {
 		present := apiColumnsPresent(rows, cols)

--- a/cmd/jetmon2/api_cli.go
+++ b/cmd/jetmon2/api_cli.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -488,6 +489,36 @@ func sameAPIOrigin(a, b *url.URL) bool {
 		return false
 	}
 	return strings.EqualFold(a.Scheme, b.Scheme) && strings.EqualFold(a.Host, b.Host)
+}
+
+func requireAPILocalOrAllowRemote(opts apiCLIOptions, allowRemote bool, command string) (bool, error) {
+	local, err := isLocalAPIBaseURL(opts.baseURL)
+	if err != nil {
+		return false, err
+	}
+	if local {
+		return false, nil
+	}
+	if allowRemote {
+		return true, nil
+	}
+	return true, fmt.Errorf("%s refuses to modify non-local API base URL %q without --allow-remote (local means localhost or loopback IP)", command, opts.baseURL)
+}
+
+func isLocalAPIBaseURL(baseURL string) (bool, error) {
+	u, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil {
+		return false, fmt.Errorf("invalid API base URL %q: %w", baseURL, err)
+	}
+	if !u.IsAbs() || u.Host == "" {
+		return false, fmt.Errorf("invalid API base URL %q: must include scheme and host", baseURL)
+	}
+	host := strings.ToLower(strings.TrimSuffix(u.Hostname(), "."))
+	if host == "localhost" || strings.HasSuffix(host, ".localhost") {
+		return true, nil
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback(), nil
 }
 
 func applyAPIRequestHeaders(req *http.Request, opts apiCLIOptions, hasBody bool, sendAutoAuth bool) {

--- a/cmd/jetmon2/api_cli.go
+++ b/cmd/jetmon2/api_cli.go
@@ -67,8 +67,10 @@ func cmdAPI(args []string) {
 		err = cmdAPISites(rest)
 	case "events":
 		err = cmdAPIEvents(rest)
+	case "webhooks":
+		err = cmdAPIWebhooks(rest)
 	default:
-		fmt.Fprintf(os.Stderr, "unknown api subcommand %q (want: health, me, request, sites, events)\n", sub)
+		fmt.Fprintf(os.Stderr, "unknown api subcommand %q (want: health, me, request, sites, events, webhooks)\n", sub)
 		printAPIUsage(os.Stderr)
 		os.Exit(1)
 	}
@@ -78,7 +80,7 @@ func cmdAPI(args []string) {
 }
 
 func printAPIUsage(w io.Writer) {
-	fmt.Fprintln(w, "usage: jetmon2 api <health|me|request|sites|events> [flags]")
+	fmt.Fprintln(w, "usage: jetmon2 api <health|me|request|sites|events|webhooks> [flags]")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Environment:")
 	fmt.Fprintln(w, "  JETMON_API_URL     API base URL (default: http://localhost:8090)")

--- a/cmd/jetmon2/api_cli.go
+++ b/cmd/jetmon2/api_cli.go
@@ -65,8 +65,10 @@ func cmdAPI(args []string) {
 		err = cmdAPIRequest(rest)
 	case "sites":
 		err = cmdAPISites(rest)
+	case "events":
+		err = cmdAPIEvents(rest)
 	default:
-		fmt.Fprintf(os.Stderr, "unknown api subcommand %q (want: health, me, request, sites)\n", sub)
+		fmt.Fprintf(os.Stderr, "unknown api subcommand %q (want: health, me, request, sites, events)\n", sub)
 		printAPIUsage(os.Stderr)
 		os.Exit(1)
 	}
@@ -76,7 +78,7 @@ func cmdAPI(args []string) {
 }
 
 func printAPIUsage(w io.Writer) {
-	fmt.Fprintln(w, "usage: jetmon2 api <health|me|request|sites> [flags]")
+	fmt.Fprintln(w, "usage: jetmon2 api <health|me|request|sites|events> [flags]")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Environment:")
 	fmt.Fprintln(w, "  JETMON_API_URL     API base URL (default: http://localhost:8090)")

--- a/cmd/jetmon2/api_cli.go
+++ b/cmd/jetmon2/api_cli.go
@@ -532,6 +532,9 @@ func writeAPIResponseTable(w io.Writer, body []byte) error {
 func apiTableRows(value any) []map[string]any {
 	switch v := value.(type) {
 	case map[string]any:
+		if rows := apiWorkflowTableRows(v); len(rows) > 0 {
+			return rows
+		}
 		for _, key := range []string{"data", "created", "sites", "steps"} {
 			if data, ok := v[key].([]any); ok {
 				return apiRowsFromArray(data)
@@ -543,6 +546,43 @@ func apiTableRows(value any) []map[string]any {
 	default:
 		return nil
 	}
+}
+
+func apiWorkflowTableRows(value map[string]any) []map[string]any {
+	steps, ok := value["steps"].([]any)
+	if !ok {
+		return nil
+	}
+	rows := make([]map[string]any, 0, len(steps))
+	for _, item := range steps {
+		step, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		row := map[string]any{"kind": "step"}
+		for k, v := range step {
+			row[k] = v
+		}
+		rows = append(rows, row)
+	}
+	cleanupResults, _ := value["cleanup_results"].([]any)
+	for _, item := range cleanupResults {
+		cleanup, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		row := map[string]any{
+			"kind":   "cleanup",
+			"name":   cleanup["resource"],
+			"id":     cleanup["id"],
+			"status": cleanup["status"],
+		}
+		if errText, ok := cleanup["error"]; ok {
+			row["detail"] = errText
+		}
+		rows = append(rows, row)
+	}
+	return rows
 }
 
 func apiRowsFromArray(data []any) []map[string]any {
@@ -567,7 +607,9 @@ func apiTableColumns(rows []map[string]any) []string {
 		{"id", "label", "active", "transport", "min_severity", "max_per_hour", "destination_preview"},
 		{"id", "status", "attempt", "event_id", "event_type", "last_status_code", "created_at"},
 		{"site_id", "status", "error"},
+		{"site_id", "action", "trigger_status", "event_ids", "event_states", "event_severities", "transition_count", "note", "error"},
 		{"site_id", "action", "note", "error"},
+		{"kind", "name", "id", "status", "detail"},
 		{"name", "status", "detail"},
 	} {
 		present := apiColumnsPresent(rows, cols)

--- a/cmd/jetmon2/api_cli.go
+++ b/cmd/jetmon2/api_cli.go
@@ -103,7 +103,7 @@ func printAPIUsage(w io.Writer) {
 func cmdAPIHealth(args []string) error {
 	opts := defaultAPIOptions()
 	fs := newAPIFlagSet("api health", &opts)
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {
@@ -115,7 +115,7 @@ func cmdAPIHealth(args []string) error {
 func cmdAPIMe(args []string) error {
 	opts := defaultAPIOptions()
 	fs := newAPIFlagSet("api me", &opts)
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {
@@ -130,7 +130,7 @@ func cmdAPIRequest(args []string) error {
 	fs.StringVar(&opts.body, "body", "", "literal request body")
 	fs.StringVar(&opts.bodyFile, "body-file", "", "file containing request body (- reads stdin)")
 	fs.StringVar(&opts.idempotencyKey, "idempotency-key", "", "Idempotency-Key header for POST retries")
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 2 {
@@ -173,6 +173,66 @@ func newAPIFlagSet(name string, opts *apiCLIOptions) *flag.FlagSet {
 		printAPIFlagUsage(fs.Output(), fs)
 	}
 	return fs
+}
+
+type apiBoolFlag interface {
+	IsBoolFlag() bool
+}
+
+func parseAPIFlags(fs *flag.FlagSet, args []string) error {
+	normalized := normalizeAPIFlagArgs(fs, args)
+	return fs.Parse(normalized)
+}
+
+func normalizeAPIFlagArgs(fs *flag.FlagSet, args []string) []string {
+	flags := []string{}
+	positionals := []string{}
+	onlyPositionals := false
+	hasTerminator := false
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if onlyPositionals || arg == "-" || !strings.HasPrefix(arg, "-") {
+			positionals = append(positionals, arg)
+			continue
+		}
+		if arg == "--" {
+			onlyPositionals = true
+			hasTerminator = true
+			continue
+		}
+
+		name, hasValue := apiFlagName(arg)
+		f := fs.Lookup(name)
+		if f == nil {
+			flags = append(flags, arg)
+			continue
+		}
+		flags = append(flags, arg)
+		if hasValue || apiFlagIsBool(f) {
+			continue
+		}
+		if i+1 < len(args) {
+			i++
+			flags = append(flags, args[i])
+		}
+	}
+	if hasTerminator {
+		flags = append(flags, "--")
+	}
+	return append(flags, positionals...)
+}
+
+func apiFlagName(arg string) (string, bool) {
+	name := strings.TrimLeft(arg, "-")
+	if idx := strings.IndexByte(name, '='); idx >= 0 {
+		return name[:idx], true
+	}
+	return name, false
+}
+
+func apiFlagIsBool(f *flag.Flag) bool {
+	bf, ok := f.Value.(apiBoolFlag)
+	return ok && bf.IsBoolFlag()
 }
 
 func printAPIFlagUsage(w io.Writer, fs *flag.FlagSet) {

--- a/cmd/jetmon2/api_cli.go
+++ b/cmd/jetmon2/api_cli.go
@@ -63,8 +63,10 @@ func cmdAPI(args []string) {
 		err = cmdAPIMe(rest)
 	case "request":
 		err = cmdAPIRequest(rest)
+	case "sites":
+		err = cmdAPISites(rest)
 	default:
-		fmt.Fprintf(os.Stderr, "unknown api subcommand %q (want: health, me, request)\n", sub)
+		fmt.Fprintf(os.Stderr, "unknown api subcommand %q (want: health, me, request, sites)\n", sub)
 		printAPIUsage(os.Stderr)
 		os.Exit(1)
 	}
@@ -74,7 +76,7 @@ func cmdAPI(args []string) {
 }
 
 func printAPIUsage(w io.Writer) {
-	fmt.Fprintln(w, "usage: jetmon2 api <health|me|request> [flags]")
+	fmt.Fprintln(w, "usage: jetmon2 api <health|me|request|sites> [flags]")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Environment:")
 	fmt.Fprintln(w, "  JETMON_API_URL     API base URL (default: http://localhost:8090)")

--- a/cmd/jetmon2/api_cli.go
+++ b/cmd/jetmon2/api_cli.go
@@ -19,10 +19,12 @@ import (
 )
 
 const defaultAPIBaseURL = "http://localhost:8090"
+const defaultAPIAuthPolicy = "same-origin"
 
 type apiCLIOptions struct {
 	baseURL        string
 	token          string
+	authPolicy     string
 	verbose        bool
 	pretty         bool
 	output         string
@@ -56,7 +58,7 @@ var apiCommandCatalog = []apiCommandInfo{
 	{Command: "request", Description: "send an arbitrary request to an API path", Example: "jetmon2 api request --output table GET /api/v1/sites"},
 	{Command: "sites list", Description: "list monitored sites with filters", Example: "jetmon2 api sites list --limit 20 --output table"},
 	{Command: "sites get", Description: "show one monitored site", Example: "jetmon2 api sites get 12345 --pretty"},
-	{Command: "sites create", Description: "create or upsert a monitored site", Example: "jetmon2 api sites create --blog-id 12345 --url https://example.com --pretty"},
+	{Command: "sites create", Description: "create a monitored site", Example: "jetmon2 api sites create --blog-id 12345 --url https://example.com --pretty"},
 	{Command: "sites update", Description: "update check settings for a site", Example: "jetmon2 api sites update 12345 --url https://example.com/health --pretty"},
 	{Command: "sites delete", Description: "delete a monitored site", Example: "jetmon2 api sites delete 12345"},
 	{Command: "sites pause", Description: "pause monitoring for a site", Example: "jetmon2 api sites pause 12345 --idempotency-key site-12345-pause"},
@@ -137,8 +139,9 @@ func printAPIUsage(w io.Writer) {
 	fmt.Fprintln(w, "Run `jetmon2 api commands --output table` for the command catalog.")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Environment:")
-	fmt.Fprintln(w, "  JETMON_API_URL     API base URL (default: http://localhost:8090)")
-	fmt.Fprintln(w, "  JETMON_API_TOKEN   Bearer token for authenticated routes")
+	fmt.Fprintln(w, "  JETMON_API_URL          API base URL (default: http://localhost:8090)")
+	fmt.Fprintln(w, "  JETMON_API_TOKEN        Bearer token for authenticated routes")
+	fmt.Fprintln(w, "  JETMON_API_AUTH_POLICY  automatic auth policy: same-origin or any-origin (default: same-origin)")
 }
 
 func cmdAPIHealth(args []string) error {
@@ -204,12 +207,13 @@ func writeAPICommands(opts apiCLIOptions) error {
 
 func defaultAPIOptions() apiCLIOptions {
 	return apiCLIOptions{
-		baseURL: envOrDefault("JETMON_API_URL", defaultAPIBaseURL),
-		token:   os.Getenv("JETMON_API_TOKEN"),
-		timeout: 10 * time.Second,
-		out:     os.Stdout,
-		errOut:  os.Stderr,
-		in:      os.Stdin,
+		baseURL:    envOrDefault("JETMON_API_URL", defaultAPIBaseURL),
+		token:      os.Getenv("JETMON_API_TOKEN"),
+		authPolicy: envOrDefault("JETMON_API_AUTH_POLICY", defaultAPIAuthPolicy),
+		timeout:    10 * time.Second,
+		out:        os.Stdout,
+		errOut:     os.Stderr,
+		in:         os.Stdin,
 	}
 }
 
@@ -221,6 +225,7 @@ func newAPIFlagSet(name string, opts *apiCLIOptions) *flag.FlagSet {
 	if tokenFlag := fs.Lookup("token"); tokenFlag != nil {
 		tokenFlag.DefValue = ""
 	}
+	fs.StringVar(&opts.authPolicy, "auth-policy", opts.authPolicy, "automatic auth policy: same-origin or any-origin")
 	fs.BoolVar(&opts.verbose, "v", false, "print request and response headers to stderr")
 	fs.BoolVar(&opts.verbose, "verbose", false, "print request and response headers to stderr")
 	fs.BoolVar(&opts.pretty, "pretty", false, "pretty-print JSON response bodies")
@@ -399,7 +404,11 @@ func doAPIRequest(ctx context.Context, client *http.Client, opts apiCLIOptions, 
 	if err != nil {
 		return apiHTTPResponse{}, err
 	}
-	applyAPIRequestHeaders(req, opts, len(body) > 0)
+	sendAutoAuth, err := shouldSendAPIAutoAuth(opts.baseURL, requestURL, opts.authPolicy)
+	if err != nil {
+		return apiHTTPResponse{}, err
+	}
+	applyAPIRequestHeaders(req, opts, len(body) > 0, sendAutoAuth)
 
 	if opts.verbose {
 		writeAPIRequestHeaders(opts.errOut, req)
@@ -451,15 +460,45 @@ func apiRequestURL(baseURL, target string) (string, error) {
 	return base.ResolveReference(rel).String(), nil
 }
 
-func applyAPIRequestHeaders(req *http.Request, opts apiCLIOptions, hasBody bool) {
+func shouldSendAPIAutoAuth(baseURL, requestURL, policy string) (bool, error) {
+	policy = strings.ToLower(strings.TrimSpace(policy))
+	if policy == "" {
+		policy = defaultAPIAuthPolicy
+	}
+	switch policy {
+	case "any-origin":
+		return true, nil
+	case "same-origin":
+		base, err := url.Parse(strings.TrimRight(baseURL, "/"))
+		if err != nil {
+			return false, fmt.Errorf("invalid API base URL %q: %w", baseURL, err)
+		}
+		target, err := url.Parse(requestURL)
+		if err != nil {
+			return false, fmt.Errorf("invalid request URL %q: %w", requestURL, err)
+		}
+		return sameAPIOrigin(base, target), nil
+	default:
+		return false, fmt.Errorf("invalid auth policy %q (want: same-origin or any-origin)", policy)
+	}
+}
+
+func sameAPIOrigin(a, b *url.URL) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	return strings.EqualFold(a.Scheme, b.Scheme) && strings.EqualFold(a.Host, b.Host)
+}
+
+func applyAPIRequestHeaders(req *http.Request, opts apiCLIOptions, hasBody bool, sendAutoAuth bool) {
 	req.Header.Set("Accept", "application/json")
 	if hasBody {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	if strings.TrimSpace(opts.token) != "" {
+	if sendAutoAuth && strings.TrimSpace(opts.token) != "" {
 		req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(opts.token))
 	}
-	if strings.TrimSpace(opts.idempotencyKey) != "" {
+	if sendAutoAuth && strings.TrimSpace(opts.idempotencyKey) != "" {
 		req.Header.Set("Idempotency-Key", strings.TrimSpace(opts.idempotencyKey))
 	}
 	for _, raw := range opts.headers {
@@ -496,8 +535,20 @@ func writeSortedHeaders(w io.Writer, prefix string, h http.Header) {
 	sort.Strings(keys)
 	for _, k := range keys {
 		for _, v := range h.Values(k) {
+			if isSensitiveAPIHeader(k) {
+				v = "[redacted]"
+			}
 			fmt.Fprintf(w, "%s%s: %s\n", prefix, k, v)
 		}
+	}
+}
+
+func isSensitiveAPIHeader(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "authorization", "proxy-authorization", "idempotency-key", "cookie", "set-cookie", "x-api-key":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/cmd/jetmon2/api_cli.go
+++ b/cmd/jetmon2/api_cli.go
@@ -457,6 +457,7 @@ func apiTableColumns(rows []map[string]any) []string {
 		{"id", "url", "active", "events", "secret_preview", "created_at"},
 		{"id", "label", "active", "transport", "min_severity", "max_per_hour", "destination_preview"},
 		{"id", "status", "attempt", "event_id", "event_type", "last_status_code", "created_at"},
+		{"site_id", "status", "error"},
 		{"site_id", "action", "note", "error"},
 		{"name", "status", "detail"},
 	} {

--- a/cmd/jetmon2/api_cli.go
+++ b/cmd/jetmon2/api_cli.go
@@ -1,0 +1,324 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+const defaultAPIBaseURL = "http://localhost:8090"
+
+type apiCLIOptions struct {
+	baseURL        string
+	token          string
+	verbose        bool
+	pretty         bool
+	timeout        time.Duration
+	body           string
+	bodyFile       string
+	idempotencyKey string
+	headers        apiHeaderFlags
+	out            io.Writer
+	errOut         io.Writer
+	in             io.Reader
+}
+
+type apiHeaderFlags []string
+
+func (h *apiHeaderFlags) String() string {
+	return strings.Join(*h, ",")
+}
+
+func (h *apiHeaderFlags) Set(v string) error {
+	if !strings.Contains(v, ":") {
+		return fmt.Errorf("header %q must be in Name: Value form", v)
+	}
+	*h = append(*h, v)
+	return nil
+}
+
+func cmdAPI(args []string) {
+	if len(args) == 0 {
+		printAPIUsage(os.Stderr)
+		os.Exit(1)
+	}
+
+	sub := args[0]
+	rest := args[1:]
+	var err error
+	switch sub {
+	case "health":
+		err = cmdAPIHealth(rest)
+	case "me":
+		err = cmdAPIMe(rest)
+	case "request":
+		err = cmdAPIRequest(rest)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown api subcommand %q (want: health, me, request)\n", sub)
+		printAPIUsage(os.Stderr)
+		os.Exit(1)
+	}
+	if err != nil {
+		logAPIErrorAndExit(err)
+	}
+}
+
+func printAPIUsage(w io.Writer) {
+	fmt.Fprintln(w, "usage: jetmon2 api <health|me|request> [flags]")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Environment:")
+	fmt.Fprintln(w, "  JETMON_API_URL     API base URL (default: http://localhost:8090)")
+	fmt.Fprintln(w, "  JETMON_API_TOKEN   Bearer token for authenticated routes")
+}
+
+func cmdAPIHealth(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api health", &opts)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("usage: jetmon2 api health [flags]")
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodGet, "/api/v1/health", nil)
+}
+
+func cmdAPIMe(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api me", &opts)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("usage: jetmon2 api me [flags]")
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodGet, "/api/v1/me", nil)
+}
+
+func cmdAPIRequest(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api request", &opts)
+	fs.StringVar(&opts.body, "body", "", "literal request body")
+	fs.StringVar(&opts.bodyFile, "body-file", "", "file containing request body (- reads stdin)")
+	fs.StringVar(&opts.idempotencyKey, "idempotency-key", "", "Idempotency-Key header for POST retries")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 2 {
+		return fmt.Errorf("usage: jetmon2 api request [flags] <method> <path-or-url>")
+	}
+
+	body, err := readAPIRequestBody(opts)
+	if err != nil {
+		return err
+	}
+	return executeAPIRequest(context.Background(), nil, opts, fs.Arg(0), fs.Arg(1), body)
+}
+
+func defaultAPIOptions() apiCLIOptions {
+	return apiCLIOptions{
+		baseURL: envOrDefault("JETMON_API_URL", defaultAPIBaseURL),
+		token:   os.Getenv("JETMON_API_TOKEN"),
+		timeout: 10 * time.Second,
+		out:     os.Stdout,
+		errOut:  os.Stderr,
+		in:      os.Stdin,
+	}
+}
+
+func newAPIFlagSet(name string, opts *apiCLIOptions) *flag.FlagSet {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.SetOutput(opts.errOut)
+	fs.StringVar(&opts.baseURL, "base-url", opts.baseURL, "API base URL")
+	fs.StringVar(&opts.token, "token", opts.token, "Bearer token")
+	fs.BoolVar(&opts.verbose, "v", false, "print request and response headers to stderr")
+	fs.BoolVar(&opts.verbose, "verbose", false, "print request and response headers to stderr")
+	fs.BoolVar(&opts.pretty, "pretty", false, "pretty-print JSON response bodies")
+	fs.DurationVar(&opts.timeout, "timeout", opts.timeout, "request timeout")
+	fs.Var(&opts.headers, "header", "additional request header in Name: Value form (repeatable)")
+	return fs
+}
+
+func readAPIRequestBody(opts apiCLIOptions) ([]byte, error) {
+	if opts.body != "" && opts.bodyFile != "" {
+		return nil, errors.New("use --body or --body-file, not both")
+	}
+	if opts.body != "" {
+		return []byte(opts.body), nil
+	}
+	if opts.bodyFile == "" {
+		return nil, nil
+	}
+	if opts.bodyFile == "-" {
+		return io.ReadAll(opts.in)
+	}
+	return os.ReadFile(opts.bodyFile)
+}
+
+func executeAPIRequest(ctx context.Context, client *http.Client, opts apiCLIOptions, method, target string, body []byte) error {
+	if opts.out == nil {
+		opts.out = io.Discard
+	}
+	if opts.errOut == nil {
+		opts.errOut = io.Discard
+	}
+	if opts.timeout <= 0 {
+		opts.timeout = 10 * time.Second
+	}
+	if client == nil {
+		client = &http.Client{Timeout: opts.timeout}
+	}
+
+	requestURL, err := apiRequestURL(opts.baseURL, target)
+	if err != nil {
+		return err
+	}
+
+	var bodyReader io.Reader
+	if len(body) > 0 {
+		bodyReader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, strings.ToUpper(method), requestURL, bodyReader)
+	if err != nil {
+		return err
+	}
+	applyAPIRequestHeaders(req, opts, len(body) > 0)
+
+	if opts.verbose {
+		writeAPIRequestHeaders(opts.errOut, req)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if opts.verbose {
+		writeAPIResponseHeaders(opts.errOut, resp)
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if err := writeAPIResponseBody(opts.out, respBody, opts.pretty); err != nil {
+		return err
+	}
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("api returned %s", resp.Status)
+	}
+	return nil
+}
+
+func apiRequestURL(baseURL, target string) (string, error) {
+	if strings.TrimSpace(target) == "" {
+		return "", errors.New("request path is required")
+	}
+	if u, err := url.Parse(target); err == nil && u.IsAbs() {
+		return u.String(), nil
+	}
+
+	base, err := url.Parse(strings.TrimRight(baseURL, "/"))
+	if err != nil {
+		return "", fmt.Errorf("invalid API base URL %q: %w", baseURL, err)
+	}
+	if !base.IsAbs() || base.Host == "" {
+		return "", fmt.Errorf("invalid API base URL %q: must include scheme and host", baseURL)
+	}
+	rel, err := url.Parse(target)
+	if err != nil {
+		return "", fmt.Errorf("invalid API path %q: %w", target, err)
+	}
+	if !strings.HasPrefix(rel.Path, "/") {
+		rel.Path = "/" + rel.Path
+	}
+	return base.ResolveReference(rel).String(), nil
+}
+
+func applyAPIRequestHeaders(req *http.Request, opts apiCLIOptions, hasBody bool) {
+	req.Header.Set("Accept", "application/json")
+	if hasBody {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if strings.TrimSpace(opts.token) != "" {
+		req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(opts.token))
+	}
+	if strings.TrimSpace(opts.idempotencyKey) != "" {
+		req.Header.Set("Idempotency-Key", strings.TrimSpace(opts.idempotencyKey))
+	}
+	for _, raw := range opts.headers {
+		name, value, ok := strings.Cut(raw, ":")
+		if !ok {
+			continue
+		}
+		req.Header.Set(strings.TrimSpace(name), strings.TrimSpace(value))
+	}
+}
+
+func writeAPIRequestHeaders(w io.Writer, req *http.Request) {
+	path := req.URL.RequestURI()
+	if path == "" {
+		path = "/"
+	}
+	fmt.Fprintf(w, "> %s %s %s\n", req.Method, path, req.Proto)
+	fmt.Fprintf(w, "> Host: %s\n", req.URL.Host)
+	writeSortedHeaders(w, "> ", req.Header)
+	fmt.Fprintln(w, ">")
+}
+
+func writeAPIResponseHeaders(w io.Writer, resp *http.Response) {
+	fmt.Fprintf(w, "< %s %s\n", resp.Proto, resp.Status)
+	writeSortedHeaders(w, "< ", resp.Header)
+	fmt.Fprintln(w, "<")
+}
+
+func writeSortedHeaders(w io.Writer, prefix string, h http.Header) {
+	keys := make([]string, 0, len(h))
+	for k := range h {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		for _, v := range h.Values(k) {
+			fmt.Fprintf(w, "%s%s: %s\n", prefix, k, v)
+		}
+	}
+}
+
+func writeAPIResponseBody(w io.Writer, body []byte, pretty bool) error {
+	body = bytes.TrimSpace(body)
+	if len(body) == 0 {
+		return nil
+	}
+	if pretty && json.Valid(body) {
+		var formatted bytes.Buffer
+		if err := json.Indent(&formatted, body, "", "  "); err != nil {
+			return err
+		}
+		body = formatted.Bytes()
+	}
+	if _, err := w.Write(body); err != nil {
+		return err
+	}
+	if !bytes.HasSuffix(body, []byte("\n")) {
+		_, err := fmt.Fprintln(w)
+		return err
+	}
+	return nil
+}
+
+func logAPIErrorAndExit(err error) {
+	fmt.Fprintf(os.Stderr, "api: %v\n", err)
+	os.Exit(1)
+}

--- a/cmd/jetmon2/api_cli.go
+++ b/cmd/jetmon2/api_cli.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"text/tabwriter"
 	"time"
 )
 
@@ -23,6 +24,7 @@ type apiCLIOptions struct {
 	token          string
 	verbose        bool
 	pretty         bool
+	output         string
 	timeout        time.Duration
 	body           string
 	bodyFile       string
@@ -160,6 +162,7 @@ func newAPIFlagSet(name string, opts *apiCLIOptions) *flag.FlagSet {
 	fs.BoolVar(&opts.verbose, "v", false, "print request and response headers to stderr")
 	fs.BoolVar(&opts.verbose, "verbose", false, "print request and response headers to stderr")
 	fs.BoolVar(&opts.pretty, "pretty", false, "pretty-print JSON response bodies")
+	fs.StringVar(&opts.output, "output", "json", "response output format: json or table")
 	fs.DurationVar(&opts.timeout, "timeout", opts.timeout, "request timeout")
 	fs.Var(&opts.headers, "header", "additional request header in Name: Value form (repeatable)")
 	return fs
@@ -185,11 +188,14 @@ func executeAPIRequest(ctx context.Context, client *http.Client, opts apiCLIOpti
 	if opts.out == nil {
 		opts.out = io.Discard
 	}
+	if err := validateAPIOutputFormat(opts.output); err != nil {
+		return err
+	}
 	resp, err := doAPIRequest(ctx, client, opts, method, target, body)
 	if err != nil {
 		return err
 	}
-	if err := writeAPIResponseBody(opts.out, resp.Body, opts.pretty); err != nil {
+	if err := writeAPIOutput(opts.out, resp.Body, opts); err != nil {
 		return err
 	}
 	if resp.StatusCode >= 400 {
@@ -344,6 +350,177 @@ func writeAPIResponseBody(w io.Writer, body []byte, pretty bool) error {
 		return err
 	}
 	return nil
+}
+
+func writeAPIValueOutput(w io.Writer, value any, opts apiCLIOptions) error {
+	if w == nil {
+		w = io.Discard
+	}
+	body, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return writeAPIOutput(w, body, opts)
+}
+
+func writeAPIOutput(w io.Writer, body []byte, opts apiCLIOptions) error {
+	if err := validateAPIOutputFormat(opts.output); err != nil {
+		return err
+	}
+	switch opts.output {
+	case "", "json":
+		return writeAPIResponseBody(w, body, opts.pretty)
+	case "table":
+		return writeAPIResponseTable(w, body)
+	}
+	return nil
+}
+
+func validateAPIOutputFormat(output string) error {
+	switch output {
+	case "", "json", "table":
+		return nil
+	default:
+		return fmt.Errorf("output must be one of: json, table")
+	}
+}
+
+func writeAPIResponseTable(w io.Writer, body []byte) error {
+	body = bytes.TrimSpace(body)
+	if len(body) == 0 {
+		return nil
+	}
+	var value any
+	if err := json.Unmarshal(body, &value); err != nil {
+		return err
+	}
+	rows := apiTableRows(value)
+	if len(rows) == 0 {
+		_, err := fmt.Fprintln(w, "no rows")
+		return err
+	}
+	columns := apiTableColumns(rows)
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	for i, col := range columns {
+		if i > 0 {
+			fmt.Fprint(tw, "\t")
+		}
+		fmt.Fprint(tw, col)
+	}
+	fmt.Fprintln(tw)
+	for _, row := range rows {
+		for i, col := range columns {
+			if i > 0 {
+				fmt.Fprint(tw, "\t")
+			}
+			fmt.Fprint(tw, apiTableValue(row[col]))
+		}
+		fmt.Fprintln(tw)
+	}
+	return tw.Flush()
+}
+
+func apiTableRows(value any) []map[string]any {
+	switch v := value.(type) {
+	case map[string]any:
+		for _, key := range []string{"data", "created", "sites", "steps"} {
+			if data, ok := v[key].([]any); ok {
+				return apiRowsFromArray(data)
+			}
+		}
+		return []map[string]any{v}
+	case []any:
+		return apiRowsFromArray(v)
+	default:
+		return nil
+	}
+}
+
+func apiRowsFromArray(data []any) []map[string]any {
+	rows := make([]map[string]any, 0, len(data))
+	for _, item := range data {
+		row, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+func apiTableColumns(rows []map[string]any) []string {
+	best := []string{}
+	for _, cols := range [][]string{
+		{"id", "blog_id", "monitor_url", "monitor_active", "current_state", "current_severity", "active_event_id"},
+		{"blog_id", "monitor_url", "monitor_active", "check_keyword", "redirect_policy", "timeout_seconds"},
+		{"id", "site_id", "check_type", "state", "severity", "started_at", "ended_at"},
+		{"id", "url", "active", "events", "secret_preview", "created_at"},
+		{"id", "label", "active", "transport", "min_severity", "max_per_hour", "destination_preview"},
+		{"id", "status", "attempt", "event_id", "event_type", "last_status_code", "created_at"},
+		{"site_id", "action", "note", "error"},
+		{"name", "status", "detail"},
+	} {
+		present := apiColumnsPresent(rows, cols)
+		if len(present) > len(best) {
+			best = present
+		}
+	}
+	if len(best) > 0 {
+		return best
+	}
+	seen := map[string]struct{}{}
+	for _, row := range rows {
+		for k := range row {
+			seen[k] = struct{}{}
+		}
+	}
+	cols := make([]string, 0, len(seen))
+	for k := range seen {
+		cols = append(cols, k)
+	}
+	sort.Strings(cols)
+	return cols
+}
+
+func apiColumnsPresent(rows []map[string]any, cols []string) []string {
+	out := []string{}
+	for _, col := range cols {
+		for _, row := range rows {
+			if _, ok := row[col]; ok {
+				out = append(out, col)
+				break
+			}
+		}
+	}
+	return out
+}
+
+func apiTableValue(v any) string {
+	switch value := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return value
+	case bool:
+		return fmt.Sprintf("%t", value)
+	case float64:
+		if value == float64(int64(value)) {
+			return fmt.Sprintf("%d", int64(value))
+		}
+		return fmt.Sprintf("%g", value)
+	case []any:
+		parts := make([]string, 0, len(value))
+		for _, item := range value {
+			parts = append(parts, apiTableValue(item))
+		}
+		return strings.Join(parts, ",")
+	default:
+		b, err := json.Marshal(value)
+		if err != nil {
+			return fmt.Sprint(value)
+		}
+		return string(b)
+	}
 }
 
 func logAPIErrorAndExit(err error) {

--- a/cmd/jetmon2/api_cli.go
+++ b/cmd/jetmon2/api_cli.go
@@ -35,6 +35,12 @@ type apiCLIOptions struct {
 
 type apiHeaderFlags []string
 
+type apiHTTPResponse struct {
+	StatusCode int
+	Status     string
+	Body       []byte
+}
+
 func (h *apiHeaderFlags) String() string {
 	return strings.Join(*h, ",")
 }
@@ -71,8 +77,10 @@ func cmdAPI(args []string) {
 		err = cmdAPIWebhooks(rest)
 	case "alert-contacts":
 		err = cmdAPIAlertContacts(rest)
+	case "smoke":
+		err = cmdAPISmoke(rest)
 	default:
-		fmt.Fprintf(os.Stderr, "unknown api subcommand %q (want: health, me, request, sites, events, webhooks, alert-contacts)\n", sub)
+		fmt.Fprintf(os.Stderr, "unknown api subcommand %q (want: health, me, request, sites, events, webhooks, alert-contacts, smoke)\n", sub)
 		printAPIUsage(os.Stderr)
 		os.Exit(1)
 	}
@@ -82,7 +90,7 @@ func cmdAPI(args []string) {
 }
 
 func printAPIUsage(w io.Writer) {
-	fmt.Fprintln(w, "usage: jetmon2 api <health|me|request|sites|events|webhooks|alert-contacts> [flags]")
+	fmt.Fprintln(w, "usage: jetmon2 api <health|me|request|sites|events|webhooks|alert-contacts|smoke> [flags]")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Environment:")
 	fmt.Fprintln(w, "  JETMON_API_URL     API base URL (default: http://localhost:8090)")
@@ -177,6 +185,20 @@ func executeAPIRequest(ctx context.Context, client *http.Client, opts apiCLIOpti
 	if opts.out == nil {
 		opts.out = io.Discard
 	}
+	resp, err := doAPIRequest(ctx, client, opts, method, target, body)
+	if err != nil {
+		return err
+	}
+	if err := writeAPIResponseBody(opts.out, resp.Body, opts.pretty); err != nil {
+		return err
+	}
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("api returned %s", resp.Status)
+	}
+	return nil
+}
+
+func doAPIRequest(ctx context.Context, client *http.Client, opts apiCLIOptions, method, target string, body []byte) (apiHTTPResponse, error) {
 	if opts.errOut == nil {
 		opts.errOut = io.Discard
 	}
@@ -189,7 +211,7 @@ func executeAPIRequest(ctx context.Context, client *http.Client, opts apiCLIOpti
 
 	requestURL, err := apiRequestURL(opts.baseURL, target)
 	if err != nil {
-		return err
+		return apiHTTPResponse{}, err
 	}
 
 	var bodyReader io.Reader
@@ -198,7 +220,7 @@ func executeAPIRequest(ctx context.Context, client *http.Client, opts apiCLIOpti
 	}
 	req, err := http.NewRequestWithContext(ctx, strings.ToUpper(method), requestURL, bodyReader)
 	if err != nil {
-		return err
+		return apiHTTPResponse{}, err
 	}
 	applyAPIRequestHeaders(req, opts, len(body) > 0)
 
@@ -208,7 +230,7 @@ func executeAPIRequest(ctx context.Context, client *http.Client, opts apiCLIOpti
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return err
+		return apiHTTPResponse{}, err
 	}
 	defer resp.Body.Close()
 
@@ -218,15 +240,13 @@ func executeAPIRequest(ctx context.Context, client *http.Client, opts apiCLIOpti
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return err
+		return apiHTTPResponse{}, err
 	}
-	if err := writeAPIResponseBody(opts.out, respBody, opts.pretty); err != nil {
-		return err
-	}
-	if resp.StatusCode >= 400 {
-		return fmt.Errorf("api returned %s", resp.Status)
-	}
-	return nil
+	return apiHTTPResponse{
+		StatusCode: resp.StatusCode,
+		Status:     resp.Status,
+		Body:       respBody,
+	}, nil
 }
 
 func apiRequestURL(baseURL, target string) (string, error) {

--- a/cmd/jetmon2/api_cli_alert_contacts.go
+++ b/cmd/jetmon2/api_cli_alert_contacts.go
@@ -1,0 +1,405 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type apiAlertContactCreateOptions struct {
+	label       string
+	active      apiOptionalBoolFlag
+	transport   string
+	destination apiAlertDestinationOptions
+	siteIDs     apiInt64SliceFlags
+	minSeverity apiOptionalStringFlag
+	maxPerHour  apiOptionalIntFlag
+}
+
+type apiAlertContactUpdateOptions struct {
+	label       apiOptionalStringFlag
+	active      apiOptionalBoolFlag
+	destination apiAlertDestinationOptions
+	siteIDs     apiInt64SliceFlags
+	clearSites  bool
+	minSeverity apiOptionalStringFlag
+	maxPerHour  apiOptionalIntFlag
+}
+
+type apiAlertDestinationOptions struct {
+	raw            string
+	address        string
+	integrationKey string
+	webhookURL     string
+}
+
+type apiAlertDeliveriesFilters struct {
+	cursor string
+	limit  int
+	status string
+}
+
+type apiAlertContactSiteFilter struct {
+	SiteIDs []int64 `json:"site_ids,omitempty"`
+}
+
+type apiAlertContactCreateRequest struct {
+	Label       string                    `json:"label"`
+	Active      *bool                     `json:"active,omitempty"`
+	Transport   string                    `json:"transport"`
+	Destination json.RawMessage           `json:"destination"`
+	SiteFilter  apiAlertContactSiteFilter `json:"site_filter"`
+	MinSeverity *string                   `json:"min_severity,omitempty"`
+	MaxPerHour  *int                      `json:"max_per_hour,omitempty"`
+}
+
+type apiAlertContactUpdateRequest struct {
+	Label       *string                    `json:"label,omitempty"`
+	Active      *bool                      `json:"active,omitempty"`
+	Destination json.RawMessage            `json:"destination,omitempty"`
+	SiteFilter  *apiAlertContactSiteFilter `json:"site_filter,omitempty"`
+	MinSeverity *string                    `json:"min_severity,omitempty"`
+	MaxPerHour  *int                       `json:"max_per_hour,omitempty"`
+}
+
+func cmdAPIAlertContacts(args []string) error {
+	if len(args) == 0 {
+		return errors.New("usage: jetmon2 api alert-contacts <list|get|create|update|delete|test|deliveries|retry> [flags]")
+	}
+
+	sub := args[0]
+	rest := args[1:]
+	switch sub {
+	case "list":
+		return cmdAPIAlertContactsList(rest)
+	case "get":
+		return cmdAPIAlertContactsGet(rest)
+	case "create":
+		return cmdAPIAlertContactsCreate(rest)
+	case "update":
+		return cmdAPIAlertContactsUpdate(rest)
+	case "delete":
+		return cmdAPIAlertContactsDelete(rest)
+	case "test":
+		return cmdAPIAlertContactsTest(rest)
+	case "deliveries":
+		return cmdAPIAlertContactsDeliveries(rest)
+	case "retry":
+		return cmdAPIAlertContactsRetry(rest)
+	default:
+		return fmt.Errorf("unknown api alert-contacts subcommand %q (want: list, get, create, update, delete, test, deliveries, retry)", sub)
+	}
+}
+
+func cmdAPIAlertContactsList(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api alert-contacts list", &opts)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return errors.New("usage: jetmon2 api alert-contacts list [flags]")
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodGet, "/api/v1/alert-contacts", nil)
+}
+
+func cmdAPIAlertContactsGet(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api alert-contacts get", &opts)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return errors.New("usage: jetmon2 api alert-contacts get [flags] <contact-id>")
+	}
+	target, err := apiAlertContactPath(fs.Arg(0), "")
+	if err != nil {
+		return err
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodGet, target, nil)
+}
+
+func cmdAPIAlertContactsCreate(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api alert-contacts create", &opts)
+	addAPIIdempotencyFlag(fs, &opts)
+	create := apiAlertContactCreateOptions{}
+	fs.StringVar(&create.label, "label", "", "alert contact label")
+	fs.Var(&create.active, "active", "alert contact enabled: true or false")
+	fs.StringVar(&create.transport, "transport", "", "transport: email, pagerduty, slack, or teams")
+	addAPIAlertDestinationFlags(fs, &create.destination)
+	fs.Var(&create.siteIDs, "site-id", "site id filter (repeatable or comma-separated)")
+	fs.Var(&create.minSeverity, "min-severity", "minimum severity: Up, Warning, Degraded, SeemsDown, or Down")
+	fs.Var(&create.maxPerHour, "max-per-hour", "maximum notifications per hour, 0 for unlimited")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return errors.New("usage: jetmon2 api alert-contacts create [flags]")
+	}
+	body, err := marshalAPIAlertContactCreateBody(create)
+	if err != nil {
+		return err
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodPost, "/api/v1/alert-contacts", body)
+}
+
+func cmdAPIAlertContactsUpdate(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api alert-contacts update", &opts)
+	update := apiAlertContactUpdateOptions{}
+	fs.Var(&update.label, "label", "alert contact label")
+	fs.Var(&update.active, "active", "alert contact enabled: true or false")
+	addAPIAlertDestinationFlags(fs, &update.destination)
+	fs.Var(&update.siteIDs, "site-id", "site id filter (repeatable or comma-separated)")
+	fs.BoolVar(&update.clearSites, "clear-sites", false, "clear site filters")
+	fs.Var(&update.minSeverity, "min-severity", "minimum severity: Up, Warning, Degraded, SeemsDown, or Down")
+	fs.Var(&update.maxPerHour, "max-per-hour", "maximum notifications per hour, 0 for unlimited")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return errors.New("usage: jetmon2 api alert-contacts update [flags] <contact-id>")
+	}
+	target, err := apiAlertContactPath(fs.Arg(0), "")
+	if err != nil {
+		return err
+	}
+	body, err := marshalAPIAlertContactUpdateBody(update)
+	if err != nil {
+		return err
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodPatch, target, body)
+}
+
+func cmdAPIAlertContactsDelete(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api alert-contacts delete", &opts)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return errors.New("usage: jetmon2 api alert-contacts delete [flags] <contact-id>")
+	}
+	target, err := apiAlertContactPath(fs.Arg(0), "")
+	if err != nil {
+		return err
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodDelete, target, nil)
+}
+
+func cmdAPIAlertContactsTest(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api alert-contacts test", &opts)
+	addAPIIdempotencyFlag(fs, &opts)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return errors.New("usage: jetmon2 api alert-contacts test [flags] <contact-id>")
+	}
+	target, err := apiAlertContactPath(fs.Arg(0), "test")
+	if err != nil {
+		return err
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodPost, target, nil)
+}
+
+func cmdAPIAlertContactsDeliveries(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api alert-contacts deliveries", &opts)
+	filters := apiAlertDeliveriesFilters{}
+	fs.StringVar(&filters.cursor, "cursor", "", "pagination cursor")
+	fs.IntVar(&filters.limit, "limit", 0, "page size (1-200)")
+	fs.StringVar(&filters.status, "status", "", "delivery status: pending, delivered, failed, or abandoned")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return errors.New("usage: jetmon2 api alert-contacts deliveries [flags] <contact-id>")
+	}
+	target, err := apiAlertContactDeliveriesPath(fs.Arg(0), filters)
+	if err != nil {
+		return err
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodGet, target, nil)
+}
+
+func cmdAPIAlertContactsRetry(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api alert-contacts retry", &opts)
+	addAPIIdempotencyFlag(fs, &opts)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 2 {
+		return errors.New("usage: jetmon2 api alert-contacts retry [flags] <contact-id> <delivery-id>")
+	}
+	target, err := apiAlertContactRetryPath(fs.Arg(0), fs.Arg(1))
+	if err != nil {
+		return err
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodPost, target, nil)
+}
+
+func addAPIAlertDestinationFlags(fs *flag.FlagSet, dest *apiAlertDestinationOptions) {
+	fs.StringVar(&dest.raw, "destination", "", "raw destination JSON")
+	fs.StringVar(&dest.address, "address", "", "email destination address")
+	fs.StringVar(&dest.integrationKey, "integration-key", "", "PagerDuty Events API v2 integration key")
+	fs.StringVar(&dest.webhookURL, "webhook-url", "", "Slack or Teams incoming webhook URL")
+}
+
+func apiAlertContactPath(rawID, suffix string) (string, error) {
+	id, err := apiPositiveID(rawID, "alert contact")
+	if err != nil {
+		return "", err
+	}
+	path := "/api/v1/alert-contacts/" + strconv.FormatInt(id, 10)
+	if suffix != "" {
+		path += "/" + strings.TrimPrefix(suffix, "/")
+	}
+	return path, nil
+}
+
+func apiAlertContactDeliveriesPath(rawID string, filters apiAlertDeliveriesFilters) (string, error) {
+	path, err := apiAlertContactPath(rawID, "deliveries")
+	if err != nil {
+		return "", err
+	}
+	if filters.limit < 0 {
+		return "", errors.New("limit must be positive")
+	}
+
+	values := url.Values{}
+	if filters.cursor != "" {
+		values.Set("cursor", filters.cursor)
+	}
+	if filters.limit > 0 {
+		values.Set("limit", strconv.Itoa(filters.limit))
+	}
+	if filters.status != "" {
+		switch filters.status {
+		case "pending", "delivered", "failed", "abandoned":
+			values.Set("status", filters.status)
+		default:
+			return "", errors.New("status must be one of: pending, delivered, failed, abandoned")
+		}
+	}
+	if len(values) == 0 {
+		return path, nil
+	}
+	return path + "?" + values.Encode(), nil
+}
+
+func apiAlertContactRetryPath(rawContactID, rawDeliveryID string) (string, error) {
+	contactID, err := apiPositiveID(rawContactID, "alert contact")
+	if err != nil {
+		return "", err
+	}
+	deliveryID, err := apiPositiveID(rawDeliveryID, "delivery")
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("/api/v1/alert-contacts/%d/deliveries/%d/retry", contactID, deliveryID), nil
+}
+
+func marshalAPIAlertContactCreateBody(opts apiAlertContactCreateOptions) ([]byte, error) {
+	if strings.TrimSpace(opts.label) == "" {
+		return nil, errors.New("label is required")
+	}
+	if strings.TrimSpace(opts.transport) == "" {
+		return nil, errors.New("transport is required")
+	}
+	destination, err := opts.destination.rawForTransport(opts.transport, true)
+	if err != nil {
+		return nil, err
+	}
+	req := apiAlertContactCreateRequest{
+		Label:       opts.label,
+		Active:      opts.active.ptr(),
+		Transport:   opts.transport,
+		Destination: destination,
+		SiteFilter:  apiAlertContactSiteFilter{SiteIDs: opts.siteIDs.valuesOrEmpty()},
+		MinSeverity: opts.minSeverity.ptr(),
+		MaxPerHour:  opts.maxPerHour.ptr(),
+	}
+	return json.Marshal(req)
+}
+
+func marshalAPIAlertContactUpdateBody(opts apiAlertContactUpdateOptions) ([]byte, error) {
+	if opts.clearSites && opts.siteIDs.set {
+		return nil, errors.New("use --site-id or --clear-sites, not both")
+	}
+	destination, err := opts.destination.rawForTransport("", false)
+	if err != nil {
+		return nil, err
+	}
+	req := apiAlertContactUpdateRequest{
+		Label:       opts.label.ptr(),
+		Active:      opts.active.ptr(),
+		Destination: destination,
+		MinSeverity: opts.minSeverity.ptr(),
+		MaxPerHour:  opts.maxPerHour.ptr(),
+	}
+	if opts.siteIDs.set || opts.clearSites {
+		req.SiteFilter = &apiAlertContactSiteFilter{SiteIDs: opts.siteIDs.valuesOrEmpty()}
+	}
+	return json.Marshal(req)
+}
+
+func (opts apiAlertDestinationOptions) rawForTransport(transport string, required bool) (json.RawMessage, error) {
+	set := 0
+	for _, v := range []string{opts.raw, opts.address, opts.integrationKey, opts.webhookURL} {
+		if strings.TrimSpace(v) != "" {
+			set++
+		}
+	}
+	if set == 0 {
+		if required {
+			return nil, errors.New("destination is required")
+		}
+		return nil, nil
+	}
+	if set > 1 {
+		return nil, errors.New("use only one destination flag")
+	}
+	if opts.raw != "" {
+		if !json.Valid([]byte(opts.raw)) {
+			return nil, errors.New("destination must be valid JSON")
+		}
+		return json.RawMessage(opts.raw), nil
+	}
+
+	var value any
+	switch {
+	case opts.address != "":
+		if transport != "" && transport != "email" {
+			return nil, errors.New("--address requires --transport email")
+		}
+		value = map[string]string{"address": opts.address}
+	case opts.integrationKey != "":
+		if transport != "" && transport != "pagerduty" {
+			return nil, errors.New("--integration-key requires --transport pagerduty")
+		}
+		value = map[string]string{"integration_key": opts.integrationKey}
+	case opts.webhookURL != "":
+		if transport != "" && transport != "slack" && transport != "teams" {
+			return nil, errors.New("--webhook-url requires --transport slack or teams")
+		}
+		value = map[string]string{"webhook_url": opts.webhookURL}
+	default:
+		return nil, errors.New("destination is required")
+	}
+
+	b, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(b), nil
+}

--- a/cmd/jetmon2/api_cli_alert_contacts.go
+++ b/cmd/jetmon2/api_cli_alert_contacts.go
@@ -100,7 +100,7 @@ func cmdAPIAlertContacts(args []string) error {
 func cmdAPIAlertContactsList(args []string) error {
 	opts := defaultAPIOptions()
 	fs := newAPIFlagSet("api alert-contacts list", &opts)
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {
@@ -112,7 +112,7 @@ func cmdAPIAlertContactsList(args []string) error {
 func cmdAPIAlertContactsGet(args []string) error {
 	opts := defaultAPIOptions()
 	fs := newAPIFlagSet("api alert-contacts get", &opts)
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {
@@ -137,7 +137,7 @@ func cmdAPIAlertContactsCreate(args []string) error {
 	fs.Var(&create.siteIDs, "site-id", "site id filter (repeatable or comma-separated)")
 	fs.Var(&create.minSeverity, "min-severity", "minimum severity: Up, Warning, Degraded, SeemsDown, or Down")
 	fs.Var(&create.maxPerHour, "max-per-hour", "maximum notifications per hour, 0 for unlimited")
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {
@@ -161,7 +161,7 @@ func cmdAPIAlertContactsUpdate(args []string) error {
 	fs.BoolVar(&update.clearSites, "clear-sites", false, "clear site filters")
 	fs.Var(&update.minSeverity, "min-severity", "minimum severity: Up, Warning, Degraded, SeemsDown, or Down")
 	fs.Var(&update.maxPerHour, "max-per-hour", "maximum notifications per hour, 0 for unlimited")
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {
@@ -181,7 +181,7 @@ func cmdAPIAlertContactsUpdate(args []string) error {
 func cmdAPIAlertContactsDelete(args []string) error {
 	opts := defaultAPIOptions()
 	fs := newAPIFlagSet("api alert-contacts delete", &opts)
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {
@@ -198,7 +198,7 @@ func cmdAPIAlertContactsTest(args []string) error {
 	opts := defaultAPIOptions()
 	fs := newAPIFlagSet("api alert-contacts test", &opts)
 	addAPIIdempotencyFlag(fs, &opts)
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {
@@ -218,7 +218,7 @@ func cmdAPIAlertContactsDeliveries(args []string) error {
 	fs.StringVar(&filters.cursor, "cursor", "", "pagination cursor")
 	fs.IntVar(&filters.limit, "limit", 0, "page size (1-200)")
 	fs.StringVar(&filters.status, "status", "", "delivery status: pending, delivered, failed, or abandoned")
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {
@@ -235,7 +235,7 @@ func cmdAPIAlertContactsRetry(args []string) error {
 	opts := defaultAPIOptions()
 	fs := newAPIFlagSet("api alert-contacts retry", &opts)
 	addAPIIdempotencyFlag(fs, &opts)
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 2 {

--- a/cmd/jetmon2/api_cli_alert_contacts_test.go
+++ b/cmd/jetmon2/api_cli_alert_contacts_test.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"encoding/json"
+	"net/url"
+	"testing"
+)
+
+func TestMarshalAPIAlertContactCreateBody(t *testing.T) {
+	var active apiOptionalBoolFlag
+	setTestFlag(t, &active, "false")
+	var siteIDs apiInt64SliceFlags
+	setTestFlag(t, &siteIDs, "42,99")
+	var minSeverity apiOptionalStringFlag
+	setTestFlag(t, &minSeverity, "Warning")
+	var maxPerHour apiOptionalIntFlag
+	setTestFlag(t, &maxPerHour, "0")
+
+	body, err := marshalAPIAlertContactCreateBody(apiAlertContactCreateOptions{
+		label:       "ops-email",
+		active:      active,
+		transport:   "email",
+		destination: apiAlertDestinationOptions{address: "ops@example.com"},
+		siteIDs:     siteIDs,
+		minSeverity: minSeverity,
+		maxPerHour:  maxPerHour,
+	})
+	if err != nil {
+		t.Fatalf("marshalAPIAlertContactCreateBody() error = %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if got["label"] != "ops-email" {
+		t.Fatalf("label = %#v", got["label"])
+	}
+	if got["active"] != false {
+		t.Fatalf("active = %#v, want false", got["active"])
+	}
+	if got["transport"] != "email" {
+		t.Fatalf("transport = %#v, want email", got["transport"])
+	}
+	dest := got["destination"].(map[string]any)
+	if dest["address"] != "ops@example.com" {
+		t.Fatalf("destination.address = %#v", dest["address"])
+	}
+	siteFilter := got["site_filter"].(map[string]any)
+	assertNumberArray(t, siteFilter["site_ids"], []int64{42, 99})
+	if got["min_severity"] != "Warning" {
+		t.Fatalf("min_severity = %#v, want Warning", got["min_severity"])
+	}
+	if got["max_per_hour"] != float64(0) {
+		t.Fatalf("max_per_hour = %#v, want 0", got["max_per_hour"])
+	}
+}
+
+func TestMarshalAPIAlertContactCreateBodyBuildsTransportDestinations(t *testing.T) {
+	tests := []struct {
+		name        string
+		transport   string
+		destination apiAlertDestinationOptions
+		wantKey     string
+		wantValue   string
+	}{
+		{
+			name:        "pagerduty",
+			transport:   "pagerduty",
+			destination: apiAlertDestinationOptions{integrationKey: "pd-key"},
+			wantKey:     "integration_key",
+			wantValue:   "pd-key",
+		},
+		{
+			name:        "slack",
+			transport:   "slack",
+			destination: apiAlertDestinationOptions{webhookURL: "https://hooks.slack.com/services/test"},
+			wantKey:     "webhook_url",
+			wantValue:   "https://hooks.slack.com/services/test",
+		},
+		{
+			name:        "teams",
+			transport:   "teams",
+			destination: apiAlertDestinationOptions{webhookURL: "https://outlook.office.com/webhook/test"},
+			wantKey:     "webhook_url",
+			wantValue:   "https://outlook.office.com/webhook/test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, err := marshalAPIAlertContactCreateBody(apiAlertContactCreateOptions{
+				label:       tt.name,
+				transport:   tt.transport,
+				destination: tt.destination,
+			})
+			if err != nil {
+				t.Fatalf("marshalAPIAlertContactCreateBody() error = %v", err)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(body, &got); err != nil {
+				t.Fatalf("unmarshal body: %v", err)
+			}
+			dest := got["destination"].(map[string]any)
+			if dest[tt.wantKey] != tt.wantValue {
+				t.Fatalf("destination[%s] = %#v, want %q", tt.wantKey, dest[tt.wantKey], tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestMarshalAPIAlertContactUpdateBodySupportsDestinationAndClearSites(t *testing.T) {
+	var label apiOptionalStringFlag
+	setTestFlag(t, &label, "platform-oncall")
+
+	body, err := marshalAPIAlertContactUpdateBody(apiAlertContactUpdateOptions{
+		label:       label,
+		destination: apiAlertDestinationOptions{raw: `{"webhook_url":"https://example.com/hook"}`},
+		clearSites:  true,
+	})
+	if err != nil {
+		t.Fatalf("marshalAPIAlertContactUpdateBody() error = %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if got["label"] != "platform-oncall" {
+		t.Fatalf("label = %#v", got["label"])
+	}
+	dest := got["destination"].(map[string]any)
+	if dest["webhook_url"] != "https://example.com/hook" {
+		t.Fatalf("destination.webhook_url = %#v", dest["webhook_url"])
+	}
+	if _, ok := got["site_filter"].(map[string]any)["site_ids"]; ok {
+		t.Fatalf("site_ids present in cleared site_filter: %#v", got["site_filter"])
+	}
+}
+
+func TestMarshalAPIAlertContactUpdateBodyRejectsConflicts(t *testing.T) {
+	var siteIDs apiInt64SliceFlags
+	setTestFlag(t, &siteIDs, "42")
+	if _, err := marshalAPIAlertContactUpdateBody(apiAlertContactUpdateOptions{siteIDs: siteIDs, clearSites: true}); err == nil {
+		t.Fatal("site filter conflict error = nil, want error")
+	}
+	if _, err := (apiAlertDestinationOptions{raw: `{}`, address: "ops@example.com"}).rawForTransport("", false); err == nil {
+		t.Fatal("destination conflict error = nil, want error")
+	}
+	if _, err := (apiAlertDestinationOptions{raw: `{not-json}`}).rawForTransport("", false); err == nil {
+		t.Fatal("invalid raw destination error = nil, want error")
+	}
+}
+
+func TestAPIAlertContactPaths(t *testing.T) {
+	got, err := apiAlertContactPath("17", "test")
+	if err != nil {
+		t.Fatalf("apiAlertContactPath() error = %v", err)
+	}
+	if got != "/api/v1/alert-contacts/17/test" {
+		t.Fatalf("path = %q, want test path", got)
+	}
+
+	got, err = apiAlertContactRetryPath("17", "88")
+	if err != nil {
+		t.Fatalf("apiAlertContactRetryPath() error = %v", err)
+	}
+	if got != "/api/v1/alert-contacts/17/deliveries/88/retry" {
+		t.Fatalf("retry path = %q, want delivery retry path", got)
+	}
+}
+
+func TestAPIAlertContactDeliveriesPath(t *testing.T) {
+	got, err := apiAlertContactDeliveriesPath("17", apiAlertDeliveriesFilters{
+		cursor: "cur-5",
+		limit:  50,
+		status: "failed",
+	})
+	if err != nil {
+		t.Fatalf("apiAlertContactDeliveriesPath() error = %v", err)
+	}
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("parse path: %v", err)
+	}
+	if u.Path != "/api/v1/alert-contacts/17/deliveries" {
+		t.Fatalf("path = %q, want deliveries path", u.Path)
+	}
+	for key, want := range map[string]string{
+		"cursor": "cur-5",
+		"limit":  "50",
+		"status": "failed",
+	} {
+		if got := u.Query().Get(key); got != want {
+			t.Fatalf("query %s = %q, want %q", key, got, want)
+		}
+	}
+}

--- a/cmd/jetmon2/api_cli_events.go
+++ b/cmd/jetmon2/api_cli_events.go
@@ -1,0 +1,270 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type apiEventsListFilters struct {
+	cursor       string
+	limit        int
+	state        string
+	stateIn      string
+	checkType    string
+	checkTypeIn  string
+	startedAtGTE string
+	startedAtLT  string
+	active       string
+}
+
+type apiTransitionsListFilters struct {
+	cursor string
+	limit  int
+}
+
+type apiEventCloseOptions struct {
+	reason string
+	note   string
+}
+
+type apiEventCloseRequest struct {
+	Reason string `json:"reason,omitempty"`
+	Note   string `json:"note,omitempty"`
+}
+
+func cmdAPIEvents(args []string) error {
+	if len(args) == 0 {
+		return errors.New("usage: jetmon2 api events <list|get|transitions|close> [flags]")
+	}
+
+	sub := args[0]
+	rest := args[1:]
+	switch sub {
+	case "list":
+		return cmdAPIEventsList(rest)
+	case "get":
+		return cmdAPIEventsGet(rest)
+	case "transitions":
+		return cmdAPIEventsTransitions(rest)
+	case "close":
+		return cmdAPIEventsClose(rest)
+	default:
+		return fmt.Errorf("unknown api events subcommand %q (want: list, get, transitions, close)", sub)
+	}
+}
+
+func cmdAPIEventsList(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api events list", &opts)
+	filters := apiEventsListFilters{}
+	fs.StringVar(&filters.cursor, "cursor", "", "pagination cursor")
+	fs.IntVar(&filters.limit, "limit", 0, "page size (1-200)")
+	fs.StringVar(&filters.state, "state", "", "filter by event state")
+	fs.StringVar(&filters.stateIn, "state-in", "", "comma-separated event states")
+	fs.StringVar(&filters.checkType, "check-type", "", "filter by check type")
+	fs.StringVar(&filters.checkTypeIn, "check-type-in", "", "comma-separated check types")
+	fs.StringVar(&filters.startedAtGTE, "started-at-gte", "", "filter events started at or after this RFC3339 timestamp")
+	fs.StringVar(&filters.startedAtLT, "started-at-lt", "", "filter events started before this RFC3339 timestamp")
+	fs.StringVar(&filters.active, "active", "", "filter open events: true or false")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return errors.New("usage: jetmon2 api events list [flags] <site-id>")
+	}
+	target, err := apiEventsListPath(fs.Arg(0), filters)
+	if err != nil {
+		return err
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodGet, target, nil)
+}
+
+func cmdAPIEventsGet(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api events get", &opts)
+	var siteID string
+	fs.StringVar(&siteID, "site-id", "", "optional site id for site-scoped event lookup")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return errors.New("usage: jetmon2 api events get [flags] <event-id>")
+	}
+	target, err := apiEventDetailPath(siteID, fs.Arg(0))
+	if err != nil {
+		return err
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodGet, target, nil)
+}
+
+func cmdAPIEventsTransitions(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api events transitions", &opts)
+	filters := apiTransitionsListFilters{}
+	fs.StringVar(&filters.cursor, "cursor", "", "pagination cursor")
+	fs.IntVar(&filters.limit, "limit", 0, "page size (1-200)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 2 {
+		return errors.New("usage: jetmon2 api events transitions [flags] <site-id> <event-id>")
+	}
+	target, err := apiEventTransitionsPath(fs.Arg(0), fs.Arg(1), filters)
+	if err != nil {
+		return err
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodGet, target, nil)
+}
+
+func cmdAPIEventsClose(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api events close", &opts)
+	addAPIIdempotencyFlag(fs, &opts)
+	closeOpts := apiEventCloseOptions{}
+	fs.StringVar(&closeOpts.reason, "reason", "", "resolution reason (default: manual_override)")
+	fs.StringVar(&closeOpts.note, "note", "", "operator note recorded in transition metadata")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 2 {
+		return errors.New("usage: jetmon2 api events close [flags] <site-id> <event-id>")
+	}
+	target, err := apiEventClosePath(fs.Arg(0), fs.Arg(1))
+	if err != nil {
+		return err
+	}
+	body, err := marshalAPIEventCloseBody(closeOpts)
+	if err != nil {
+		return err
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodPost, target, body)
+}
+
+func apiEventsListPath(rawSiteID string, filters apiEventsListFilters) (string, error) {
+	siteID, err := apiPositiveID(rawSiteID, "site")
+	if err != nil {
+		return "", err
+	}
+	if filters.limit < 0 {
+		return "", errors.New("limit must be positive")
+	}
+	if filters.state != "" && filters.stateIn != "" {
+		return "", errors.New("use --state or --state-in, not both")
+	}
+	if filters.checkType != "" && filters.checkTypeIn != "" {
+		return "", errors.New("use --check-type or --check-type-in, not both")
+	}
+
+	values := url.Values{}
+	if filters.cursor != "" {
+		values.Set("cursor", filters.cursor)
+	}
+	if filters.limit > 0 {
+		values.Set("limit", strconv.Itoa(filters.limit))
+	}
+	if filters.state != "" {
+		values.Set("state", filters.state)
+	}
+	if filters.stateIn != "" {
+		values.Set("state__in", filters.stateIn)
+	}
+	if filters.checkType != "" {
+		values.Set("check_type", filters.checkType)
+	}
+	if filters.checkTypeIn != "" {
+		values.Set("check_type__in", filters.checkTypeIn)
+	}
+	if filters.startedAtGTE != "" {
+		values.Set("started_at__gte", filters.startedAtGTE)
+	}
+	if filters.startedAtLT != "" {
+		values.Set("started_at__lt", filters.startedAtLT)
+	}
+	if strings.TrimSpace(filters.active) != "" {
+		active, err := strconv.ParseBool(filters.active)
+		if err != nil {
+			return "", errors.New("active must be true or false")
+		}
+		values.Set("active", strconv.FormatBool(active))
+	}
+
+	path := "/api/v1/sites/" + strconv.FormatInt(siteID, 10) + "/events"
+	if len(values) == 0 {
+		return path, nil
+	}
+	return path + "?" + values.Encode(), nil
+}
+
+func apiEventDetailPath(rawSiteID, rawEventID string) (string, error) {
+	eventID, err := apiPositiveID(rawEventID, "event")
+	if err != nil {
+		return "", err
+	}
+	if rawSiteID == "" {
+		return "/api/v1/events/" + strconv.FormatInt(eventID, 10), nil
+	}
+	siteID, err := apiPositiveID(rawSiteID, "site")
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("/api/v1/sites/%d/events/%d", siteID, eventID), nil
+}
+
+func apiEventTransitionsPath(rawSiteID, rawEventID string, filters apiTransitionsListFilters) (string, error) {
+	path, err := apiEventDetailPath(rawSiteID, rawEventID)
+	if err != nil {
+		return "", err
+	}
+	if rawSiteID == "" {
+		return "", errors.New("site id is required for transitions")
+	}
+	if filters.limit < 0 {
+		return "", errors.New("limit must be positive")
+	}
+
+	values := url.Values{}
+	if filters.cursor != "" {
+		values.Set("cursor", filters.cursor)
+	}
+	if filters.limit > 0 {
+		values.Set("limit", strconv.Itoa(filters.limit))
+	}
+	path += "/transitions"
+	if len(values) == 0 {
+		return path, nil
+	}
+	return path + "?" + values.Encode(), nil
+}
+
+func apiEventClosePath(rawSiteID, rawEventID string) (string, error) {
+	path, err := apiEventDetailPath(rawSiteID, rawEventID)
+	if err != nil {
+		return "", err
+	}
+	if rawSiteID == "" {
+		return "", errors.New("site id is required for close")
+	}
+	return path + "/close", nil
+}
+
+func marshalAPIEventCloseBody(opts apiEventCloseOptions) ([]byte, error) {
+	req := apiEventCloseRequest{
+		Reason: opts.reason,
+		Note:   opts.note,
+	}
+	return json.Marshal(req)
+}
+
+func apiPositiveID(raw, label string) (int64, error) {
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || id <= 0 {
+		return 0, fmt.Errorf("%s id must be a positive integer", label)
+	}
+	return id, nil
+}

--- a/cmd/jetmon2/api_cli_events.go
+++ b/cmd/jetmon2/api_cli_events.go
@@ -72,7 +72,7 @@ func cmdAPIEventsList(args []string) error {
 	fs.StringVar(&filters.startedAtGTE, "started-at-gte", "", "filter events started at or after this RFC3339 timestamp")
 	fs.StringVar(&filters.startedAtLT, "started-at-lt", "", "filter events started before this RFC3339 timestamp")
 	fs.StringVar(&filters.active, "active", "", "filter open events: true or false")
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {
@@ -90,7 +90,7 @@ func cmdAPIEventsGet(args []string) error {
 	fs := newAPIFlagSet("api events get", &opts)
 	var siteID string
 	fs.StringVar(&siteID, "site-id", "", "optional site id for site-scoped event lookup")
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {
@@ -109,7 +109,7 @@ func cmdAPIEventsTransitions(args []string) error {
 	filters := apiTransitionsListFilters{}
 	fs.StringVar(&filters.cursor, "cursor", "", "pagination cursor")
 	fs.IntVar(&filters.limit, "limit", 0, "page size (1-200)")
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 2 {
@@ -129,7 +129,7 @@ func cmdAPIEventsClose(args []string) error {
 	closeOpts := apiEventCloseOptions{}
 	fs.StringVar(&closeOpts.reason, "reason", "", "resolution reason (default: manual_override)")
 	fs.StringVar(&closeOpts.note, "note", "", "operator note recorded in transition metadata")
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 2 {

--- a/cmd/jetmon2/api_cli_events_test.go
+++ b/cmd/jetmon2/api_cli_events_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"encoding/json"
+	"net/url"
+	"testing"
+)
+
+func TestAPIEventsListPath(t *testing.T) {
+	got, err := apiEventsListPath("42", apiEventsListFilters{
+		cursor:       "cur-2",
+		limit:        20,
+		state:        "Down",
+		checkTypeIn:  "http,tls_expiry",
+		startedAtGTE: "2026-04-28T10:00:00Z",
+		startedAtLT:  "2026-04-29T10:00:00Z",
+		active:       "true",
+	})
+	if err != nil {
+		t.Fatalf("apiEventsListPath() error = %v", err)
+	}
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("parse path: %v", err)
+	}
+	if u.Path != "/api/v1/sites/42/events" {
+		t.Fatalf("path = %q, want site events path", u.Path)
+	}
+	q := u.Query()
+	for key, want := range map[string]string{
+		"cursor":          "cur-2",
+		"limit":           "20",
+		"state":           "Down",
+		"check_type__in":  "http,tls_expiry",
+		"started_at__gte": "2026-04-28T10:00:00Z",
+		"started_at__lt":  "2026-04-29T10:00:00Z",
+		"active":          "true",
+	} {
+		if got := q.Get(key); got != want {
+			t.Fatalf("query %s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestAPIEventsListPathRejectsAmbiguousFilters(t *testing.T) {
+	if _, err := apiEventsListPath("42", apiEventsListFilters{state: "Down", stateIn: "Up,Down"}); err == nil {
+		t.Fatal("apiEventsListPath() state error = nil, want error")
+	}
+	if _, err := apiEventsListPath("42", apiEventsListFilters{checkType: "http", checkTypeIn: "http,tls"}); err == nil {
+		t.Fatal("apiEventsListPath() check type error = nil, want error")
+	}
+}
+
+func TestAPIEventDetailPath(t *testing.T) {
+	got, err := apiEventDetailPath("", "99")
+	if err != nil {
+		t.Fatalf("apiEventDetailPath() direct error = %v", err)
+	}
+	if got != "/api/v1/events/99" {
+		t.Fatalf("direct path = %q, want /api/v1/events/99", got)
+	}
+
+	got, err = apiEventDetailPath("42", "99")
+	if err != nil {
+		t.Fatalf("apiEventDetailPath() scoped error = %v", err)
+	}
+	if got != "/api/v1/sites/42/events/99" {
+		t.Fatalf("scoped path = %q, want site-scoped event path", got)
+	}
+}
+
+func TestAPIEventTransitionsPath(t *testing.T) {
+	got, err := apiEventTransitionsPath("42", "99", apiTransitionsListFilters{
+		cursor: "cur-3",
+		limit:  100,
+	})
+	if err != nil {
+		t.Fatalf("apiEventTransitionsPath() error = %v", err)
+	}
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("parse path: %v", err)
+	}
+	if u.Path != "/api/v1/sites/42/events/99/transitions" {
+		t.Fatalf("path = %q, want transitions path", u.Path)
+	}
+	if got := u.Query().Get("cursor"); got != "cur-3" {
+		t.Fatalf("cursor = %q, want cur-3", got)
+	}
+	if got := u.Query().Get("limit"); got != "100" {
+		t.Fatalf("limit = %q, want 100", got)
+	}
+}
+
+func TestAPIEventClosePath(t *testing.T) {
+	got, err := apiEventClosePath("42", "99")
+	if err != nil {
+		t.Fatalf("apiEventClosePath() error = %v", err)
+	}
+	if got != "/api/v1/sites/42/events/99/close" {
+		t.Fatalf("path = %q, want close path", got)
+	}
+}
+
+func TestMarshalAPIEventCloseBody(t *testing.T) {
+	body, err := marshalAPIEventCloseBody(apiEventCloseOptions{
+		reason: "false_alarm",
+		note:   "verified from dashboard",
+	})
+	if err != nil {
+		t.Fatalf("marshalAPIEventCloseBody() error = %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if got["reason"] != "false_alarm" {
+		t.Fatalf("reason = %#v, want false_alarm", got["reason"])
+	}
+	if got["note"] != "verified from dashboard" {
+		t.Fatalf("note = %#v, want dashboard note", got["note"])
+	}
+
+	body, err = marshalAPIEventCloseBody(apiEventCloseOptions{})
+	if err != nil {
+		t.Fatalf("marshalAPIEventCloseBody(empty) error = %v", err)
+	}
+	if string(body) != "{}" {
+		t.Fatalf("empty body = %s, want {}", body)
+	}
+}

--- a/cmd/jetmon2/api_cli_remote_guard_test.go
+++ b/cmd/jetmon2/api_cli_remote_guard_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestIsLocalAPIBaseURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		want    bool
+	}{
+		{name: "localhost", baseURL: "http://localhost:8090", want: true},
+		{name: "localhost subdomain", baseURL: "http://jetmon.localhost:8090", want: true},
+		{name: "ipv4 loopback", baseURL: "http://127.0.0.1:8090", want: true},
+		{name: "ipv6 loopback", baseURL: "http://[::1]:8090", want: true},
+		{name: "private lan is remote", baseURL: "http://10.0.0.171:8090", want: false},
+		{name: "public hostname", baseURL: "https://jetmon-api.example.test", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := isLocalAPIBaseURL(tt.baseURL)
+			if err != nil {
+				t.Fatalf("isLocalAPIBaseURL() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("isLocalAPIBaseURL(%q) = %v, want %v", tt.baseURL, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRemoteWorkflowGuardRequiresAllowRemote(t *testing.T) {
+	opts := apiCLIOptions{baseURL: "https://jetmon-api.example.test"}
+	remote, err := requireAPILocalOrAllowRemote(opts, false, "api smoke")
+	if err == nil {
+		t.Fatal("requireAPILocalOrAllowRemote() error = nil, want refusal")
+	}
+	if !remote {
+		t.Fatal("remote = false, want true")
+	}
+	if !strings.Contains(err.Error(), "--allow-remote") {
+		t.Fatalf("error = %v, want --allow-remote hint", err)
+	}
+
+	remote, err = requireAPILocalOrAllowRemote(opts, true, "api smoke")
+	if err != nil {
+		t.Fatalf("requireAPILocalOrAllowRemote(... allow) error = %v", err)
+	}
+	if !remote {
+		t.Fatal("remote = false with remote URL and allow flag, want true")
+	}
+}
+
+func TestRunAPISitesBulkAddRemoteGuard(t *testing.T) {
+	opts := apiCLIOptions{baseURL: "https://jetmon-api.example.test", out: ioDiscard{}, errOut: ioDiscard{}}
+	bulk := apiSitesBulkAddOptions{
+		count:       1,
+		batch:       "remote-batch",
+		source:      "fixture",
+		blogIDStart: defaultAPIBulkAddBlogIDStart,
+	}
+	err := runAPISitesBulkAdd(context.Background(), nil, opts, bulk)
+	if err == nil || !strings.Contains(err.Error(), "--allow-remote") {
+		t.Fatalf("runAPISitesBulkAdd() error = %v, want --allow-remote refusal", err)
+	}
+
+	bulk.allowRemote = true
+	bulk.batch = ""
+	err = runAPISitesBulkAdd(context.Background(), nil, opts, bulk)
+	if err == nil || !strings.Contains(err.Error(), "requires --batch") {
+		t.Fatalf("runAPISitesBulkAdd() error = %v, want remote batch requirement", err)
+	}
+}
+
+func TestRunAPISitesBulkAddDryRunAllowsRemotePlanning(t *testing.T) {
+	var stdout bytes.Buffer
+	err := runAPISitesBulkAdd(context.Background(), nil, apiCLIOptions{
+		baseURL: "https://jetmon-api.example.test",
+		out:     &stdout,
+		errOut:  ioDiscard{},
+	}, apiSitesBulkAddOptions{
+		count:       1,
+		source:      "fixture",
+		blogIDStart: defaultAPIBulkAddBlogIDStart,
+		dryRun:      true,
+	})
+	if err != nil {
+		t.Fatalf("runAPISitesBulkAdd() dry-run error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"dry_run":true`) {
+		t.Fatalf("stdout = %s, want dry-run output", stdout.String())
+	}
+}
+
+func TestRunAPISitesCleanupRemoteGuard(t *testing.T) {
+	opts := apiCLIOptions{baseURL: "https://jetmon-api.example.test", out: ioDiscard{}, errOut: ioDiscard{}}
+	cleanup := apiSitesCleanupOptions{batch: "remote-batch", count: 1, ignoreNotFound: true}
+	err := runAPISitesCleanup(context.Background(), nil, opts, cleanup)
+	if err == nil || !strings.Contains(err.Error(), "--allow-remote") {
+		t.Fatalf("runAPISitesCleanup() error = %v, want --allow-remote refusal", err)
+	}
+
+	cleanup.allowRemote = true
+	cleanup.allowUnmarked = true
+	err = runAPISitesCleanup(context.Background(), nil, opts, cleanup)
+	if err == nil || !strings.Contains(err.Error(), "cannot use --allow-unmarked") {
+		t.Fatalf("runAPISitesCleanup() error = %v, want allow-unmarked refusal", err)
+	}
+}
+
+func TestRunAPISitesSimulateFailureRemoteGuard(t *testing.T) {
+	opts := apiCLIOptions{baseURL: "https://jetmon-api.example.test", out: ioDiscard{}, errOut: ioDiscard{}}
+	sim := apiSitesSimulateFailureOptions{
+		mode:         "http-500",
+		batch:        "remote-batch",
+		count:        1,
+		trigger:      false,
+		pollInterval: 1,
+	}
+	err := runAPISitesSimulateFailure(context.Background(), nil, opts, sim)
+	if err == nil || !strings.Contains(err.Error(), "--allow-remote") {
+		t.Fatalf("runAPISitesSimulateFailure() error = %v, want --allow-remote refusal", err)
+	}
+
+	sim.allowRemote = true
+	sim.batch = ""
+	err = runAPISitesSimulateFailure(context.Background(), nil, opts, sim)
+	if err == nil || !strings.Contains(err.Error(), "requires --batch") {
+		t.Fatalf("runAPISitesSimulateFailure() error = %v, want remote batch requirement", err)
+	}
+}
+
+func TestRunAPISmokeRemoteGuard(t *testing.T) {
+	err := runAPISmoke(context.Background(), nil, apiCLIOptions{
+		baseURL: "https://jetmon-api.example.test",
+		out:     ioDiscard{},
+		errOut:  ioDiscard{},
+	}, apiSmokeOptions{batch: "remote-smoke", exercise: "none"})
+	if err == nil || !strings.Contains(err.Error(), "--allow-remote") {
+		t.Fatalf("runAPISmoke() error = %v, want --allow-remote refusal", err)
+	}
+}

--- a/cmd/jetmon2/api_cli_remote_guard_test.go
+++ b/cmd/jetmon2/api_cli_remote_guard_test.go
@@ -23,14 +23,36 @@ func TestIsLocalAPIBaseURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := isLocalAPIBaseURL(tt.baseURL)
+			got, err := isLocalAPIURL(tt.baseURL)
 			if err != nil {
-				t.Fatalf("isLocalAPIBaseURL() error = %v", err)
+				t.Fatalf("isLocalAPIURL() error = %v", err)
 			}
 			if got != tt.want {
-				t.Fatalf("isLocalAPIBaseURL(%q) = %v, want %v", tt.baseURL, got, tt.want)
+				t.Fatalf("isLocalAPIURL(%q) = %v, want %v", tt.baseURL, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestExecuteAPIRequestRejectsRemoteWrite(t *testing.T) {
+	err := executeAPIRequest(context.Background(), nil, apiCLIOptions{
+		baseURL: "https://jetmon-api.example.test",
+		out:     ioDiscard{},
+		errOut:  ioDiscard{},
+	}, "POST", "/api/v1/sites", []byte(`{}`))
+	if err == nil || !strings.Contains(err.Error(), "--allow-remote") {
+		t.Fatalf("executeAPIRequest() error = %v, want --allow-remote refusal", err)
+	}
+}
+
+func TestExecuteAPIRequestRejectsAbsoluteRemoteWriteWithLocalBase(t *testing.T) {
+	err := executeAPIRequest(context.Background(), nil, apiCLIOptions{
+		baseURL: "http://localhost:8090",
+		out:     ioDiscard{},
+		errOut:  ioDiscard{},
+	}, "DELETE", "https://jetmon-api.example.test/api/v1/sites/42", nil)
+	if err == nil || !strings.Contains(err.Error(), "--allow-remote") {
+		t.Fatalf("executeAPIRequest() error = %v, want --allow-remote refusal", err)
 	}
 }
 
@@ -69,7 +91,7 @@ func TestRunAPISitesBulkAddRemoteGuard(t *testing.T) {
 		t.Fatalf("runAPISitesBulkAdd() error = %v, want --allow-remote refusal", err)
 	}
 
-	bulk.allowRemote = true
+	opts.allowRemote = true
 	bulk.batch = ""
 	err = runAPISitesBulkAdd(context.Background(), nil, opts, bulk)
 	if err == nil || !strings.Contains(err.Error(), "requires --batch") {
@@ -105,7 +127,7 @@ func TestRunAPISitesCleanupRemoteGuard(t *testing.T) {
 		t.Fatalf("runAPISitesCleanup() error = %v, want --allow-remote refusal", err)
 	}
 
-	cleanup.allowRemote = true
+	opts.allowRemote = true
 	cleanup.allowUnmarked = true
 	err = runAPISitesCleanup(context.Background(), nil, opts, cleanup)
 	if err == nil || !strings.Contains(err.Error(), "cannot use --allow-unmarked") {
@@ -127,7 +149,7 @@ func TestRunAPISitesSimulateFailureRemoteGuard(t *testing.T) {
 		t.Fatalf("runAPISitesSimulateFailure() error = %v, want --allow-remote refusal", err)
 	}
 
-	sim.allowRemote = true
+	opts.allowRemote = true
 	sim.batch = ""
 	err = runAPISitesSimulateFailure(context.Background(), nil, opts, sim)
 	if err == nil || !strings.Contains(err.Error(), "requires --batch") {
@@ -146,10 +168,11 @@ func TestRunAPISmokeRemoteGuard(t *testing.T) {
 	}
 
 	err = runAPISmoke(context.Background(), nil, apiCLIOptions{
-		baseURL: "https://jetmon-api.example.test",
-		out:     ioDiscard{},
-		errOut:  ioDiscard{},
-	}, apiSmokeOptions{allowRemote: true, exercise: "none"})
+		baseURL:     "https://jetmon-api.example.test",
+		allowRemote: true,
+		out:         ioDiscard{},
+		errOut:      ioDiscard{},
+	}, apiSmokeOptions{exercise: "none"})
 	if err == nil || !strings.Contains(err.Error(), "requires --batch") {
 		t.Fatalf("runAPISmoke() error = %v, want remote batch requirement", err)
 	}

--- a/cmd/jetmon2/api_cli_remote_guard_test.go
+++ b/cmd/jetmon2/api_cli_remote_guard_test.go
@@ -144,4 +144,13 @@ func TestRunAPISmokeRemoteGuard(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "--allow-remote") {
 		t.Fatalf("runAPISmoke() error = %v, want --allow-remote refusal", err)
 	}
+
+	err = runAPISmoke(context.Background(), nil, apiCLIOptions{
+		baseURL: "https://jetmon-api.example.test",
+		out:     ioDiscard{},
+		errOut:  ioDiscard{},
+	}, apiSmokeOptions{allowRemote: true, exercise: "none"})
+	if err == nil || !strings.Contains(err.Error(), "requires --batch") {
+		t.Fatalf("runAPISmoke() error = %v, want remote batch requirement", err)
+	}
 }

--- a/cmd/jetmon2/api_cli_sites.go
+++ b/cmd/jetmon2/api_cli_sites.go
@@ -129,7 +129,7 @@ func cmdAPISitesList(args []string) error {
 	fs.IntVar(&filters.severityGTE, "severity-gte", -1, "minimum current severity")
 	fs.StringVar(&filters.monitorActive, "monitor-active", "", "filter active sites: true or false")
 	fs.StringVar(&filters.q, "q", "", "monitor URL substring search")
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {
@@ -145,7 +145,7 @@ func cmdAPISitesList(args []string) error {
 func cmdAPISitesGet(args []string) error {
 	opts := defaultAPIOptions()
 	fs := newAPIFlagSet("api sites get", &opts)
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {
@@ -173,7 +173,7 @@ func cmdAPISitesCreate(args []string) error {
 	fs.Var(&create.customHeaders, "custom-header", "site custom header in Name: Value form (repeatable)")
 	fs.Var(&create.alertCooldownMinutes, "alert-cooldown-minutes", "per-site alert cooldown in minutes")
 	fs.Var(&create.checkInterval, "check-interval", "check interval in minutes")
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {
@@ -202,7 +202,7 @@ func cmdAPISitesUpdate(args []string) error {
 	fs.Var(&update.checkInterval, "check-interval", "check interval in minutes")
 	fs.Var(&update.maintenanceStart, "maintenance-start", "maintenance start RFC3339 timestamp; empty clears it")
 	fs.Var(&update.maintenanceEnd, "maintenance-end", "maintenance end RFC3339 timestamp; empty clears it")
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {
@@ -222,7 +222,7 @@ func cmdAPISitesUpdate(args []string) error {
 func cmdAPISitesDelete(args []string) error {
 	opts := defaultAPIOptions()
 	fs := newAPIFlagSet("api sites delete", &opts)
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {
@@ -239,7 +239,7 @@ func cmdAPISitesPostAction(args []string, usageName, suffix string) error {
 	opts := defaultAPIOptions()
 	fs := newAPIFlagSet("api sites "+usageName, &opts)
 	addAPIIdempotencyFlag(fs, &opts)
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {

--- a/cmd/jetmon2/api_cli_sites.go
+++ b/cmd/jetmon2/api_cli_sites.go
@@ -81,7 +81,7 @@ type apiSiteUpdateRequest struct {
 
 func cmdAPISites(args []string) error {
 	if len(args) == 0 {
-		return errors.New("usage: jetmon2 api sites <list|get|create|update|delete|pause|resume|trigger-now|bulk-add> [flags]")
+		return errors.New("usage: jetmon2 api sites <list|get|create|update|delete|pause|resume|trigger-now|bulk-add|simulate-failure> [flags]")
 	}
 
 	sub := args[0]
@@ -105,13 +105,15 @@ func cmdAPISites(args []string) error {
 		return cmdAPISitesPostAction(rest, "trigger-now", "trigger-now")
 	case "bulk-add":
 		return cmdAPISitesBulkAdd(rest)
+	case "simulate-failure":
+		return cmdAPISitesSimulateFailure(rest)
 	default:
-		return fmt.Errorf("unknown api sites subcommand %q (want: list, get, create, update, delete, pause, resume, trigger-now, bulk-add)", sub)
+		return fmt.Errorf("unknown api sites subcommand %q (want: list, get, create, update, delete, pause, resume, trigger-now, bulk-add, simulate-failure)", sub)
 	}
 }
 
 func printAPISitesUsage(w io.Writer) {
-	fmt.Fprintln(w, "usage: jetmon2 api sites <list|get|create|update|delete|pause|resume|trigger-now|bulk-add> [flags]")
+	fmt.Fprintln(w, "usage: jetmon2 api sites <list|get|create|update|delete|pause|resume|trigger-now|bulk-add|simulate-failure> [flags]")
 }
 
 func cmdAPISitesList(args []string) error {

--- a/cmd/jetmon2/api_cli_sites.go
+++ b/cmd/jetmon2/api_cli_sites.go
@@ -81,7 +81,7 @@ type apiSiteUpdateRequest struct {
 
 func cmdAPISites(args []string) error {
 	if len(args) == 0 {
-		return errors.New("usage: jetmon2 api sites <list|get|create|update|delete|pause|resume|trigger-now> [flags]")
+		return errors.New("usage: jetmon2 api sites <list|get|create|update|delete|pause|resume|trigger-now|bulk-add> [flags]")
 	}
 
 	sub := args[0]
@@ -103,13 +103,15 @@ func cmdAPISites(args []string) error {
 		return cmdAPISitesPostAction(rest, "resume", "resume")
 	case "trigger-now":
 		return cmdAPISitesPostAction(rest, "trigger-now", "trigger-now")
+	case "bulk-add":
+		return cmdAPISitesBulkAdd(rest)
 	default:
-		return fmt.Errorf("unknown api sites subcommand %q (want: list, get, create, update, delete, pause, resume, trigger-now)", sub)
+		return fmt.Errorf("unknown api sites subcommand %q (want: list, get, create, update, delete, pause, resume, trigger-now, bulk-add)", sub)
 	}
 }
 
 func printAPISitesUsage(w io.Writer) {
-	fmt.Fprintln(w, "usage: jetmon2 api sites <list|get|create|update|delete|pause|resume|trigger-now> [flags]")
+	fmt.Fprintln(w, "usage: jetmon2 api sites <list|get|create|update|delete|pause|resume|trigger-now|bulk-add> [flags]")
 }
 
 func cmdAPISitesList(args []string) error {

--- a/cmd/jetmon2/api_cli_sites.go
+++ b/cmd/jetmon2/api_cli_sites.go
@@ -1,0 +1,491 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type apiSitesListFilters struct {
+	cursor        string
+	limit         int
+	state         string
+	stateIn       string
+	severityGTE   int
+	monitorActive string
+	q             string
+}
+
+type apiSiteCreateOptions struct {
+	blogID               int64
+	monitorURL           string
+	monitorActive        apiOptionalBoolFlag
+	bucketNo             apiOptionalIntFlag
+	checkKeyword         apiOptionalStringFlag
+	redirectPolicy       apiOptionalStringFlag
+	timeoutSeconds       apiOptionalIntFlag
+	customHeaders        apiStringMapFlags
+	alertCooldownMinutes apiOptionalIntFlag
+	checkInterval        apiOptionalIntFlag
+}
+
+type apiSiteUpdateOptions struct {
+	monitorURL           apiOptionalStringFlag
+	monitorActive        apiOptionalBoolFlag
+	bucketNo             apiOptionalIntFlag
+	checkKeyword         apiOptionalStringFlag
+	redirectPolicy       apiOptionalStringFlag
+	timeoutSeconds       apiOptionalIntFlag
+	customHeaders        apiStringMapFlags
+	clearCustomHeaders   bool
+	alertCooldownMinutes apiOptionalIntFlag
+	checkInterval        apiOptionalIntFlag
+	maintenanceStart     apiOptionalStringFlag
+	maintenanceEnd       apiOptionalStringFlag
+}
+
+type apiSiteCreateRequest struct {
+	BlogID               int64              `json:"blog_id"`
+	MonitorURL           string             `json:"monitor_url"`
+	MonitorActive        *bool              `json:"monitor_active,omitempty"`
+	BucketNo             *int               `json:"bucket_no,omitempty"`
+	CheckKeyword         *string            `json:"check_keyword,omitempty"`
+	RedirectPolicy       *string            `json:"redirect_policy,omitempty"`
+	TimeoutSeconds       *int               `json:"timeout_seconds,omitempty"`
+	CustomHeaders        *map[string]string `json:"custom_headers,omitempty"`
+	AlertCooldownMinutes *int               `json:"alert_cooldown_minutes,omitempty"`
+	CheckInterval        *int               `json:"check_interval,omitempty"`
+}
+
+type apiSiteUpdateRequest struct {
+	MonitorURL           *string            `json:"monitor_url,omitempty"`
+	MonitorActive        *bool              `json:"monitor_active,omitempty"`
+	BucketNo             *int               `json:"bucket_no,omitempty"`
+	CheckKeyword         *string            `json:"check_keyword,omitempty"`
+	RedirectPolicy       *string            `json:"redirect_policy,omitempty"`
+	TimeoutSeconds       *int               `json:"timeout_seconds,omitempty"`
+	CustomHeaders        *map[string]string `json:"custom_headers,omitempty"`
+	AlertCooldownMinutes *int               `json:"alert_cooldown_minutes,omitempty"`
+	CheckInterval        *int               `json:"check_interval,omitempty"`
+	MaintenanceStart     *string            `json:"maintenance_start,omitempty"`
+	MaintenanceEnd       *string            `json:"maintenance_end,omitempty"`
+}
+
+func cmdAPISites(args []string) error {
+	if len(args) == 0 {
+		return errors.New("usage: jetmon2 api sites <list|get|create|update|delete|pause|resume|trigger-now> [flags]")
+	}
+
+	sub := args[0]
+	rest := args[1:]
+	switch sub {
+	case "list":
+		return cmdAPISitesList(rest)
+	case "get":
+		return cmdAPISitesGet(rest)
+	case "create":
+		return cmdAPISitesCreate(rest)
+	case "update":
+		return cmdAPISitesUpdate(rest)
+	case "delete":
+		return cmdAPISitesDelete(rest)
+	case "pause":
+		return cmdAPISitesPostAction(rest, "pause", "pause")
+	case "resume":
+		return cmdAPISitesPostAction(rest, "resume", "resume")
+	case "trigger-now":
+		return cmdAPISitesPostAction(rest, "trigger-now", "trigger-now")
+	default:
+		return fmt.Errorf("unknown api sites subcommand %q (want: list, get, create, update, delete, pause, resume, trigger-now)", sub)
+	}
+}
+
+func printAPISitesUsage(w io.Writer) {
+	fmt.Fprintln(w, "usage: jetmon2 api sites <list|get|create|update|delete|pause|resume|trigger-now> [flags]")
+}
+
+func cmdAPISitesList(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api sites list", &opts)
+	filters := apiSitesListFilters{severityGTE: -1}
+	fs.StringVar(&filters.cursor, "cursor", "", "pagination cursor")
+	fs.IntVar(&filters.limit, "limit", 0, "page size (1-200)")
+	fs.StringVar(&filters.state, "state", "", "filter by current state")
+	fs.StringVar(&filters.stateIn, "state-in", "", "comma-separated current states")
+	fs.IntVar(&filters.severityGTE, "severity-gte", -1, "minimum current severity")
+	fs.StringVar(&filters.monitorActive, "monitor-active", "", "filter active sites: true or false")
+	fs.StringVar(&filters.q, "q", "", "monitor URL substring search")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return errors.New("usage: jetmon2 api sites list [flags]")
+	}
+	target, err := apiSitesListPath(filters)
+	if err != nil {
+		return err
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodGet, target, nil)
+}
+
+func cmdAPISitesGet(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api sites get", &opts)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return errors.New("usage: jetmon2 api sites get [flags] <site-id>")
+	}
+	target, err := apiSiteResourcePath(fs.Arg(0), "")
+	if err != nil {
+		return err
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodGet, target, nil)
+}
+
+func cmdAPISitesCreate(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api sites create", &opts)
+	addAPIIdempotencyFlag(fs, &opts)
+	create := apiSiteCreateOptions{}
+	fs.Int64Var(&create.blogID, "blog-id", 0, "site blog_id")
+	fs.StringVar(&create.monitorURL, "url", "", "site monitor URL")
+	fs.Var(&create.monitorActive, "monitor-active", "monitoring enabled: true or false")
+	fs.Var(&create.bucketNo, "bucket-no", "bucket number")
+	fs.Var(&create.checkKeyword, "check-keyword", "keyword required in response body")
+	fs.Var(&create.redirectPolicy, "redirect-policy", "redirect policy: follow, alert, or fail")
+	fs.Var(&create.timeoutSeconds, "timeout-seconds", "per-site timeout in seconds")
+	fs.Var(&create.customHeaders, "custom-header", "site custom header in Name: Value form (repeatable)")
+	fs.Var(&create.alertCooldownMinutes, "alert-cooldown-minutes", "per-site alert cooldown in minutes")
+	fs.Var(&create.checkInterval, "check-interval", "check interval in minutes")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return errors.New("usage: jetmon2 api sites create [flags]")
+	}
+	body, err := marshalAPISiteCreateBody(create)
+	if err != nil {
+		return err
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodPost, "/api/v1/sites", body)
+}
+
+func cmdAPISitesUpdate(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api sites update", &opts)
+	update := apiSiteUpdateOptions{}
+	fs.Var(&update.monitorURL, "url", "site monitor URL")
+	fs.Var(&update.monitorActive, "monitor-active", "monitoring enabled: true or false")
+	fs.Var(&update.bucketNo, "bucket-no", "bucket number")
+	fs.Var(&update.checkKeyword, "check-keyword", "keyword required in response body; empty clears it")
+	fs.Var(&update.redirectPolicy, "redirect-policy", "redirect policy: follow, alert, or fail")
+	fs.Var(&update.timeoutSeconds, "timeout-seconds", "per-site timeout in seconds")
+	fs.Var(&update.customHeaders, "custom-header", "site custom header in Name: Value form (repeatable)")
+	fs.BoolVar(&update.clearCustomHeaders, "clear-custom-headers", false, "clear all site custom headers")
+	fs.Var(&update.alertCooldownMinutes, "alert-cooldown-minutes", "per-site alert cooldown in minutes")
+	fs.Var(&update.checkInterval, "check-interval", "check interval in minutes")
+	fs.Var(&update.maintenanceStart, "maintenance-start", "maintenance start RFC3339 timestamp; empty clears it")
+	fs.Var(&update.maintenanceEnd, "maintenance-end", "maintenance end RFC3339 timestamp; empty clears it")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return errors.New("usage: jetmon2 api sites update [flags] <site-id>")
+	}
+	target, err := apiSiteResourcePath(fs.Arg(0), "")
+	if err != nil {
+		return err
+	}
+	body, err := marshalAPISiteUpdateBody(update)
+	if err != nil {
+		return err
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodPatch, target, body)
+}
+
+func cmdAPISitesDelete(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api sites delete", &opts)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return errors.New("usage: jetmon2 api sites delete [flags] <site-id>")
+	}
+	target, err := apiSiteResourcePath(fs.Arg(0), "")
+	if err != nil {
+		return err
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodDelete, target, nil)
+}
+
+func cmdAPISitesPostAction(args []string, usageName, suffix string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api sites "+usageName, &opts)
+	addAPIIdempotencyFlag(fs, &opts)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return fmt.Errorf("usage: jetmon2 api sites %s [flags] <site-id>", usageName)
+	}
+	target, err := apiSiteResourcePath(fs.Arg(0), suffix)
+	if err != nil {
+		return err
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodPost, target, nil)
+}
+
+func addAPIIdempotencyFlag(fs *flag.FlagSet, opts *apiCLIOptions) {
+	fs.StringVar(&opts.idempotencyKey, "idempotency-key", "", "Idempotency-Key header for POST retries")
+}
+
+func apiSitesListPath(filters apiSitesListFilters) (string, error) {
+	if filters.limit < 0 {
+		return "", errors.New("limit must be positive")
+	}
+	if filters.severityGTE < -1 {
+		return "", errors.New("severity-gte must be zero or greater")
+	}
+	if filters.state != "" && filters.stateIn != "" {
+		return "", errors.New("use --state or --state-in, not both")
+	}
+
+	values := url.Values{}
+	if filters.cursor != "" {
+		values.Set("cursor", filters.cursor)
+	}
+	if filters.limit > 0 {
+		values.Set("limit", strconv.Itoa(filters.limit))
+	}
+	if filters.state != "" {
+		values.Set("state", filters.state)
+	}
+	if filters.stateIn != "" {
+		values.Set("state__in", filters.stateIn)
+	}
+	if filters.severityGTE >= 0 {
+		values.Set("severity__gte", strconv.Itoa(filters.severityGTE))
+	}
+	if strings.TrimSpace(filters.monitorActive) != "" {
+		active, err := strconv.ParseBool(filters.monitorActive)
+		if err != nil {
+			return "", errors.New("monitor-active must be true or false")
+		}
+		values.Set("monitor_active", strconv.FormatBool(active))
+	}
+	if filters.q != "" {
+		values.Set("q", filters.q)
+	}
+
+	if len(values) == 0 {
+		return "/api/v1/sites", nil
+	}
+	return "/api/v1/sites?" + values.Encode(), nil
+}
+
+func apiSiteResourcePath(rawID, suffix string) (string, error) {
+	id, err := strconv.ParseInt(rawID, 10, 64)
+	if err != nil || id <= 0 {
+		return "", errors.New("site id must be a positive integer")
+	}
+	path := "/api/v1/sites/" + strconv.FormatInt(id, 10)
+	if suffix != "" {
+		path += "/" + strings.TrimPrefix(suffix, "/")
+	}
+	return path, nil
+}
+
+func marshalAPISiteCreateBody(opts apiSiteCreateOptions) ([]byte, error) {
+	if opts.blogID <= 0 {
+		return nil, errors.New("blog-id is required and must be a positive integer")
+	}
+	if strings.TrimSpace(opts.monitorURL) == "" {
+		return nil, errors.New("url is required")
+	}
+
+	req := apiSiteCreateRequest{
+		BlogID:               opts.blogID,
+		MonitorURL:           opts.monitorURL,
+		MonitorActive:        opts.monitorActive.ptr(),
+		BucketNo:             opts.bucketNo.ptr(),
+		CheckKeyword:         opts.checkKeyword.ptr(),
+		RedirectPolicy:       opts.redirectPolicy.ptr(),
+		TimeoutSeconds:       opts.timeoutSeconds.ptr(),
+		CustomHeaders:        opts.customHeaders.ptr(),
+		AlertCooldownMinutes: opts.alertCooldownMinutes.ptr(),
+		CheckInterval:        opts.checkInterval.ptr(),
+	}
+	return json.Marshal(req)
+}
+
+func marshalAPISiteUpdateBody(opts apiSiteUpdateOptions) ([]byte, error) {
+	if opts.clearCustomHeaders && opts.customHeaders.set {
+		return nil, errors.New("use --custom-header or --clear-custom-headers, not both")
+	}
+
+	req := apiSiteUpdateRequest{
+		MonitorURL:           opts.monitorURL.ptr(),
+		MonitorActive:        opts.monitorActive.ptr(),
+		BucketNo:             opts.bucketNo.ptr(),
+		CheckKeyword:         opts.checkKeyword.ptr(),
+		RedirectPolicy:       opts.redirectPolicy.ptr(),
+		TimeoutSeconds:       opts.timeoutSeconds.ptr(),
+		CustomHeaders:        opts.customHeaders.ptr(),
+		AlertCooldownMinutes: opts.alertCooldownMinutes.ptr(),
+		CheckInterval:        opts.checkInterval.ptr(),
+		MaintenanceStart:     opts.maintenanceStart.ptr(),
+		MaintenanceEnd:       opts.maintenanceEnd.ptr(),
+	}
+	if opts.clearCustomHeaders {
+		empty := map[string]string{}
+		req.CustomHeaders = &empty
+	}
+	return json.Marshal(req)
+}
+
+type apiOptionalBoolFlag struct {
+	value bool
+	set   bool
+}
+
+func (f *apiOptionalBoolFlag) Set(v string) error {
+	parsed, err := strconv.ParseBool(v)
+	if err != nil {
+		return err
+	}
+	f.value = parsed
+	f.set = true
+	return nil
+}
+
+func (f *apiOptionalBoolFlag) String() string {
+	if !f.set {
+		return ""
+	}
+	return strconv.FormatBool(f.value)
+}
+
+func (f *apiOptionalBoolFlag) IsBoolFlag() bool {
+	return true
+}
+
+func (f apiOptionalBoolFlag) ptr() *bool {
+	if !f.set {
+		return nil
+	}
+	v := f.value
+	return &v
+}
+
+type apiOptionalIntFlag struct {
+	value int
+	set   bool
+}
+
+func (f *apiOptionalIntFlag) Set(v string) error {
+	parsed, err := strconv.Atoi(v)
+	if err != nil {
+		return err
+	}
+	f.value = parsed
+	f.set = true
+	return nil
+}
+
+func (f *apiOptionalIntFlag) String() string {
+	if !f.set {
+		return ""
+	}
+	return strconv.Itoa(f.value)
+}
+
+func (f apiOptionalIntFlag) ptr() *int {
+	if !f.set {
+		return nil
+	}
+	v := f.value
+	return &v
+}
+
+type apiOptionalStringFlag struct {
+	value string
+	set   bool
+}
+
+func (f *apiOptionalStringFlag) Set(v string) error {
+	f.value = v
+	f.set = true
+	return nil
+}
+
+func (f *apiOptionalStringFlag) String() string {
+	return f.value
+}
+
+func (f apiOptionalStringFlag) ptr() *string {
+	if !f.set {
+		return nil
+	}
+	v := f.value
+	return &v
+}
+
+type apiStringMapFlags struct {
+	values map[string]string
+	set    bool
+}
+
+func (f *apiStringMapFlags) Set(v string) error {
+	name, value, ok := strings.Cut(v, ":")
+	if !ok {
+		return fmt.Errorf("custom header %q must be in Name: Value form", v)
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return errors.New("custom header name must not be empty")
+	}
+	if f.values == nil {
+		f.values = map[string]string{}
+	}
+	f.values[name] = strings.TrimSpace(value)
+	f.set = true
+	return nil
+}
+
+func (f *apiStringMapFlags) String() string {
+	if !f.set {
+		return ""
+	}
+	keys := make([]string, 0, len(f.values))
+	for k := range f.values {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+": "+f.values[k])
+	}
+	return strings.Join(parts, ", ")
+}
+
+func (f apiStringMapFlags) ptr() *map[string]string {
+	if !f.set {
+		return nil
+	}
+	values := make(map[string]string, len(f.values))
+	for k, v := range f.values {
+		values[k] = v
+	}
+	return &values
+}

--- a/cmd/jetmon2/api_cli_sites.go
+++ b/cmd/jetmon2/api_cli_sites.go
@@ -81,7 +81,7 @@ type apiSiteUpdateRequest struct {
 
 func cmdAPISites(args []string) error {
 	if len(args) == 0 {
-		return errors.New("usage: jetmon2 api sites <list|get|create|update|delete|pause|resume|trigger-now|bulk-add|simulate-failure> [flags]")
+		return errors.New("usage: jetmon2 api sites <list|get|create|update|delete|pause|resume|trigger-now|bulk-add|cleanup|simulate-failure> [flags]")
 	}
 
 	sub := args[0]
@@ -105,15 +105,17 @@ func cmdAPISites(args []string) error {
 		return cmdAPISitesPostAction(rest, "trigger-now", "trigger-now")
 	case "bulk-add":
 		return cmdAPISitesBulkAdd(rest)
+	case "cleanup":
+		return cmdAPISitesCleanup(rest)
 	case "simulate-failure":
 		return cmdAPISitesSimulateFailure(rest)
 	default:
-		return fmt.Errorf("unknown api sites subcommand %q (want: list, get, create, update, delete, pause, resume, trigger-now, bulk-add, simulate-failure)", sub)
+		return fmt.Errorf("unknown api sites subcommand %q (want: list, get, create, update, delete, pause, resume, trigger-now, bulk-add, cleanup, simulate-failure)", sub)
 	}
 }
 
 func printAPISitesUsage(w io.Writer) {
-	fmt.Fprintln(w, "usage: jetmon2 api sites <list|get|create|update|delete|pause|resume|trigger-now|bulk-add|simulate-failure> [flags]")
+	fmt.Fprintln(w, "usage: jetmon2 api sites <list|get|create|update|delete|pause|resume|trigger-now|bulk-add|cleanup|simulate-failure> [flags]")
 }
 
 func cmdAPISitesList(args []string) error {

--- a/cmd/jetmon2/api_cli_sites_bulk.go
+++ b/cmd/jetmon2/api_cli_sites_bulk.go
@@ -21,6 +21,7 @@ const (
 
 type apiSitesBulkAddOptions struct {
 	count                int
+	batch                string
 	source               string
 	file                 string
 	blogIDStart          int64
@@ -54,6 +55,7 @@ func cmdAPISitesBulkAdd(args []string) error {
 		blogIDStart: defaultAPIBulkAddBlogIDStart,
 	}
 	fs.IntVar(&bulk.count, "count", 0, "number of sites to create, max 200")
+	fs.StringVar(&bulk.batch, "batch", "", "stable batch label; derives blog ids and stores a custom header marker")
 	fs.StringVar(&bulk.source, "source", bulk.source, "site source: fixture, file, or stdin")
 	fs.StringVar(&bulk.file, "file", "", "source file for --source file")
 	fs.Int64Var(&bulk.blogIDStart, "blog-id-start", bulk.blogIDStart, "first blog_id to assign")
@@ -295,6 +297,9 @@ func planAPIBulkSiteCreates(entries []apiBulkSiteEntry, opts apiSitesBulkAddOpti
 	if opts.blogIDStart <= 0 {
 		return nil, errors.New("blog-id-start must be a positive integer")
 	}
+	if opts.batch != "" && opts.blogIDStart == defaultAPIBulkAddBlogIDStart {
+		opts.blogIDStart = apiCLIBatchBlogIDStart(opts.batch)
+	}
 	if len(entries) == 0 {
 		return nil, errors.New("no sites found in source")
 	}
@@ -312,10 +317,13 @@ func planAPIBulkSiteCreates(entries []apiBulkSiteEntry, opts apiSitesBulkAddOpti
 			AlertCooldownMinutes: entry.AlertCooldownMinutes,
 			CheckInterval:        entry.CheckInterval,
 		}
-		if len(entry.CustomHeaders) > 0 {
-			headers := make(map[string]string, len(entry.CustomHeaders))
+		if len(entry.CustomHeaders) > 0 || opts.batch != "" {
+			headers := make(map[string]string, len(entry.CustomHeaders)+1)
 			for k, v := range entry.CustomHeaders {
 				headers[k] = v
+			}
+			if opts.batch != "" {
+				headers[apiCLIBatchHeader] = opts.batch
 			}
 			req.CustomHeaders = &headers
 		}

--- a/cmd/jetmon2/api_cli_sites_bulk.go
+++ b/cmd/jetmon2/api_cli_sites_bulk.go
@@ -1,0 +1,379 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	apiSitesBulkAddMaxCount      = 200
+	defaultAPIBulkAddBlogIDStart = int64(900000000)
+)
+
+type apiSitesBulkAddOptions struct {
+	count                int
+	source               string
+	file                 string
+	blogIDStart          int64
+	dryRun               bool
+	idempotencyKeyPrefix string
+	monitorActive        apiOptionalBoolFlag
+}
+
+type apiBulkSiteEntry struct {
+	MonitorURL           string            `json:"monitor_url"`
+	CheckKeyword         *string           `json:"check_keyword,omitempty"`
+	RedirectPolicy       *string           `json:"redirect_policy,omitempty"`
+	TimeoutSeconds       *int              `json:"timeout_seconds,omitempty"`
+	CustomHeaders        map[string]string `json:"custom_headers,omitempty"`
+	AlertCooldownMinutes *int              `json:"alert_cooldown_minutes,omitempty"`
+	CheckInterval        *int              `json:"check_interval,omitempty"`
+}
+
+type apiSitesBulkAddOutput struct {
+	DryRun  bool              `json:"dry_run,omitempty"`
+	Count   int               `json:"count"`
+	Sites   []json.RawMessage `json:"sites,omitempty"`
+	Created []json.RawMessage `json:"created,omitempty"`
+}
+
+func cmdAPISitesBulkAdd(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api sites bulk-add", &opts)
+	bulk := apiSitesBulkAddOptions{
+		source:      "fixture",
+		blogIDStart: defaultAPIBulkAddBlogIDStart,
+	}
+	fs.IntVar(&bulk.count, "count", 0, "number of sites to create, max 200")
+	fs.StringVar(&bulk.source, "source", bulk.source, "site source: fixture, file, or stdin")
+	fs.StringVar(&bulk.file, "file", "", "source file for --source file")
+	fs.Int64Var(&bulk.blogIDStart, "blog-id-start", bulk.blogIDStart, "first blog_id to assign")
+	fs.BoolVar(&bulk.dryRun, "dry-run", false, "print planned create payloads without sending requests")
+	fs.StringVar(&bulk.idempotencyKeyPrefix, "idempotency-key-prefix", "", "prefix for per-site Idempotency-Key headers")
+	fs.Var(&bulk.monitorActive, "monitor-active", "override monitor_active for every generated site")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return errors.New("usage: jetmon2 api sites bulk-add [flags]")
+	}
+	return runAPISitesBulkAdd(context.Background(), nil, opts, bulk)
+}
+
+func runAPISitesBulkAdd(ctx context.Context, client *http.Client, opts apiCLIOptions, bulk apiSitesBulkAddOptions) error {
+	if opts.out == nil {
+		opts.out = io.Discard
+	}
+	entries, err := loadAPIBulkSiteEntries(bulk, opts.in)
+	if err != nil {
+		return err
+	}
+	planned, err := planAPIBulkSiteCreates(entries, bulk)
+	if err != nil {
+		return err
+	}
+
+	if bulk.dryRun {
+		sites, err := marshalAPIBulkSiteRequests(planned)
+		if err != nil {
+			return err
+		}
+		return writeAPIJSON(opts.out, apiSitesBulkAddOutput{
+			DryRun: true,
+			Count:  len(sites),
+			Sites:  sites,
+		}, opts.pretty)
+	}
+
+	created := make([]json.RawMessage, 0, len(planned))
+	for i, req := range planned {
+		body, err := json.Marshal(req)
+		if err != nil {
+			return err
+		}
+		requestOpts := opts
+		var response bytes.Buffer
+		requestOpts.out = &response
+		if bulk.idempotencyKeyPrefix != "" {
+			requestOpts.idempotencyKey = fmt.Sprintf("%s-%03d", bulk.idempotencyKeyPrefix, i+1)
+		}
+		if err := executeAPIRequest(ctx, client, requestOpts, http.MethodPost, "/api/v1/sites", body); err != nil {
+			if response.Len() > 0 {
+				_, _ = opts.out.Write(response.Bytes())
+			}
+			return fmt.Errorf("create site %d (%s): %w", req.BlogID, req.MonitorURL, err)
+		}
+		created = append(created, json.RawMessage(bytes.TrimSpace(response.Bytes())))
+	}
+
+	return writeAPIJSON(opts.out, apiSitesBulkAddOutput{
+		Count:   len(created),
+		Created: created,
+	}, opts.pretty)
+}
+
+func loadAPIBulkSiteEntries(opts apiSitesBulkAddOptions, in io.Reader) ([]apiBulkSiteEntry, error) {
+	var data []byte
+	var err error
+	switch opts.source {
+	case "fixture":
+		if opts.file != "" {
+			return nil, errors.New("--file is only valid with --source file")
+		}
+		data = apiCLISiteFixture
+	case "file":
+		if opts.file == "" {
+			return nil, errors.New("--file is required with --source file")
+		}
+		data, err = os.ReadFile(opts.file)
+		if err != nil {
+			return nil, err
+		}
+	case "stdin":
+		if in == nil {
+			return nil, errors.New("stdin source requires an input reader")
+		}
+		data, err = io.ReadAll(in)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, errors.New("source must be one of: fixture, file, stdin")
+	}
+	return parseAPIBulkSiteEntries(data)
+}
+
+func parseAPIBulkSiteEntries(data []byte) ([]apiBulkSiteEntry, error) {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return nil, errors.New("site source is empty")
+	}
+	if trimmed[0] == '[' || trimmed[0] == '{' || trimmed[0] == '"' {
+		return parseAPIBulkJSONSiteEntries(trimmed)
+	}
+	return parseAPIBulkCSVSiteEntries(trimmed)
+}
+
+func parseAPIBulkJSONSiteEntries(data []byte) ([]apiBulkSiteEntry, error) {
+	var raw []json.RawMessage
+	if data[0] == '[' {
+		if err := json.Unmarshal(data, &raw); err != nil {
+			return nil, err
+		}
+	} else {
+		raw = []json.RawMessage{data}
+	}
+	entries := make([]apiBulkSiteEntry, 0, len(raw))
+	for _, item := range raw {
+		var entry apiBulkSiteEntry
+		if err := json.Unmarshal(item, &entry); err != nil {
+			return nil, err
+		}
+		entries = append(entries, entry)
+	}
+	return validateAPIBulkSiteEntries(entries)
+}
+
+func parseAPIBulkCSVSiteEntries(data []byte) ([]apiBulkSiteEntry, error) {
+	r := csv.NewReader(bytes.NewReader(data))
+	r.TrimLeadingSpace = true
+	r.FieldsPerRecord = -1
+	records, err := r.ReadAll()
+	if err != nil {
+		return nil, err
+	}
+	if len(records) == 0 {
+		return nil, errors.New("site source is empty")
+	}
+
+	header := apiBulkCSVHeader(records[0])
+	start := 0
+	if len(header) > 0 {
+		start = 1
+	}
+
+	entries := make([]apiBulkSiteEntry, 0, len(records)-start)
+	for _, record := range records[start:] {
+		if len(record) == 0 || strings.TrimSpace(record[0]) == "" {
+			continue
+		}
+		if len(header) == 0 {
+			entries = append(entries, apiBulkSiteEntry{MonitorURL: strings.TrimSpace(record[0])})
+			continue
+		}
+		entry, err := apiBulkSiteEntryFromCSVRecord(header, record)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, entry)
+	}
+	return validateAPIBulkSiteEntries(entries)
+}
+
+func apiBulkCSVHeader(record []string) map[string]int {
+	header := map[string]int{}
+	hasURL := false
+	for i, col := range record {
+		name := strings.ToLower(strings.TrimSpace(col))
+		header[name] = i
+		if name == "monitor_url" || name == "url" {
+			hasURL = true
+		}
+	}
+	if !hasURL {
+		return nil
+	}
+	return header
+}
+
+func apiBulkSiteEntryFromCSVRecord(header map[string]int, record []string) (apiBulkSiteEntry, error) {
+	entry := apiBulkSiteEntry{}
+	entry.MonitorURL = csvField(header, record, "monitor_url")
+	if entry.MonitorURL == "" {
+		entry.MonitorURL = csvField(header, record, "url")
+	}
+	if v := csvField(header, record, "check_keyword"); v != "" {
+		entry.CheckKeyword = &v
+	}
+	if v := csvField(header, record, "redirect_policy"); v != "" {
+		entry.RedirectPolicy = &v
+	}
+	if v := csvField(header, record, "timeout_seconds"); v != "" {
+		parsed, err := strconv.Atoi(v)
+		if err != nil {
+			return entry, fmt.Errorf("timeout_seconds must be an integer: %w", err)
+		}
+		entry.TimeoutSeconds = &parsed
+	}
+	if v := csvField(header, record, "check_interval"); v != "" {
+		parsed, err := strconv.Atoi(v)
+		if err != nil {
+			return entry, fmt.Errorf("check_interval must be an integer: %w", err)
+		}
+		entry.CheckInterval = &parsed
+	}
+	return entry, nil
+}
+
+func csvField(header map[string]int, record []string, name string) string {
+	idx, ok := header[name]
+	if !ok || idx >= len(record) {
+		return ""
+	}
+	return strings.TrimSpace(record[idx])
+}
+
+func validateAPIBulkSiteEntries(entries []apiBulkSiteEntry) ([]apiBulkSiteEntry, error) {
+	if len(entries) == 0 {
+		return nil, errors.New("no sites found in source")
+	}
+	for i := range entries {
+		entries[i].MonitorURL = strings.TrimSpace(entries[i].MonitorURL)
+		if entries[i].MonitorURL == "" {
+			return nil, fmt.Errorf("site source entry %d is missing monitor_url", i+1)
+		}
+	}
+	return entries, nil
+}
+
+func planAPIBulkSiteCreates(entries []apiBulkSiteEntry, opts apiSitesBulkAddOptions) ([]apiSiteCreateRequest, error) {
+	if opts.count <= 0 {
+		return nil, errors.New("count is required and must be positive")
+	}
+	if opts.count > apiSitesBulkAddMaxCount {
+		return nil, fmt.Errorf("count must be <= %d", apiSitesBulkAddMaxCount)
+	}
+	if opts.blogIDStart <= 0 {
+		return nil, errors.New("blog-id-start must be a positive integer")
+	}
+	if len(entries) == 0 {
+		return nil, errors.New("no sites found in source")
+	}
+
+	out := make([]apiSiteCreateRequest, 0, opts.count)
+	for i := 0; i < opts.count; i++ {
+		entry := entries[i%len(entries)]
+		req := apiSiteCreateRequest{
+			BlogID:               opts.blogIDStart + int64(i),
+			MonitorURL:           entry.MonitorURL,
+			MonitorActive:        opts.monitorActive.ptr(),
+			CheckKeyword:         entry.CheckKeyword,
+			RedirectPolicy:       entry.RedirectPolicy,
+			TimeoutSeconds:       entry.TimeoutSeconds,
+			AlertCooldownMinutes: entry.AlertCooldownMinutes,
+			CheckInterval:        entry.CheckInterval,
+		}
+		if len(entry.CustomHeaders) > 0 {
+			headers := make(map[string]string, len(entry.CustomHeaders))
+			for k, v := range entry.CustomHeaders {
+				headers[k] = v
+			}
+			req.CustomHeaders = &headers
+		}
+		out = append(out, req)
+	}
+	return out, nil
+}
+
+func marshalAPIBulkSiteRequests(requests []apiSiteCreateRequest) ([]json.RawMessage, error) {
+	out := make([]json.RawMessage, 0, len(requests))
+	for _, req := range requests {
+		b, err := json.Marshal(req)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, json.RawMessage(b))
+	}
+	return out, nil
+}
+
+func writeAPIJSON(w io.Writer, v any, pretty bool) error {
+	if w == nil {
+		w = io.Discard
+	}
+	var (
+		b   []byte
+		err error
+	)
+	if pretty {
+		b, err = json.MarshalIndent(v, "", "  ")
+	} else {
+		b, err = json.Marshal(v)
+	}
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(w, string(b))
+	return err
+}
+
+func (e *apiBulkSiteEntry) UnmarshalJSON(data []byte) error {
+	var urlOnly string
+	if err := json.Unmarshal(data, &urlOnly); err == nil {
+		e.MonitorURL = urlOnly
+		return nil
+	}
+
+	type bulkSiteEntry apiBulkSiteEntry
+	var aux struct {
+		bulkSiteEntry
+		URL string `json:"url"`
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	*e = apiBulkSiteEntry(aux.bulkSiteEntry)
+	if e.MonitorURL == "" {
+		e.MonitorURL = aux.URL
+	}
+	return nil
+}

--- a/cmd/jetmon2/api_cli_sites_bulk.go
+++ b/cmd/jetmon2/api_cli_sites_bulk.go
@@ -62,7 +62,7 @@ func cmdAPISitesBulkAdd(args []string) error {
 	fs.BoolVar(&bulk.dryRun, "dry-run", false, "print planned create payloads without sending requests")
 	fs.StringVar(&bulk.idempotencyKeyPrefix, "idempotency-key-prefix", "", "prefix for per-site Idempotency-Key headers")
 	fs.Var(&bulk.monitorActive, "monitor-active", "override monitor_active for every generated site")
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {

--- a/cmd/jetmon2/api_cli_sites_bulk.go
+++ b/cmd/jetmon2/api_cli_sites_bulk.go
@@ -26,7 +26,6 @@ type apiSitesBulkAddOptions struct {
 	file                 string
 	blogIDStart          int64
 	dryRun               bool
-	allowRemote          bool
 	idempotencyKeyPrefix string
 	monitorActive        apiOptionalBoolFlag
 }
@@ -61,7 +60,6 @@ func cmdAPISitesBulkAdd(args []string) error {
 	fs.StringVar(&bulk.file, "file", "", "source file for --source file")
 	fs.Int64Var(&bulk.blogIDStart, "blog-id-start", bulk.blogIDStart, "first blog_id to assign")
 	fs.BoolVar(&bulk.dryRun, "dry-run", false, "print planned create payloads without sending requests")
-	fs.BoolVar(&bulk.allowRemote, "allow-remote", false, "allow writes to a non-local API base URL")
 	fs.StringVar(&bulk.idempotencyKeyPrefix, "idempotency-key-prefix", "", "prefix for per-site Idempotency-Key headers")
 	fs.Var(&bulk.monitorActive, "monitor-active", "override monitor_active for every generated site")
 	if err := parseAPIFlags(fs, args); err != nil {
@@ -98,7 +96,7 @@ func runAPISitesBulkAdd(ctx context.Context, client *http.Client, opts apiCLIOpt
 		}, opts)
 	}
 
-	remote, err := requireAPILocalOrAllowRemote(opts, bulk.allowRemote, "api sites bulk-add")
+	remote, err := requireAPILocalOrAllowRemote(opts, opts.allowRemote, "api sites bulk-add")
 	if err != nil {
 		return err
 	}

--- a/cmd/jetmon2/api_cli_sites_bulk.go
+++ b/cmd/jetmon2/api_cli_sites_bulk.go
@@ -26,6 +26,7 @@ type apiSitesBulkAddOptions struct {
 	file                 string
 	blogIDStart          int64
 	dryRun               bool
+	allowRemote          bool
 	idempotencyKeyPrefix string
 	monitorActive        apiOptionalBoolFlag
 }
@@ -60,6 +61,7 @@ func cmdAPISitesBulkAdd(args []string) error {
 	fs.StringVar(&bulk.file, "file", "", "source file for --source file")
 	fs.Int64Var(&bulk.blogIDStart, "blog-id-start", bulk.blogIDStart, "first blog_id to assign")
 	fs.BoolVar(&bulk.dryRun, "dry-run", false, "print planned create payloads without sending requests")
+	fs.BoolVar(&bulk.allowRemote, "allow-remote", false, "allow writes to a non-local API base URL")
 	fs.StringVar(&bulk.idempotencyKeyPrefix, "idempotency-key-prefix", "", "prefix for per-site Idempotency-Key headers")
 	fs.Var(&bulk.monitorActive, "monitor-active", "override monitor_active for every generated site")
 	if err := parseAPIFlags(fs, args); err != nil {
@@ -94,6 +96,14 @@ func runAPISitesBulkAdd(ctx context.Context, client *http.Client, opts apiCLIOpt
 			Count:  len(sites),
 			Sites:  sites,
 		}, opts)
+	}
+
+	remote, err := requireAPILocalOrAllowRemote(opts, bulk.allowRemote, "api sites bulk-add")
+	if err != nil {
+		return err
+	}
+	if remote && strings.TrimSpace(bulk.batch) == "" {
+		return errors.New("api sites bulk-add requires --batch when --allow-remote targets a non-local API")
 	}
 
 	created := make([]json.RawMessage, 0, len(planned))

--- a/cmd/jetmon2/api_cli_sites_bulk.go
+++ b/cmd/jetmon2/api_cli_sites_bulk.go
@@ -89,11 +89,11 @@ func runAPISitesBulkAdd(ctx context.Context, client *http.Client, opts apiCLIOpt
 		if err != nil {
 			return err
 		}
-		return writeAPIJSON(opts.out, apiSitesBulkAddOutput{
+		return writeAPIValueOutput(opts.out, apiSitesBulkAddOutput{
 			DryRun: true,
 			Count:  len(sites),
 			Sites:  sites,
-		}, opts.pretty)
+		}, opts)
 	}
 
 	created := make([]json.RawMessage, 0, len(planned))
@@ -117,10 +117,10 @@ func runAPISitesBulkAdd(ctx context.Context, client *http.Client, opts apiCLIOpt
 		created = append(created, json.RawMessage(bytes.TrimSpace(response.Bytes())))
 	}
 
-	return writeAPIJSON(opts.out, apiSitesBulkAddOutput{
+	return writeAPIValueOutput(opts.out, apiSitesBulkAddOutput{
 		Count:   len(created),
 		Created: created,
-	}, opts.pretty)
+	}, opts)
 }
 
 func loadAPIBulkSiteEntries(opts apiSitesBulkAddOptions, in io.Reader) ([]apiBulkSiteEntry, error) {
@@ -342,26 +342,6 @@ func marshalAPIBulkSiteRequests(requests []apiSiteCreateRequest) ([]json.RawMess
 		out = append(out, json.RawMessage(b))
 	}
 	return out, nil
-}
-
-func writeAPIJSON(w io.Writer, v any, pretty bool) error {
-	if w == nil {
-		w = io.Discard
-	}
-	var (
-		b   []byte
-		err error
-	)
-	if pretty {
-		b, err = json.MarshalIndent(v, "", "  ")
-	} else {
-		b, err = json.Marshal(v)
-	}
-	if err != nil {
-		return err
-	}
-	_, err = fmt.Fprintln(w, string(b))
-	return err
 }
 
 func (e *apiBulkSiteEntry) UnmarshalJSON(data []byte) error {

--- a/cmd/jetmon2/api_cli_sites_bulk_test.go
+++ b/cmd/jetmon2/api_cli_sites_bulk_test.go
@@ -93,6 +93,24 @@ func TestPlanAPIBulkSiteCreatesCyclesFixtureEntries(t *testing.T) {
 	}
 }
 
+func TestPlanAPIBulkSiteCreatesUsesBatchMarker(t *testing.T) {
+	entries := []apiBulkSiteEntry{{MonitorURL: "https://example.com/"}}
+	planned, err := planAPIBulkSiteCreates(entries, apiSitesBulkAddOptions{
+		count:       1,
+		batch:       "batch-a",
+		blogIDStart: defaultAPIBulkAddBlogIDStart,
+	})
+	if err != nil {
+		t.Fatalf("planAPIBulkSiteCreates() error = %v", err)
+	}
+	if planned[0].BlogID != apiCLIBatchBlogIDStart("batch-a") {
+		t.Fatalf("blog_id = %d, want batch-derived id", planned[0].BlogID)
+	}
+	if planned[0].CustomHeaders == nil || (*planned[0].CustomHeaders)[apiCLIBatchHeader] != "batch-a" {
+		t.Fatalf("custom headers = %#v, want batch marker", planned[0].CustomHeaders)
+	}
+}
+
 func TestPlanAPIBulkSiteCreatesRejectsUnboundedCount(t *testing.T) {
 	_, err := planAPIBulkSiteCreates([]apiBulkSiteEntry{{MonitorURL: "https://example.com/"}}, apiSitesBulkAddOptions{
 		count:       apiSitesBulkAddMaxCount + 1,

--- a/cmd/jetmon2/api_cli_sites_bulk_test.go
+++ b/cmd/jetmon2/api_cli_sites_bulk_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestParseAPIBulkJSONSiteEntries(t *testing.T) {
+	entries, err := parseAPIBulkSiteEntries([]byte(`[
+		"https://example.com/",
+		{"url":"https://wordpress.com/","check_keyword":"WordPress","redirect_policy":"follow","timeout_seconds":5}
+	]`))
+	if err != nil {
+		t.Fatalf("parseAPIBulkSiteEntries() error = %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("len(entries) = %d, want 2", len(entries))
+	}
+	if entries[0].MonitorURL != "https://example.com/" {
+		t.Fatalf("first URL = %q", entries[0].MonitorURL)
+	}
+	if entries[1].MonitorURL != "https://wordpress.com/" {
+		t.Fatalf("second URL = %q", entries[1].MonitorURL)
+	}
+	if entries[1].CheckKeyword == nil || *entries[1].CheckKeyword != "WordPress" {
+		t.Fatalf("check_keyword = %#v, want WordPress", entries[1].CheckKeyword)
+	}
+	if entries[1].TimeoutSeconds == nil || *entries[1].TimeoutSeconds != 5 {
+		t.Fatalf("timeout_seconds = %#v, want 5", entries[1].TimeoutSeconds)
+	}
+}
+
+func TestParseAPIBulkCSVSiteEntries(t *testing.T) {
+	source := strings.NewReader("monitor_url,check_keyword,redirect_policy,check_interval\nhttps://example.com/,Example Domain,follow,5\n")
+	entries, err := loadAPIBulkSiteEntries(apiSitesBulkAddOptions{source: "stdin"}, source)
+	if err != nil {
+		t.Fatalf("loadAPIBulkSiteEntries() error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1", len(entries))
+	}
+	if entries[0].MonitorURL != "https://example.com/" {
+		t.Fatalf("monitor_url = %q", entries[0].MonitorURL)
+	}
+	if entries[0].CheckKeyword == nil || *entries[0].CheckKeyword != "Example Domain" {
+		t.Fatalf("check_keyword = %#v, want Example Domain", entries[0].CheckKeyword)
+	}
+	if entries[0].CheckInterval == nil || *entries[0].CheckInterval != 5 {
+		t.Fatalf("check_interval = %#v, want 5", entries[0].CheckInterval)
+	}
+}
+
+func TestParseAPIBulkNewlineSiteEntries(t *testing.T) {
+	entries, err := parseAPIBulkSiteEntries([]byte("https://example.com/\nhttps://wordpress.com/\n"))
+	if err != nil {
+		t.Fatalf("parseAPIBulkSiteEntries() error = %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("len(entries) = %d, want 2", len(entries))
+	}
+	if entries[1].MonitorURL != "https://wordpress.com/" {
+		t.Fatalf("second URL = %q", entries[1].MonitorURL)
+	}
+}
+
+func TestPlanAPIBulkSiteCreatesCyclesFixtureEntries(t *testing.T) {
+	var active apiOptionalBoolFlag
+	setTestFlag(t, &active, "false")
+	entries := []apiBulkSiteEntry{
+		{MonitorURL: "https://example.com/"},
+		{MonitorURL: "https://wordpress.com/"},
+	}
+	planned, err := planAPIBulkSiteCreates(entries, apiSitesBulkAddOptions{
+		count:         3,
+		blogIDStart:   900,
+		monitorActive: active,
+	})
+	if err != nil {
+		t.Fatalf("planAPIBulkSiteCreates() error = %v", err)
+	}
+	if len(planned) != 3 {
+		t.Fatalf("len(planned) = %d, want 3", len(planned))
+	}
+	if planned[0].BlogID != 900 || planned[2].BlogID != 902 {
+		t.Fatalf("blog ids = %d, %d; want 900, 902", planned[0].BlogID, planned[2].BlogID)
+	}
+	if planned[2].MonitorURL != "https://example.com/" {
+		t.Fatalf("cycled URL = %q, want first source URL", planned[2].MonitorURL)
+	}
+	if planned[0].MonitorActive == nil || *planned[0].MonitorActive {
+		t.Fatalf("monitor_active = %#v, want false", planned[0].MonitorActive)
+	}
+}
+
+func TestPlanAPIBulkSiteCreatesRejectsUnboundedCount(t *testing.T) {
+	_, err := planAPIBulkSiteCreates([]apiBulkSiteEntry{{MonitorURL: "https://example.com/"}}, apiSitesBulkAddOptions{
+		count:       apiSitesBulkAddMaxCount + 1,
+		blogIDStart: 900,
+	})
+	if err == nil {
+		t.Fatal("planAPIBulkSiteCreates() error = nil, want max count error")
+	}
+}
+
+func TestLoadAPIBulkFixture(t *testing.T) {
+	entries, err := loadAPIBulkSiteEntries(apiSitesBulkAddOptions{source: "fixture"}, nil)
+	if err != nil {
+		t.Fatalf("load fixture error = %v", err)
+	}
+	if len(entries) < 8 {
+		t.Fatalf("fixture entries = %d, want at least 8", len(entries))
+	}
+}
+
+func TestMarshalAPIBulkSiteRequests(t *testing.T) {
+	keyword := "Example Domain"
+	requests := []apiSiteCreateRequest{{
+		BlogID:       900,
+		MonitorURL:   "https://example.com/",
+		CheckKeyword: &keyword,
+	}}
+	raw, err := marshalAPIBulkSiteRequests(requests)
+	if err != nil {
+		t.Fatalf("marshalAPIBulkSiteRequests() error = %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw[0], &got); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+	if got["blog_id"] != float64(900) {
+		t.Fatalf("blog_id = %#v, want 900", got["blog_id"])
+	}
+	if got["check_keyword"] != "Example Domain" {
+		t.Fatalf("check_keyword = %#v, want Example Domain", got["check_keyword"])
+	}
+}

--- a/cmd/jetmon2/api_cli_sites_cleanup.go
+++ b/cmd/jetmon2/api_cli_sites_cleanup.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -17,6 +18,7 @@ type apiSitesCleanupOptions struct {
 	blogIDStart    int64
 	dryRun         bool
 	ignoreNotFound bool
+	allowUnmarked  bool
 }
 
 type apiSitesCleanupSummary struct {
@@ -45,6 +47,7 @@ func cmdAPISitesCleanup(args []string) error {
 	fs.Int64Var(&cleanup.blogIDStart, "blog-id-start", 0, "first batch blog_id; default derives from --batch")
 	fs.BoolVar(&cleanup.dryRun, "dry-run", false, "print the planned deletes without sending requests")
 	fs.BoolVar(&cleanup.ignoreNotFound, "ignore-not-found", cleanup.ignoreNotFound, "treat 404 responses as already cleaned")
+	fs.BoolVar(&cleanup.allowUnmarked, "allow-unmarked", false, "allow cleanup of --batch targets that do not expose the matching CLI batch marker")
 	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
@@ -75,6 +78,35 @@ func runAPISitesCleanup(ctx context.Context, client *http.Client, opts apiCLIOpt
 			result.Status = "would_delete"
 			summary.Sites = append(summary.Sites, result)
 			continue
+		}
+		if cleanup.batch != "" && !cleanup.allowUnmarked {
+			ok, exists, err := apiSiteBelongsToBatch(ctx, client, opts, siteID, cleanup.batch)
+			if err != nil {
+				result.Status = "failed"
+				result.Error = err.Error()
+				summary.Sites = append(summary.Sites, result)
+				_ = writeAPIValueOutput(opts.out, summary, opts)
+				return fmt.Errorf("verify site %d batch marker: %w", siteID, err)
+			}
+			if !exists && cleanup.ignoreNotFound {
+				result.Status = "not_found"
+				summary.Sites = append(summary.Sites, result)
+				continue
+			}
+			if !exists {
+				result.Status = "failed"
+				result.Error = "site not found"
+				summary.Sites = append(summary.Sites, result)
+				_ = writeAPIValueOutput(opts.out, summary, opts)
+				return fmt.Errorf("site %d not found", siteID)
+			}
+			if !ok {
+				result.Status = "skipped_unmatched_batch"
+				result.Error = fmt.Sprintf("site does not expose cli_batch %q", cleanup.batch)
+				summary.Sites = append(summary.Sites, result)
+				_ = writeAPIValueOutput(opts.out, summary, opts)
+				return fmt.Errorf("site %d does not belong to CLI batch %q", siteID, cleanup.batch)
+			}
 		}
 		resp, err := doAPIRequest(ctx, client, opts, http.MethodDelete, "/api/v1/sites/"+strconv.FormatInt(siteID, 10), nil)
 		if err != nil {
@@ -129,4 +161,36 @@ func apiCleanupSiteIDs(cleanup apiSitesCleanupOptions) ([]int64, error) {
 		ids = append(ids, start+int64(i))
 	}
 	return ids, nil
+}
+
+func apiSiteBelongsToBatch(ctx context.Context, client *http.Client, opts apiCLIOptions, siteID int64, batch string) (bool, bool, error) {
+	resp, err := doAPIRequest(ctx, client, opts, http.MethodGet, "/api/v1/sites/"+strconv.FormatInt(siteID, 10), nil)
+	if err != nil {
+		return false, false, err
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return false, false, nil
+	}
+	if resp.StatusCode >= 400 {
+		body := strings.TrimSpace(string(resp.Body))
+		if body == "" {
+			body = resp.Status
+		}
+		return false, true, fmt.Errorf("site lookup returned %s: %s", resp.Status, body)
+	}
+	siteBatch, err := apiSiteCLIBatch(resp.Body)
+	if err != nil {
+		return false, true, err
+	}
+	return siteBatch == batch, true, nil
+}
+
+func apiSiteCLIBatch(body []byte) (string, error) {
+	var site struct {
+		CLIBatch string `json:"cli_batch"`
+	}
+	if err := json.Unmarshal(body, &site); err != nil {
+		return "", err
+	}
+	return site.CLIBatch, nil
 }

--- a/cmd/jetmon2/api_cli_sites_cleanup.go
+++ b/cmd/jetmon2/api_cli_sites_cleanup.go
@@ -17,6 +17,7 @@ type apiSitesCleanupOptions struct {
 	count          int
 	blogIDStart    int64
 	dryRun         bool
+	allowRemote    bool
 	ignoreNotFound bool
 	allowUnmarked  bool
 }
@@ -46,6 +47,7 @@ func cmdAPISitesCleanup(args []string) error {
 	fs.IntVar(&cleanup.count, "count", cleanup.count, "number of batch-derived site ids to delete, max 200")
 	fs.Int64Var(&cleanup.blogIDStart, "blog-id-start", 0, "first batch blog_id; default derives from --batch")
 	fs.BoolVar(&cleanup.dryRun, "dry-run", false, "print the planned deletes without sending requests")
+	fs.BoolVar(&cleanup.allowRemote, "allow-remote", false, "allow deletes against a non-local API base URL")
 	fs.BoolVar(&cleanup.ignoreNotFound, "ignore-not-found", cleanup.ignoreNotFound, "treat 404 responses as already cleaned")
 	fs.BoolVar(&cleanup.allowUnmarked, "allow-unmarked", false, "allow cleanup of --batch targets that do not expose the matching CLI batch marker")
 	if err := parseAPIFlags(fs, args); err != nil {
@@ -64,6 +66,20 @@ func runAPISitesCleanup(ctx context.Context, client *http.Client, opts apiCLIOpt
 	siteIDs, err := apiCleanupSiteIDs(cleanup)
 	if err != nil {
 		return err
+	}
+	if !cleanup.dryRun {
+		remote, err := requireAPILocalOrAllowRemote(opts, cleanup.allowRemote, "api sites cleanup")
+		if err != nil {
+			return err
+		}
+		if remote {
+			if strings.TrimSpace(cleanup.batch) == "" {
+				return errors.New("api sites cleanup requires --batch when --allow-remote targets a non-local API")
+			}
+			if cleanup.allowUnmarked {
+				return errors.New("api sites cleanup cannot use --allow-unmarked with --allow-remote")
+			}
+		}
 	}
 
 	summary := apiSitesCleanupSummary{

--- a/cmd/jetmon2/api_cli_sites_cleanup.go
+++ b/cmd/jetmon2/api_cli_sites_cleanup.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+type apiSitesCleanupOptions struct {
+	batch          string
+	siteIDs        apiInt64SliceFlags
+	count          int
+	blogIDStart    int64
+	dryRun         bool
+	ignoreNotFound bool
+}
+
+type apiSitesCleanupSummary struct {
+	DryRun bool                    `json:"dry_run,omitempty"`
+	Batch  string                  `json:"batch,omitempty"`
+	Count  int                     `json:"count"`
+	Sites  []apiSitesCleanupResult `json:"sites"`
+}
+
+type apiSitesCleanupResult struct {
+	SiteID int64  `json:"site_id"`
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+}
+
+func cmdAPISitesCleanup(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api sites cleanup", &opts)
+	cleanup := apiSitesCleanupOptions{
+		count:          apiSitesBulkAddMaxCount,
+		ignoreNotFound: true,
+	}
+	fs.StringVar(&cleanup.batch, "batch", "", "batch label whose deterministic site ids should be deleted")
+	fs.Var(&cleanup.siteIDs, "site-id", "explicit site id to delete (repeatable or comma-separated)")
+	fs.IntVar(&cleanup.count, "count", cleanup.count, "number of batch-derived site ids to delete, max 200")
+	fs.Int64Var(&cleanup.blogIDStart, "blog-id-start", 0, "first batch blog_id; default derives from --batch")
+	fs.BoolVar(&cleanup.dryRun, "dry-run", false, "print the planned deletes without sending requests")
+	fs.BoolVar(&cleanup.ignoreNotFound, "ignore-not-found", cleanup.ignoreNotFound, "treat 404 responses as already cleaned")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return errors.New("usage: jetmon2 api sites cleanup [flags]")
+	}
+	return runAPISitesCleanup(context.Background(), nil, opts, cleanup)
+}
+
+func runAPISitesCleanup(ctx context.Context, client *http.Client, opts apiCLIOptions, cleanup apiSitesCleanupOptions) error {
+	if opts.out == nil {
+		opts.out = io.Discard
+	}
+	siteIDs, err := apiCleanupSiteIDs(cleanup)
+	if err != nil {
+		return err
+	}
+
+	summary := apiSitesCleanupSummary{
+		DryRun: cleanup.dryRun,
+		Batch:  cleanup.batch,
+		Count:  len(siteIDs),
+		Sites:  make([]apiSitesCleanupResult, 0, len(siteIDs)),
+	}
+	for _, siteID := range siteIDs {
+		result := apiSitesCleanupResult{SiteID: siteID}
+		if cleanup.dryRun {
+			result.Status = "would_delete"
+			summary.Sites = append(summary.Sites, result)
+			continue
+		}
+		resp, err := doAPIRequest(ctx, client, opts, http.MethodDelete, "/api/v1/sites/"+strconv.FormatInt(siteID, 10), nil)
+		if err != nil {
+			result.Status = "failed"
+			result.Error = err.Error()
+			summary.Sites = append(summary.Sites, result)
+			_ = writeAPIValueOutput(opts.out, summary, opts)
+			return fmt.Errorf("delete site %d: %w", siteID, err)
+		}
+		switch {
+		case resp.StatusCode == http.StatusNotFound && cleanup.ignoreNotFound:
+			result.Status = "not_found"
+		case resp.StatusCode >= 400:
+			result.Status = "failed"
+			result.Error = strings.TrimSpace(string(resp.Body))
+			if result.Error == "" {
+				result.Error = resp.Status
+			}
+			summary.Sites = append(summary.Sites, result)
+			_ = writeAPIValueOutput(opts.out, summary, opts)
+			return fmt.Errorf("delete site %d returned %s", siteID, resp.Status)
+		default:
+			result.Status = "deleted"
+		}
+		summary.Sites = append(summary.Sites, result)
+	}
+	return writeAPIValueOutput(opts.out, summary, opts)
+}
+
+func apiCleanupSiteIDs(cleanup apiSitesCleanupOptions) ([]int64, error) {
+	if cleanup.siteIDs.set {
+		return cleanup.siteIDs.valuesOrEmpty(), nil
+	}
+	if cleanup.batch == "" && cleanup.blogIDStart == 0 {
+		return nil, errors.New("use --batch, --blog-id-start, or --site-id")
+	}
+	if cleanup.count <= 0 {
+		return nil, errors.New("count must be positive")
+	}
+	if cleanup.count > apiSitesBulkAddMaxCount {
+		return nil, fmt.Errorf("count must be <= %d", apiSitesBulkAddMaxCount)
+	}
+	start := cleanup.blogIDStart
+	if start == 0 {
+		start = apiCLIBatchBlogIDStart(cleanup.batch)
+	}
+	if start <= 0 {
+		return nil, errors.New("blog-id-start must be positive")
+	}
+	ids := make([]int64, 0, cleanup.count)
+	for i := 0; i < cleanup.count; i++ {
+		ids = append(ids, start+int64(i))
+	}
+	return ids, nil
+}

--- a/cmd/jetmon2/api_cli_sites_cleanup.go
+++ b/cmd/jetmon2/api_cli_sites_cleanup.go
@@ -45,7 +45,7 @@ func cmdAPISitesCleanup(args []string) error {
 	fs.Int64Var(&cleanup.blogIDStart, "blog-id-start", 0, "first batch blog_id; default derives from --batch")
 	fs.BoolVar(&cleanup.dryRun, "dry-run", false, "print the planned deletes without sending requests")
 	fs.BoolVar(&cleanup.ignoreNotFound, "ignore-not-found", cleanup.ignoreNotFound, "treat 404 responses as already cleaned")
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {

--- a/cmd/jetmon2/api_cli_sites_cleanup.go
+++ b/cmd/jetmon2/api_cli_sites_cleanup.go
@@ -164,7 +164,7 @@ func apiCleanupSiteIDs(cleanup apiSitesCleanupOptions) ([]int64, error) {
 }
 
 func apiSiteBelongsToBatch(ctx context.Context, client *http.Client, opts apiCLIOptions, siteID int64, batch string) (bool, bool, error) {
-	resp, err := doAPIRequest(ctx, client, opts, http.MethodGet, "/api/v1/sites/"+strconv.FormatInt(siteID, 10), nil)
+	resp, err := doAPIRequest(ctx, client, opts, http.MethodGet, apiSitePathWithCLIMetadata(siteID), nil)
 	if err != nil {
 		return false, false, err
 	}
@@ -183,6 +183,10 @@ func apiSiteBelongsToBatch(ctx context.Context, client *http.Client, opts apiCLI
 		return false, true, err
 	}
 	return siteBatch == batch, true, nil
+}
+
+func apiSitePathWithCLIMetadata(siteID int64) string {
+	return "/api/v1/sites/" + strconv.FormatInt(siteID, 10) + "?include_cli_metadata=true"
 }
 
 func apiSiteCLIBatch(body []byte) (string, error) {

--- a/cmd/jetmon2/api_cli_sites_cleanup.go
+++ b/cmd/jetmon2/api_cli_sites_cleanup.go
@@ -17,7 +17,6 @@ type apiSitesCleanupOptions struct {
 	count          int
 	blogIDStart    int64
 	dryRun         bool
-	allowRemote    bool
 	ignoreNotFound bool
 	allowUnmarked  bool
 }
@@ -47,7 +46,6 @@ func cmdAPISitesCleanup(args []string) error {
 	fs.IntVar(&cleanup.count, "count", cleanup.count, "number of batch-derived site ids to delete, max 200")
 	fs.Int64Var(&cleanup.blogIDStart, "blog-id-start", 0, "first batch blog_id; default derives from --batch")
 	fs.BoolVar(&cleanup.dryRun, "dry-run", false, "print the planned deletes without sending requests")
-	fs.BoolVar(&cleanup.allowRemote, "allow-remote", false, "allow deletes against a non-local API base URL")
 	fs.BoolVar(&cleanup.ignoreNotFound, "ignore-not-found", cleanup.ignoreNotFound, "treat 404 responses as already cleaned")
 	fs.BoolVar(&cleanup.allowUnmarked, "allow-unmarked", false, "allow cleanup of --batch targets that do not expose the matching CLI batch marker")
 	if err := parseAPIFlags(fs, args); err != nil {
@@ -68,7 +66,7 @@ func runAPISitesCleanup(ctx context.Context, client *http.Client, opts apiCLIOpt
 		return err
 	}
 	if !cleanup.dryRun {
-		remote, err := requireAPILocalOrAllowRemote(opts, cleanup.allowRemote, "api sites cleanup")
+		remote, err := requireAPILocalOrAllowRemote(opts, opts.allowRemote, "api sites cleanup")
 		if err != nil {
 			return err
 		}

--- a/cmd/jetmon2/api_cli_sites_cleanup_test.go
+++ b/cmd/jetmon2/api_cli_sites_cleanup_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunAPISitesCleanupDeletesBatchAndIgnoresMissing(t *testing.T) {
+	var calls []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls = append(calls, r.Method+" "+r.URL.Path)
+		switch {
+		case r.Method == http.MethodDelete && strings.HasSuffix(r.URL.Path, "000"):
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodDelete && strings.HasSuffix(r.URL.Path, "001"):
+			writeTestStatusJSON(t, w, http.StatusNotFound, map[string]string{"code": "site_not_found"})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer srv.Close()
+
+	var stdout bytes.Buffer
+	start := apiCLIBatchBlogIDStart("cleanup-batch")
+	err := runAPISitesCleanup(context.Background(), srv.Client(), apiCLIOptions{
+		baseURL: srv.URL,
+		timeout: time.Second,
+		out:     &stdout,
+		errOut:  ioDiscard{},
+	}, apiSitesCleanupOptions{
+		batch:          "cleanup-batch",
+		count:          2,
+		ignoreNotFound: true,
+	})
+	if err != nil {
+		t.Fatalf("runAPISitesCleanup() error = %v\nstdout=%s", err, stdout.String())
+	}
+	var summary apiSitesCleanupSummary
+	if err := json.Unmarshal(stdout.Bytes(), &summary); err != nil {
+		t.Fatalf("unmarshal summary: %v\n%s", err, stdout.String())
+	}
+	if summary.Batch != "cleanup-batch" || summary.Count != 2 {
+		t.Fatalf("summary = %#v", summary)
+	}
+	if summary.Sites[0].SiteID != start || summary.Sites[0].Status != "deleted" {
+		t.Fatalf("first cleanup result = %#v", summary.Sites[0])
+	}
+	if summary.Sites[1].SiteID != start+1 || summary.Sites[1].Status != "not_found" {
+		t.Fatalf("second cleanup result = %#v", summary.Sites[1])
+	}
+	wantCalls := []string{
+		"DELETE /api/v1/sites/" + strconvInt64(start),
+		"DELETE /api/v1/sites/" + strconvInt64(start+1),
+	}
+	if strings.Join(calls, "\n") != strings.Join(wantCalls, "\n") {
+		t.Fatalf("calls:\n%s\nwant:\n%s", strings.Join(calls, "\n"), strings.Join(wantCalls, "\n"))
+	}
+}
+
+func TestRunAPISitesCleanupDryRunTable(t *testing.T) {
+	var stdout bytes.Buffer
+	err := runAPISitesCleanup(context.Background(), nil, apiCLIOptions{
+		output: "table",
+		out:    &stdout,
+		errOut: ioDiscard{},
+	}, apiSitesCleanupOptions{
+		siteIDs: mustSiteIDs(t, "42,43"),
+		dryRun:  true,
+	})
+	if err != nil {
+		t.Fatalf("runAPISitesCleanup() error = %v", err)
+	}
+	got := stdout.String()
+	for _, want := range []string{
+		"site_id  status",
+		"42       would_delete",
+		"43       would_delete",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("table missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestAPICleanupSiteIDsFromBatch(t *testing.T) {
+	ids, err := apiCleanupSiteIDs(apiSitesCleanupOptions{batch: "batch-a", count: 3})
+	if err != nil {
+		t.Fatalf("apiCleanupSiteIDs() error = %v", err)
+	}
+	start := apiCLIBatchBlogIDStart("batch-a")
+	want := []int64{start, start + 1, start + 2}
+	for i := range want {
+		if ids[i] != want[i] {
+			t.Fatalf("ids[%d] = %d, want %d", i, ids[i], want[i])
+		}
+	}
+}
+
+func strconvInt64(v int64) string {
+	return strconv.FormatInt(v, 10)
+}

--- a/cmd/jetmon2/api_cli_sites_cleanup_test.go
+++ b/cmd/jetmon2/api_cli_sites_cleanup_test.go
@@ -15,7 +15,7 @@ import (
 func TestRunAPISitesCleanupDeletesBatchAndIgnoresMissing(t *testing.T) {
 	var calls []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls = append(calls, r.Method+" "+r.URL.Path)
+		calls = append(calls, r.Method+" "+r.URL.RequestURI())
 		switch {
 		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "000"):
 			writeTestJSON(t, w, map[string]any{"id": apiCLIBatchBlogIDStart("cleanup-batch"), "cli_batch": "cleanup-batch"})
@@ -58,9 +58,9 @@ func TestRunAPISitesCleanupDeletesBatchAndIgnoresMissing(t *testing.T) {
 		t.Fatalf("second cleanup result = %#v", summary.Sites[1])
 	}
 	wantCalls := []string{
-		"GET /api/v1/sites/" + strconvInt64(start),
+		"GET /api/v1/sites/" + strconvInt64(start) + "?include_cli_metadata=true",
 		"DELETE /api/v1/sites/" + strconvInt64(start),
-		"GET /api/v1/sites/" + strconvInt64(start+1),
+		"GET /api/v1/sites/" + strconvInt64(start+1) + "?include_cli_metadata=true",
 	}
 	if strings.Join(calls, "\n") != strings.Join(wantCalls, "\n") {
 		t.Fatalf("calls:\n%s\nwant:\n%s", strings.Join(calls, "\n"), strings.Join(wantCalls, "\n"))
@@ -70,7 +70,7 @@ func TestRunAPISitesCleanupDeletesBatchAndIgnoresMissing(t *testing.T) {
 func TestRunAPISitesCleanupRejectsUnmatchedBatchMarker(t *testing.T) {
 	var calls []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls = append(calls, r.Method+" "+r.URL.Path)
+		calls = append(calls, r.Method+" "+r.URL.RequestURI())
 		switch {
 		case r.Method == http.MethodGet:
 			writeTestJSON(t, w, map[string]any{"id": 42, "cli_batch": "other-batch"})
@@ -101,7 +101,7 @@ func TestRunAPISitesCleanupRejectsUnmatchedBatchMarker(t *testing.T) {
 	if got := summary.Sites[0].Status; got != "skipped_unmatched_batch" {
 		t.Fatalf("status = %q, want skipped_unmatched_batch", got)
 	}
-	if strings.Join(calls, "\n") != "GET /api/v1/sites/42" {
+	if strings.Join(calls, "\n") != "GET /api/v1/sites/42?include_cli_metadata=true" {
 		t.Fatalf("calls:\n%s\nwant only GET", strings.Join(calls, "\n"))
 	}
 }

--- a/cmd/jetmon2/api_cli_sites_cleanup_test.go
+++ b/cmd/jetmon2/api_cli_sites_cleanup_test.go
@@ -17,9 +17,11 @@ func TestRunAPISitesCleanupDeletesBatchAndIgnoresMissing(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls = append(calls, r.Method+" "+r.URL.Path)
 		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "000"):
+			writeTestJSON(t, w, map[string]any{"id": apiCLIBatchBlogIDStart("cleanup-batch"), "cli_batch": "cleanup-batch"})
 		case r.Method == http.MethodDelete && strings.HasSuffix(r.URL.Path, "000"):
 			w.WriteHeader(http.StatusNoContent)
-		case r.Method == http.MethodDelete && strings.HasSuffix(r.URL.Path, "001"):
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "001"):
 			writeTestStatusJSON(t, w, http.StatusNotFound, map[string]string{"code": "site_not_found"})
 		default:
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
@@ -56,11 +58,51 @@ func TestRunAPISitesCleanupDeletesBatchAndIgnoresMissing(t *testing.T) {
 		t.Fatalf("second cleanup result = %#v", summary.Sites[1])
 	}
 	wantCalls := []string{
+		"GET /api/v1/sites/" + strconvInt64(start),
 		"DELETE /api/v1/sites/" + strconvInt64(start),
-		"DELETE /api/v1/sites/" + strconvInt64(start+1),
+		"GET /api/v1/sites/" + strconvInt64(start+1),
 	}
 	if strings.Join(calls, "\n") != strings.Join(wantCalls, "\n") {
 		t.Fatalf("calls:\n%s\nwant:\n%s", strings.Join(calls, "\n"), strings.Join(wantCalls, "\n"))
+	}
+}
+
+func TestRunAPISitesCleanupRejectsUnmatchedBatchMarker(t *testing.T) {
+	var calls []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls = append(calls, r.Method+" "+r.URL.Path)
+		switch {
+		case r.Method == http.MethodGet:
+			writeTestJSON(t, w, map[string]any{"id": 42, "cli_batch": "other-batch"})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer srv.Close()
+
+	var stdout bytes.Buffer
+	err := runAPISitesCleanup(context.Background(), srv.Client(), apiCLIOptions{
+		baseURL: srv.URL,
+		timeout: time.Second,
+		out:     &stdout,
+		errOut:  ioDiscard{},
+	}, apiSitesCleanupOptions{
+		batch:          "cleanup-batch",
+		siteIDs:        mustSiteIDs(t, "42"),
+		ignoreNotFound: true,
+	})
+	if err == nil {
+		t.Fatal("runAPISitesCleanup() error = nil, want batch mismatch")
+	}
+	var summary apiSitesCleanupSummary
+	if err := json.Unmarshal(stdout.Bytes(), &summary); err != nil {
+		t.Fatalf("unmarshal summary: %v\n%s", err, stdout.String())
+	}
+	if got := summary.Sites[0].Status; got != "skipped_unmatched_batch" {
+		t.Fatalf("status = %q, want skipped_unmatched_batch", got)
+	}
+	if strings.Join(calls, "\n") != "GET /api/v1/sites/42" {
+		t.Fatalf("calls:\n%s\nwant only GET", strings.Join(calls, "\n"))
 	}
 }
 

--- a/cmd/jetmon2/api_cli_sites_fixture.go
+++ b/cmd/jetmon2/api_cli_sites_fixture.go
@@ -1,0 +1,6 @@
+package main
+
+import _ "embed"
+
+//go:embed testdata/api-cli-sites.json
+var apiCLISiteFixture []byte

--- a/cmd/jetmon2/api_cli_sites_simulate.go
+++ b/cmd/jetmon2/api_cli_sites_simulate.go
@@ -33,7 +33,6 @@ type apiSitesSimulateFailureOptions struct {
 	idempotencyKeyPrefix   string
 	fixtureURL             string
 	fixtureProbeURL        string
-	allowRemote            bool
 	allowUnmarkedBatch     bool
 	expectEventState       string
 	expectEventSeverity    apiOptionalIntFlag
@@ -108,7 +107,6 @@ func cmdAPISitesSimulateFailure(args []string) error {
 	fs.StringVar(&sim.idempotencyKeyPrefix, "idempotency-key-prefix", "", "prefix for per-site POST Idempotency-Key headers")
 	fs.StringVar(&sim.fixtureURL, "fixture-url", sim.fixtureURL, "Docker fixture monitor URL, auto, or off")
 	fs.StringVar(&sim.fixtureProbeURL, "fixture-probe-url", sim.fixtureProbeURL, "URL used when --fixture-url=auto")
-	fs.BoolVar(&sim.allowRemote, "allow-remote", false, "allow mutation against a non-local API base URL")
 	fs.BoolVar(&sim.allowUnmarkedBatch, "allow-unmarked", false, "allow mutation of --batch targets that do not expose the matching CLI batch marker")
 	fs.StringVar(&sim.expectEventState, "expect-event-state", "", "require at least one active event with this state after polling")
 	fs.Var(&sim.expectEventSeverity, "expect-event-severity", "require at least one active event with this severity after polling")
@@ -127,7 +125,7 @@ func runAPISitesSimulateFailure(ctx context.Context, client *http.Client, opts a
 	if opts.out == nil {
 		opts.out = io.Discard
 	}
-	remote, err := requireAPILocalOrAllowRemote(opts, sim.allowRemote, "api sites simulate-failure")
+	remote, err := requireAPILocalOrAllowRemote(opts, opts.allowRemote, "api sites simulate-failure")
 	if err != nil {
 		return err
 	}

--- a/cmd/jetmon2/api_cli_sites_simulate.go
+++ b/cmd/jetmon2/api_cli_sites_simulate.go
@@ -33,6 +33,7 @@ type apiSitesSimulateFailureOptions struct {
 	idempotencyKeyPrefix   string
 	fixtureURL             string
 	fixtureProbeURL        string
+	allowRemote            bool
 	allowUnmarkedBatch     bool
 	expectEventState       string
 	expectEventSeverity    apiOptionalIntFlag
@@ -107,6 +108,7 @@ func cmdAPISitesSimulateFailure(args []string) error {
 	fs.StringVar(&sim.idempotencyKeyPrefix, "idempotency-key-prefix", "", "prefix for per-site POST Idempotency-Key headers")
 	fs.StringVar(&sim.fixtureURL, "fixture-url", sim.fixtureURL, "Docker fixture monitor URL, auto, or off")
 	fs.StringVar(&sim.fixtureProbeURL, "fixture-probe-url", sim.fixtureProbeURL, "URL used when --fixture-url=auto")
+	fs.BoolVar(&sim.allowRemote, "allow-remote", false, "allow mutation against a non-local API base URL")
 	fs.BoolVar(&sim.allowUnmarkedBatch, "allow-unmarked", false, "allow mutation of --batch targets that do not expose the matching CLI batch marker")
 	fs.StringVar(&sim.expectEventState, "expect-event-state", "", "require at least one active event with this state after polling")
 	fs.Var(&sim.expectEventSeverity, "expect-event-severity", "require at least one active event with this severity after polling")
@@ -124,6 +126,18 @@ func cmdAPISitesSimulateFailure(args []string) error {
 func runAPISitesSimulateFailure(ctx context.Context, client *http.Client, opts apiCLIOptions, sim apiSitesSimulateFailureOptions) error {
 	if opts.out == nil {
 		opts.out = io.Discard
+	}
+	remote, err := requireAPILocalOrAllowRemote(opts, sim.allowRemote, "api sites simulate-failure")
+	if err != nil {
+		return err
+	}
+	if remote {
+		if strings.TrimSpace(sim.batch) == "" {
+			return errors.New("api sites simulate-failure requires --batch when --allow-remote targets a non-local API")
+		}
+		if sim.allowUnmarkedBatch {
+			return errors.New("api sites simulate-failure cannot use --allow-unmarked with --allow-remote")
+		}
 	}
 	fixtureURL := apiSimulationFixtureURL(ctx, sim)
 	def, err := apiFailureMode(sim.mode, fixtureURL)

--- a/cmd/jetmon2/api_cli_sites_simulate.go
+++ b/cmd/jetmon2/api_cli_sites_simulate.go
@@ -105,7 +105,7 @@ func cmdAPISitesSimulateFailure(args []string) error {
 	fs.Var(&sim.expectEventSeverity, "expect-event-severity", "require at least one active event with this severity after polling")
 	fs.BoolVar(&sim.requireTransition, "require-transition", false, "require at least one event transition after polling")
 	fs.StringVar(&sim.expectTransitionReason, "expect-transition-reason", "", "require at least one transition with this reason after polling")
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {

--- a/cmd/jetmon2/api_cli_sites_simulate.go
+++ b/cmd/jetmon2/api_cli_sites_simulate.go
@@ -33,6 +33,7 @@ type apiSitesSimulateFailureOptions struct {
 	idempotencyKeyPrefix   string
 	fixtureURL             string
 	fixtureProbeURL        string
+	allowUnmarkedBatch     bool
 	expectEventState       string
 	expectEventSeverity    apiOptionalIntFlag
 	requireTransition      bool
@@ -106,6 +107,7 @@ func cmdAPISitesSimulateFailure(args []string) error {
 	fs.StringVar(&sim.idempotencyKeyPrefix, "idempotency-key-prefix", "", "prefix for per-site POST Idempotency-Key headers")
 	fs.StringVar(&sim.fixtureURL, "fixture-url", sim.fixtureURL, "Docker fixture monitor URL, auto, or off")
 	fs.StringVar(&sim.fixtureProbeURL, "fixture-probe-url", sim.fixtureProbeURL, "URL used when --fixture-url=auto")
+	fs.BoolVar(&sim.allowUnmarkedBatch, "allow-unmarked", false, "allow mutation of --batch targets that do not expose the matching CLI batch marker")
 	fs.StringVar(&sim.expectEventState, "expect-event-state", "", "require at least one active event with this state after polling")
 	fs.Var(&sim.expectEventSeverity, "expect-event-severity", "require at least one active event with this severity after polling")
 	fs.BoolVar(&sim.requireTransition, "require-transition", false, "require at least one event transition after polling")
@@ -159,6 +161,15 @@ func runAPISitesSimulateFailure(ctx context.Context, client *http.Client, opts a
 
 func runAPISiteSimulation(ctx context.Context, client *http.Client, opts apiCLIOptions, sim apiSitesSimulateFailureOptions, def apiFailureModeDefinition, siteID int64, index int) (apiSimulatedSiteResult, error) {
 	result := apiSimulatedSiteResult{SiteID: siteID}
+	if sim.batch != "" && !sim.allowUnmarkedBatch {
+		ok, exists, err := apiSiteBelongsToBatch(ctx, client, opts, siteID, sim.batch)
+		if err != nil {
+			return result, err
+		}
+		if exists && !ok {
+			return result, fmt.Errorf("site %d does not belong to CLI batch %q", siteID, sim.batch)
+		}
+	}
 	update := apiSiteUpdateRequest{
 		MonitorURL:     &def.MonitorURL,
 		CheckKeyword:   def.CheckKeyword,

--- a/cmd/jetmon2/api_cli_sites_simulate.go
+++ b/cmd/jetmon2/api_cli_sites_simulate.go
@@ -6,22 +6,37 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
 
+const (
+	apiFixtureAuto              = "auto"
+	apiFixtureOff               = "off"
+	defaultAPIFixtureMonitorURL = "http://api-fixture:8091"
+	defaultAPIFixtureProbeURL   = "http://localhost:18091/health"
+)
+
 type apiSitesSimulateFailureOptions struct {
-	mode                 string
-	batch                string
-	siteIDs              apiInt64SliceFlags
-	count                int
-	blogIDStart          int64
-	createMissing        bool
-	trigger              bool
-	wait                 time.Duration
-	pollInterval         time.Duration
-	idempotencyKeyPrefix string
+	mode                   string
+	batch                  string
+	siteIDs                apiInt64SliceFlags
+	count                  int
+	blogIDStart            int64
+	createMissing          bool
+	trigger                bool
+	wait                   time.Duration
+	pollInterval           time.Duration
+	idempotencyKeyPrefix   string
+	fixtureURL             string
+	fixtureProbeURL        string
+	expectEventState       string
+	expectEventSeverity    apiOptionalIntFlag
+	requireTransition      bool
+	expectTransitionReason string
 }
 
 type apiFailureModeDefinition struct {
@@ -40,6 +55,7 @@ type apiSimulateFailureSummary struct {
 	Wait          string                   `json:"wait"`
 	Trigger       bool                     `json:"trigger"`
 	CreateMissing bool                     `json:"create_missing"`
+	FixtureURL    string                   `json:"fixture_url,omitempty"`
 	Sites         []apiSimulatedSiteResult `json:"sites"`
 }
 
@@ -67,6 +83,11 @@ func cmdAPISitesSimulateFailure(args []string) error {
 		count:        1,
 		trigger:      true,
 		pollInterval: 2 * time.Second,
+		fixtureURL:   envOrDefault("JETMON_API_FIXTURE_URL", apiFixtureAuto),
+		fixtureProbeURL: envOrDefault(
+			"JETMON_API_FIXTURE_PROBE_URL",
+			defaultAPIFixtureProbeURL,
+		),
 	}
 	fs.StringVar(&sim.mode, "mode", sim.mode, "failure mode: unreachable, http-500, http-403, redirect, keyword, timeout, or tls")
 	fs.StringVar(&sim.batch, "batch", "", "batch label whose deterministic site ids should be mutated")
@@ -78,6 +99,12 @@ func cmdAPISitesSimulateFailure(args []string) error {
 	fs.DurationVar(&sim.wait, "wait", 0, "poll duration for active events after mutation")
 	fs.DurationVar(&sim.pollInterval, "poll-interval", sim.pollInterval, "active-event poll interval when --wait is set")
 	fs.StringVar(&sim.idempotencyKeyPrefix, "idempotency-key-prefix", "", "prefix for per-site POST Idempotency-Key headers")
+	fs.StringVar(&sim.fixtureURL, "fixture-url", sim.fixtureURL, "Docker fixture monitor URL, auto, or off")
+	fs.StringVar(&sim.fixtureProbeURL, "fixture-probe-url", sim.fixtureProbeURL, "URL used when --fixture-url=auto")
+	fs.StringVar(&sim.expectEventState, "expect-event-state", "", "require at least one active event with this state after polling")
+	fs.Var(&sim.expectEventSeverity, "expect-event-severity", "require at least one active event with this severity after polling")
+	fs.BoolVar(&sim.requireTransition, "require-transition", false, "require at least one event transition after polling")
+	fs.StringVar(&sim.expectTransitionReason, "expect-transition-reason", "", "require at least one transition with this reason after polling")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -91,7 +118,8 @@ func runAPISitesSimulateFailure(ctx context.Context, client *http.Client, opts a
 	if opts.out == nil {
 		opts.out = io.Discard
 	}
-	def, err := apiFailureMode(sim.mode)
+	fixtureURL := apiSimulationFixtureURL(ctx, sim)
+	def, err := apiFailureMode(sim.mode, fixtureURL)
 	if err != nil {
 		return err
 	}
@@ -109,6 +137,7 @@ func runAPISitesSimulateFailure(ctx context.Context, client *http.Client, opts a
 		Wait:          sim.wait.String(),
 		Trigger:       sim.trigger,
 		CreateMissing: sim.createMissing,
+		FixtureURL:    fixtureURL,
 		Sites:         make([]apiSimulatedSiteResult, 0, len(siteIDs)),
 	}
 	for i, siteID := range siteIDs {
@@ -167,7 +196,7 @@ func runAPISiteSimulation(ctx context.Context, client *http.Client, opts apiCLIO
 		result.TriggerNow = body
 	}
 
-	events, transitions, err := waitForSimulationEvents(ctx, client, opts, siteID, sim.wait, sim.pollInterval)
+	events, transitions, err := waitForSimulationEvents(ctx, client, opts, siteID, sim)
 	if err != nil {
 		return result, err
 	}
@@ -175,6 +204,9 @@ func runAPISiteSimulation(ctx context.Context, client *http.Client, opts apiCLIO
 	result.Transitions = transitions
 	if len(transitions) == 0 {
 		result.Note = "no active events returned; trigger-now reports check results but regular orchestrator rounds create failure events"
+	}
+	if err := validateSimulationExpectations(result, sim); err != nil {
+		return result, err
 	}
 	return result, nil
 }
@@ -200,22 +232,33 @@ func createMissingSimulationSite(ctx context.Context, client *http.Client, opts 
 	return apiWorkflowRequestJSON(ctx, client, opts, http.MethodPost, "/api/v1/sites", req, apiSimulationIDKey(sim, index, "create-site"))
 }
 
-func waitForSimulationEvents(ctx context.Context, client *http.Client, opts apiCLIOptions, siteID int64, wait, pollInterval time.Duration) (json.RawMessage, []apiSimulatedTransition, error) {
-	deadline := time.Now().Add(wait)
+func waitForSimulationEvents(ctx context.Context, client *http.Client, opts apiCLIOptions, siteID int64, sim apiSitesSimulateFailureOptions) (json.RawMessage, []apiSimulatedTransition, error) {
+	deadline := time.Now().Add(sim.wait)
 	for {
 		body, err := apiWorkflowRequestJSON(ctx, client, opts, http.MethodGet, fmt.Sprintf("/api/v1/sites/%d/events?active=true&limit=10", siteID), nil, "")
 		if err != nil {
 			return nil, nil, err
 		}
 		ids := eventIDsFromList(body)
-		if len(ids) > 0 || wait <= 0 || time.Now().After(deadline) {
-			transitions, err := querySimulationTransitions(ctx, client, opts, siteID, ids)
-			return body, transitions, err
+		transitions, err := querySimulationTransitions(ctx, client, opts, siteID, ids)
+		if err != nil {
+			return nil, nil, err
+		}
+		if simulationHasExpectations(sim) && sim.wait > 0 {
+			result := apiSimulatedSiteResult{SiteID: siteID, Events: body, Transitions: transitions}
+			if validateSimulationExpectations(result, sim) == nil {
+				return body, transitions, nil
+			}
+		} else if len(ids) > 0 || sim.wait <= 0 || time.Now().After(deadline) {
+			return body, transitions, nil
+		}
+		if sim.wait <= 0 || time.Now().After(deadline) {
+			return body, transitions, nil
 		}
 		select {
 		case <-ctx.Done():
 			return nil, nil, ctx.Err()
-		case <-time.After(pollInterval):
+		case <-time.After(sim.pollInterval):
 		}
 	}
 }
@@ -233,21 +276,142 @@ func querySimulationTransitions(ctx context.Context, client *http.Client, opts a
 }
 
 func eventIDsFromList(body json.RawMessage) []int64 {
-	var envelope struct {
-		Data []struct {
-			ID int64 `json:"id"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal(body, &envelope); err != nil {
+	events, err := simulationEventsFromList(body)
+	if err != nil {
 		return nil
 	}
-	ids := make([]int64, 0, len(envelope.Data))
-	for _, event := range envelope.Data {
+	ids := make([]int64, 0, len(events))
+	for _, event := range events {
 		if event.ID > 0 {
 			ids = append(ids, event.ID)
 		}
 	}
 	return ids
+}
+
+type apiSimulationListedEvent struct {
+	ID       int64  `json:"id"`
+	State    string `json:"state"`
+	Severity int    `json:"severity"`
+}
+
+type apiSimulationListedTransition struct {
+	ID            int64   `json:"id"`
+	EventID       int64   `json:"event_id"`
+	Reason        string  `json:"reason"`
+	StateAfter    *string `json:"state_after"`
+	SeverityAfter *int    `json:"severity_after"`
+}
+
+func simulationEventsFromList(body json.RawMessage) ([]apiSimulationListedEvent, error) {
+	var envelope struct {
+		Data []apiSimulationListedEvent `json:"data"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, err
+	}
+	return envelope.Data, nil
+}
+
+func simulationTransitionsFromResults(results []apiSimulatedTransition) ([]apiSimulationListedTransition, error) {
+	rows := []apiSimulationListedTransition{}
+	for _, result := range results {
+		var envelope struct {
+			Data []apiSimulationListedTransition `json:"data"`
+		}
+		if err := json.Unmarshal(result.Transitions, &envelope); err != nil {
+			return nil, err
+		}
+		rows = append(rows, envelope.Data...)
+	}
+	return rows, nil
+}
+
+func validateSimulationExpectations(result apiSimulatedSiteResult, sim apiSitesSimulateFailureOptions) error {
+	if !simulationHasExpectations(sim) {
+		return nil
+	}
+	events, err := simulationEventsFromList(result.Events)
+	if err != nil {
+		return fmt.Errorf("decode active events response: %w", err)
+	}
+	var failures []string
+	if sim.expectEventState != "" && !simulationHasEventState(events, sim.expectEventState) {
+		failures = append(failures, fmt.Sprintf("expected active event state %q, got %s", sim.expectEventState, formatSimulationEvents(events)))
+	}
+	if sim.expectEventSeverity.set && !simulationHasEventSeverity(events, sim.expectEventSeverity.value) {
+		failures = append(failures, fmt.Sprintf("expected active event severity %d, got %s", sim.expectEventSeverity.value, formatSimulationEvents(events)))
+	}
+	transitions, err := simulationTransitionsFromResults(result.Transitions)
+	if err != nil {
+		return fmt.Errorf("decode transition response: %w", err)
+	}
+	if sim.requireTransition && len(transitions) == 0 {
+		failures = append(failures, "expected at least one transition, got none")
+	}
+	if sim.expectTransitionReason != "" && !simulationHasTransitionReason(transitions, sim.expectTransitionReason) {
+		failures = append(failures, fmt.Sprintf("expected transition reason %q, got %s", sim.expectTransitionReason, formatSimulationTransitions(transitions)))
+	}
+	if len(failures) > 0 {
+		return errors.New(strings.Join(failures, "; "))
+	}
+	return nil
+}
+
+func simulationHasExpectations(sim apiSitesSimulateFailureOptions) bool {
+	return sim.expectEventState != "" ||
+		sim.expectEventSeverity.set ||
+		sim.requireTransition ||
+		sim.expectTransitionReason != ""
+}
+
+func simulationHasEventState(events []apiSimulationListedEvent, state string) bool {
+	for _, event := range events {
+		if event.State == state {
+			return true
+		}
+	}
+	return false
+}
+
+func simulationHasEventSeverity(events []apiSimulationListedEvent, severity int) bool {
+	for _, event := range events {
+		if event.Severity == severity {
+			return true
+		}
+	}
+	return false
+}
+
+func simulationHasTransitionReason(transitions []apiSimulationListedTransition, reason string) bool {
+	for _, transition := range transitions {
+		if transition.Reason == reason {
+			return true
+		}
+	}
+	return false
+}
+
+func formatSimulationEvents(events []apiSimulationListedEvent) string {
+	if len(events) == 0 {
+		return "none"
+	}
+	parts := make([]string, 0, len(events))
+	for _, event := range events {
+		parts = append(parts, fmt.Sprintf("#%d state=%q severity=%d", event.ID, event.State, event.Severity))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func formatSimulationTransitions(transitions []apiSimulationListedTransition) string {
+	if len(transitions) == 0 {
+		return "none"
+	}
+	parts := make([]string, 0, len(transitions))
+	for _, transition := range transitions {
+		parts = append(parts, fmt.Sprintf("#%d event=%d reason=%q", transition.ID, transition.EventID, transition.Reason))
+	}
+	return strings.Join(parts, ", ")
 }
 
 func apiSimulationSiteIDs(sim apiSitesSimulateFailureOptions) ([]int64, error) {
@@ -281,7 +445,45 @@ func apiSimulationIDKey(sim apiSitesSimulateFailureOptions, index int, suffix st
 	return fmt.Sprintf("%s-%03d-%s", sim.idempotencyKeyPrefix, index+1, suffix)
 }
 
-func apiFailureMode(mode string) (apiFailureModeDefinition, error) {
+func apiSimulationFixtureURL(ctx context.Context, sim apiSitesSimulateFailureOptions) string {
+	fixtureURL := strings.TrimSpace(sim.fixtureURL)
+	switch strings.ToLower(fixtureURL) {
+	case "", apiFixtureOff, "none", "false":
+		return ""
+	case apiFixtureAuto:
+		if apiFixtureAvailable(ctx, sim.fixtureProbeURL) {
+			return defaultAPIFixtureMonitorURL
+		}
+		return ""
+	default:
+		return strings.TrimRight(fixtureURL, "/")
+	}
+}
+
+func apiFixtureAvailable(ctx context.Context, probeURL string) bool {
+	probeURL = strings.TrimSpace(probeURL)
+	if probeURL == "" {
+		return false
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, 750*time.Millisecond)
+	defer cancel()
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, probeURL, nil)
+	if err != nil {
+		return false
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+func apiFailureMode(mode, fixtureBase string) (apiFailureModeDefinition, error) {
+	if strings.TrimSpace(fixtureBase) != "" {
+		return apiFixtureFailureMode(mode, strings.TrimRight(fixtureBase, "/"))
+	}
+
 	policyFollow := "follow"
 	policyFail := "fail"
 	missingKeyword := "jetmon-api-cli-keyword-that-should-not-exist"
@@ -342,4 +544,74 @@ func apiFailureMode(mode string) (apiFailureModeDefinition, error) {
 	default:
 		return apiFailureModeDefinition{}, errors.New("mode must be one of: unreachable, http-500, http-403, redirect, keyword, timeout, tls")
 	}
+}
+
+func apiFixtureFailureMode(mode, fixtureBase string) (apiFailureModeDefinition, error) {
+	policyFollow := "follow"
+	policyFail := "fail"
+	missingKeyword := "jetmon-api-cli-keyword-that-should-not-exist"
+	timeoutShort := 1
+	switch mode {
+	case "unreachable":
+		return apiFailureMode(mode, "")
+	case "http-500":
+		return apiFailureModeDefinition{
+			Mode:           mode,
+			Description:    "Docker fixture HTTP 500 response",
+			MonitorURL:     fixtureBase + "/status/500",
+			RedirectPolicy: policyFollow,
+		}, nil
+	case "http-403":
+		return apiFailureModeDefinition{
+			Mode:           mode,
+			Description:    "Docker fixture HTTP 403 response",
+			MonitorURL:     fixtureBase + "/status/403",
+			RedirectPolicy: policyFollow,
+		}, nil
+	case "redirect":
+		return apiFailureModeDefinition{
+			Mode:           mode,
+			Description:    "Docker fixture redirect response with fail policy",
+			MonitorURL:     fixtureBase + "/redirect",
+			RedirectPolicy: policyFail,
+		}, nil
+	case "keyword":
+		return apiFailureModeDefinition{
+			Mode:           mode,
+			Description:    "Docker fixture keyword mismatch",
+			MonitorURL:     fixtureBase + "/keyword",
+			CheckKeyword:   &missingKeyword,
+			RedirectPolicy: policyFollow,
+		}, nil
+	case "timeout":
+		return apiFailureModeDefinition{
+			Mode:           mode,
+			Description:    "Docker fixture slow response with short timeout",
+			MonitorURL:     fixtureBase + "/slow?delay=5s",
+			RedirectPolicy: policyFollow,
+			TimeoutSeconds: &timeoutShort,
+		}, nil
+	case "tls":
+		return apiFailureModeDefinition{
+			Mode:           mode,
+			Description:    "Docker fixture self-signed TLS certificate",
+			MonitorURL:     apiFixtureTLSBase(fixtureBase) + "/tls",
+			RedirectPolicy: policyFollow,
+		}, nil
+	default:
+		return apiFailureModeDefinition{}, errors.New("mode must be one of: unreachable, http-500, http-403, redirect, keyword, timeout, tls")
+	}
+}
+
+func apiFixtureTLSBase(fixtureBase string) string {
+	u, err := url.Parse(fixtureBase)
+	if err != nil || u.Host == "" {
+		return strings.TrimRight(fixtureBase, "/")
+	}
+	u.Scheme = "https"
+	host, port, err := net.SplitHostPort(u.Host)
+	if err == nil && port == "8091" {
+		u.Host = net.JoinHostPort(host, "8443")
+	}
+	return strings.TrimRight(u.String(), "/")
 }

--- a/cmd/jetmon2/api_cli_sites_simulate.go
+++ b/cmd/jetmon2/api_cli_sites_simulate.go
@@ -116,11 +116,11 @@ func runAPISitesSimulateFailure(ctx context.Context, client *http.Client, opts a
 		summary.Sites = append(summary.Sites, result)
 		if err != nil {
 			summary.Sites[len(summary.Sites)-1].Error = err.Error()
-			_ = writeAPIJSON(opts.out, summary, opts.pretty)
+			_ = writeAPIValueOutput(opts.out, summary, opts)
 			return fmt.Errorf("simulate failure for site %d: %w", siteID, err)
 		}
 	}
-	return writeAPIJSON(opts.out, summary, opts.pretty)
+	return writeAPIValueOutput(opts.out, summary, opts)
 }
 
 func runAPISiteSimulation(ctx context.Context, client *http.Client, opts apiCLIOptions, sim apiSitesSimulateFailureOptions, def apiFailureModeDefinition, siteID int64, index int) (apiSimulatedSiteResult, error) {

--- a/cmd/jetmon2/api_cli_sites_simulate.go
+++ b/cmd/jetmon2/api_cli_sites_simulate.go
@@ -60,14 +60,19 @@ type apiSimulateFailureSummary struct {
 }
 
 type apiSimulatedSiteResult struct {
-	SiteID      int64                    `json:"site_id"`
-	Action      string                   `json:"action"`
-	Site        json.RawMessage          `json:"site,omitempty"`
-	TriggerNow  json.RawMessage          `json:"trigger_now,omitempty"`
-	Events      json.RawMessage          `json:"events,omitempty"`
-	Transitions []apiSimulatedTransition `json:"transitions,omitempty"`
-	Note        string                   `json:"note,omitempty"`
-	Error       string                   `json:"error,omitempty"`
+	SiteID          int64                    `json:"site_id"`
+	Action          string                   `json:"action"`
+	TriggerStatus   string                   `json:"trigger_status,omitempty"`
+	EventIDs        []int64                  `json:"event_ids,omitempty"`
+	EventStates     []string                 `json:"event_states,omitempty"`
+	EventSeverities []int                    `json:"event_severities,omitempty"`
+	TransitionCount int                      `json:"transition_count"`
+	Site            json.RawMessage          `json:"site,omitempty"`
+	TriggerNow      json.RawMessage          `json:"trigger_now,omitempty"`
+	Events          json.RawMessage          `json:"events,omitempty"`
+	Transitions     []apiSimulatedTransition `json:"transitions,omitempty"`
+	Note            string                   `json:"note,omitempty"`
+	Error           string                   `json:"error,omitempty"`
 }
 
 type apiSimulatedTransition struct {
@@ -194,6 +199,9 @@ func runAPISiteSimulation(ctx context.Context, client *http.Client, opts apiCLIO
 			return result, err
 		}
 		result.TriggerNow = body
+		result.TriggerStatus = apiTriggerNowStatus(body)
+	} else {
+		result.TriggerStatus = "skipped"
 	}
 
 	events, transitions, err := waitForSimulationEvents(ctx, client, opts, siteID, sim)
@@ -202,6 +210,8 @@ func runAPISiteSimulation(ctx context.Context, client *http.Client, opts apiCLIO
 	}
 	result.Events = events
 	result.Transitions = transitions
+	result.EventIDs, result.EventStates, result.EventSeverities = summarizeSimulationEvents(events)
+	result.TransitionCount = simulationTransitionCount(transitions)
 	if len(transitions) == 0 {
 		result.Note = "no active events returned; trigger-now reports check results but regular orchestrator rounds create failure events"
 	}
@@ -325,6 +335,53 @@ func simulationTransitionsFromResults(results []apiSimulatedTransition) ([]apiSi
 		rows = append(rows, envelope.Data...)
 	}
 	return rows, nil
+}
+
+func apiTriggerNowStatus(body json.RawMessage) string {
+	var envelope struct {
+		Result struct {
+			HTTPCode  int  `json:"http_code"`
+			ErrorCode int  `json:"error_code"`
+			Success   bool `json:"success"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return "unknown"
+	}
+	if envelope.Result.Success {
+		return "success"
+	}
+	if envelope.Result.HTTPCode > 0 {
+		return fmt.Sprintf("failed_http_%d", envelope.Result.HTTPCode)
+	}
+	if envelope.Result.ErrorCode > 0 {
+		return fmt.Sprintf("failed_error_%d", envelope.Result.ErrorCode)
+	}
+	return "failed"
+}
+
+func summarizeSimulationEvents(body json.RawMessage) ([]int64, []string, []int) {
+	events, err := simulationEventsFromList(body)
+	if err != nil {
+		return nil, nil, nil
+	}
+	ids := make([]int64, 0, len(events))
+	states := make([]string, 0, len(events))
+	severities := make([]int, 0, len(events))
+	for _, event := range events {
+		ids = append(ids, event.ID)
+		states = append(states, event.State)
+		severities = append(severities, event.Severity)
+	}
+	return ids, states, severities
+}
+
+func simulationTransitionCount(results []apiSimulatedTransition) int {
+	transitions, err := simulationTransitionsFromResults(results)
+	if err != nil {
+		return 0
+	}
+	return len(transitions)
 }
 
 func validateSimulationExpectations(result apiSimulatedSiteResult, sim apiSitesSimulateFailureOptions) error {

--- a/cmd/jetmon2/api_cli_sites_simulate.go
+++ b/cmd/jetmon2/api_cli_sites_simulate.go
@@ -1,0 +1,345 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type apiSitesSimulateFailureOptions struct {
+	mode                 string
+	batch                string
+	siteIDs              apiInt64SliceFlags
+	count                int
+	blogIDStart          int64
+	createMissing        bool
+	trigger              bool
+	wait                 time.Duration
+	pollInterval         time.Duration
+	idempotencyKeyPrefix string
+}
+
+type apiFailureModeDefinition struct {
+	Mode           string
+	Description    string
+	MonitorURL     string
+	CheckKeyword   *string
+	RedirectPolicy string
+	TimeoutSeconds *int
+	CustomHeaders  map[string]string
+}
+
+type apiSimulateFailureSummary struct {
+	Mode          string                   `json:"mode"`
+	Batch         string                   `json:"batch,omitempty"`
+	Wait          string                   `json:"wait"`
+	Trigger       bool                     `json:"trigger"`
+	CreateMissing bool                     `json:"create_missing"`
+	Sites         []apiSimulatedSiteResult `json:"sites"`
+}
+
+type apiSimulatedSiteResult struct {
+	SiteID      int64                    `json:"site_id"`
+	Action      string                   `json:"action"`
+	Site        json.RawMessage          `json:"site,omitempty"`
+	TriggerNow  json.RawMessage          `json:"trigger_now,omitempty"`
+	Events      json.RawMessage          `json:"events,omitempty"`
+	Transitions []apiSimulatedTransition `json:"transitions,omitempty"`
+	Note        string                   `json:"note,omitempty"`
+	Error       string                   `json:"error,omitempty"`
+}
+
+type apiSimulatedTransition struct {
+	EventID     int64           `json:"event_id"`
+	Transitions json.RawMessage `json:"transitions"`
+}
+
+func cmdAPISitesSimulateFailure(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api sites simulate-failure", &opts)
+	sim := apiSitesSimulateFailureOptions{
+		mode:         "http-500",
+		count:        1,
+		trigger:      true,
+		pollInterval: 2 * time.Second,
+	}
+	fs.StringVar(&sim.mode, "mode", sim.mode, "failure mode: unreachable, http-500, http-403, redirect, keyword, timeout, or tls")
+	fs.StringVar(&sim.batch, "batch", "", "batch label whose deterministic site ids should be mutated")
+	fs.Var(&sim.siteIDs, "site-id", "explicit site id to mutate (repeatable or comma-separated)")
+	fs.IntVar(&sim.count, "count", sim.count, "number of batch-derived site ids to mutate")
+	fs.Int64Var(&sim.blogIDStart, "blog-id-start", 0, "first batch blog_id; default derives from --batch")
+	fs.BoolVar(&sim.createMissing, "create-missing", false, "create a site if the target id does not exist")
+	fs.BoolVar(&sim.trigger, "trigger", sim.trigger, "call trigger-now after mutation")
+	fs.DurationVar(&sim.wait, "wait", 0, "poll duration for active events after mutation")
+	fs.DurationVar(&sim.pollInterval, "poll-interval", sim.pollInterval, "active-event poll interval when --wait is set")
+	fs.StringVar(&sim.idempotencyKeyPrefix, "idempotency-key-prefix", "", "prefix for per-site POST Idempotency-Key headers")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return errors.New("usage: jetmon2 api sites simulate-failure [flags]")
+	}
+	return runAPISitesSimulateFailure(context.Background(), nil, opts, sim)
+}
+
+func runAPISitesSimulateFailure(ctx context.Context, client *http.Client, opts apiCLIOptions, sim apiSitesSimulateFailureOptions) error {
+	if opts.out == nil {
+		opts.out = io.Discard
+	}
+	def, err := apiFailureMode(sim.mode)
+	if err != nil {
+		return err
+	}
+	siteIDs, err := apiSimulationSiteIDs(sim)
+	if err != nil {
+		return err
+	}
+	if sim.pollInterval <= 0 {
+		return errors.New("poll-interval must be positive")
+	}
+
+	summary := apiSimulateFailureSummary{
+		Mode:          def.Mode,
+		Batch:         sim.batch,
+		Wait:          sim.wait.String(),
+		Trigger:       sim.trigger,
+		CreateMissing: sim.createMissing,
+		Sites:         make([]apiSimulatedSiteResult, 0, len(siteIDs)),
+	}
+	for i, siteID := range siteIDs {
+		result, err := runAPISiteSimulation(ctx, client, opts, sim, def, siteID, i)
+		summary.Sites = append(summary.Sites, result)
+		if err != nil {
+			summary.Sites[len(summary.Sites)-1].Error = err.Error()
+			_ = writeAPIJSON(opts.out, summary, opts.pretty)
+			return fmt.Errorf("simulate failure for site %d: %w", siteID, err)
+		}
+	}
+	return writeAPIJSON(opts.out, summary, opts.pretty)
+}
+
+func runAPISiteSimulation(ctx context.Context, client *http.Client, opts apiCLIOptions, sim apiSitesSimulateFailureOptions, def apiFailureModeDefinition, siteID int64, index int) (apiSimulatedSiteResult, error) {
+	result := apiSimulatedSiteResult{SiteID: siteID}
+	update := apiSiteUpdateRequest{
+		MonitorURL:     &def.MonitorURL,
+		CheckKeyword:   def.CheckKeyword,
+		RedirectPolicy: &def.RedirectPolicy,
+		TimeoutSeconds: def.TimeoutSeconds,
+	}
+	if len(def.CustomHeaders) > 0 || sim.batch != "" {
+		headers := make(map[string]string, len(def.CustomHeaders)+1)
+		for k, v := range def.CustomHeaders {
+			headers[k] = v
+		}
+		if sim.batch != "" {
+			headers[apiCLIBatchHeader] = sim.batch
+		}
+		update.CustomHeaders = &headers
+	}
+
+	site, err := apiWorkflowRequestJSON(ctx, client, opts, http.MethodPatch, fmt.Sprintf("/api/v1/sites/%d", siteID), update, "")
+	if err != nil {
+		var httpErr apiWorkflowHTTPError
+		if errors.As(err, &httpErr) && strings.Contains(httpErr.Status, "404") && sim.createMissing {
+			site, err = createMissingSimulationSite(ctx, client, opts, sim, def, siteID, index)
+			if err != nil {
+				return result, err
+			}
+			result.Action = "created"
+		} else {
+			return result, err
+		}
+	} else {
+		result.Action = "updated"
+	}
+	result.Site = site
+
+	if sim.trigger {
+		body, err := apiWorkflowRequestJSON(ctx, client, opts, http.MethodPost, fmt.Sprintf("/api/v1/sites/%d/trigger-now", siteID), nil, apiSimulationIDKey(sim, index, "trigger-now"))
+		if err != nil {
+			return result, err
+		}
+		result.TriggerNow = body
+	}
+
+	events, transitions, err := waitForSimulationEvents(ctx, client, opts, siteID, sim.wait, sim.pollInterval)
+	if err != nil {
+		return result, err
+	}
+	result.Events = events
+	result.Transitions = transitions
+	if len(transitions) == 0 {
+		result.Note = "no active events returned; trigger-now reports check results but regular orchestrator rounds create failure events"
+	}
+	return result, nil
+}
+
+func createMissingSimulationSite(ctx context.Context, client *http.Client, opts apiCLIOptions, sim apiSitesSimulateFailureOptions, def apiFailureModeDefinition, siteID int64, index int) (json.RawMessage, error) {
+	headers := map[string]string{}
+	for k, v := range def.CustomHeaders {
+		headers[k] = v
+	}
+	if sim.batch != "" {
+		headers[apiCLIBatchHeader] = sim.batch
+	}
+	req := apiSiteCreateRequest{
+		BlogID:         siteID,
+		MonitorURL:     def.MonitorURL,
+		CheckKeyword:   def.CheckKeyword,
+		RedirectPolicy: &def.RedirectPolicy,
+		TimeoutSeconds: def.TimeoutSeconds,
+	}
+	if len(headers) > 0 {
+		req.CustomHeaders = &headers
+	}
+	return apiWorkflowRequestJSON(ctx, client, opts, http.MethodPost, "/api/v1/sites", req, apiSimulationIDKey(sim, index, "create-site"))
+}
+
+func waitForSimulationEvents(ctx context.Context, client *http.Client, opts apiCLIOptions, siteID int64, wait, pollInterval time.Duration) (json.RawMessage, []apiSimulatedTransition, error) {
+	deadline := time.Now().Add(wait)
+	for {
+		body, err := apiWorkflowRequestJSON(ctx, client, opts, http.MethodGet, fmt.Sprintf("/api/v1/sites/%d/events?active=true&limit=10", siteID), nil, "")
+		if err != nil {
+			return nil, nil, err
+		}
+		ids := eventIDsFromList(body)
+		if len(ids) > 0 || wait <= 0 || time.Now().After(deadline) {
+			transitions, err := querySimulationTransitions(ctx, client, opts, siteID, ids)
+			return body, transitions, err
+		}
+		select {
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
+func querySimulationTransitions(ctx context.Context, client *http.Client, opts apiCLIOptions, siteID int64, eventIDs []int64) ([]apiSimulatedTransition, error) {
+	out := make([]apiSimulatedTransition, 0, len(eventIDs))
+	for _, eventID := range eventIDs {
+		body, err := apiWorkflowRequestJSON(ctx, client, opts, http.MethodGet, fmt.Sprintf("/api/v1/sites/%d/events/%d/transitions", siteID, eventID), nil, "")
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, apiSimulatedTransition{EventID: eventID, Transitions: body})
+	}
+	return out, nil
+}
+
+func eventIDsFromList(body json.RawMessage) []int64 {
+	var envelope struct {
+		Data []struct {
+			ID int64 `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil
+	}
+	ids := make([]int64, 0, len(envelope.Data))
+	for _, event := range envelope.Data {
+		if event.ID > 0 {
+			ids = append(ids, event.ID)
+		}
+	}
+	return ids
+}
+
+func apiSimulationSiteIDs(sim apiSitesSimulateFailureOptions) ([]int64, error) {
+	if sim.siteIDs.set {
+		return sim.siteIDs.valuesOrEmpty(), nil
+	}
+	if sim.batch == "" && sim.blogIDStart == 0 {
+		return nil, errors.New("use --batch, --blog-id-start, or --site-id")
+	}
+	if sim.count <= 0 {
+		return nil, errors.New("count must be positive")
+	}
+	start := sim.blogIDStart
+	if start == 0 {
+		start = apiCLIBatchBlogIDStart(sim.batch)
+	}
+	if start <= 0 {
+		return nil, errors.New("blog-id-start must be positive")
+	}
+	ids := make([]int64, 0, sim.count)
+	for i := 0; i < sim.count; i++ {
+		ids = append(ids, start+int64(i))
+	}
+	return ids, nil
+}
+
+func apiSimulationIDKey(sim apiSitesSimulateFailureOptions, index int, suffix string) string {
+	if sim.idempotencyKeyPrefix == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s-%03d-%s", sim.idempotencyKeyPrefix, index+1, suffix)
+}
+
+func apiFailureMode(mode string) (apiFailureModeDefinition, error) {
+	policyFollow := "follow"
+	policyFail := "fail"
+	missingKeyword := "jetmon-api-cli-keyword-that-should-not-exist"
+	timeoutShort := 2
+	switch mode {
+	case "unreachable":
+		return apiFailureModeDefinition{
+			Mode:           mode,
+			Description:    "reserved TEST-NET-1 address expected to be unreachable",
+			MonitorURL:     "http://192.0.2.1/",
+			RedirectPolicy: policyFollow,
+			TimeoutSeconds: &timeoutShort,
+		}, nil
+	case "http-500":
+		return apiFailureModeDefinition{
+			Mode:           mode,
+			Description:    "HTTP 500 response",
+			MonitorURL:     "https://httpbin.org/status/500",
+			RedirectPolicy: policyFollow,
+		}, nil
+	case "http-403":
+		return apiFailureModeDefinition{
+			Mode:           mode,
+			Description:    "HTTP 403 response",
+			MonitorURL:     "https://httpbin.org/status/403",
+			RedirectPolicy: policyFollow,
+		}, nil
+	case "redirect":
+		return apiFailureModeDefinition{
+			Mode:           mode,
+			Description:    "redirect response with fail policy",
+			MonitorURL:     "https://httpbin.org/redirect-to?url=https%3A%2F%2Fexample.com%2F",
+			RedirectPolicy: policyFail,
+		}, nil
+	case "keyword":
+		return apiFailureModeDefinition{
+			Mode:           mode,
+			Description:    "keyword mismatch against example.com",
+			MonitorURL:     "https://example.com/",
+			CheckKeyword:   &missingKeyword,
+			RedirectPolicy: policyFollow,
+		}, nil
+	case "timeout":
+		return apiFailureModeDefinition{
+			Mode:           mode,
+			Description:    "slow response with short timeout",
+			MonitorURL:     "https://httpbin.org/delay/10",
+			RedirectPolicy: policyFollow,
+			TimeoutSeconds: &timeoutShort,
+		}, nil
+	case "tls":
+		return apiFailureModeDefinition{
+			Mode:           mode,
+			Description:    "expired TLS certificate",
+			MonitorURL:     "https://expired.badssl.com/",
+			RedirectPolicy: policyFollow,
+		}, nil
+	default:
+		return apiFailureModeDefinition{}, errors.New("mode must be one of: unreachable, http-500, http-403, redirect, keyword, timeout, tls")
+	}
+}

--- a/cmd/jetmon2/api_cli_sites_simulate_test.go
+++ b/cmd/jetmon2/api_cli_sites_simulate_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestRunAPISitesSimulateFailureUpdatesAndReportsEvents(t *testing.T) {
+	var severity apiOptionalIntFlag
+	setTestFlag(t, &severity, "3")
 	var calls []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls = append(calls, r.Method+" "+r.URL.String())
@@ -27,11 +29,19 @@ func TestRunAPISitesSimulateFailureUpdatesAndReportsEvents(t *testing.T) {
 			writeTestJSON(t, w, map[string]any{"result": map[string]any{"success": false, "http_code": 500}})
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/sites/42/events":
 			writeTestJSON(t, w, map[string]any{
-				"data": []any{map[string]any{"id": 99, "state": "Seems Down"}},
+				"data": []any{map[string]any{"id": 99, "state": "Seems Down", "severity": 3}},
 				"page": map[string]any{"limit": 10},
 			})
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/sites/42/events/99/transitions":
-			writeTestJSON(t, w, map[string]any{"data": []any{map[string]any{"id": 1, "event_id": 99}}})
+			writeTestJSON(t, w, map[string]any{
+				"data": []any{map[string]any{
+					"id":             1,
+					"event_id":       99,
+					"severity_after": 3,
+					"state_after":    "Seems Down",
+					"reason":         "opened",
+				}},
+			})
 		default:
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
 		}
@@ -46,10 +56,14 @@ func TestRunAPISitesSimulateFailureUpdatesAndReportsEvents(t *testing.T) {
 		out:     &stdout,
 		errOut:  ioDiscard{},
 	}, apiSitesSimulateFailureOptions{
-		mode:         "http-500",
-		siteIDs:      mustSiteIDs(t, "42"),
-		trigger:      true,
-		pollInterval: time.Millisecond,
+		mode:                   "http-500",
+		siteIDs:                mustSiteIDs(t, "42"),
+		trigger:                true,
+		pollInterval:           time.Millisecond,
+		expectEventState:       "Seems Down",
+		expectEventSeverity:    severity,
+		requireTransition:      true,
+		expectTransitionReason: "opened",
 	})
 	if err != nil {
 		t.Fatalf("runAPISitesSimulateFailure() error = %v\nstdout=%s", err, stdout.String())
@@ -75,6 +89,101 @@ func TestRunAPISitesSimulateFailureUpdatesAndReportsEvents(t *testing.T) {
 	}
 	if strings.Join(calls, "\n") != strings.Join(wantCalls, "\n") {
 		t.Fatalf("calls:\n%s\nwant:\n%s", strings.Join(calls, "\n"), strings.Join(wantCalls, "\n"))
+	}
+}
+
+func TestRunAPISitesSimulateFailurePollsUntilAssertionsMatch(t *testing.T) {
+	var eventPolls int
+	var transitionPolls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPatch && r.URL.Path == "/api/v1/sites/42":
+			writeTestJSON(t, w, map[string]any{"id": 42})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/sites/42/events":
+			eventPolls++
+			state := "Seems Down"
+			severity := 3
+			if eventPolls > 1 {
+				state = "Down"
+				severity = 4
+			}
+			writeTestJSON(t, w, map[string]any{
+				"data": []any{map[string]any{"id": 99, "state": state, "severity": severity}},
+				"page": map[string]any{"limit": 10},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/sites/42/events/99/transitions":
+			transitionPolls++
+			reason := "opened"
+			if transitionPolls > 1 {
+				reason = "verifier_confirmed"
+			}
+			writeTestJSON(t, w, map[string]any{
+				"data": []any{map[string]any{"id": transitionPolls, "event_id": 99, "reason": reason}},
+			})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer srv.Close()
+
+	var stdout bytes.Buffer
+	err := runAPISitesSimulateFailure(context.Background(), srv.Client(), apiCLIOptions{
+		baseURL: srv.URL,
+		timeout: time.Second,
+		out:     &stdout,
+		errOut:  ioDiscard{},
+	}, apiSitesSimulateFailureOptions{
+		mode:                   "http-500",
+		siteIDs:                mustSiteIDs(t, "42"),
+		trigger:                false,
+		wait:                   100 * time.Millisecond,
+		pollInterval:           time.Millisecond,
+		expectEventState:       "Down",
+		expectTransitionReason: "verifier_confirmed",
+	})
+	if err != nil {
+		t.Fatalf("runAPISitesSimulateFailure() error = %v\nstdout=%s", err, stdout.String())
+	}
+	if eventPolls < 2 || transitionPolls < 2 {
+		t.Fatalf("eventPolls=%d transitionPolls=%d, want at least 2 each", eventPolls, transitionPolls)
+	}
+}
+
+func TestRunAPISitesSimulateFailureFailsWhenAssertionsDoNotMatch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPatch && r.URL.Path == "/api/v1/sites/42":
+			writeTestJSON(t, w, map[string]any{"id": 42})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/sites/42/events":
+			writeTestJSON(t, w, map[string]any{"data": []any{}, "page": map[string]any{"limit": 10}})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer srv.Close()
+
+	var stdout bytes.Buffer
+	err := runAPISitesSimulateFailure(context.Background(), srv.Client(), apiCLIOptions{
+		baseURL: srv.URL,
+		timeout: time.Second,
+		out:     &stdout,
+		errOut:  ioDiscard{},
+	}, apiSitesSimulateFailureOptions{
+		mode:              "http-500",
+		siteIDs:           mustSiteIDs(t, "42"),
+		trigger:           false,
+		pollInterval:      time.Millisecond,
+		expectEventState:  "Seems Down",
+		requireTransition: true,
+	})
+	if err == nil {
+		t.Fatalf("runAPISitesSimulateFailure() error = nil\nstdout=%s", stdout.String())
+	}
+	if !strings.Contains(err.Error(), `expected active event state "Seems Down"`) {
+		t.Fatalf("error = %v, want event-state assertion failure", err)
+	}
+	if !strings.Contains(stdout.String(), "expected at least one transition") {
+		t.Fatalf("stdout = %s, want transition assertion failure", stdout.String())
 	}
 }
 
@@ -140,7 +249,7 @@ func TestAPISimulationSiteIDsFromBatch(t *testing.T) {
 func TestAPIFailureModesCoverRoadmapTargets(t *testing.T) {
 	for _, mode := range []string{"unreachable", "http-500", "http-403", "redirect", "keyword", "timeout", "tls"} {
 		t.Run(mode, func(t *testing.T) {
-			def, err := apiFailureMode(mode)
+			def, err := apiFailureMode(mode, "")
 			if err != nil {
 				t.Fatalf("apiFailureMode(%q) error = %v", mode, err)
 			}
@@ -148,6 +257,57 @@ func TestAPIFailureModesCoverRoadmapTargets(t *testing.T) {
 				t.Fatalf("definition = %#v, want URL and redirect policy", def)
 			}
 		})
+	}
+}
+
+func TestAPIFailureModesPreferFixtureWhenConfigured(t *testing.T) {
+	tests := []struct {
+		mode string
+		url  string
+	}{
+		{mode: "http-500", url: "http://api-fixture:8091/status/500"},
+		{mode: "http-403", url: "http://api-fixture:8091/status/403"},
+		{mode: "redirect", url: "http://api-fixture:8091/redirect"},
+		{mode: "keyword", url: "http://api-fixture:8091/keyword"},
+		{mode: "timeout", url: "http://api-fixture:8091/slow?delay=5s"},
+		{mode: "tls", url: "https://api-fixture:8443/tls"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.mode, func(t *testing.T) {
+			def, err := apiFailureMode(tt.mode, "http://api-fixture:8091")
+			if err != nil {
+				t.Fatalf("apiFailureMode(%q) error = %v", tt.mode, err)
+			}
+			if def.MonitorURL != tt.url {
+				t.Fatalf("MonitorURL = %q, want %q", def.MonitorURL, tt.url)
+			}
+		})
+	}
+}
+
+func TestAPISimulationFixtureURLAutoDetection(t *testing.T) {
+	fixture := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			t.Fatalf("probe path = %q, want /health", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer fixture.Close()
+
+	got := apiSimulationFixtureURL(context.Background(), apiSitesSimulateFailureOptions{
+		fixtureURL:      apiFixtureAuto,
+		fixtureProbeURL: fixture.URL + "/health",
+	})
+	if got != defaultAPIFixtureMonitorURL {
+		t.Fatalf("fixture URL = %q, want default Docker monitor URL", got)
+	}
+
+	got = apiSimulationFixtureURL(context.Background(), apiSitesSimulateFailureOptions{
+		fixtureURL:      apiFixtureAuto,
+		fixtureProbeURL: "http://127.0.0.1:1/health",
+	})
+	if got != "" {
+		t.Fatalf("fixture URL = %q, want fallback to public endpoints", got)
 	}
 }
 

--- a/cmd/jetmon2/api_cli_sites_simulate_test.go
+++ b/cmd/jetmon2/api_cli_sites_simulate_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunAPISitesSimulateFailureUpdatesAndReportsEvents(t *testing.T) {
+	var calls []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls = append(calls, r.Method+" "+r.URL.String())
+		switch {
+		case r.Method == http.MethodPatch && r.URL.Path == "/api/v1/sites/42":
+			var body map[string]any
+			decodeTestJSON(t, r, &body)
+			if body["monitor_url"] != "https://httpbin.org/status/500" {
+				t.Fatalf("monitor_url = %#v, want http-500 URL", body["monitor_url"])
+			}
+			writeTestJSON(t, w, map[string]any{"id": 42, "monitor_url": body["monitor_url"]})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sites/42/trigger-now":
+			writeTestJSON(t, w, map[string]any{"result": map[string]any{"success": false, "http_code": 500}})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/sites/42/events":
+			writeTestJSON(t, w, map[string]any{
+				"data": []any{map[string]any{"id": 99, "state": "Seems Down"}},
+				"page": map[string]any{"limit": 10},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/sites/42/events/99/transitions":
+			writeTestJSON(t, w, map[string]any{"data": []any{map[string]any{"id": 1, "event_id": 99}}})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer srv.Close()
+
+	var stdout bytes.Buffer
+	err := runAPISitesSimulateFailure(context.Background(), srv.Client(), apiCLIOptions{
+		baseURL: srv.URL,
+		token:   "token-123",
+		timeout: time.Second,
+		out:     &stdout,
+		errOut:  ioDiscard{},
+	}, apiSitesSimulateFailureOptions{
+		mode:         "http-500",
+		siteIDs:      mustSiteIDs(t, "42"),
+		trigger:      true,
+		pollInterval: time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("runAPISitesSimulateFailure() error = %v\nstdout=%s", err, stdout.String())
+	}
+	var summary apiSimulateFailureSummary
+	if err := json.Unmarshal(stdout.Bytes(), &summary); err != nil {
+		t.Fatalf("unmarshal summary: %v\n%s", err, stdout.String())
+	}
+	if summary.Mode != "http-500" || len(summary.Sites) != 1 {
+		t.Fatalf("summary = %#v", summary)
+	}
+	if summary.Sites[0].Action != "updated" {
+		t.Fatalf("action = %q, want updated", summary.Sites[0].Action)
+	}
+	if len(summary.Sites[0].Transitions) != 1 || summary.Sites[0].Transitions[0].EventID != 99 {
+		t.Fatalf("transitions = %#v, want event 99", summary.Sites[0].Transitions)
+	}
+	wantCalls := []string{
+		"PATCH /api/v1/sites/42",
+		"POST /api/v1/sites/42/trigger-now",
+		"GET /api/v1/sites/42/events?active=true&limit=10",
+		"GET /api/v1/sites/42/events/99/transitions",
+	}
+	if strings.Join(calls, "\n") != strings.Join(wantCalls, "\n") {
+		t.Fatalf("calls:\n%s\nwant:\n%s", strings.Join(calls, "\n"), strings.Join(wantCalls, "\n"))
+	}
+}
+
+func TestRunAPISitesSimulateFailureCanCreateMissing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPatch && r.URL.Path == "/api/v1/sites/42":
+			writeTestStatusJSON(t, w, http.StatusNotFound, map[string]string{"code": "site_not_found"})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sites":
+			var body map[string]any
+			decodeTestJSON(t, r, &body)
+			if body["blog_id"] != float64(42) {
+				t.Fatalf("blog_id = %#v, want 42", body["blog_id"])
+			}
+			writeTestStatusJSON(t, w, http.StatusCreated, map[string]any{"id": 42})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/sites/42/events":
+			writeTestJSON(t, w, map[string]any{"data": []any{}, "page": map[string]any{"limit": 10}})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer srv.Close()
+
+	var stdout bytes.Buffer
+	err := runAPISitesSimulateFailure(context.Background(), srv.Client(), apiCLIOptions{
+		baseURL: srv.URL,
+		timeout: time.Second,
+		out:     &stdout,
+		errOut:  ioDiscard{},
+	}, apiSitesSimulateFailureOptions{
+		mode:          "keyword",
+		siteIDs:       mustSiteIDs(t, "42"),
+		createMissing: true,
+		trigger:       false,
+		pollInterval:  time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("runAPISitesSimulateFailure() error = %v\nstdout=%s", err, stdout.String())
+	}
+	var summary apiSimulateFailureSummary
+	if err := json.Unmarshal(stdout.Bytes(), &summary); err != nil {
+		t.Fatalf("unmarshal summary: %v\n%s", err, stdout.String())
+	}
+	if summary.Sites[0].Action != "created" {
+		t.Fatalf("action = %q, want created", summary.Sites[0].Action)
+	}
+}
+
+func TestAPISimulationSiteIDsFromBatch(t *testing.T) {
+	ids, err := apiSimulationSiteIDs(apiSitesSimulateFailureOptions{batch: "batch-a", count: 3})
+	if err != nil {
+		t.Fatalf("apiSimulationSiteIDs() error = %v", err)
+	}
+	start := apiCLIBatchBlogIDStart("batch-a")
+	want := []int64{start, start + 1, start + 2}
+	for i := range want {
+		if ids[i] != want[i] {
+			t.Fatalf("ids[%d] = %d, want %d", i, ids[i], want[i])
+		}
+	}
+}
+
+func TestAPIFailureModesCoverRoadmapTargets(t *testing.T) {
+	for _, mode := range []string{"unreachable", "http-500", "http-403", "redirect", "keyword", "timeout", "tls"} {
+		t.Run(mode, func(t *testing.T) {
+			def, err := apiFailureMode(mode)
+			if err != nil {
+				t.Fatalf("apiFailureMode(%q) error = %v", mode, err)
+			}
+			if def.MonitorURL == "" || def.RedirectPolicy == "" {
+				t.Fatalf("definition = %#v, want URL and redirect policy", def)
+			}
+		})
+	}
+}
+
+func mustSiteIDs(t *testing.T, raw string) apiInt64SliceFlags {
+	t.Helper()
+	var ids apiInt64SliceFlags
+	if err := ids.Set(raw); err != nil {
+		t.Fatalf("set site ids: %v", err)
+	}
+	return ids
+}

--- a/cmd/jetmon2/api_cli_sites_simulate_test.go
+++ b/cmd/jetmon2/api_cli_sites_simulate_test.go
@@ -247,6 +247,44 @@ func TestRunAPISitesSimulateFailureCanCreateMissing(t *testing.T) {
 	}
 }
 
+func TestRunAPISitesSimulateFailureRejectsUnmatchedBatchMarker(t *testing.T) {
+	start := apiCLIBatchBlogIDStart("simulation-batch")
+	var calls []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls = append(calls, r.Method+" "+r.URL.Path)
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/sites/"+strconvInt64(start):
+			writeTestJSON(t, w, map[string]any{"id": start, "cli_batch": "other-batch"})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer srv.Close()
+
+	var stdout bytes.Buffer
+	err := runAPISitesSimulateFailure(context.Background(), srv.Client(), apiCLIOptions{
+		baseURL: srv.URL,
+		timeout: time.Second,
+		out:     &stdout,
+		errOut:  ioDiscard{},
+	}, apiSitesSimulateFailureOptions{
+		mode:         "http-500",
+		batch:        "simulation-batch",
+		count:        1,
+		trigger:      false,
+		pollInterval: time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("runAPISitesSimulateFailure() error = nil, want batch mismatch")
+	}
+	if !strings.Contains(err.Error(), `does not belong to CLI batch "simulation-batch"`) {
+		t.Fatalf("error = %v, want batch mismatch", err)
+	}
+	if strings.Join(calls, "\n") != "GET /api/v1/sites/"+strconvInt64(start) {
+		t.Fatalf("calls:\n%s\nwant only GET", strings.Join(calls, "\n"))
+	}
+}
+
 func TestAPISimulationSiteIDsFromBatch(t *testing.T) {
 	ids, err := apiSimulationSiteIDs(apiSitesSimulateFailureOptions{batch: "batch-a", count: 3})
 	if err != nil {

--- a/cmd/jetmon2/api_cli_sites_simulate_test.go
+++ b/cmd/jetmon2/api_cli_sites_simulate_test.go
@@ -78,6 +78,21 @@ func TestRunAPISitesSimulateFailureUpdatesAndReportsEvents(t *testing.T) {
 	if summary.Sites[0].Action != "updated" {
 		t.Fatalf("action = %q, want updated", summary.Sites[0].Action)
 	}
+	if summary.Sites[0].TriggerStatus != "failed_http_500" {
+		t.Fatalf("trigger status = %q, want failed_http_500", summary.Sites[0].TriggerStatus)
+	}
+	if got := summary.Sites[0].EventIDs; len(got) != 1 || got[0] != 99 {
+		t.Fatalf("event ids = %#v, want [99]", got)
+	}
+	if got := summary.Sites[0].EventStates; len(got) != 1 || got[0] != "Seems Down" {
+		t.Fatalf("event states = %#v, want [Seems Down]", got)
+	}
+	if got := summary.Sites[0].EventSeverities; len(got) != 1 || got[0] != 3 {
+		t.Fatalf("event severities = %#v, want [3]", got)
+	}
+	if summary.Sites[0].TransitionCount != 1 {
+		t.Fatalf("transition count = %d, want 1", summary.Sites[0].TransitionCount)
+	}
 	if len(summary.Sites[0].Transitions) != 1 || summary.Sites[0].Transitions[0].EventID != 99 {
 		t.Fatalf("transitions = %#v, want event 99", summary.Sites[0].Transitions)
 	}

--- a/cmd/jetmon2/api_cli_sites_simulate_test.go
+++ b/cmd/jetmon2/api_cli_sites_simulate_test.go
@@ -251,9 +251,11 @@ func TestRunAPISitesSimulateFailureRejectsUnmatchedBatchMarker(t *testing.T) {
 	start := apiCLIBatchBlogIDStart("simulation-batch")
 	var calls []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls = append(calls, r.Method+" "+r.URL.Path)
+		calls = append(calls, r.Method+" "+r.URL.RequestURI())
 		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/sites/"+strconvInt64(start):
+		case r.Method == http.MethodGet &&
+			r.URL.Path == "/api/v1/sites/"+strconvInt64(start) &&
+			r.URL.Query().Get("include_cli_metadata") == "true":
 			writeTestJSON(t, w, map[string]any{"id": start, "cli_batch": "other-batch"})
 		default:
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
@@ -280,7 +282,7 @@ func TestRunAPISitesSimulateFailureRejectsUnmatchedBatchMarker(t *testing.T) {
 	if !strings.Contains(err.Error(), `does not belong to CLI batch "simulation-batch"`) {
 		t.Fatalf("error = %v, want batch mismatch", err)
 	}
-	if strings.Join(calls, "\n") != "GET /api/v1/sites/"+strconvInt64(start) {
+	if strings.Join(calls, "\n") != "GET /api/v1/sites/"+strconvInt64(start)+"?include_cli_metadata=true" {
 		t.Fatalf("calls:\n%s\nwant only GET", strings.Join(calls, "\n"))
 	}
 }

--- a/cmd/jetmon2/api_cli_sites_test.go
+++ b/cmd/jetmon2/api_cli_sites_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"encoding/json"
+	"net/url"
+	"testing"
+)
+
+func TestAPISitesListPath(t *testing.T) {
+	got, err := apiSitesListPath(apiSitesListFilters{
+		cursor:        "cur-1",
+		limit:         25,
+		stateIn:       "Down,Seems Down",
+		severityGTE:   3,
+		monitorActive: "1",
+		q:             "example.com",
+	})
+	if err != nil {
+		t.Fatalf("apiSitesListPath() error = %v", err)
+	}
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("parse path: %v", err)
+	}
+	if u.Path != "/api/v1/sites" {
+		t.Fatalf("path = %q, want /api/v1/sites", u.Path)
+	}
+	q := u.Query()
+	for key, want := range map[string]string{
+		"cursor":         "cur-1",
+		"limit":          "25",
+		"state__in":      "Down,Seems Down",
+		"severity__gte":  "3",
+		"monitor_active": "true",
+		"q":              "example.com",
+	} {
+		if got := q.Get(key); got != want {
+			t.Fatalf("query %s = %q, want %q in %s", key, got, want, got)
+		}
+	}
+}
+
+func TestAPISitesListPathRejectsAmbiguousStateFilter(t *testing.T) {
+	_, err := apiSitesListPath(apiSitesListFilters{state: "Down", stateIn: "Up,Down"})
+	if err == nil {
+		t.Fatal("apiSitesListPath() error = nil, want error")
+	}
+}
+
+func TestAPISiteResourcePath(t *testing.T) {
+	got, err := apiSiteResourcePath("42", "trigger-now")
+	if err != nil {
+		t.Fatalf("apiSiteResourcePath() error = %v", err)
+	}
+	if got != "/api/v1/sites/42/trigger-now" {
+		t.Fatalf("path = %q, want trigger-now path", got)
+	}
+	if _, err := apiSiteResourcePath("0", ""); err == nil {
+		t.Fatal("apiSiteResourcePath() error = nil, want invalid id error")
+	}
+}
+
+func TestMarshalAPISiteCreateBody(t *testing.T) {
+	var active apiOptionalBoolFlag
+	setTestFlag(t, &active, "false")
+	var bucket apiOptionalIntFlag
+	setTestFlag(t, &bucket, "7")
+	var redirect apiOptionalStringFlag
+	setTestFlag(t, &redirect, "alert")
+	var headers apiStringMapFlags
+	setTestFlag(t, &headers, "X-Jetmon-Test: yes")
+
+	body, err := marshalAPISiteCreateBody(apiSiteCreateOptions{
+		blogID:         12345,
+		monitorURL:     "https://example.com",
+		monitorActive:  active,
+		bucketNo:       bucket,
+		redirectPolicy: redirect,
+		customHeaders:  headers,
+	})
+	if err != nil {
+		t.Fatalf("marshalAPISiteCreateBody() error = %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if got["blog_id"] != float64(12345) {
+		t.Fatalf("blog_id = %#v, want 12345", got["blog_id"])
+	}
+	if got["monitor_url"] != "https://example.com" {
+		t.Fatalf("monitor_url = %#v", got["monitor_url"])
+	}
+	if got["monitor_active"] != false {
+		t.Fatalf("monitor_active = %#v, want false", got["monitor_active"])
+	}
+	if got["bucket_no"] != float64(7) {
+		t.Fatalf("bucket_no = %#v, want 7", got["bucket_no"])
+	}
+	if got["redirect_policy"] != "alert" {
+		t.Fatalf("redirect_policy = %#v, want alert", got["redirect_policy"])
+	}
+	custom, ok := got["custom_headers"].(map[string]any)
+	if !ok {
+		t.Fatalf("custom_headers = %#v, want object", got["custom_headers"])
+	}
+	if custom["X-Jetmon-Test"] != "yes" {
+		t.Fatalf("custom header = %#v, want yes", custom["X-Jetmon-Test"])
+	}
+}
+
+func TestMarshalAPISiteUpdateBodySupportsClears(t *testing.T) {
+	var keyword apiOptionalStringFlag
+	setTestFlag(t, &keyword, "")
+	var maintenanceEnd apiOptionalStringFlag
+	setTestFlag(t, &maintenanceEnd, "")
+
+	body, err := marshalAPISiteUpdateBody(apiSiteUpdateOptions{
+		checkKeyword:       keyword,
+		clearCustomHeaders: true,
+		maintenanceEnd:     maintenanceEnd,
+	})
+	if err != nil {
+		t.Fatalf("marshalAPISiteUpdateBody() error = %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if got["check_keyword"] != "" {
+		t.Fatalf("check_keyword = %#v, want empty string", got["check_keyword"])
+	}
+	if got["maintenance_end"] != "" {
+		t.Fatalf("maintenance_end = %#v, want empty string", got["maintenance_end"])
+	}
+	custom, ok := got["custom_headers"].(map[string]any)
+	if !ok {
+		t.Fatalf("custom_headers = %#v, want object", got["custom_headers"])
+	}
+	if len(custom) != 0 {
+		t.Fatalf("custom_headers = %#v, want empty object", custom)
+	}
+}
+
+func TestMarshalAPISiteUpdateBodyRejectsCustomHeaderConflict(t *testing.T) {
+	var headers apiStringMapFlags
+	setTestFlag(t, &headers, "X-Test: yes")
+	_, err := marshalAPISiteUpdateBody(apiSiteUpdateOptions{
+		customHeaders:      headers,
+		clearCustomHeaders: true,
+	})
+	if err == nil {
+		t.Fatal("marshalAPISiteUpdateBody() error = nil, want conflict error")
+	}
+}
+
+func setTestFlag(t *testing.T, v interface{ Set(string) error }, raw string) {
+	t.Helper()
+	if err := v.Set(raw); err != nil {
+		t.Fatalf("Set(%q) error = %v", raw, err)
+	}
+}

--- a/cmd/jetmon2/api_cli_test.go
+++ b/cmd/jetmon2/api_cli_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
+	"flag"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -135,6 +137,64 @@ func TestExecuteAPIRequestReturnsErrorForHTTPFailureAfterWritingBody(t *testing.
 	}
 	if got := stdout.String(); !strings.Contains(got, `"missing token"`) {
 		t.Fatalf("stdout = %q, want error body", got)
+	}
+}
+
+func TestAPIFlagUsageUsesLongDashesAndHidesTokenDefault(t *testing.T) {
+	var stderr bytes.Buffer
+	opts := apiCLIOptions{
+		baseURL: "http://localhost:8090",
+		token:   "token-should-not-print",
+		timeout: 10 * time.Second,
+		errOut:  &stderr,
+	}
+	fs := newAPIFlagSet("api health", &opts)
+	fs.Usage()
+
+	got := stderr.String()
+	for _, want := range []string{
+		"Usage of api health:",
+		"--base-url string",
+		"--header value",
+		"--output string",
+		"--pretty",
+		"--timeout duration",
+		"--token string",
+		"-v",
+		"--verbose",
+		`API base URL (default "http://localhost:8090")`,
+		`request timeout (default 10s)`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("usage missing %q:\n%s", want, got)
+		}
+	}
+	for _, unwanted := range []string{
+		"  -base-url",
+		"  -header",
+		"  -output",
+		"  -pretty",
+		"  -timeout",
+		"  -token",
+		"  -verbose",
+		"token-should-not-print",
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("usage contains %q:\n%s", unwanted, got)
+		}
+	}
+}
+
+func TestAPIHelpReturnsFlagErrHelp(t *testing.T) {
+	var stderr bytes.Buffer
+	opts := apiCLIOptions{baseURL: "http://localhost:8090", timeout: 10 * time.Second, errOut: &stderr}
+	fs := newAPIFlagSet("api health", &opts)
+	err := fs.Parse([]string{"--help"})
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("Parse(--help) error = %v, want flag.ErrHelp", err)
+	}
+	if got := stderr.String(); !strings.Contains(got, "--base-url string") {
+		t.Fatalf("usage = %q, want long-dash flag output", got)
 	}
 }
 

--- a/cmd/jetmon2/api_cli_test.go
+++ b/cmd/jetmon2/api_cli_test.go
@@ -283,6 +283,64 @@ func TestWriteAPIResponseTableUsesNestedWorkflowRows(t *testing.T) {
 	}
 }
 
+func TestWriteAPIResponseTableIncludesSimulationSummaryColumns(t *testing.T) {
+	body := []byte(`{
+		"mode": "http-500",
+		"sites": [
+			{
+				"site_id": 42,
+				"action": "updated",
+				"trigger_status": "failed_http_500",
+				"event_ids": [99],
+				"event_states": ["Seems Down"],
+				"event_severities": [3],
+				"transition_count": 1
+			}
+		]
+	}`)
+	var out bytes.Buffer
+	if err := writeAPIResponseTable(&out, body); err != nil {
+		t.Fatalf("writeAPIResponseTable() error = %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"site_id  action   trigger_status   event_ids  event_states  event_severities  transition_count",
+		"42       updated  failed_http_500  99         Seems Down    3                 1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("table missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestWriteAPIResponseTableIncludesSmokeCleanupRows(t *testing.T) {
+	body := []byte(`{
+		"steps": [
+			{"name": "health", "status": "ok"},
+			{"name": "me", "status": "ok"}
+		],
+		"cleanup_results": [
+			{"resource": "alert_contact", "id": 77, "status": "deleted"},
+			{"resource": "site", "id": 910, "status": "failed", "error": "not found"}
+		]
+	}`)
+	var out bytes.Buffer
+	if err := writeAPIResponseTable(&out, body); err != nil {
+		t.Fatalf("writeAPIResponseTable() error = %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"kind     name           id   status   detail",
+		"step     health              ok",
+		"cleanup  alert_contact  77   deleted",
+		"cleanup  site           910  failed   not found",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("table missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestWriteAPIResponseTableFallsBackToSortedColumns(t *testing.T) {
 	body := []byte(`{"zeta":"last","alpha":"first"}`)
 	var out bytes.Buffer

--- a/cmd/jetmon2/api_cli_test.go
+++ b/cmd/jetmon2/api_cli_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAPIRequestURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		target  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "absolute path",
+			baseURL: "http://localhost:8090",
+			target:  "/api/v1/health",
+			want:    "http://localhost:8090/api/v1/health",
+		},
+		{
+			name:    "relative path",
+			baseURL: "http://localhost:8090/",
+			target:  "api/v1/me",
+			want:    "http://localhost:8090/api/v1/me",
+		},
+		{
+			name:    "absolute url",
+			baseURL: "http://localhost:8090",
+			target:  "http://127.0.0.1:9000/api/v1/health",
+			want:    "http://127.0.0.1:9000/api/v1/health",
+		},
+		{
+			name:    "base requires host",
+			baseURL: "localhost:8090",
+			target:  "/api/v1/health",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := apiRequestURL(tt.baseURL, tt.target)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("apiRequestURL() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("apiRequestURL() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("apiRequestURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExecuteAPIRequestSendsAuthAndVerboseHeaders(t *testing.T) {
+	var sawAuth, sawIDKey bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got == "Bearer token-123" {
+			sawAuth = true
+		}
+		if got := r.Header.Get("Idempotency-Key"); got == "idem-1" {
+			sawIDKey = true
+		}
+		w.Header().Set("X-Test-Response", "yes")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	opts := apiCLIOptions{
+		baseURL:        srv.URL,
+		token:          "token-123",
+		idempotencyKey: "idem-1",
+		verbose:        true,
+		pretty:         true,
+		timeout:        time.Second,
+		out:            &stdout,
+		errOut:         &stderr,
+	}
+	if err := executeAPIRequest(context.Background(), srv.Client(), opts, http.MethodPost, "/api/v1/sites/42/trigger-now", []byte(`{}`)); err != nil {
+		t.Fatalf("executeAPIRequest() error = %v", err)
+	}
+	if !sawAuth {
+		t.Fatal("Authorization header was not sent")
+	}
+	if !sawIDKey {
+		t.Fatal("Idempotency-Key header was not sent")
+	}
+	if got := stdout.String(); !strings.Contains(got, "{\n  \"ok\": true\n}") {
+		t.Fatalf("stdout = %q, want pretty JSON body", got)
+	}
+	errOut := stderr.String()
+	for _, want := range []string{
+		"> POST /api/v1/sites/42/trigger-now HTTP/1.1",
+		"> Authorization: Bearer token-123",
+		"> Idempotency-Key: idem-1",
+		"< HTTP/1.1 201 Created",
+		"< X-Test-Response: yes",
+	} {
+		if !strings.Contains(errOut, want) {
+			t.Fatalf("stderr missing %q:\n%s", want, errOut)
+		}
+	}
+}
+
+func TestExecuteAPIRequestReturnsErrorForHTTPFailureAfterWritingBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"missing token"}`))
+	}))
+	defer srv.Close()
+
+	var stdout bytes.Buffer
+	opts := apiCLIOptions{
+		baseURL: srv.URL,
+		timeout: time.Second,
+		out:     &stdout,
+		errOut:  ioDiscard{},
+	}
+	err := executeAPIRequest(context.Background(), srv.Client(), opts, http.MethodGet, "/api/v1/me", nil)
+	if err == nil {
+		t.Fatal("executeAPIRequest() error = nil, want error")
+	}
+	if got := stdout.String(); !strings.Contains(got, `"missing token"`) {
+		t.Fatalf("stdout = %q, want error body", got)
+	}
+}
+
+type ioDiscard struct{}
+
+func (ioDiscard) Write(p []byte) (int, error) {
+	return len(p), nil
+}

--- a/cmd/jetmon2/api_cli_test.go
+++ b/cmd/jetmon2/api_cli_test.go
@@ -235,6 +235,38 @@ func TestParseAPIFlagsPreservesPositionalsAfterDoubleDash(t *testing.T) {
 	}
 }
 
+func TestNewAPIFlagSetHonorsPresetOutputDefault(t *testing.T) {
+	var stderr bytes.Buffer
+	opts := apiCLIOptions{output: "table", errOut: &stderr}
+	fs := newAPIFlagSet("api commands", &opts)
+	if err := parseAPIFlags(fs, nil); err != nil {
+		t.Fatalf("parseAPIFlags() error = %v", err)
+	}
+	if opts.output != "table" {
+		t.Fatalf("output = %q, want table", opts.output)
+	}
+}
+
+func TestWriteAPICommandsTable(t *testing.T) {
+	var out bytes.Buffer
+	err := writeAPICommands(apiCLIOptions{output: "table", out: &out})
+	if err != nil {
+		t.Fatalf("writeAPICommands() error = %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"command                    description",
+		"sites simulate-failure",
+		"mutate test sites into known failure modes",
+		"commands",
+		"list API CLI commands and examples",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("commands table missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestWriteAPIResponseTableForSiteList(t *testing.T) {
 	body := []byte(`{
 		"data": [

--- a/cmd/jetmon2/api_cli_test.go
+++ b/cmd/jetmon2/api_cli_test.go
@@ -249,6 +249,7 @@ func TestAPIFlagUsageUsesLongDashesAndHidesTokenDefault(t *testing.T) {
 	got := stderr.String()
 	for _, want := range []string{
 		"Usage of api health:",
+		"--allow-remote",
 		"--auth-policy string",
 		"--base-url string",
 		"--header value",
@@ -267,6 +268,7 @@ func TestAPIFlagUsageUsesLongDashesAndHidesTokenDefault(t *testing.T) {
 	}
 	for _, unwanted := range []string{
 		"  -base-url",
+		"  -allow-remote",
 		"  -header",
 		"  -output",
 		"  -pretty",

--- a/cmd/jetmon2/api_cli_test.go
+++ b/cmd/jetmon2/api_cli_test.go
@@ -75,6 +75,8 @@ func TestExecuteAPIRequestSendsAuthAndVerboseHeaders(t *testing.T) {
 			sawIDKey = true
 		}
 		w.Header().Set("X-Test-Response", "yes")
+		w.Header().Set("Set-Cookie", "session=secret-cookie")
+		w.Header().Set("X-Api-Key", "response-api-key")
 		w.WriteHeader(http.StatusCreated)
 		_, _ = w.Write([]byte(`{"ok":true}`))
 	}))
@@ -106,14 +108,107 @@ func TestExecuteAPIRequestSendsAuthAndVerboseHeaders(t *testing.T) {
 	errOut := stderr.String()
 	for _, want := range []string{
 		"> POST /api/v1/sites/42/trigger-now HTTP/1.1",
-		"> Authorization: Bearer token-123",
-		"> Idempotency-Key: idem-1",
+		"> Authorization: [redacted]",
+		"> Idempotency-Key: [redacted]",
 		"< HTTP/1.1 201 Created",
+		"< Set-Cookie: [redacted]",
+		"< X-Api-Key: [redacted]",
 		"< X-Test-Response: yes",
 	} {
 		if !strings.Contains(errOut, want) {
 			t.Fatalf("stderr missing %q:\n%s", want, errOut)
 		}
+	}
+	for _, secret := range []string{"token-123", "idem-1", "secret-cookie", "response-api-key"} {
+		if strings.Contains(errOut, secret) {
+			t.Fatalf("stderr leaked %q:\n%s", secret, errOut)
+		}
+	}
+}
+
+func TestExecuteAPIRequestSkipsAutomaticAuthForDifferentOrigin(t *testing.T) {
+	base := httptest.NewServer(http.NotFoundHandler())
+	defer base.Close()
+
+	var sawAuth, sawIDKey bool
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuth = r.Header.Get("Authorization") != ""
+		sawIDKey = r.Header.Get("Idempotency-Key") != ""
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer target.Close()
+
+	var stdout bytes.Buffer
+	opts := apiCLIOptions{
+		baseURL:        base.URL,
+		token:          "token-123",
+		idempotencyKey: "idem-1",
+		timeout:        time.Second,
+		out:            &stdout,
+		errOut:         ioDiscard{},
+	}
+	if err := executeAPIRequest(context.Background(), target.Client(), opts, http.MethodPost, target.URL+"/api/v1/sites", []byte(`{}`)); err != nil {
+		t.Fatalf("executeAPIRequest() error = %v", err)
+	}
+	if sawAuth {
+		t.Fatal("Authorization header was sent to a different origin")
+	}
+	if sawIDKey {
+		t.Fatal("Idempotency-Key header was sent to a different origin")
+	}
+}
+
+func TestExecuteAPIRequestAnyOriginPolicySendsAutomaticAuth(t *testing.T) {
+	base := httptest.NewServer(http.NotFoundHandler())
+	defer base.Close()
+
+	var sawAuth, sawIDKey bool
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuth = r.Header.Get("Authorization") == "Bearer token-123"
+		sawIDKey = r.Header.Get("Idempotency-Key") == "idem-1"
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer target.Close()
+
+	var stdout bytes.Buffer
+	opts := apiCLIOptions{
+		baseURL:        base.URL,
+		token:          "token-123",
+		authPolicy:     "any-origin",
+		idempotencyKey: "idem-1",
+		timeout:        time.Second,
+		out:            &stdout,
+		errOut:         ioDiscard{},
+	}
+	if err := executeAPIRequest(context.Background(), target.Client(), opts, http.MethodPost, target.URL+"/api/v1/sites", []byte(`{}`)); err != nil {
+		t.Fatalf("executeAPIRequest() error = %v", err)
+	}
+	if !sawAuth {
+		t.Fatal("Authorization header was not sent with any-origin policy")
+	}
+	if !sawIDKey {
+		t.Fatal("Idempotency-Key header was not sent with any-origin policy")
+	}
+}
+
+func TestExecuteAPIRequestRejectsInvalidAuthPolicy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("server should not be called")
+	}))
+	defer srv.Close()
+
+	err := executeAPIRequest(context.Background(), srv.Client(), apiCLIOptions{
+		baseURL:    srv.URL,
+		authPolicy: "sometimes",
+		timeout:    time.Second,
+		out:        ioDiscard{},
+		errOut:     ioDiscard{},
+	}, http.MethodGet, "/api/v1/health", nil)
+	if err == nil {
+		t.Fatal("executeAPIRequest() error = nil, want invalid auth policy")
+	}
+	if !strings.Contains(err.Error(), "invalid auth policy") {
+		t.Fatalf("error = %v, want invalid auth policy", err)
 	}
 }
 
@@ -154,6 +249,7 @@ func TestAPIFlagUsageUsesLongDashesAndHidesTokenDefault(t *testing.T) {
 	got := stderr.String()
 	for _, want := range []string{
 		"Usage of api health:",
+		"--auth-policy string",
 		"--base-url string",
 		"--header value",
 		"--output string",

--- a/cmd/jetmon2/api_cli_test.go
+++ b/cmd/jetmon2/api_cli_test.go
@@ -189,12 +189,49 @@ func TestAPIHelpReturnsFlagErrHelp(t *testing.T) {
 	var stderr bytes.Buffer
 	opts := apiCLIOptions{baseURL: "http://localhost:8090", timeout: 10 * time.Second, errOut: &stderr}
 	fs := newAPIFlagSet("api health", &opts)
-	err := fs.Parse([]string{"--help"})
+	err := parseAPIFlags(fs, []string{"--help"})
 	if !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("Parse(--help) error = %v, want flag.ErrHelp", err)
 	}
 	if got := stderr.String(); !strings.Contains(got, "--base-url string") {
 		t.Fatalf("usage = %q, want long-dash flag output", got)
+	}
+}
+
+func TestParseAPIFlagsAllowsFlagsAfterPositionals(t *testing.T) {
+	var stderr bytes.Buffer
+	opts := apiCLIOptions{baseURL: "http://localhost:8090", timeout: 10 * time.Second, errOut: &stderr}
+	fs := newAPIFlagSet("api sites get", &opts)
+
+	err := parseAPIFlags(fs, []string{"12345", "--pretty", "--output", "table", "--header", "X-Test: yes"})
+	if err != nil {
+		t.Fatalf("parseAPIFlags() error = %v", err)
+	}
+	if !opts.pretty {
+		t.Fatal("pretty = false, want true")
+	}
+	if opts.output != "table" {
+		t.Fatalf("output = %q, want table", opts.output)
+	}
+	if got := opts.headers; len(got) != 1 || got[0] != "X-Test: yes" {
+		t.Fatalf("headers = %#v, want X-Test header", got)
+	}
+	if got := fs.Args(); len(got) != 1 || got[0] != "12345" {
+		t.Fatalf("args = %#v, want [12345]", got)
+	}
+}
+
+func TestParseAPIFlagsPreservesPositionalsAfterDoubleDash(t *testing.T) {
+	var stderr bytes.Buffer
+	opts := apiCLIOptions{baseURL: "http://localhost:8090", timeout: 10 * time.Second, errOut: &stderr}
+	fs := newAPIFlagSet("api request", &opts)
+
+	err := parseAPIFlags(fs, []string{"GET", "--", "--not-a-flag"})
+	if err != nil {
+		t.Fatalf("parseAPIFlags() error = %v", err)
+	}
+	if got := fs.Args(); len(got) != 2 || got[0] != "GET" || got[1] != "--not-a-flag" {
+		t.Fatalf("args = %#v, want GET and literal --not-a-flag", got)
 	}
 }
 

--- a/cmd/jetmon2/api_cli_test.go
+++ b/cmd/jetmon2/api_cli_test.go
@@ -138,6 +138,72 @@ func TestExecuteAPIRequestReturnsErrorForHTTPFailureAfterWritingBody(t *testing.
 	}
 }
 
+func TestWriteAPIResponseTableForSiteList(t *testing.T) {
+	body := []byte(`{
+		"data": [
+			{"id": 42, "monitor_url": "https://example.com", "monitor_active": true, "current_state": "Up", "current_severity": 0},
+			{"id": 43, "monitor_url": "https://wordpress.com", "monitor_active": false, "current_state": "Paused", "current_severity": 0}
+		],
+		"page": {"limit": 50}
+	}`)
+	var out bytes.Buffer
+	if err := writeAPIResponseTable(&out, body); err != nil {
+		t.Fatalf("writeAPIResponseTable() error = %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"id  monitor_url            monitor_active  current_state  current_severity",
+		"42  https://example.com    true            Up             0",
+		"43  https://wordpress.com  false           Paused         0",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("table missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestWriteAPIResponseTableUsesNestedWorkflowRows(t *testing.T) {
+	body := []byte(`{
+		"mode": "http-500",
+		"sites": [
+			{"site_id": 42, "action": "updated", "note": "no active events returned"},
+			{"site_id": 43, "action": "created", "error": "trigger failed"}
+		]
+	}`)
+	var out bytes.Buffer
+	if err := writeAPIResponseTable(&out, body); err != nil {
+		t.Fatalf("writeAPIResponseTable() error = %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"site_id  action   note                       error",
+		"42       updated  no active events returned",
+		"43       created                             trigger failed",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("table missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestWriteAPIResponseTableFallsBackToSortedColumns(t *testing.T) {
+	body := []byte(`{"zeta":"last","alpha":"first"}`)
+	var out bytes.Buffer
+	if err := writeAPIResponseTable(&out, body); err != nil {
+		t.Fatalf("writeAPIResponseTable() error = %v", err)
+	}
+	if got := out.String(); !strings.HasPrefix(got, "alpha  zeta\n") {
+		t.Fatalf("table = %q, want sorted fallback columns", got)
+	}
+}
+
+func TestWriteAPIOutputRejectsUnknownFormat(t *testing.T) {
+	err := writeAPIOutput(ioDiscard{}, []byte(`{"ok":true}`), apiCLIOptions{output: "yaml"})
+	if err == nil {
+		t.Fatal("writeAPIOutput() error = nil, want bad output format")
+	}
+}
+
 type ioDiscard struct{}
 
 func (ioDiscard) Write(p []byte) (int, error) {

--- a/cmd/jetmon2/api_cli_webhooks.go
+++ b/cmd/jetmon2/api_cli_webhooks.go
@@ -92,7 +92,7 @@ func cmdAPIWebhooks(args []string) error {
 func cmdAPIWebhooksList(args []string) error {
 	opts := defaultAPIOptions()
 	fs := newAPIFlagSet("api webhooks list", &opts)
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {
@@ -104,7 +104,7 @@ func cmdAPIWebhooksList(args []string) error {
 func cmdAPIWebhooksGet(args []string) error {
 	opts := defaultAPIOptions()
 	fs := newAPIFlagSet("api webhooks get", &opts)
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {
@@ -127,7 +127,7 @@ func cmdAPIWebhooksCreate(args []string) error {
 	fs.Var(&create.events, "event", "event type filter (repeatable or comma-separated)")
 	fs.Var(&create.siteIDs, "site-id", "site id filter (repeatable or comma-separated)")
 	fs.Var(&create.states, "state", "state filter (repeatable or comma-separated)")
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {
@@ -152,7 +152,7 @@ func cmdAPIWebhooksUpdate(args []string) error {
 	fs.BoolVar(&update.clearSites, "clear-sites", false, "clear site filters")
 	fs.Var(&update.states, "state", "state filter (repeatable or comma-separated)")
 	fs.BoolVar(&update.clearStates, "clear-states", false, "clear state filters")
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {
@@ -172,7 +172,7 @@ func cmdAPIWebhooksUpdate(args []string) error {
 func cmdAPIWebhooksDelete(args []string) error {
 	opts := defaultAPIOptions()
 	fs := newAPIFlagSet("api webhooks delete", &opts)
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {
@@ -189,7 +189,7 @@ func cmdAPIWebhooksRotateSecret(args []string) error {
 	opts := defaultAPIOptions()
 	fs := newAPIFlagSet("api webhooks rotate-secret", &opts)
 	addAPIIdempotencyFlag(fs, &opts)
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {
@@ -209,7 +209,7 @@ func cmdAPIWebhooksDeliveries(args []string) error {
 	fs.StringVar(&filters.cursor, "cursor", "", "pagination cursor")
 	fs.IntVar(&filters.limit, "limit", 0, "page size (1-200)")
 	fs.StringVar(&filters.status, "status", "", "delivery status: pending, delivered, failed, or abandoned")
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {
@@ -226,7 +226,7 @@ func cmdAPIWebhooksRetry(args []string) error {
 	opts := defaultAPIOptions()
 	fs := newAPIFlagSet("api webhooks retry", &opts)
 	addAPIIdempotencyFlag(fs, &opts)
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 2 {

--- a/cmd/jetmon2/api_cli_webhooks.go
+++ b/cmd/jetmon2/api_cli_webhooks.go
@@ -1,0 +1,404 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type apiWebhookCreateOptions struct {
+	url     string
+	active  apiOptionalBoolFlag
+	events  apiStringSliceFlags
+	siteIDs apiInt64SliceFlags
+	states  apiStringSliceFlags
+}
+
+type apiWebhookUpdateOptions struct {
+	url         apiOptionalStringFlag
+	active      apiOptionalBoolFlag
+	events      apiStringSliceFlags
+	clearEvents bool
+	siteIDs     apiInt64SliceFlags
+	clearSites  bool
+	states      apiStringSliceFlags
+	clearStates bool
+}
+
+type apiWebhookDeliveriesFilters struct {
+	cursor string
+	limit  int
+	status string
+}
+
+type apiWebhookSiteFilter struct {
+	SiteIDs []int64 `json:"site_ids,omitempty"`
+}
+
+type apiWebhookStateFilter struct {
+	States []string `json:"states,omitempty"`
+}
+
+type apiWebhookCreateRequest struct {
+	URL         string                `json:"url"`
+	Active      *bool                 `json:"active,omitempty"`
+	Events      []string              `json:"events"`
+	SiteFilter  apiWebhookSiteFilter  `json:"site_filter"`
+	StateFilter apiWebhookStateFilter `json:"state_filter"`
+}
+
+type apiWebhookUpdateRequest struct {
+	URL         *string                `json:"url,omitempty"`
+	Active      *bool                  `json:"active,omitempty"`
+	Events      *[]string              `json:"events,omitempty"`
+	SiteFilter  *apiWebhookSiteFilter  `json:"site_filter,omitempty"`
+	StateFilter *apiWebhookStateFilter `json:"state_filter,omitempty"`
+}
+
+func cmdAPIWebhooks(args []string) error {
+	if len(args) == 0 {
+		return errors.New("usage: jetmon2 api webhooks <list|get|create|update|delete|rotate-secret|deliveries|retry> [flags]")
+	}
+
+	sub := args[0]
+	rest := args[1:]
+	switch sub {
+	case "list":
+		return cmdAPIWebhooksList(rest)
+	case "get":
+		return cmdAPIWebhooksGet(rest)
+	case "create":
+		return cmdAPIWebhooksCreate(rest)
+	case "update":
+		return cmdAPIWebhooksUpdate(rest)
+	case "delete":
+		return cmdAPIWebhooksDelete(rest)
+	case "rotate-secret":
+		return cmdAPIWebhooksRotateSecret(rest)
+	case "deliveries":
+		return cmdAPIWebhooksDeliveries(rest)
+	case "retry":
+		return cmdAPIWebhooksRetry(rest)
+	default:
+		return fmt.Errorf("unknown api webhooks subcommand %q (want: list, get, create, update, delete, rotate-secret, deliveries, retry)", sub)
+	}
+}
+
+func cmdAPIWebhooksList(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api webhooks list", &opts)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return errors.New("usage: jetmon2 api webhooks list [flags]")
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodGet, "/api/v1/webhooks", nil)
+}
+
+func cmdAPIWebhooksGet(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api webhooks get", &opts)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return errors.New("usage: jetmon2 api webhooks get [flags] <webhook-id>")
+	}
+	target, err := apiWebhookPath(fs.Arg(0), "")
+	if err != nil {
+		return err
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodGet, target, nil)
+}
+
+func cmdAPIWebhooksCreate(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api webhooks create", &opts)
+	addAPIIdempotencyFlag(fs, &opts)
+	create := apiWebhookCreateOptions{}
+	fs.StringVar(&create.url, "url", "", "webhook destination URL")
+	fs.Var(&create.active, "active", "webhook enabled: true or false")
+	fs.Var(&create.events, "event", "event type filter (repeatable or comma-separated)")
+	fs.Var(&create.siteIDs, "site-id", "site id filter (repeatable or comma-separated)")
+	fs.Var(&create.states, "state", "state filter (repeatable or comma-separated)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return errors.New("usage: jetmon2 api webhooks create [flags]")
+	}
+	body, err := marshalAPIWebhookCreateBody(create)
+	if err != nil {
+		return err
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodPost, "/api/v1/webhooks", body)
+}
+
+func cmdAPIWebhooksUpdate(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api webhooks update", &opts)
+	update := apiWebhookUpdateOptions{}
+	fs.Var(&update.url, "url", "webhook destination URL")
+	fs.Var(&update.active, "active", "webhook enabled: true or false")
+	fs.Var(&update.events, "event", "event type filter (repeatable or comma-separated)")
+	fs.BoolVar(&update.clearEvents, "clear-events", false, "clear event filters")
+	fs.Var(&update.siteIDs, "site-id", "site id filter (repeatable or comma-separated)")
+	fs.BoolVar(&update.clearSites, "clear-sites", false, "clear site filters")
+	fs.Var(&update.states, "state", "state filter (repeatable or comma-separated)")
+	fs.BoolVar(&update.clearStates, "clear-states", false, "clear state filters")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return errors.New("usage: jetmon2 api webhooks update [flags] <webhook-id>")
+	}
+	target, err := apiWebhookPath(fs.Arg(0), "")
+	if err != nil {
+		return err
+	}
+	body, err := marshalAPIWebhookUpdateBody(update)
+	if err != nil {
+		return err
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodPatch, target, body)
+}
+
+func cmdAPIWebhooksDelete(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api webhooks delete", &opts)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return errors.New("usage: jetmon2 api webhooks delete [flags] <webhook-id>")
+	}
+	target, err := apiWebhookPath(fs.Arg(0), "")
+	if err != nil {
+		return err
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodDelete, target, nil)
+}
+
+func cmdAPIWebhooksRotateSecret(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api webhooks rotate-secret", &opts)
+	addAPIIdempotencyFlag(fs, &opts)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return errors.New("usage: jetmon2 api webhooks rotate-secret [flags] <webhook-id>")
+	}
+	target, err := apiWebhookPath(fs.Arg(0), "rotate-secret")
+	if err != nil {
+		return err
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodPost, target, nil)
+}
+
+func cmdAPIWebhooksDeliveries(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api webhooks deliveries", &opts)
+	filters := apiWebhookDeliveriesFilters{}
+	fs.StringVar(&filters.cursor, "cursor", "", "pagination cursor")
+	fs.IntVar(&filters.limit, "limit", 0, "page size (1-200)")
+	fs.StringVar(&filters.status, "status", "", "delivery status: pending, delivered, failed, or abandoned")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return errors.New("usage: jetmon2 api webhooks deliveries [flags] <webhook-id>")
+	}
+	target, err := apiWebhookDeliveriesPath(fs.Arg(0), filters)
+	if err != nil {
+		return err
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodGet, target, nil)
+}
+
+func cmdAPIWebhooksRetry(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api webhooks retry", &opts)
+	addAPIIdempotencyFlag(fs, &opts)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 2 {
+		return errors.New("usage: jetmon2 api webhooks retry [flags] <webhook-id> <delivery-id>")
+	}
+	target, err := apiWebhookRetryPath(fs.Arg(0), fs.Arg(1))
+	if err != nil {
+		return err
+	}
+	return executeAPIRequest(context.Background(), nil, opts, http.MethodPost, target, nil)
+}
+
+func apiWebhookPath(rawID, suffix string) (string, error) {
+	id, err := apiPositiveID(rawID, "webhook")
+	if err != nil {
+		return "", err
+	}
+	path := "/api/v1/webhooks/" + strconv.FormatInt(id, 10)
+	if suffix != "" {
+		path += "/" + strings.TrimPrefix(suffix, "/")
+	}
+	return path, nil
+}
+
+func apiWebhookDeliveriesPath(rawID string, filters apiWebhookDeliveriesFilters) (string, error) {
+	path, err := apiWebhookPath(rawID, "deliveries")
+	if err != nil {
+		return "", err
+	}
+	if filters.limit < 0 {
+		return "", errors.New("limit must be positive")
+	}
+
+	values := url.Values{}
+	if filters.cursor != "" {
+		values.Set("cursor", filters.cursor)
+	}
+	if filters.limit > 0 {
+		values.Set("limit", strconv.Itoa(filters.limit))
+	}
+	if filters.status != "" {
+		switch filters.status {
+		case "pending", "delivered", "failed", "abandoned":
+			values.Set("status", filters.status)
+		default:
+			return "", errors.New("status must be one of: pending, delivered, failed, abandoned")
+		}
+	}
+	if len(values) == 0 {
+		return path, nil
+	}
+	return path + "?" + values.Encode(), nil
+}
+
+func apiWebhookRetryPath(rawWebhookID, rawDeliveryID string) (string, error) {
+	webhookID, err := apiPositiveID(rawWebhookID, "webhook")
+	if err != nil {
+		return "", err
+	}
+	deliveryID, err := apiPositiveID(rawDeliveryID, "delivery")
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("/api/v1/webhooks/%d/deliveries/%d/retry", webhookID, deliveryID), nil
+}
+
+func marshalAPIWebhookCreateBody(opts apiWebhookCreateOptions) ([]byte, error) {
+	if strings.TrimSpace(opts.url) == "" {
+		return nil, errors.New("url is required")
+	}
+	req := apiWebhookCreateRequest{
+		URL:         opts.url,
+		Active:      opts.active.ptr(),
+		Events:      opts.events.valuesOrEmpty(),
+		SiteFilter:  apiWebhookSiteFilter{SiteIDs: opts.siteIDs.valuesOrEmpty()},
+		StateFilter: apiWebhookStateFilter{States: opts.states.valuesOrEmpty()},
+	}
+	return json.Marshal(req)
+}
+
+func marshalAPIWebhookUpdateBody(opts apiWebhookUpdateOptions) ([]byte, error) {
+	if opts.clearEvents && opts.events.set {
+		return nil, errors.New("use --event or --clear-events, not both")
+	}
+	if opts.clearSites && opts.siteIDs.set {
+		return nil, errors.New("use --site-id or --clear-sites, not both")
+	}
+	if opts.clearStates && opts.states.set {
+		return nil, errors.New("use --state or --clear-states, not both")
+	}
+
+	req := apiWebhookUpdateRequest{
+		URL:    opts.url.ptr(),
+		Active: opts.active.ptr(),
+	}
+	if opts.events.set || opts.clearEvents {
+		events := opts.events.valuesOrEmpty()
+		req.Events = &events
+	}
+	if opts.siteIDs.set || opts.clearSites {
+		req.SiteFilter = &apiWebhookSiteFilter{SiteIDs: opts.siteIDs.valuesOrEmpty()}
+	}
+	if opts.states.set || opts.clearStates {
+		req.StateFilter = &apiWebhookStateFilter{States: opts.states.valuesOrEmpty()}
+	}
+	return json.Marshal(req)
+}
+
+type apiStringSliceFlags struct {
+	values []string
+	set    bool
+}
+
+func (f *apiStringSliceFlags) Set(v string) error {
+	for _, part := range strings.Split(v, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		f.values = append(f.values, part)
+		f.set = true
+	}
+	return nil
+}
+
+func (f *apiStringSliceFlags) String() string {
+	return strings.Join(f.values, ",")
+}
+
+func (f apiStringSliceFlags) valuesOrEmpty() []string {
+	if !f.set {
+		return []string{}
+	}
+	out := make([]string, len(f.values))
+	copy(out, f.values)
+	return out
+}
+
+type apiInt64SliceFlags struct {
+	values []int64
+	set    bool
+}
+
+func (f *apiInt64SliceFlags) Set(v string) error {
+	for _, part := range strings.Split(v, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		id, err := apiPositiveID(part, "site")
+		if err != nil {
+			return err
+		}
+		f.values = append(f.values, id)
+		f.set = true
+	}
+	return nil
+}
+
+func (f *apiInt64SliceFlags) String() string {
+	parts := make([]string, len(f.values))
+	for i, v := range f.values {
+		parts[i] = strconv.FormatInt(v, 10)
+	}
+	return strings.Join(parts, ",")
+}
+
+func (f apiInt64SliceFlags) valuesOrEmpty() []int64 {
+	if !f.set {
+		return []int64{}
+	}
+	out := make([]int64, len(f.values))
+	copy(out, f.values)
+	return out
+}

--- a/cmd/jetmon2/api_cli_webhooks_test.go
+++ b/cmd/jetmon2/api_cli_webhooks_test.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"encoding/json"
+	"net/url"
+	"testing"
+)
+
+func TestMarshalAPIWebhookCreateBody(t *testing.T) {
+	var active apiOptionalBoolFlag
+	setTestFlag(t, &active, "false")
+	var events apiStringSliceFlags
+	setTestFlag(t, &events, "event.opened,event.closed")
+	var siteIDs apiInt64SliceFlags
+	setTestFlag(t, &siteIDs, "42,99")
+	var states apiStringSliceFlags
+	setTestFlag(t, &states, "Down")
+
+	body, err := marshalAPIWebhookCreateBody(apiWebhookCreateOptions{
+		url:     "https://example.com/hook",
+		active:  active,
+		events:  events,
+		siteIDs: siteIDs,
+		states:  states,
+	})
+	if err != nil {
+		t.Fatalf("marshalAPIWebhookCreateBody() error = %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if got["url"] != "https://example.com/hook" {
+		t.Fatalf("url = %#v", got["url"])
+	}
+	if got["active"] != false {
+		t.Fatalf("active = %#v, want false", got["active"])
+	}
+	assertStringArray(t, got["events"], []string{"event.opened", "event.closed"})
+	siteFilter := got["site_filter"].(map[string]any)
+	assertNumberArray(t, siteFilter["site_ids"], []int64{42, 99})
+	stateFilter := got["state_filter"].(map[string]any)
+	assertStringArray(t, stateFilter["states"], []string{"Down"})
+}
+
+func TestMarshalAPIWebhookCreateBodyDefaultsFiltersToMatchAll(t *testing.T) {
+	body, err := marshalAPIWebhookCreateBody(apiWebhookCreateOptions{
+		url: "https://example.com/hook",
+	})
+	if err != nil {
+		t.Fatalf("marshalAPIWebhookCreateBody() error = %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	assertStringArray(t, got["events"], []string{})
+	if _, ok := got["site_filter"].(map[string]any)["site_ids"]; ok {
+		t.Fatalf("site_ids present in empty site_filter: %#v", got["site_filter"])
+	}
+	if _, ok := got["state_filter"].(map[string]any)["states"]; ok {
+		t.Fatalf("states present in empty state_filter: %#v", got["state_filter"])
+	}
+}
+
+func TestMarshalAPIWebhookUpdateBodySupportsClears(t *testing.T) {
+	body, err := marshalAPIWebhookUpdateBody(apiWebhookUpdateOptions{
+		clearEvents: true,
+		clearSites:  true,
+		clearStates: true,
+	})
+	if err != nil {
+		t.Fatalf("marshalAPIWebhookUpdateBody() error = %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	assertStringArray(t, got["events"], []string{})
+	if _, ok := got["site_filter"].(map[string]any)["site_ids"]; ok {
+		t.Fatalf("site_ids present in cleared site_filter: %#v", got["site_filter"])
+	}
+	if _, ok := got["state_filter"].(map[string]any)["states"]; ok {
+		t.Fatalf("states present in cleared state_filter: %#v", got["state_filter"])
+	}
+}
+
+func TestMarshalAPIWebhookUpdateBodyRejectsClearConflicts(t *testing.T) {
+	var events apiStringSliceFlags
+	setTestFlag(t, &events, "event.opened")
+	if _, err := marshalAPIWebhookUpdateBody(apiWebhookUpdateOptions{events: events, clearEvents: true}); err == nil {
+		t.Fatal("events conflict error = nil, want error")
+	}
+
+	var siteIDs apiInt64SliceFlags
+	setTestFlag(t, &siteIDs, "42")
+	if _, err := marshalAPIWebhookUpdateBody(apiWebhookUpdateOptions{siteIDs: siteIDs, clearSites: true}); err == nil {
+		t.Fatal("sites conflict error = nil, want error")
+	}
+
+	var states apiStringSliceFlags
+	setTestFlag(t, &states, "Down")
+	if _, err := marshalAPIWebhookUpdateBody(apiWebhookUpdateOptions{states: states, clearStates: true}); err == nil {
+		t.Fatal("states conflict error = nil, want error")
+	}
+}
+
+func TestAPIWebhookPaths(t *testing.T) {
+	got, err := apiWebhookPath("7", "rotate-secret")
+	if err != nil {
+		t.Fatalf("apiWebhookPath() error = %v", err)
+	}
+	if got != "/api/v1/webhooks/7/rotate-secret" {
+		t.Fatalf("path = %q, want rotate-secret path", got)
+	}
+
+	got, err = apiWebhookRetryPath("7", "44")
+	if err != nil {
+		t.Fatalf("apiWebhookRetryPath() error = %v", err)
+	}
+	if got != "/api/v1/webhooks/7/deliveries/44/retry" {
+		t.Fatalf("retry path = %q, want delivery retry path", got)
+	}
+}
+
+func TestAPIWebhookDeliveriesPath(t *testing.T) {
+	got, err := apiWebhookDeliveriesPath("7", apiWebhookDeliveriesFilters{
+		cursor: "cur-4",
+		limit:  25,
+		status: "abandoned",
+	})
+	if err != nil {
+		t.Fatalf("apiWebhookDeliveriesPath() error = %v", err)
+	}
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("parse path: %v", err)
+	}
+	if u.Path != "/api/v1/webhooks/7/deliveries" {
+		t.Fatalf("path = %q, want deliveries path", u.Path)
+	}
+	for key, want := range map[string]string{
+		"cursor": "cur-4",
+		"limit":  "25",
+		"status": "abandoned",
+	} {
+		if got := u.Query().Get(key); got != want {
+			t.Fatalf("query %s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestAPIWebhookDeliveriesPathRejectsBadStatus(t *testing.T) {
+	_, err := apiWebhookDeliveriesPath("7", apiWebhookDeliveriesFilters{status: "waiting"})
+	if err == nil {
+		t.Fatal("apiWebhookDeliveriesPath() error = nil, want bad status error")
+	}
+}
+
+func assertStringArray(t *testing.T, got any, want []string) {
+	t.Helper()
+	items, ok := got.([]any)
+	if !ok {
+		t.Fatalf("value = %#v, want JSON array", got)
+	}
+	if len(items) != len(want) {
+		t.Fatalf("array len = %d, want %d: %#v", len(items), len(want), items)
+	}
+	for i, wantItem := range want {
+		if items[i] != wantItem {
+			t.Fatalf("array[%d] = %#v, want %q", i, items[i], wantItem)
+		}
+	}
+}
+
+func assertNumberArray(t *testing.T, got any, want []int64) {
+	t.Helper()
+	items, ok := got.([]any)
+	if !ok {
+		t.Fatalf("value = %#v, want JSON array", got)
+	}
+	if len(items) != len(want) {
+		t.Fatalf("array len = %d, want %d: %#v", len(items), len(want), items)
+	}
+	for i, wantItem := range want {
+		if items[i] != float64(wantItem) {
+			t.Fatalf("array[%d] = %#v, want %d", i, items[i], wantItem)
+		}
+	}
+}

--- a/cmd/jetmon2/api_cli_workflows.go
+++ b/cmd/jetmon2/api_cli_workflows.go
@@ -26,7 +26,6 @@ type apiSmokeOptions struct {
 	blogID               int64
 	url                  string
 	cleanup              bool
-	allowRemote          bool
 	exercise             string
 	idempotencyKeyPrefix string
 }
@@ -88,7 +87,6 @@ func cmdAPISmoke(args []string) error {
 	fs.Int64Var(&smoke.blogID, "blog-id", 0, "specific blog_id to create; default derives from --batch")
 	fs.StringVar(&smoke.url, "url", smoke.url, "site monitor URL to create")
 	fs.BoolVar(&smoke.cleanup, "cleanup", smoke.cleanup, "delete smoke-created resources before exit")
-	fs.BoolVar(&smoke.allowRemote, "allow-remote", false, "allow smoke-created resources on a non-local API base URL")
 	fs.StringVar(&smoke.exercise, "exercise", smoke.exercise, "extra path to exercise: alert-contact or none")
 	fs.StringVar(&smoke.idempotencyKeyPrefix, "idempotency-key-prefix", "", "prefix for smoke POST Idempotency-Key headers")
 	if err := parseAPIFlags(fs, args); err != nil {
@@ -104,7 +102,7 @@ func runAPISmoke(ctx context.Context, client *http.Client, opts apiCLIOptions, s
 	if opts.out == nil {
 		opts.out = io.Discard
 	}
-	remote, err := requireAPILocalOrAllowRemote(opts, smoke.allowRemote, "api smoke")
+	remote, err := requireAPILocalOrAllowRemote(opts, opts.allowRemote, "api smoke")
 	if err != nil {
 		return err
 	}

--- a/cmd/jetmon2/api_cli_workflows.go
+++ b/cmd/jetmon2/api_cli_workflows.go
@@ -1,0 +1,327 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	apiCLIBatchHeader       = "X-Jetmon-CLI-Batch"
+	apiSmokeDefaultURL      = "https://example.com/"
+	apiSmokeDefaultKeyword  = "Example Domain"
+	apiSmokeAlertTestEmail  = "jetmon-api-cli@example.invalid"
+	apiSmokeDefaultExercise = "alert-contact"
+)
+
+type apiSmokeOptions struct {
+	batch                string
+	blogID               int64
+	url                  string
+	cleanup              bool
+	exercise             string
+	idempotencyKeyPrefix string
+}
+
+type apiSmokeSummary struct {
+	Batch          string                  `json:"batch"`
+	BlogID         int64                   `json:"blog_id"`
+	BaseURL        string                  `json:"base_url"`
+	Cleanup        bool                    `json:"cleanup"`
+	Steps          []apiSmokeStep          `json:"steps"`
+	Site           json.RawMessage         `json:"site,omitempty"`
+	TriggerNow     json.RawMessage         `json:"trigger_now,omitempty"`
+	Events         json.RawMessage         `json:"events,omitempty"`
+	AlertContact   json.RawMessage         `json:"alert_contact,omitempty"`
+	AlertTest      json.RawMessage         `json:"alert_test,omitempty"`
+	CleanupResults []apiSmokeCleanupResult `json:"cleanup_results,omitempty"`
+}
+
+type apiSmokeStep struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Detail string `json:"detail,omitempty"`
+}
+
+type apiSmokeCleanupResult struct {
+	Resource string `json:"resource"`
+	ID       int64  `json:"id"`
+	Status   string `json:"status"`
+	Error    string `json:"error,omitempty"`
+}
+
+type apiWorkflowHTTPError struct {
+	Method string
+	Target string
+	Status string
+	Body   []byte
+}
+
+func (e apiWorkflowHTTPError) Error() string {
+	body := strings.TrimSpace(string(e.Body))
+	if len(body) > 300 {
+		body = body[:300] + "..."
+	}
+	if body == "" {
+		return fmt.Sprintf("%s %s returned %s", e.Method, e.Target, e.Status)
+	}
+	return fmt.Sprintf("%s %s returned %s: %s", e.Method, e.Target, e.Status, body)
+}
+
+func cmdAPISmoke(args []string) error {
+	opts := defaultAPIOptions()
+	fs := newAPIFlagSet("api smoke", &opts)
+	smoke := apiSmokeOptions{
+		url:      apiSmokeDefaultURL,
+		cleanup:  true,
+		exercise: apiSmokeDefaultExercise,
+	}
+	fs.StringVar(&smoke.batch, "batch", "", "stable batch label for generated test resources")
+	fs.Int64Var(&smoke.blogID, "blog-id", 0, "specific blog_id to create; default derives from --batch")
+	fs.StringVar(&smoke.url, "url", smoke.url, "site monitor URL to create")
+	fs.BoolVar(&smoke.cleanup, "cleanup", smoke.cleanup, "delete smoke-created resources before exit")
+	fs.StringVar(&smoke.exercise, "exercise", smoke.exercise, "extra path to exercise: alert-contact or none")
+	fs.StringVar(&smoke.idempotencyKeyPrefix, "idempotency-key-prefix", "", "prefix for smoke POST Idempotency-Key headers")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return errors.New("usage: jetmon2 api smoke [flags]")
+	}
+	return runAPISmoke(context.Background(), nil, opts, smoke)
+}
+
+func runAPISmoke(ctx context.Context, client *http.Client, opts apiCLIOptions, smoke apiSmokeOptions) error {
+	if opts.out == nil {
+		opts.out = io.Discard
+	}
+	if smoke.batch == "" {
+		smoke.batch = apiCLINewBatchID("smoke")
+	}
+	if smoke.blogID == 0 {
+		smoke.blogID = apiCLIBatchBlogIDStart(smoke.batch)
+	}
+	if smoke.url == "" {
+		smoke.url = apiSmokeDefaultURL
+	}
+	if smoke.exercise == "" {
+		smoke.exercise = apiSmokeDefaultExercise
+	}
+	if smoke.exercise != "alert-contact" && smoke.exercise != "none" {
+		return errors.New("exercise must be one of: alert-contact, none")
+	}
+
+	summary := apiSmokeSummary{
+		Batch:   smoke.batch,
+		BlogID:  smoke.blogID,
+		BaseURL: opts.baseURL,
+		Cleanup: smoke.cleanup,
+	}
+	var createdContactID int64
+	siteCreated := false
+
+	cleanup := func() {
+		if !smoke.cleanup {
+			return
+		}
+		if createdContactID > 0 {
+			target := "/api/v1/alert-contacts/" + strconv.FormatInt(createdContactID, 10)
+			err := apiWorkflowDelete(ctx, client, opts, target)
+			result := apiSmokeCleanupResult{Resource: "alert_contact", ID: createdContactID, Status: "deleted"}
+			if err != nil {
+				result.Status = "failed"
+				result.Error = err.Error()
+			}
+			summary.CleanupResults = append(summary.CleanupResults, result)
+		}
+		if siteCreated {
+			target := "/api/v1/sites/" + strconv.FormatInt(smoke.blogID, 10)
+			err := apiWorkflowDelete(ctx, client, opts, target)
+			result := apiSmokeCleanupResult{Resource: "site", ID: smoke.blogID, Status: "deleted"}
+			if err != nil {
+				result.Status = "failed"
+				result.Error = err.Error()
+			}
+			summary.CleanupResults = append(summary.CleanupResults, result)
+		}
+	}
+
+	step := func(name string, fn func() error) error {
+		if err := fn(); err != nil {
+			summary.Steps = append(summary.Steps, apiSmokeStep{Name: name, Status: "failed", Detail: err.Error()})
+			cleanup()
+			_ = writeAPIJSON(opts.out, summary, opts.pretty)
+			return fmt.Errorf("smoke %s failed: %w", name, err)
+		}
+		summary.Steps = append(summary.Steps, apiSmokeStep{Name: name, Status: "ok"})
+		return nil
+	}
+
+	if err := step("health", func() error {
+		_, err := apiWorkflowRequestJSON(ctx, client, opts, http.MethodGet, "/api/v1/health", nil, "")
+		return err
+	}); err != nil {
+		return err
+	}
+	if err := step("me", func() error {
+		_, err := apiWorkflowRequestJSON(ctx, client, opts, http.MethodGet, "/api/v1/me", nil, "")
+		return err
+	}); err != nil {
+		return err
+	}
+	if err := step("create_site", func() error {
+		keyword := apiSmokeDefaultKeyword
+		redirectPolicy := "follow"
+		checkInterval := 5
+		headers := map[string]string{apiCLIBatchHeader: smoke.batch}
+		site, err := apiWorkflowRequestJSON(ctx, client, opts, http.MethodPost, "/api/v1/sites", apiSiteCreateRequest{
+			BlogID:         smoke.blogID,
+			MonitorURL:     smoke.url,
+			CheckKeyword:   &keyword,
+			RedirectPolicy: &redirectPolicy,
+			CheckInterval:  &checkInterval,
+			CustomHeaders:  &headers,
+		}, apiSmokeIDKey(smoke, "create-site"))
+		if err != nil {
+			return err
+		}
+		siteCreated = true
+		summary.Site = site
+		return nil
+	}); err != nil {
+		return err
+	}
+	if err := step("trigger_now", func() error {
+		body, err := apiWorkflowRequestJSON(ctx, client, opts, http.MethodPost, fmt.Sprintf("/api/v1/sites/%d/trigger-now", smoke.blogID), nil, apiSmokeIDKey(smoke, "trigger-now"))
+		if err != nil {
+			return err
+		}
+		summary.TriggerNow = body
+		return nil
+	}); err != nil {
+		return err
+	}
+	if err := step("events", func() error {
+		body, err := apiWorkflowRequestJSON(ctx, client, opts, http.MethodGet, fmt.Sprintf("/api/v1/sites/%d/events?limit=5", smoke.blogID), nil, "")
+		if err != nil {
+			return err
+		}
+		summary.Events = body
+		return nil
+	}); err != nil {
+		return err
+	}
+	if smoke.exercise == "alert-contact" {
+		if err := step("create_alert_contact", func() error {
+			contact, err := apiWorkflowRequestJSON(ctx, client, opts, http.MethodPost, "/api/v1/alert-contacts", apiAlertContactCreateRequest{
+				Label:       "api-cli-smoke-" + smoke.batch,
+				Transport:   "email",
+				Destination: json.RawMessage(`{"address":"` + apiSmokeAlertTestEmail + `"}`),
+				SiteFilter:  apiAlertContactSiteFilter{SiteIDs: []int64{smoke.blogID}},
+			}, apiSmokeIDKey(smoke, "create-alert-contact"))
+			if err != nil {
+				return err
+			}
+			id, err := apiJSONInt64(contact, "id")
+			if err != nil {
+				return err
+			}
+			createdContactID = id
+			summary.AlertContact = contact
+			return nil
+		}); err != nil {
+			return err
+		}
+		if err := step("alert_contact_test", func() error {
+			body, err := apiWorkflowRequestJSON(ctx, client, opts, http.MethodPost, fmt.Sprintf("/api/v1/alert-contacts/%d/test", createdContactID), nil, apiSmokeIDKey(smoke, "alert-contact-test"))
+			if err != nil {
+				return err
+			}
+			summary.AlertTest = body
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+
+	cleanup()
+	return writeAPIJSON(opts.out, summary, opts.pretty)
+}
+
+func apiWorkflowRequestJSON(ctx context.Context, client *http.Client, opts apiCLIOptions, method, target string, body any, idempotencyKey string) (json.RawMessage, error) {
+	var payload []byte
+	var err error
+	if body != nil {
+		payload, err = json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	requestOpts := opts
+	requestOpts.idempotencyKey = idempotencyKey
+	resp, err := doAPIRequest(ctx, client, requestOpts, method, target, payload)
+	if err != nil {
+		return nil, err
+	}
+	trimmed := json.RawMessage(strings.TrimSpace(string(resp.Body)))
+	if len(trimmed) == 0 {
+		trimmed = json.RawMessage(`null`)
+	}
+	if resp.StatusCode >= 400 {
+		return trimmed, apiWorkflowHTTPError{Method: method, Target: target, Status: resp.Status, Body: resp.Body}
+	}
+	return trimmed, nil
+}
+
+func apiWorkflowDelete(ctx context.Context, client *http.Client, opts apiCLIOptions, target string) error {
+	resp, err := doAPIRequest(ctx, client, opts, http.MethodDelete, target, nil)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode >= 400 {
+		return apiWorkflowHTTPError{Method: http.MethodDelete, Target: target, Status: resp.Status, Body: resp.Body}
+	}
+	return nil
+}
+
+func apiJSONInt64(body json.RawMessage, field string) (int64, error) {
+	var obj map[string]any
+	if err := json.Unmarshal(body, &obj); err != nil {
+		return 0, err
+	}
+	raw, ok := obj[field]
+	if !ok {
+		return 0, fmt.Errorf("response missing %q", field)
+	}
+	switch v := raw.(type) {
+	case float64:
+		return int64(v), nil
+	default:
+		return 0, fmt.Errorf("response field %q is %T, want number", field, raw)
+	}
+}
+
+func apiSmokeIDKey(smoke apiSmokeOptions, suffix string) string {
+	if smoke.idempotencyKeyPrefix == "" {
+		return ""
+	}
+	return smoke.idempotencyKeyPrefix + "-" + suffix
+}
+
+func apiCLINewBatchID(prefix string) string {
+	return fmt.Sprintf("%s-%s", prefix, time.Now().UTC().Format("20060102T150405Z"))
+}
+
+func apiCLIBatchBlogIDStart(batch string) int64 {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(batch))
+	// Reserve a deterministic 1,000-id slot in the high local-test range.
+	return 910000000 + int64(h.Sum32()%90000)*1000
+}

--- a/cmd/jetmon2/api_cli_workflows.go
+++ b/cmd/jetmon2/api_cli_workflows.go
@@ -89,7 +89,7 @@ func cmdAPISmoke(args []string) error {
 	fs.BoolVar(&smoke.cleanup, "cleanup", smoke.cleanup, "delete smoke-created resources before exit")
 	fs.StringVar(&smoke.exercise, "exercise", smoke.exercise, "extra path to exercise: alert-contact or none")
 	fs.StringVar(&smoke.idempotencyKeyPrefix, "idempotency-key-prefix", "", "prefix for smoke POST Idempotency-Key headers")
-	if err := fs.Parse(args); err != nil {
+	if err := parseAPIFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {

--- a/cmd/jetmon2/api_cli_workflows.go
+++ b/cmd/jetmon2/api_cli_workflows.go
@@ -26,6 +26,7 @@ type apiSmokeOptions struct {
 	blogID               int64
 	url                  string
 	cleanup              bool
+	allowRemote          bool
 	exercise             string
 	idempotencyKeyPrefix string
 }
@@ -87,6 +88,7 @@ func cmdAPISmoke(args []string) error {
 	fs.Int64Var(&smoke.blogID, "blog-id", 0, "specific blog_id to create; default derives from --batch")
 	fs.StringVar(&smoke.url, "url", smoke.url, "site monitor URL to create")
 	fs.BoolVar(&smoke.cleanup, "cleanup", smoke.cleanup, "delete smoke-created resources before exit")
+	fs.BoolVar(&smoke.allowRemote, "allow-remote", false, "allow smoke-created resources on a non-local API base URL")
 	fs.StringVar(&smoke.exercise, "exercise", smoke.exercise, "extra path to exercise: alert-contact or none")
 	fs.StringVar(&smoke.idempotencyKeyPrefix, "idempotency-key-prefix", "", "prefix for smoke POST Idempotency-Key headers")
 	if err := parseAPIFlags(fs, args); err != nil {
@@ -101,6 +103,9 @@ func cmdAPISmoke(args []string) error {
 func runAPISmoke(ctx context.Context, client *http.Client, opts apiCLIOptions, smoke apiSmokeOptions) error {
 	if opts.out == nil {
 		opts.out = io.Discard
+	}
+	if _, err := requireAPILocalOrAllowRemote(opts, smoke.allowRemote, "api smoke"); err != nil {
+		return err
 	}
 	if smoke.batch == "" {
 		smoke.batch = apiCLINewBatchID("smoke")

--- a/cmd/jetmon2/api_cli_workflows.go
+++ b/cmd/jetmon2/api_cli_workflows.go
@@ -157,7 +157,7 @@ func runAPISmoke(ctx context.Context, client *http.Client, opts apiCLIOptions, s
 		if err := fn(); err != nil {
 			summary.Steps = append(summary.Steps, apiSmokeStep{Name: name, Status: "failed", Detail: err.Error()})
 			cleanup()
-			_ = writeAPIJSON(opts.out, summary, opts.pretty)
+			_ = writeAPIValueOutput(opts.out, summary, opts)
 			return fmt.Errorf("smoke %s failed: %w", name, err)
 		}
 		summary.Steps = append(summary.Steps, apiSmokeStep{Name: name, Status: "ok"})
@@ -252,7 +252,7 @@ func runAPISmoke(ctx context.Context, client *http.Client, opts apiCLIOptions, s
 	}
 
 	cleanup()
-	return writeAPIJSON(opts.out, summary, opts.pretty)
+	return writeAPIValueOutput(opts.out, summary, opts)
 }
 
 func apiWorkflowRequestJSON(ctx context.Context, client *http.Client, opts apiCLIOptions, method, target string, body any, idempotencyKey string) (json.RawMessage, error) {

--- a/cmd/jetmon2/api_cli_workflows.go
+++ b/cmd/jetmon2/api_cli_workflows.go
@@ -104,8 +104,12 @@ func runAPISmoke(ctx context.Context, client *http.Client, opts apiCLIOptions, s
 	if opts.out == nil {
 		opts.out = io.Discard
 	}
-	if _, err := requireAPILocalOrAllowRemote(opts, smoke.allowRemote, "api smoke"); err != nil {
+	remote, err := requireAPILocalOrAllowRemote(opts, smoke.allowRemote, "api smoke")
+	if err != nil {
 		return err
+	}
+	if remote && strings.TrimSpace(smoke.batch) == "" {
+		return errors.New("api smoke requires --batch when --allow-remote targets a non-local API")
 	}
 	if smoke.batch == "" {
 		smoke.batch = apiCLINewBatchID("smoke")

--- a/cmd/jetmon2/api_cli_workflows_test.go
+++ b/cmd/jetmon2/api_cli_workflows_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunAPISmokeHappyPath(t *testing.T) {
+	var calls []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls = append(calls, r.Method+" "+r.URL.Path)
+		if r.URL.Path != "/api/v1/health" && r.Header.Get("Authorization") != "Bearer token-123" {
+			t.Fatalf("missing auth for %s %s", r.Method, r.URL.Path)
+		}
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/health":
+			writeTestJSON(t, w, map[string]string{"status": "ok"})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/me":
+			writeTestJSON(t, w, map[string]any{"consumer_name": "api-cli-test", "scope": "admin"})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sites":
+			var body map[string]any
+			decodeTestJSON(t, r, &body)
+			if body["blog_id"] != float64(910) {
+				t.Fatalf("blog_id = %#v, want 910", body["blog_id"])
+			}
+			headers := body["custom_headers"].(map[string]any)
+			if headers[apiCLIBatchHeader] != "smoke-test" {
+				t.Fatalf("batch header = %#v, want smoke-test", headers[apiCLIBatchHeader])
+			}
+			writeTestStatusJSON(t, w, http.StatusCreated, map[string]any{"id": 910, "blog_id": 910})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sites/910/trigger-now":
+			writeTestJSON(t, w, map[string]any{"result": map[string]any{"success": true}})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/sites/910/events":
+			writeTestJSON(t, w, map[string]any{"data": []any{}, "page": map[string]any{"limit": 5}})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/alert-contacts":
+			writeTestStatusJSON(t, w, http.StatusCreated, map[string]any{"id": 77, "label": "api-cli-smoke-smoke-test"})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/alert-contacts/77/test":
+			writeTestJSON(t, w, map[string]any{"contact_id": 77, "delivered": true})
+		case r.Method == http.MethodDelete && r.URL.Path == "/api/v1/alert-contacts/77":
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodDelete && r.URL.Path == "/api/v1/sites/910":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	var stdout bytes.Buffer
+	err := runAPISmoke(context.Background(), srv.Client(), apiCLIOptions{
+		baseURL: srv.URL,
+		token:   "token-123",
+		timeout: time.Second,
+		out:     &stdout,
+		errOut:  ioDiscard{},
+	}, apiSmokeOptions{
+		batch:    "smoke-test",
+		blogID:   910,
+		url:      "https://example.com/",
+		cleanup:  true,
+		exercise: "alert-contact",
+	})
+	if err != nil {
+		t.Fatalf("runAPISmoke() error = %v\nstdout=%s", err, stdout.String())
+	}
+
+	var summary apiSmokeSummary
+	if err := json.Unmarshal(stdout.Bytes(), &summary); err != nil {
+		t.Fatalf("unmarshal summary: %v\n%s", err, stdout.String())
+	}
+	if summary.Batch != "smoke-test" || summary.BlogID != 910 {
+		t.Fatalf("summary batch/id = %q/%d", summary.Batch, summary.BlogID)
+	}
+	if len(summary.Steps) != 7 {
+		t.Fatalf("steps = %#v, want 7 steps", summary.Steps)
+	}
+	for _, step := range summary.Steps {
+		if step.Status != "ok" {
+			t.Fatalf("step %#v, want ok", step)
+		}
+	}
+	if len(summary.CleanupResults) != 2 {
+		t.Fatalf("cleanup results = %#v, want contact and site cleanup", summary.CleanupResults)
+	}
+	wantCalls := []string{
+		"GET /api/v1/health",
+		"GET /api/v1/me",
+		"POST /api/v1/sites",
+		"POST /api/v1/sites/910/trigger-now",
+		"GET /api/v1/sites/910/events",
+		"POST /api/v1/alert-contacts",
+		"POST /api/v1/alert-contacts/77/test",
+		"DELETE /api/v1/alert-contacts/77",
+		"DELETE /api/v1/sites/910",
+	}
+	if strings.Join(calls, "\n") != strings.Join(wantCalls, "\n") {
+		t.Fatalf("calls:\n%s\nwant:\n%s", strings.Join(calls, "\n"), strings.Join(wantCalls, "\n"))
+	}
+}
+
+func TestRunAPISmokeWritesFailureSummary(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/health":
+			writeTestJSON(t, w, map[string]string{"status": "ok"})
+		case "/api/v1/me":
+			writeTestStatusJSON(t, w, http.StatusUnauthorized, map[string]string{"error": "missing token"})
+		default:
+			t.Fatalf("unexpected request: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	var stdout bytes.Buffer
+	err := runAPISmoke(context.Background(), srv.Client(), apiCLIOptions{
+		baseURL: srv.URL,
+		timeout: time.Second,
+		out:     &stdout,
+		errOut:  ioDiscard{},
+	}, apiSmokeOptions{
+		batch:    "smoke-failure",
+		blogID:   911,
+		cleanup:  true,
+		exercise: "none",
+	})
+	if err == nil {
+		t.Fatal("runAPISmoke() error = nil, want auth failure")
+	}
+	var summary apiSmokeSummary
+	if err := json.Unmarshal(stdout.Bytes(), &summary); err != nil {
+		t.Fatalf("unmarshal summary: %v\n%s", err, stdout.String())
+	}
+	if len(summary.Steps) != 2 {
+		t.Fatalf("steps = %#v, want health + failed me", summary.Steps)
+	}
+	if summary.Steps[1].Name != "me" || summary.Steps[1].Status != "failed" {
+		t.Fatalf("failed step = %#v, want me failed", summary.Steps[1])
+	}
+}
+
+func TestAPICLIBatchBlogIDStartStable(t *testing.T) {
+	first := apiCLIBatchBlogIDStart("batch-a")
+	second := apiCLIBatchBlogIDStart("batch-a")
+	if first != second {
+		t.Fatalf("batch id start not stable: %d != %d", first, second)
+	}
+	if first < 910000000 || first >= 1000000000 {
+		t.Fatalf("batch id start = %d, want high local-test range", first)
+	}
+}
+
+func decodeTestJSON(t *testing.T, r *http.Request, v any) {
+	t.Helper()
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		t.Fatalf("decode request body: %v", err)
+	}
+}
+
+func writeTestJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	writeTestStatusJSON(t, w, http.StatusOK, v)
+}
+
+func writeTestStatusJSON(t *testing.T, w http.ResponseWriter, status int, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+}

--- a/cmd/jetmon2/main.go
+++ b/cmd/jetmon2/main.go
@@ -59,6 +59,8 @@ func main() {
 		cmdReload()
 	case "keys":
 		cmdKeys(os.Args[2:])
+	case "api":
+		cmdAPI(os.Args[2:])
 	case "site-tenants":
 		cmdSiteTenants(os.Args[2:])
 	case "rollout":

--- a/cmd/jetmon2/testdata/README.md
+++ b/cmd/jetmon2/testdata/README.md
@@ -1,0 +1,14 @@
+# API CLI Site Fixture
+
+`api-cli-sites.json` is the embedded default source for:
+
+```bash
+jetmon2 api sites bulk-add --count <n>
+```
+
+The list is intentionally small and local-test oriented. It mixes always-up
+targets, redirects, slow responses, HTTP error responses, TLS/certificate
+failures, custom-header checks, and keyword checks so Docker API testing can
+exercise more than one site behavior without inventing fake public domains.
+
+Do not use this fixture as a production monitoring seed list.

--- a/cmd/jetmon2/testdata/api-cli-sites.json
+++ b/cmd/jetmon2/testdata/api-cli-sites.json
@@ -1,0 +1,51 @@
+[
+  {
+    "monitor_url": "https://example.com/",
+    "check_keyword": "Example Domain",
+    "redirect_policy": "follow",
+    "check_interval": 5
+  },
+  {
+    "monitor_url": "https://wordpress.com/",
+    "check_keyword": "WordPress",
+    "redirect_policy": "follow",
+    "check_interval": 5
+  },
+  {
+    "monitor_url": "https://httpbin.org/status/204",
+    "redirect_policy": "follow"
+  },
+  {
+    "monitor_url": "https://httpbin.org/status/404",
+    "redirect_policy": "follow"
+  },
+  {
+    "monitor_url": "https://httpbin.org/status/500",
+    "redirect_policy": "follow"
+  },
+  {
+    "monitor_url": "https://httpbin.org/delay/3",
+    "timeout_seconds": 5,
+    "redirect_policy": "follow"
+  },
+  {
+    "monitor_url": "https://httpbin.org/redirect-to?url=https%3A%2F%2Fexample.com%2F",
+    "redirect_policy": "alert"
+  },
+  {
+    "monitor_url": "https://httpbin.org/headers",
+    "check_keyword": "X-Jetmon-CLI",
+    "custom_headers": {
+      "X-Jetmon-CLI": "fixture"
+    },
+    "redirect_policy": "follow"
+  },
+  {
+    "monitor_url": "https://expired.badssl.com/",
+    "redirect_policy": "follow"
+  },
+  {
+    "monitor_url": "https://wrong.host.badssl.com/",
+    "redirect_policy": "follow"
+  }
+]

--- a/docker/.env-sample
+++ b/docker/.env-sample
@@ -29,6 +29,11 @@ VERIFLIER_HOST_PORT=7803
 DASHBOARD_HOST_PORT=8080
 API_HOST_PORT=8090
 
+# Host-published ports for the deterministic API CLI failure fixture. Jetmon
+# containers use http://api-fixture:8091 and https://api-fixture:8443 directly.
+API_FIXTURE_HTTP_HOST_PORT=18091
+API_FIXTURE_HTTPS_HOST_PORT=18443
+
 # Host-published port for the local Mailpit web UI. Jetmon sends SMTP to the
 # internal mailpit:1025 address; the SMTP port is not published to the host.
 MAILPIT_HOST_PORT=8025

--- a/docker/Dockerfile_api_fixture
+++ b/docker/Dockerfile_api_fixture
@@ -1,0 +1,17 @@
+FROM golang:1.22 AS builder
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o jetmon-testsite ./cmd/jetmon-testsite/
+
+FROM scratch
+
+COPY --from=builder /src/jetmon-testsite /jetmon-testsite
+
+EXPOSE 8091/tcp 8443/tcp
+
+ENTRYPOINT ["/jetmon-testsite"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -98,6 +98,22 @@ services:
       retries: 12
       start_period: 10s
 
+  api-fixture:
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile_api_fixture
+    init: true
+    restart: unless-stopped
+    ports:
+      - "${BIND_ADDR:-127.0.0.1}:${API_FIXTURE_HTTP_HOST_PORT:-18091}:8091"
+      - "${BIND_ADDR:-127.0.0.1}:${API_FIXTURE_HTTPS_HOST_PORT:-18443}:8443"
+    healthcheck:
+      test: ["CMD", "/jetmon-testsite", "healthcheck"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 5s
+
   mailpit:
     image: axllent/mailpit:v1.29
     restart: unless-stopped

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,12 @@ capture load-bearing choices that the current v2 implementation depends on.
 
 Start with [`adr/README.md`](adr/README.md) for the ADR format and index.
 
+## User Guides
+
+| Document | Purpose |
+|---|---|
+| [`api-cli-guide.md`](api-cli-guide.md) | Feature guide and examples for using `jetmon2 api` against the internal REST API during local testing, rehearsals, and CI smoke runs. |
+
 ## Planning Notes
 
 Planning notes capture future options and open design threads. They are not

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,10 @@ Start with [`adr/README.md`](adr/README.md) for the ADR format and index.
 
 | Document | Purpose |
 |---|---|
+| [`getting-started.md`](getting-started.md) | Local Docker setup, build/test commands, API CLI smoke runs, fixture failure simulation, and tenant import basics. |
+| [`operations-guide.md`](operations-guide.md) | Production configuration, host setup, rollout modes, delivery workers, metrics, dashboard checks, and debugging. |
+| [`data-model.md`](data-model.md) | Legacy and v2 tables, additive migrations, event-sourced incident state, legacy projection, and tenant mapping. |
+| [`support-guide.md`](support-guide.md) | Happiness Engineer workflows for explaining alerts, missed alerts, false positives, maintenance windows, and WPCOM payloads. |
 | [`api-cli-guide.md`](api-cli-guide.md) | Feature guide and examples for using `jetmon2 api` against the internal REST API during local testing, rehearsals, and CI smoke runs. |
 
 ## Planning Notes

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Start with [`adr/README.md`](adr/README.md) for the ADR format and index.
 | [`data-model.md`](data-model.md) | Legacy and v2 tables, additive migrations, event-sourced incident state, legacy projection, and tenant mapping. |
 | [`support-guide.md`](support-guide.md) | Happiness Engineer workflows for explaining alerts, missed alerts, false positives, maintenance windows, and WPCOM payloads. |
 | [`api-cli-guide.md`](api-cli-guide.md) | Feature guide and examples for using `jetmon2 api` against the internal REST API during local testing, rehearsals, and CI smoke runs. |
+| [`v1-to-v2-migration.md`](v1-to-v2-migration.md) | Full production migration runbook from v1 to v2, including preparation, same-server replacement, fresh-server takeover, monitoring, revert paths, dynamic ownership cutover, and v1 teardown. |
 
 ## Planning Notes
 
@@ -31,5 +32,5 @@ accepted architecture decisions.
 | [`jetmon-deliverer-rollout.md`](jetmon-deliverer-rollout.md) | Operational rollout policy for moving outbound dispatch from embedded `jetmon2` workers to standalone `jetmon-deliverer`. |
 | [`outbound-credential-encryption-plan.md`](outbound-credential-encryption-plan.md) | Migration plan for encrypting webhook secrets and alert-contact destination credentials after the current plaintext v2 model. |
 | [`public-api-gateway-tenant-contract.md`](public-api-gateway-tenant-contract.md) | Gateway boundary contract, implemented Jetmon-side tenant ownership checks, and remaining public-exposure prerequisites. |
-| [`v1-to-v2-pinned-rollout.md`](v1-to-v2-pinned-rollout.md) | Initial production migration plan for replacing v1 static-bucket hosts with v2 hosts pinned to the same ranges before enabling dynamic ownership. |
+| [`v1-to-v2-pinned-rollout.md`](v1-to-v2-pinned-rollout.md) | Compatibility pointer to the consolidated v1-to-v2 migration runbook. |
 | [`v3-probe-agent-architecture-options.md`](v3-probe-agent-architecture-options.md) | Post-v2 architecture options for evolving from main servers plus Verifliers toward a probe-agent architecture. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ accepted architecture decisions.
 
 | Document | Purpose |
 |---|---|
+| [`api-cli-roadmap.md`](api-cli-roadmap.md) | Prioritized plan for a local `jetmon2 api` helper CLI that exercises the internal REST API during Docker and rollout testing. |
 | [`jetmon-deliverer-rollout.md`](jetmon-deliverer-rollout.md) | Operational rollout policy for moving outbound dispatch from embedded `jetmon2` workers to standalone `jetmon-deliverer`. |
 | [`outbound-credential-encryption-plan.md`](outbound-credential-encryption-plan.md) | Migration plan for encrypting webhook secrets and alert-contact destination credentials after the current plaintext v2 model. |
 | [`public-api-gateway-tenant-contract.md`](public-api-gateway-tenant-contract.md) | Gateway boundary contract, implemented Jetmon-side tenant ownership checks, and remaining public-exposure prerequisites. |

--- a/docs/adr/0008-shadow-v2-state-migration.md
+++ b/docs/adr/0008-shadow-v2-state-migration.md
@@ -2,6 +2,10 @@
 
 **Status:** Accepted (2026-04-27)
 
+Operational rollout steps live in
+[`../v1-to-v2-migration.md`](../v1-to-v2-migration.md). This ADR explains the
+state-model decision behind that runbook.
+
 ## Context
 
 Jetmon 2 replaces mutable v1 status handling with event-sourced incident

--- a/docs/api-cli-guide.md
+++ b/docs/api-cli-guide.md
@@ -41,9 +41,9 @@ The token helpers use the Docker Compose stack from the repository root. Use
 be revoked.
 
 Every command also accepts `--base-url`, `--token`, `--auth-policy`,
-`--timeout`, `--header`, `--pretty`, `--output table`, `-v`, and `--verbose`.
-JSON is the default output for automation. Use `--pretty` when reading JSON
-directly and `--output table` for stable summary tables.
+`--allow-remote`, `--timeout`, `--header`, `--pretty`, `--output table`, `-v`,
+and `--verbose`. JSON is the default output for automation. Use `--pretty`
+when reading JSON directly and `--output table` for stable summary tables.
 
 Automatic `--token` and `--idempotency-key` headers are sent only to the
 configured API origin by default, including when `api request` is given an
@@ -52,13 +52,23 @@ another trusted API host. Custom `--header` values are always treated as
 explicit operator input. Verbose mode redacts common sensitive headers before
 printing them.
 
-The test-data workflow commands refuse to modify a non-local API unless
+Every POST, PUT, PATCH, and DELETE refuses to modify a non-local API unless
 `--allow-remote` is supplied. Local means `localhost`, a `*.localhost` name, or
 a loopback IP address; private LAN hosts still count as remote. On remote API
 targets, `smoke`, `sites bulk-add`, `sites cleanup`, and
 `sites simulate-failure` also require `--batch`, and remote cleanup/simulation
 keep the CLI batch marker check mandatory. Dry-run planning does not contact
 the API and is not blocked.
+
+Security notes:
+- Prefer `--auth-policy any-origin` as a one-command flag. Exporting
+  `JETMON_API_AUTH_POLICY=any-origin` is convenient but persistent; later
+  absolute-URL requests can attach the token to a different trusted host.
+- Manual sensitive headers such as `--header 'Authorization: ...'` are explicit
+  operator input and bypass same-origin automatic auth protections. Use them
+  only with trusted URLs.
+- API error bodies are printed as returned by the server for internal debugging.
+  Do not point this CLI at untrusted API servers.
 
 List the command catalog and examples when you need to discover the expanded
 tree without returning to this guide:
@@ -114,6 +124,11 @@ POST and PATCH requests can take literal JSON, a file, or stdin:
   --pretty \
   PATCH /api/v1/sites/12345
 ```
+
+`api request` is intentionally an escape hatch, not a hardened data transfer
+tool. Request bodies and response bodies are read into memory; avoid very large
+files or endpoints that stream unbounded responses. Non-local writes still
+require `--allow-remote`.
 
 ## Site Management
 
@@ -258,6 +273,8 @@ The Docker-local `api-fixture` service also exposes a receiver at
 `http://localhost:18091/webhook/requests` to inspect recorded deliveries or
 `DELETE` the same path to clear them. Add `?secret=<webhook-secret>` to the
 receiver URL when you want the fixture to verify `X-Jetmon-Signature`.
+Webhook secrets returned by create/rotate responses are shown once; treat the
+JSON output like a credential and avoid saving it in logs.
 
 ```bash
 ./bin/jetmon2 api webhooks create \
@@ -334,6 +351,11 @@ not fit a test case:
   --destination '{"webhook_url":"https://example.test/teams"}' \
   --pretty
 ```
+
+PagerDuty integration keys and Slack/Teams webhook URLs are credentials. The
+CLI does not print request bodies in verbose mode, but shell history and saved
+JSON output can still retain values supplied through `--integration-key`,
+`--webhook-url`, or `--destination`.
 
 ## Smoke Workflows
 
@@ -439,6 +461,7 @@ Target explicit site IDs instead of a batch:
 - Use `--batch` and `sites cleanup` for disposable data so local runs do not
   touch unrelated sites.
 - Use `--verbose` when debugging auth, rate limits, idempotency behavior, or
-  unexpected server errors.
+  unexpected server errors. Header values are redacted, but response bodies are
+  not.
 - Treat tokens as local secrets. Do not commit exported tokens, shell history
   snippets, or generated local config containing credentials.

--- a/docs/api-cli-guide.md
+++ b/docs/api-cli-guide.md
@@ -66,22 +66,24 @@ when debugging auth, rate limiting, or idempotency:
 Use `api request` when a route exists but a typed CLI wrapper does not yet.
 
 ```bash
-./bin/jetmon2 api request GET '/api/v1/sites?limit=5' --output table
+./bin/jetmon2 api request --output table GET '/api/v1/sites?limit=5'
 ```
 
 POST and PATCH requests can take literal JSON, a file, or stdin:
 
 ```bash
-./bin/jetmon2 api request POST /api/v1/sites \
+./bin/jetmon2 api request \
   --idempotency-key local-site-12345-create \
   --body '{"blog_id":12345,"monitor_url":"https://example.com","monitor_active":true}' \
-  --pretty
+  --pretty \
+  POST /api/v1/sites
 ```
 
 ```bash
-./bin/jetmon2 api request PATCH /api/v1/sites/12345 \
+./bin/jetmon2 api request \
   --body-file site-update.json \
-  --pretty
+  --pretty \
+  PATCH /api/v1/sites/12345
 ```
 
 ## Site Management
@@ -92,7 +94,7 @@ get, create, update, delete, pause, resume, and trigger-now.
 ```bash
 ./bin/jetmon2 api sites list --limit 20 --output table
 ./bin/jetmon2 api sites list --monitor-active=true --state-in 'Seems Down,Down' --severity-gte 3 --output table
-./bin/jetmon2 api sites get 12345 --pretty
+./bin/jetmon2 api sites get --pretty 12345
 ```
 
 Create a monitored site with explicit per-site check behavior:
@@ -113,21 +115,22 @@ Update a site when testing redirects, keyword checks, custom headers, or
 maintenance windows:
 
 ```bash
-./bin/jetmon2 api sites update 12345 \
+./bin/jetmon2 api sites update \
   --url https://example.com/health \
   --check-keyword Example \
   --custom-header 'X-Jetmon-Test: api-cli' \
   --maintenance-start 2026-04-28T18:00:00Z \
   --maintenance-end 2026-04-28T19:00:00Z \
-  --pretty
+  --pretty \
+  12345
 ```
 
 Pause, resume, and run an immediate check:
 
 ```bash
-./bin/jetmon2 api sites pause 12345 --idempotency-key site-12345-pause --pretty
-./bin/jetmon2 api sites resume 12345 --idempotency-key site-12345-resume --pretty
-./bin/jetmon2 api sites trigger-now 12345 --idempotency-key site-12345-trigger --pretty
+./bin/jetmon2 api sites pause --idempotency-key site-12345-pause --pretty 12345
+./bin/jetmon2 api sites resume --idempotency-key site-12345-resume --pretty 12345
+./bin/jetmon2 api sites trigger-now --idempotency-key site-12345-trigger --pretty 12345
 ```
 
 Delete disposable sites:
@@ -186,20 +189,21 @@ list active incidents for a site, inspect an event, fetch transition history,
 and manually close false alarms or operator-resolved incidents.
 
 ```bash
-./bin/jetmon2 api events list 12345 --active=true --output table
-./bin/jetmon2 api events list 12345 --state 'Seems Down' --limit 10 --pretty
-./bin/jetmon2 api events get --site-id 12345 98765 --pretty
-./bin/jetmon2 api events transitions 12345 98765 --output table
+./bin/jetmon2 api events list --active=true --output table 12345
+./bin/jetmon2 api events list --state 'Seems Down' --limit 10 --pretty 12345
+./bin/jetmon2 api events get --site-id 12345 --pretty 98765
+./bin/jetmon2 api events transitions --output table 12345 98765
 ```
 
 Close an event with an explicit reason and note:
 
 ```bash
-./bin/jetmon2 api events close 12345 98765 \
+./bin/jetmon2 api events close \
   --reason manual_override \
   --note 'Confirmed maintenance outside scheduled window' \
   --idempotency-key event-98765-close \
-  --pretty
+  --pretty \
+  12345 98765
 ```
 
 ## Webhooks
@@ -221,16 +225,16 @@ rows.
 
 ```bash
 ./bin/jetmon2 api webhooks list --output table
-./bin/jetmon2 api webhooks get 77 --pretty
-./bin/jetmon2 api webhooks deliveries 77 --status failed --output table
-./bin/jetmon2 api webhooks retry 77 555 --idempotency-key webhook-77-delivery-555-retry --pretty
-./bin/jetmon2 api webhooks rotate-secret 77 --idempotency-key webhook-77-rotate --pretty
+./bin/jetmon2 api webhooks get --pretty 77
+./bin/jetmon2 api webhooks deliveries --status failed --output table 77
+./bin/jetmon2 api webhooks retry --idempotency-key webhook-77-delivery-555-retry --pretty 77 555
+./bin/jetmon2 api webhooks rotate-secret --idempotency-key webhook-77-rotate --pretty 77
 ```
 
 Update filters without rebuilding the whole object:
 
 ```bash
-./bin/jetmon2 api webhooks update 77 --clear-sites --state Down --pretty
+./bin/jetmon2 api webhooks update --clear-sites --state Down --pretty 77
 ```
 
 ## Alert Contacts
@@ -268,9 +272,9 @@ Create a Slack contact:
 Exercise the send-test path and inspect delivery rows:
 
 ```bash
-./bin/jetmon2 api alert-contacts test 12 --idempotency-key alert-12-test --pretty
-./bin/jetmon2 api alert-contacts deliveries 12 --status failed --output table
-./bin/jetmon2 api alert-contacts retry 12 9001 --idempotency-key alert-12-delivery-9001-retry --pretty
+./bin/jetmon2 api alert-contacts test --idempotency-key alert-12-test --pretty 12
+./bin/jetmon2 api alert-contacts deliveries --status failed --output table 12
+./bin/jetmon2 api alert-contacts retry --idempotency-key alert-12-delivery-9001-retry --pretty 12 9001
 ```
 
 Use `--destination` for raw transport-specific JSON when a shortcut flag does

--- a/docs/api-cli-guide.md
+++ b/docs/api-cli-guide.md
@@ -306,6 +306,23 @@ JETMON_API_TOKEN=jm_replace_with_the_printed_token \
 make api-cli-smoke
 ```
 
+Use `api-cli-validate` for a fuller live pass against the guide's Docker-local
+workflow. It builds the binary, checks health and identity, exercises the
+generic request escape hatch, dry-runs batch creation, runs `api smoke`, runs a
+deterministic failure simulation assertion, and cleans up the validation
+batches on exit:
+
+```bash
+JETMON_API_URL=http://localhost:${API_HOST_PORT:-8090} \
+JETMON_API_TOKEN=jm_replace_with_the_printed_token \
+make api-cli-validate
+```
+
+The validation target uses `API_VALIDATE_BATCH`, `API_VALIDATE_MODE`,
+`API_VALIDATE_WAIT`, and `API_VALIDATE_COUNT` when you need to vary the default
+batch label or failure scenario. Set `API_VALIDATE_SKIP_FAILURE=1` to run only
+the health, identity, request, batch dry-run, and smoke checks.
+
 ## Failure Simulation
 
 `sites simulate-failure` mutates one or more sites into a known failure mode,

--- a/docs/api-cli-guide.md
+++ b/docs/api-cli-guide.md
@@ -45,6 +45,13 @@ Every command also accepts `--base-url`, `--token`, `--timeout`, `--header`,
 for automation. Use `--pretty` when reading JSON directly and `--output table`
 for stable summary tables.
 
+List the command catalog and examples when you need to discover the expanded
+tree without returning to this guide:
+
+```bash
+./bin/jetmon2 api commands --output table
+```
+
 ## Health and Identity
 
 Use `health` before authenticating anything. It checks the API and database

--- a/docs/api-cli-guide.md
+++ b/docs/api-cli-guide.md
@@ -230,6 +230,12 @@ Webhooks receive HMAC-signed POSTs for matching event transitions. The CLI can
 create, update, rotate secrets, inspect deliveries, and retry failed delivery
 rows.
 
+The Docker-local `api-fixture` service also exposes a receiver at
+`http://api-fixture:8091/webhook`. From the host, use
+`http://localhost:18091/webhook/requests` to inspect recorded deliveries or
+`DELETE` the same path to clear them. Add `?secret=<webhook-secret>` to the
+receiver URL when you want the fixture to verify `X-Jetmon-Signature`.
+
 ```bash
 ./bin/jetmon2 api webhooks create \
   --url https://receiver.example.test/jetmon \

--- a/docs/api-cli-guide.md
+++ b/docs/api-cli-guide.md
@@ -55,9 +55,10 @@ printing them.
 The test-data workflow commands refuse to modify a non-local API unless
 `--allow-remote` is supplied. Local means `localhost`, a `*.localhost` name, or
 a loopback IP address; private LAN hosts still count as remote. On remote API
-targets, `sites bulk-add`, `sites cleanup`, and `sites simulate-failure` also
-require `--batch`, and remote cleanup/simulation keep the CLI batch marker
-check mandatory. Dry-run planning does not contact the API and is not blocked.
+targets, `smoke`, `sites bulk-add`, `sites cleanup`, and
+`sites simulate-failure` also require `--batch`, and remote cleanup/simulation
+keep the CLI batch marker check mandatory. Dry-run planning does not contact
+the API and is not blocked.
 
 List the command catalog and examples when you need to discover the expanded
 tree without returning to this guide:

--- a/docs/api-cli-guide.md
+++ b/docs/api-cli-guide.md
@@ -22,8 +22,8 @@ Start Docker and create an API key inside the `jetmon` container:
 ```bash
 cd docker
 docker compose up --build -d
-docker compose exec jetmon ./jetmon2 keys create --consumer api-cli --scope admin --created-by docker-local
 cd ..
+make api-cli-token-create
 ```
 
 Point the CLI at the Docker-local API and token:
@@ -32,6 +32,13 @@ Point the CLI at the Docker-local API and token:
 export JETMON_API_URL=http://localhost:${API_HOST_PORT:-8090}
 export JETMON_API_TOKEN=jm_replace_with_the_printed_token
 ```
+
+The token helpers use the Docker Compose stack from the repository root. Use
+`API_CLI_TOKEN_CONSUMER`, `API_CLI_TOKEN_SCOPE`, `API_CLI_TOKEN_TTL`, and
+`API_CLI_TOKEN_CREATED_BY` to vary token creation. Use
+`make api-cli-token-list` to find local key IDs and
+`API_CLI_TOKEN_ID=<id> make api-cli-token-revoke` when a rehearsal token should
+be revoked.
 
 Every command also accepts `--base-url`, `--token`, `--timeout`, `--header`,
 `--pretty`, `--output table`, `-v`, and `--verbose`. JSON is the default output

--- a/docs/api-cli-guide.md
+++ b/docs/api-cli-guide.md
@@ -40,10 +40,17 @@ The token helpers use the Docker Compose stack from the repository root. Use
 `API_CLI_TOKEN_ID=<id> make api-cli-token-revoke` when a rehearsal token should
 be revoked.
 
-Every command also accepts `--base-url`, `--token`, `--timeout`, `--header`,
-`--pretty`, `--output table`, `-v`, and `--verbose`. JSON is the default output
-for automation. Use `--pretty` when reading JSON directly and `--output table`
-for stable summary tables.
+Every command also accepts `--base-url`, `--token`, `--auth-policy`,
+`--timeout`, `--header`, `--pretty`, `--output table`, `-v`, and `--verbose`.
+JSON is the default output for automation. Use `--pretty` when reading JSON
+directly and `--output table` for stable summary tables.
+
+Automatic `--token` and `--idempotency-key` headers are sent only to the
+configured API origin by default, including when `api request` is given an
+absolute URL. Use `--auth-policy any-origin` only when intentionally targeting
+another trusted API host. Custom `--header` values are always treated as
+explicit operator input. Verbose mode redacts common sensitive headers before
+printing them.
 
 List the command catalog and examples when you need to discover the expanded
 tree without returning to this guide:
@@ -197,8 +204,10 @@ Clean up a batch after testing:
 ```
 
 By default, cleanup verifies each existing `--batch` target still exposes the
-matching derived `cli_batch` marker before deleting it. Use `--allow-unmarked`
-only when cleaning up older local data created before the marker check existed.
+matching derived `cli_batch` marker before deleting it. The CLI requests that
+marker through the API's opt-in `include_cli_metadata=true` projection. Use
+`--allow-unmarked` only when cleaning up older local data created before the
+marker check existed.
 
 ## Events and Transitions
 
@@ -368,9 +377,11 @@ Supported modes are `unreachable`, `http-500`, `http-403`, `redirect`,
 ```
 
 When `--batch` targets an existing site, simulation verifies the site's
-`cli_batch` marker before mutating it. `--create-missing` is still allowed for
-empty deterministic slots because the created site receives the marker. Use
-`--allow-unmarked` only for legacy local batches that predate the marker.
+`cli_batch` marker before mutating it. The marker is fetched through the API's
+opt-in `include_cli_metadata=true` projection. `--create-missing` is still
+allowed for empty deterministic slots because the created site receives the
+marker. Use `--allow-unmarked` only for legacy local batches that predate the
+marker.
 
 When Docker Compose is running, the command probes
 `http://localhost:18091/health` and uses the Docker-internal `api-fixture`

--- a/docs/api-cli-guide.md
+++ b/docs/api-cli-guide.md
@@ -196,6 +196,10 @@ Clean up a batch after testing:
 ./bin/jetmon2 api sites cleanup --batch local-smoke --count 5 --output table
 ```
 
+By default, cleanup verifies each existing `--batch` target still exposes the
+matching derived `cli_batch` marker before deleting it. Use `--allow-unmarked`
+only when cleaning up older local data created before the marker check existed.
+
 ## Events and Transitions
 
 Events are the API source of truth for incident state. Use event commands to
@@ -356,6 +360,11 @@ Supported modes are `unreachable`, `http-500`, `http-403`, `redirect`,
   --wait 15s \
   --pretty
 ```
+
+When `--batch` targets an existing site, simulation verifies the site's
+`cli_batch` marker before mutating it. `--create-missing` is still allowed for
+empty deterministic slots because the created site receives the marker. Use
+`--allow-unmarked` only for legacy local batches that predate the marker.
 
 When Docker Compose is running, the command probes
 `http://localhost:18091/health` and uses the Docker-internal `api-fixture`

--- a/docs/api-cli-guide.md
+++ b/docs/api-cli-guide.md
@@ -1,0 +1,366 @@
+# API CLI Feature Guide
+
+`jetmon2 api` is the local operator and developer interface for Jetmon's
+internal `/api/v1` API. It wraps the common API paths with typed commands,
+repeatable request payloads, Docker-local defaults, and output modes that work
+for both humans and scripts.
+
+Use this guide for day-to-day examples. Use [`../API.md`](../API.md) as the
+endpoint contract reference when you need exact response shapes, request
+schemas, pagination semantics, or design rationale.
+
+## Setup
+
+Build the local binary:
+
+```bash
+make build
+```
+
+Start Docker and create an API key inside the `jetmon` container:
+
+```bash
+cd docker
+docker compose up --build -d
+docker compose exec jetmon ./jetmon2 keys create --consumer api-cli --scope admin --created-by docker-local
+cd ..
+```
+
+Point the CLI at the Docker-local API and token:
+
+```bash
+export JETMON_API_URL=http://localhost:${API_HOST_PORT:-8090}
+export JETMON_API_TOKEN=jm_replace_with_the_printed_token
+```
+
+Every command also accepts `--base-url`, `--token`, `--timeout`, `--header`,
+`--pretty`, `--output table`, `-v`, and `--verbose`. JSON is the default output
+for automation. Use `--pretty` when reading JSON directly and `--output table`
+for stable summary tables.
+
+## Health and Identity
+
+Use `health` before authenticating anything. It checks the API and database
+health endpoint.
+
+```bash
+./bin/jetmon2 api health --pretty
+```
+
+Use `me` to confirm the token, consumer name, scope, and rate limit seen by the
+API server.
+
+```bash
+./bin/jetmon2 api me --pretty
+```
+
+Verbose mode prints request and response headers to stderr, which is useful
+when debugging auth, rate limiting, or idempotency:
+
+```bash
+./bin/jetmon2 api me --verbose --pretty
+```
+
+## Request Escape Hatch
+
+Use `api request` when a route exists but a typed CLI wrapper does not yet.
+
+```bash
+./bin/jetmon2 api request GET '/api/v1/sites?limit=5' --output table
+```
+
+POST and PATCH requests can take literal JSON, a file, or stdin:
+
+```bash
+./bin/jetmon2 api request POST /api/v1/sites \
+  --idempotency-key local-site-12345-create \
+  --body '{"blog_id":12345,"monitor_url":"https://example.com","monitor_active":true}' \
+  --pretty
+```
+
+```bash
+./bin/jetmon2 api request PATCH /api/v1/sites/12345 \
+  --body-file site-update.json \
+  --pretty
+```
+
+## Site Management
+
+Sites are keyed by the existing `blog_id`. The typed site commands cover list,
+get, create, update, delete, pause, resume, and trigger-now.
+
+```bash
+./bin/jetmon2 api sites list --limit 20 --output table
+./bin/jetmon2 api sites list --monitor-active=true --state-in 'Seems Down,Down' --severity-gte 3 --output table
+./bin/jetmon2 api sites get 12345 --pretty
+```
+
+Create a monitored site with explicit per-site check behavior:
+
+```bash
+./bin/jetmon2 api sites create \
+  --blog-id 12345 \
+  --url https://example.com \
+  --monitor-active=true \
+  --redirect-policy follow \
+  --timeout-seconds 5 \
+  --check-interval 1 \
+  --idempotency-key site-12345-create \
+  --pretty
+```
+
+Update a site when testing redirects, keyword checks, custom headers, or
+maintenance windows:
+
+```bash
+./bin/jetmon2 api sites update 12345 \
+  --url https://example.com/health \
+  --check-keyword Example \
+  --custom-header 'X-Jetmon-Test: api-cli' \
+  --maintenance-start 2026-04-28T18:00:00Z \
+  --maintenance-end 2026-04-28T19:00:00Z \
+  --pretty
+```
+
+Pause, resume, and run an immediate check:
+
+```bash
+./bin/jetmon2 api sites pause 12345 --idempotency-key site-12345-pause --pretty
+./bin/jetmon2 api sites resume 12345 --idempotency-key site-12345-resume --pretty
+./bin/jetmon2 api sites trigger-now 12345 --idempotency-key site-12345-trigger --pretty
+```
+
+Delete disposable sites:
+
+```bash
+./bin/jetmon2 api sites delete 12345
+```
+
+## Batch Test Sites
+
+`sites bulk-add` creates bounded, repeatable local test data. The default source
+is the checked-in fixture of public URLs with up, redirect, slow, error, TLS,
+header, and keyword-check examples.
+
+Preview the payloads:
+
+```bash
+./bin/jetmon2 api sites bulk-add --count 5 --batch local-smoke --dry-run --pretty
+```
+
+Create the batch:
+
+```bash
+./bin/jetmon2 api sites bulk-add \
+  --count 5 \
+  --batch local-smoke \
+  --idempotency-key-prefix local-smoke \
+  --pretty
+```
+
+The batch label derives deterministic blog IDs and stores an
+`X-Jetmon-CLI-Batch` custom header marker so later smoke, simulation, and
+cleanup commands can target only CLI-created data.
+
+Use your own source list when needed:
+
+```bash
+./bin/jetmon2 api sites bulk-add --source file --file sites.csv --count 10 --batch private-repro --pretty
+```
+
+Accepted source formats are newline URLs, CSV with a `url` or `monitor_url`
+column, or JSON objects using fields such as `monitor_url`, `check_keyword`,
+`redirect_policy`, `timeout_seconds`, `custom_headers`, `alert_cooldown_minutes`,
+and `check_interval`.
+
+Clean up a batch after testing:
+
+```bash
+./bin/jetmon2 api sites cleanup --batch local-smoke --count 5 --output table
+```
+
+## Events and Transitions
+
+Events are the API source of truth for incident state. Use event commands to
+list active incidents for a site, inspect an event, fetch transition history,
+and manually close false alarms or operator-resolved incidents.
+
+```bash
+./bin/jetmon2 api events list 12345 --active=true --output table
+./bin/jetmon2 api events list 12345 --state 'Seems Down' --limit 10 --pretty
+./bin/jetmon2 api events get --site-id 12345 98765 --pretty
+./bin/jetmon2 api events transitions 12345 98765 --output table
+```
+
+Close an event with an explicit reason and note:
+
+```bash
+./bin/jetmon2 api events close 12345 98765 \
+  --reason manual_override \
+  --note 'Confirmed maintenance outside scheduled window' \
+  --idempotency-key event-98765-close \
+  --pretty
+```
+
+## Webhooks
+
+Webhooks receive HMAC-signed POSTs for matching event transitions. The CLI can
+create, update, rotate secrets, inspect deliveries, and retry failed delivery
+rows.
+
+```bash
+./bin/jetmon2 api webhooks create \
+  --url https://receiver.example.test/jetmon \
+  --active=true \
+  --event event.opened,event.severity_changed,event.closed \
+  --site-id 12345 \
+  --state 'Down,Seems Down' \
+  --idempotency-key webhook-local-create \
+  --pretty
+```
+
+```bash
+./bin/jetmon2 api webhooks list --output table
+./bin/jetmon2 api webhooks get 77 --pretty
+./bin/jetmon2 api webhooks deliveries 77 --status failed --output table
+./bin/jetmon2 api webhooks retry 77 555 --idempotency-key webhook-77-delivery-555-retry --pretty
+./bin/jetmon2 api webhooks rotate-secret 77 --idempotency-key webhook-77-rotate --pretty
+```
+
+Update filters without rebuilding the whole object:
+
+```bash
+./bin/jetmon2 api webhooks update 77 --clear-sites --state Down --pretty
+```
+
+## Alert Contacts
+
+Alert contacts are managed delivery channels backed by the same transition
+source as webhooks. Supported transports are `email`, `pagerduty`, `slack`, and
+`teams`.
+
+Create an email contact:
+
+```bash
+./bin/jetmon2 api alert-contacts create \
+  --label 'Local smoke email' \
+  --transport email \
+  --address alerts@example.test \
+  --active=true \
+  --min-severity SeemsDown \
+  --max-per-hour 10 \
+  --idempotency-key alert-email-create \
+  --pretty
+```
+
+Create a Slack contact:
+
+```bash
+./bin/jetmon2 api alert-contacts create \
+  --label 'Local Slack' \
+  --transport slack \
+  --webhook-url https://hooks.slack.com/services/example \
+  --site-id 12345 \
+  --min-severity Down \
+  --pretty
+```
+
+Exercise the send-test path and inspect delivery rows:
+
+```bash
+./bin/jetmon2 api alert-contacts test 12 --idempotency-key alert-12-test --pretty
+./bin/jetmon2 api alert-contacts deliveries 12 --status failed --output table
+./bin/jetmon2 api alert-contacts retry 12 9001 --idempotency-key alert-12-delivery-9001-retry --pretty
+```
+
+Use `--destination` for raw transport-specific JSON when a shortcut flag does
+not fit a test case:
+
+```bash
+./bin/jetmon2 api alert-contacts create \
+  --label 'Raw destination example' \
+  --transport teams \
+  --destination '{"webhook_url":"https://example.test/teams"}' \
+  --pretty
+```
+
+## Smoke Workflows
+
+`api smoke` runs a compact end-to-end sanity pass against Docker-local API
+components: health, auth identity, site creation, trigger-now, event listing,
+alert-contact creation, alert-contact send-test, and best-effort cleanup.
+
+```bash
+./bin/jetmon2 api smoke --batch local-smoke --pretty
+```
+
+The Makefile target builds the binary first and runs the standard smoke path:
+
+```bash
+JETMON_API_URL=http://localhost:${API_HOST_PORT:-8090} \
+JETMON_API_TOKEN=jm_replace_with_the_printed_token \
+make api-cli-smoke
+```
+
+## Failure Simulation
+
+`sites simulate-failure` mutates one or more sites into a known failure mode,
+optionally creates missing test sites, triggers immediate checks, polls active
+events, fetches transitions, and returns non-zero when a site fails the workflow
+or an assertion does not match.
+
+Supported modes are `unreachable`, `http-500`, `http-403`, `redirect`,
+`keyword`, `timeout`, and `tls`.
+
+```bash
+./bin/jetmon2 api sites simulate-failure \
+  --batch local-smoke \
+  --count 1 \
+  --create-missing \
+  --mode http-500 \
+  --wait 15s \
+  --pretty
+```
+
+When Docker Compose is running, the command probes
+`http://localhost:18091/health` and uses the Docker-internal `api-fixture`
+service for deterministic HTTP status, redirect, keyword, timeout, and TLS
+cases. Force public endpoint fallbacks with `--fixture-url=off`.
+
+Use assertions when a CI or rehearsal run should fail unless the expected API
+state appears before the wait window expires:
+
+```bash
+./bin/jetmon2 api sites simulate-failure \
+  --batch local-smoke \
+  --mode http-500 \
+  --wait 30s \
+  --expect-event-state 'Seems Down' \
+  --expect-event-severity 3 \
+  --require-transition \
+  --expect-transition-reason opened \
+  --pretty
+```
+
+Target explicit site IDs instead of a batch:
+
+```bash
+./bin/jetmon2 api sites simulate-failure \
+  --site-id 12345 \
+  --site-id 12346 \
+  --mode timeout \
+  --wait 20s \
+  --output table
+```
+
+## Automation Notes
+
+- Prefer `--idempotency-key` or `--idempotency-key-prefix` for create, close,
+  retry, trigger, and test actions that scripts may repeat.
+- Use JSON output for scripts; use table output only for human-readable status.
+- Use `--batch` and `sites cleanup` for disposable data so local runs do not
+  touch unrelated sites.
+- Use `--verbose` when debugging auth, rate limits, idempotency behavior, or
+  unexpected server errors.
+- Treat tokens as local secrets. Do not commit exported tokens, shell history
+  snippets, or generated local config containing credentials.

--- a/docs/api-cli-guide.md
+++ b/docs/api-cli-guide.md
@@ -52,6 +52,13 @@ another trusted API host. Custom `--header` values are always treated as
 explicit operator input. Verbose mode redacts common sensitive headers before
 printing them.
 
+The test-data workflow commands refuse to modify a non-local API unless
+`--allow-remote` is supplied. Local means `localhost`, a `*.localhost` name, or
+a loopback IP address; private LAN hosts still count as remote. On remote API
+targets, `sites bulk-add`, `sites cleanup`, and `sites simulate-failure` also
+require `--batch`, and remote cleanup/simulation keep the CLI batch marker
+check mandatory. Dry-run planning does not contact the API and is not blocked.
+
 List the command catalog and examples when you need to discover the expanded
 tree without returning to this guide:
 
@@ -186,6 +193,9 @@ The batch label derives deterministic blog IDs and stores an
 `X-Jetmon-CLI-Batch` custom header marker so later smoke, simulation, and
 cleanup commands can target only CLI-created data.
 
+Against a non-local API, add `--allow-remote`; `--batch` remains required so
+the created rows carry the CLI marker.
+
 Use your own source list when needed:
 
 ```bash
@@ -208,6 +218,9 @@ matching derived `cli_batch` marker before deleting it. The CLI requests that
 marker through the API's opt-in `include_cli_metadata=true` projection. Use
 `--allow-unmarked` only when cleaning up older local data created before the
 marker check existed.
+
+Against a non-local API, cleanup requires `--allow-remote --batch` and rejects
+`--allow-unmarked`.
 
 ## Events and Transitions
 
@@ -382,6 +395,9 @@ opt-in `include_cli_metadata=true` projection. `--create-missing` is still
 allowed for empty deterministic slots because the created site receives the
 marker. Use `--allow-unmarked` only for legacy local batches that predate the
 marker.
+
+Against a non-local API, simulation requires `--allow-remote --batch` and
+rejects `--allow-unmarked`.
 
 When Docker Compose is running, the command probes
 `http://localhost:18091/health` and uses the Docker-internal `api-fixture`

--- a/docs/api-cli-roadmap.md
+++ b/docs/api-cli-roadmap.md
@@ -96,11 +96,12 @@ but it should not become a generic `curl` clone.
   CLI-created site batches after smoke, bulk-add, and failure simulation runs.
 - [x] Add a one-command `make api-cli-smoke` entrypoint for the documented local
   smoke path.
-- [ ] Add a deterministic Docker-local failure fixture service for response
+- [x] Add a deterministic Docker-local failure fixture service for response
   codes, redirects, keyword mismatch, slow responses, and TLS edge cases.
-- [ ] Teach failure simulation to prefer the Docker-local fixture when it is
-  available, then assert exact event/transition behavior without depending on
-  public endpoint timing.
+- [x] Teach failure simulation to prefer the Docker-local fixture when it is
+  available, while retaining public endpoint fallback behavior.
+- [x] Add deterministic failure-simulation assertions for exact
+  event/transition behavior without depending on public endpoint timing.
 
 ## Completed
 
@@ -169,3 +170,13 @@ but it should not become a generic `curl` clone.
 - [x] 2026-04-28: Verified a fresh Docker Compose rebuild after Docker bridge
   networking was repaired, ran `make api-cli-smoke` against the rebuilt API on
   alternate host ports, and live-tested `sites cleanup --batch`.
+- [x] 2026-04-28: Added the Docker-local `api-fixture` service with stable
+  response-code, redirect, keyword, slow-response, and self-signed TLS
+  endpoints for deterministic API CLI failure simulation.
+- [x] 2026-04-28: Updated `sites simulate-failure` to auto-detect the fixture
+  via `http://localhost:18091/health`, use Docker-internal fixture URLs when
+  available, and keep public endpoint fallbacks via `--fixture-url=off`.
+- [x] 2026-04-28: Added strict failure-simulation assertions for expected event
+  state, event severity, transition presence, and transition reason. Assertion
+  mode keeps polling until the expectations match or `--wait` expires, then
+  returns a non-zero summary with the last observed API state.

--- a/docs/api-cli-roadmap.md
+++ b/docs/api-cli-roadmap.md
@@ -122,7 +122,7 @@ but it should not become a generic `curl` clone.
   feature guide and Docker-local smoke path.
 - [x] Improve table output for workflow commands with event IDs, states,
   severities, transition counts, trigger results, and cleanup status.
-- [ ] Add shell completion or richer command discovery for the expanded
+- [x] Add shell completion or richer command discovery for the expanded
   `jetmon2 api` command tree.
 - [ ] Extend `api-fixture` into a local webhook receiver so smoke tests can
   verify outbound webhook delivery and signing behavior end-to-end.
@@ -221,3 +221,5 @@ but it should not become a generic `curl` clone.
   transition counts, and smoke cleanup rows in stable table columns.
 - [x] 2026-04-28: Added Docker-local API token convenience targets for
   creating, listing, and revoking rehearsal tokens from the repository root.
+- [x] 2026-04-28: Added `jetmon2 api commands` as a table-first command
+  catalog with descriptions and examples for the expanded API CLI tree.

--- a/docs/api-cli-roadmap.md
+++ b/docs/api-cli-roadmap.md
@@ -23,7 +23,7 @@ but it should not become a generic `curl` clone.
 
 - [x] Add `sites list|get|create|update|delete|pause|resume|trigger-now`.
 - [x] Add `events list|get|transitions|close`.
-- [ ] Add `webhooks list|get|create|update|delete|rotate-secret|deliveries|retry`.
+- [x] Add `webhooks list|get|create|update|delete|rotate-secret|deliveries|retry`.
 - [ ] Add `alert-contacts list|get|create|update|delete|test|deliveries|retry`.
 - [ ] Keep typed command payloads close to the OpenAPI component schemas or shared
   request structs so CLI examples do not drift from the server contract.
@@ -105,3 +105,8 @@ but it should not become a generic `curl` clone.
   `list|get|transitions|close` commands with site-scoped list/transition/close
   paths, direct or site-scoped event lookup, close payload flags, idempotency
   support, and focused path/body tests.
+- [x] 2026-04-28: Added typed `jetmon2 api webhooks`
+  `list|get|create|update|delete|rotate-secret|deliveries|retry` commands with
+  typed event/site/state filter payloads, explicit filter-clearing flags,
+  delivery status filters, idempotency support for POST actions, and focused
+  path/body tests.

--- a/docs/api-cli-roadmap.md
+++ b/docs/api-cli-roadmap.md
@@ -120,7 +120,7 @@ but it should not become a generic `curl` clone.
   operator explicitly opts out.
 - [x] Add a reproducible documentation/live validation target for the API CLI
   feature guide and Docker-local smoke path.
-- [ ] Improve table output for workflow commands with event IDs, states,
+- [x] Improve table output for workflow commands with event IDs, states,
   severities, transition counts, trigger results, and cleanup status.
 - [ ] Add shell completion or richer command discovery for the expanded
   `jetmon2 api` command tree.
@@ -216,3 +216,6 @@ but it should not become a generic `curl` clone.
   `scripts/api-cli-validate.sh` for a live Docker-local validation pass across
   the feature guide's health, identity, generic request, smoke, failure
   simulation, and cleanup paths.
+- [x] 2026-04-28: Improved workflow table output by surfacing failure
+  simulation trigger status, event IDs, event states, event severities,
+  transition counts, and smoke cleanup rows in stable table columns.

--- a/docs/api-cli-roadmap.md
+++ b/docs/api-cli-roadmap.md
@@ -1,0 +1,99 @@
+# API CLI Roadmap
+
+Status: started on `feature/api-cli`.
+
+This roadmap tracks a local developer/operator CLI for exercising the internal
+Jetmon `/api/v1` surface without remembering endpoint paths, auth headers, and
+payload shapes by hand. The CLI should make local Docker testing repeatable,
+but it should not become a generic `curl` clone.
+
+## P0 - Request Foundation
+
+- [x] Add `jetmon2 api health` for unauthenticated API/database health checks.
+- [x] Add `jetmon2 api me` for validating Bearer-token auth and API-key identity.
+- [x] Add `jetmon2 api request <method> <path-or-url>` as the escape hatch for
+  newly-added routes before typed commands exist.
+- [x] Read `JETMON_API_URL` and `JETMON_API_TOKEN`, with Docker-local defaults.
+- [x] Add `-v` / `--verbose` to print full request and response headers for local
+  debugging.
+- [x] Support request bodies from `--body`, `--body-file`, and stdin, plus
+  `--idempotency-key` for POST retry testing.
+
+## P1 - Typed Resource Commands
+
+- [ ] Add `sites list|get|create|update|delete|pause|resume|trigger-now`.
+- [ ] Add `events list|get|transitions|close`.
+- [ ] Add `webhooks list|get|create|update|delete|rotate-secret|deliveries|retry`.
+- [ ] Add `alert-contacts list|get|create|update|delete|test|deliveries|retry`.
+- [ ] Keep typed command payloads close to the OpenAPI component schemas or shared
+  request structs so CLI examples do not drift from the server contract.
+- [ ] Add `sites bulk-add --count <n>` for creating a bounded batch of real
+  monitored URLs for local testing. Support `--source fixture|file|stdin` so the
+  default is repeatable but operators can supply their own CSV/JSON/newline
+  list without recompiling the CLI.
+- [ ] Add a curated local fixture of real public URLs with mixed behavior:
+  always-up examples, redirects, slow responses, client/server error responses,
+  TLS edge cases, and keyword-check candidates. Keep the fixture small,
+  documented, and safe for local-only test data generation.
+
+## P2 - Local Smoke Workflows
+
+- [ ] Add `jetmon2 api smoke` to run a local end-to-end sanity pass against Docker:
+  health, auth, create a site, trigger a check, read events, and exercise a
+  webhook or alert-contact test path.
+- [ ] Add `jetmon2 api sites simulate-failure` to intentionally mutate one or
+  more CLI-created test sites into known failure states, trigger checks, and
+  show the resulting event IDs and transitions.
+- [ ] Support targeted failure modes for simulation: unreachable host, HTTP 500,
+  HTTP 403, redirect-policy failure, keyword mismatch, timeout/slow response,
+  and TLS/certificate failure.
+- [ ] Track CLI-created test-site batches with a stable label or metadata marker
+  so smoke tests and failure simulations can operate on `--batch <id>`,
+  `--count <n>`, or explicit site IDs without touching unrelated local data.
+- [ ] Add cleanup behavior for resources created by smoke runs.
+- [ ] Return non-zero exit codes and concise failure summaries suitable for CI.
+
+## Test Site Source Ideas
+
+- **Recommended path:** Start with a curated checked-in fixture plus
+  operator-supplied file/stdin imports. Use real public endpoints for network
+  realism, add a Docker failure fixture later for deterministic event
+  assertions, and cycle through the source list with varied site settings for
+  larger `--count` values instead of inventing fake public domains.
+- **Curated fixture:** Check in a small `docs/testdata` or `internal/testdata`
+  source list with public endpoints selected for deterministic behavior. This
+  should be the default because it keeps local test runs repeatable.
+- **Operator-supplied file/stdin:** Accept newline, CSV, or JSON site lists so
+  developers can test with a private list of real customer-like domains without
+  committing those domains to the repo.
+- **Docker failure fixture:** Add a local test-site container later for the
+  most deterministic failure simulation. Real public sites are useful for
+  network realism, but local fixture endpoints are better for asserting exact
+  event transitions.
+- **Generated variants:** For `--count` larger than the curated fixture, cycle
+  through the source list with deterministic suffix metadata and varied
+  per-site settings: redirect policy, keyword, timeout, custom headers, and
+  check interval. Do not invent nonexistent public domains as "real" sites.
+- **External top-site lists:** If broader realism is needed, allow importing an
+  operator-downloaded ranked domain list. Keep download/fetch outside the CLI at
+  first so local tests remain reproducible and do not depend on third-party
+  availability.
+
+## P3 - Output Ergonomics
+
+- [ ] Add stable table output for list commands while keeping JSON as the default
+  automation-friendly format.
+- [x] Add `--pretty` for formatted JSON and preserve raw JSON for scripts.
+- [ ] Add examples to `API.md`, Docker docs, and the v1-to-v2 rollout rehearsal
+  docs once the command shape has stabilized.
+
+## Completed
+
+- [x] 2026-04-28: Created the `feature/api-cli` branch and initial roadmap.
+- [x] 2026-04-28: Added the `jetmon2 api` command group with `health`, `me`,
+  and generic `request` subcommands.
+- [x] 2026-04-28: Added local defaults, Bearer-token auth, repeatable custom
+  headers, idempotency-key support, request body helpers, JSON pretty printing,
+  and verbose request/response header logging.
+- [x] 2026-04-28: Added focused tests for URL resolution, auth/idempotency
+  headers, verbose output, pretty JSON output, and HTTP error handling.

--- a/docs/api-cli-roadmap.md
+++ b/docs/api-cli-roadmap.md
@@ -1,6 +1,6 @@
 # API CLI Roadmap
 
-Status: started on `feature/api-cli`.
+Status: completed on `feature/api-cli`.
 
 This roadmap tracks a local developer/operator CLI for exercising the internal
 Jetmon `/api/v1` surface without remembering endpoint paths, auth headers, and
@@ -55,21 +55,22 @@ but it should not become a generic `curl` clone.
 
 ## Test Site Source Ideas
 
-- **Recommended path:** Start with a curated checked-in fixture plus
-  operator-supplied file/stdin imports. Use real public endpoints for network
-  realism, add a Docker failure fixture later for deterministic event
-  assertions, and cycle through the source list with varied site settings for
-  larger `--count` values instead of inventing fake public domains.
+- **Implemented path:** Use a curated checked-in fixture plus operator-supplied
+  file/stdin imports for repeatable test-site creation. Use real public
+  endpoints for network realism, and use the Docker-local `api-fixture` service
+  for deterministic event assertions. For larger `--count` values, cycle
+  through the source list with varied site settings instead of inventing fake
+  public domains.
 - **Curated fixture:** Check in a small `docs/testdata` or `internal/testdata`
   source list with public endpoints selected for deterministic behavior. This
   should be the default because it keeps local test runs repeatable.
 - **Operator-supplied file/stdin:** Accept newline, CSV, or JSON site lists so
   developers can test with a private list of real customer-like domains without
   committing those domains to the repo.
-- **Docker failure fixture:** Add a local test-site container later for the
-  most deterministic failure simulation. Real public sites are useful for
-  network realism, but local fixture endpoints are better for asserting exact
-  event transitions.
+- **Docker failure fixture:** The local `api-fixture` service provides the most
+  deterministic failure simulation. Real public sites remain useful for network
+  realism, but local fixture endpoints are better for asserting exact event
+  transitions.
 - **Generated variants:** For `--count` larger than the curated fixture, cycle
   through the source list with deterministic suffix metadata and varied
   per-site settings: redirect policy, keyword, timeout, custom headers, and

--- a/docs/api-cli-roadmap.md
+++ b/docs/api-cli-roadmap.md
@@ -1,6 +1,6 @@
 # API CLI Roadmap
 
-Status: completed on `feature/api-cli`.
+Status: active on `feature/api-cli`.
 
 This roadmap tracks a local developer/operator CLI for exercising the internal
 Jetmon `/api/v1` surface without remembering endpoint paths, auth headers, and
@@ -110,6 +110,25 @@ but it should not become a generic `curl` clone.
   generic requests, site management, batch test data, events, webhooks, alert
   contacts, smoke runs, failure simulation, cleanup, and automation patterns.
 
+## P6 - Operator Ergonomics and Safety
+
+- [x] Allow API CLI flags before or after positional arguments so examples like
+  `sites get 123 --pretty` work the way operators naturally type them.
+- [ ] Add batch ownership safety checks for destructive or mutating batch
+  workflows. `sites cleanup --batch` and `sites simulate-failure --batch`
+  should verify the target still belongs to the requested CLI batch unless the
+  operator explicitly opts out.
+- [ ] Add a reproducible documentation/live validation target for the API CLI
+  feature guide and Docker-local smoke path.
+- [ ] Improve table output for workflow commands with event IDs, states,
+  severities, transition counts, trigger results, and cleanup status.
+- [ ] Add shell completion or richer command discovery for the expanded
+  `jetmon2 api` command tree.
+- [ ] Extend `api-fixture` into a local webhook receiver so smoke tests can
+  verify outbound webhook delivery and signing behavior end-to-end.
+- [ ] Add a local API-token convenience target or wrapper for creating and
+  revoking Docker-local API CLI tokens during rehearsals.
+
 ## Completed
 
 - [x] 2026-04-28: Created the `feature/api-cli` branch and initial roadmap.
@@ -190,3 +209,6 @@ but it should not become a generic `curl` clone.
 - [x] 2026-04-28: Added `docs/api-cli-guide.md` as a feature-oriented API CLI
   usage guide with local setup, command examples, workflow recipes, failure
   simulation assertions, and automation notes.
+- [x] 2026-04-28: Allowed API CLI flags before or after positional arguments by
+  normalizing recognized flags before parsing while preserving `--` literals;
+  added tests for interspersed flags and help output.

--- a/docs/api-cli-roadmap.md
+++ b/docs/api-cli-roadmap.md
@@ -118,7 +118,7 @@ but it should not become a generic `curl` clone.
   workflows. `sites cleanup --batch` and `sites simulate-failure --batch`
   should verify the target still belongs to the requested CLI batch unless the
   operator explicitly opts out.
-- [ ] Add a reproducible documentation/live validation target for the API CLI
+- [x] Add a reproducible documentation/live validation target for the API CLI
   feature guide and Docker-local smoke path.
 - [ ] Improve table output for workflow commands with event IDs, states,
   severities, transition counts, trigger results, and cleanup status.
@@ -212,3 +212,7 @@ but it should not become a generic `curl` clone.
 - [x] 2026-04-28: Allowed API CLI flags before or after positional arguments by
   normalizing recognized flags before parsing while preserving `--` literals;
   added tests for interspersed flags and help output.
+- [x] 2026-04-28: Added `make api-cli-validate` and
+  `scripts/api-cli-validate.sh` for a live Docker-local validation pass across
+  the feature guide's health, identity, generic request, smoke, failure
+  simulation, and cleanup paths.

--- a/docs/api-cli-roadmap.md
+++ b/docs/api-cli-roadmap.md
@@ -134,6 +134,9 @@ but it should not become a generic `curl` clone.
 
 ## Completed
 
+- [x] 2026-04-28: Refreshed the root README into a shorter Jetmon 2 project
+  front door and moved dense setup, operations, data-model, and support
+  material into focused docs.
 - [x] 2026-04-28: Created the `feature/api-cli` branch and initial roadmap.
 - [x] 2026-04-28: Added the `jetmon2 api` command group with `health`, `me`,
   and generic `request` subcommands.

--- a/docs/api-cli-roadmap.md
+++ b/docs/api-cli-roadmap.md
@@ -41,17 +41,17 @@ but it should not become a generic `curl` clone.
 - [x] Add `jetmon2 api smoke` to run a local end-to-end sanity pass against Docker:
   health, auth, create a site, trigger a check, read events, and exercise a
   webhook or alert-contact test path.
-- [ ] Add `jetmon2 api sites simulate-failure` to intentionally mutate one or
+- [x] Add `jetmon2 api sites simulate-failure` to intentionally mutate one or
   more CLI-created test sites into known failure states, trigger checks, and
   show the resulting event IDs and transitions.
-- [ ] Support targeted failure modes for simulation: unreachable host, HTTP 500,
+- [x] Support targeted failure modes for simulation: unreachable host, HTTP 500,
   HTTP 403, redirect-policy failure, keyword mismatch, timeout/slow response,
   and TLS/certificate failure.
-- [ ] Track CLI-created test-site batches with a stable label or metadata marker
+- [x] Track CLI-created test-site batches with a stable label or metadata marker
   so smoke tests and failure simulations can operate on `--batch <id>`,
   `--count <n>`, or explicit site IDs without touching unrelated local data.
 - [x] Add cleanup behavior for resources created by smoke runs.
-- [ ] Return non-zero exit codes and concise failure summaries suitable for CI.
+- [x] Return non-zero exit codes and concise failure summaries suitable for CI.
 
 ## Test Site Source Ideas
 
@@ -129,3 +129,14 @@ but it should not become a generic `curl` clone.
   sanity checks covering health, auth identity, site creation, trigger-now,
   event listing, alert-contact creation, alert-contact send-test, JSON step
   summaries, and best-effort cleanup of created resources.
+- [x] 2026-04-28: Added `jetmon2 api sites simulate-failure` with explicit
+  `--site-id` targets or deterministic `--batch`/`--count` site IDs,
+  `--create-missing`, optional trigger-now, active-event polling, transition
+  lookup for returned event IDs, and JSON summaries that include per-site
+  errors before exiting non-zero.
+- [x] 2026-04-28: Added simulation modes for unreachable hosts, HTTP 500, HTTP
+  403, redirect-policy failure, keyword mismatch, timeout/slow responses, and
+  TLS certificate failure.
+- [x] 2026-04-28: Added CLI batch tracking through deterministic blog ID ranges
+  and the `X-Jetmon-CLI-Batch` custom-header marker for smoke-created sites,
+  bulk-added sites, and simulated failure targets.

--- a/docs/api-cli-roadmap.md
+++ b/docs/api-cli-roadmap.md
@@ -124,8 +124,11 @@ but it should not become a generic `curl` clone.
   severities, transition counts, trigger results, and cleanup status.
 - [x] Add shell completion or richer command discovery for the expanded
   `jetmon2 api` command tree.
-- [ ] Extend `api-fixture` into a local webhook receiver so smoke tests can
-  verify outbound webhook delivery and signing behavior end-to-end.
+- [x] Extend `api-fixture` into a local webhook receiver that records webhook
+  deliveries and verifies `X-Jetmon-Signature` when a shared secret is supplied.
+- [ ] Wire API CLI smoke or validation workflows to create a Docker-local
+  webhook, share the generated secret with the fixture receiver, and assert
+  delivery plus signature verification end-to-end.
 - [x] Add a local API-token convenience target or wrapper for creating and
   revoking Docker-local API CLI tokens during rehearsals.
 
@@ -226,3 +229,7 @@ but it should not become a generic `curl` clone.
 - [x] 2026-04-28: Added derived site `cli_batch` responses and batch marker
   checks for `sites cleanup --batch` and `sites simulate-failure --batch`, with
   `--allow-unmarked` as the explicit legacy opt-out.
+- [x] 2026-04-28: Extended `api-fixture` with `/webhook` and
+  `/webhook/requests` endpoints that record deliveries, expose captured
+  signature headers, clear recorded requests, and verify signatures when a
+  `secret` query parameter is supplied.

--- a/docs/api-cli-roadmap.md
+++ b/docs/api-cli-roadmap.md
@@ -24,7 +24,7 @@ but it should not become a generic `curl` clone.
 - [x] Add `sites list|get|create|update|delete|pause|resume|trigger-now`.
 - [x] Add `events list|get|transitions|close`.
 - [x] Add `webhooks list|get|create|update|delete|rotate-secret|deliveries|retry`.
-- [ ] Add `alert-contacts list|get|create|update|delete|test|deliveries|retry`.
+- [x] Add `alert-contacts list|get|create|update|delete|test|deliveries|retry`.
 - [ ] Keep typed command payloads close to the OpenAPI component schemas or shared
   request structs so CLI examples do not drift from the server contract.
 - [ ] Add `sites bulk-add --count <n>` for creating a bounded batch of real
@@ -110,3 +110,8 @@ but it should not become a generic `curl` clone.
   typed event/site/state filter payloads, explicit filter-clearing flags,
   delivery status filters, idempotency support for POST actions, and focused
   path/body tests.
+- [x] 2026-04-28: Added typed `jetmon2 api alert-contacts`
+  `list|get|create|update|delete|test|deliveries|retry` commands with
+  transport-specific destination shortcuts, raw destination JSON support, site
+  filter clearing, delivery status filters, idempotency support for POST
+  actions, and focused path/body tests.

--- a/docs/api-cli-roadmap.md
+++ b/docs/api-cli-roadmap.md
@@ -241,11 +241,11 @@ but it should not become a generic `curl` clone.
   explicit `--auth-policy any-origin` opt-in, keeping `cli_batch` out of the
   canonical site response, and clarifying the `sites create` command catalog
   wording.
-- [x] 2026-04-28: Added `--allow-remote` guardrails for API CLI test-data
-  workflows. Non-local API targets now refuse smoke, bulk-add, cleanup, and
-  failure simulation writes without the explicit flag; remote smoke, bulk-add,
-  cleanup, and simulation also require `--batch`, and remote cleanup/simulation
-  keep marker verification mandatory.
+- [x] 2026-04-28: Added `--allow-remote` guardrails for API CLI writes.
+  Non-local API targets now refuse POST, PUT, PATCH, and DELETE requests
+  without the explicit flag; remote smoke, bulk-add, cleanup, and simulation
+  also require `--batch`, and remote cleanup/simulation keep marker
+  verification mandatory.
 - [x] 2026-04-28: Extended `api-fixture` with `/webhook` and
   `/webhook/requests` endpoints that record deliveries, expose captured
   signature headers, clear recorded requests, and verify signatures when a

--- a/docs/api-cli-roadmap.md
+++ b/docs/api-cli-roadmap.md
@@ -104,6 +104,12 @@ but it should not become a generic `curl` clone.
 - [x] Add deterministic failure-simulation assertions for exact
   event/transition behavior without depending on public endpoint timing.
 
+## P5 - Feature Documentation
+
+- [x] Add a feature guide with setup instructions and examples for health,
+  generic requests, site management, batch test data, events, webhooks, alert
+  contacts, smoke runs, failure simulation, cleanup, and automation patterns.
+
 ## Completed
 
 - [x] 2026-04-28: Created the `feature/api-cli` branch and initial roadmap.
@@ -181,3 +187,6 @@ but it should not become a generic `curl` clone.
   state, event severity, transition presence, and transition reason. Assertion
   mode keeps polling until the expectations match or `--wait` expires, then
   returns a non-zero summary with the last observed API state.
+- [x] 2026-04-28: Added `docs/api-cli-guide.md` as a feature-oriented API CLI
+  usage guide with local setup, command examples, workflow recipes, failure
+  simulation assertions, and automation notes.

--- a/docs/api-cli-roadmap.md
+++ b/docs/api-cli-roadmap.md
@@ -87,6 +87,21 @@ but it should not become a generic `curl` clone.
 - [x] Add examples to `API.md`, Docker docs, and the v1-to-v2 rollout rehearsal
   docs once the command shape has stabilized.
 
+## P4 - Hardening and Repeatability
+
+- [x] Re-run a fresh `docker compose up --build -d` and API CLI smoke pass after
+  Docker bridge networking is healthy, so the branch is verified through the
+  normal container entrypoint instead of only the host-run binary.
+- [x] Add `jetmon2 api sites cleanup --batch <id>` for removing deterministic
+  CLI-created site batches after smoke, bulk-add, and failure simulation runs.
+- [x] Add a one-command `make api-cli-smoke` entrypoint for the documented local
+  smoke path.
+- [ ] Add a deterministic Docker-local failure fixture service for response
+  codes, redirects, keyword mismatch, slow responses, and TLS edge cases.
+- [ ] Teach failure simulation to prefer the Docker-local fixture when it is
+  available, then assert exact event/transition behavior without depending on
+  public endpoint timing.
+
 ## Completed
 
 - [x] 2026-04-28: Created the `feature/api-cli` branch and initial roadmap.
@@ -145,3 +160,12 @@ but it should not become a generic `curl` clone.
   default script-friendly output.
 - [x] 2026-04-28: Documented API CLI setup and examples in `API.md`, the Docker
   development loop, and the pinned v1-to-v2 rollout rehearsal runbook.
+- [x] 2026-04-28: Added `jetmon2 api sites cleanup` with deterministic
+  batch-derived IDs, explicit site IDs, dry-run output, 404-tolerant cleanup,
+  and JSON/table summaries for removing local CLI test data.
+- [x] 2026-04-28: Added `make api-cli-smoke` as the repeatable local API CLI
+  smoke entrypoint and documented cleanup examples in API, Docker, and rollout
+  docs.
+- [x] 2026-04-28: Verified a fresh Docker Compose rebuild after Docker bridge
+  networking was repaired, ran `make api-cli-smoke` against the rebuilt API on
+  alternate host ports, and live-tested `sites cleanup --batch`.

--- a/docs/api-cli-roadmap.md
+++ b/docs/api-cli-roadmap.md
@@ -81,10 +81,10 @@ but it should not become a generic `curl` clone.
 
 ## P3 - Output Ergonomics
 
-- [ ] Add stable table output for list commands while keeping JSON as the default
+- [x] Add stable table output for list commands while keeping JSON as the default
   automation-friendly format.
 - [x] Add `--pretty` for formatted JSON and preserve raw JSON for scripts.
-- [ ] Add examples to `API.md`, Docker docs, and the v1-to-v2 rollout rehearsal
+- [x] Add examples to `API.md`, Docker docs, and the v1-to-v2 rollout rehearsal
   docs once the command shape has stabilized.
 
 ## Completed
@@ -140,3 +140,8 @@ but it should not become a generic `curl` clone.
 - [x] 2026-04-28: Added CLI batch tracking through deterministic blog ID ranges
   and the `X-Jetmon-CLI-Batch` custom-header marker for smoke-created sites,
   bulk-added sites, and simulated failure targets.
+- [x] 2026-04-28: Added `--output table` with stable resource-oriented columns
+  for API list responses and CLI workflow summaries while keeping JSON as the
+  default script-friendly output.
+- [x] 2026-04-28: Documented API CLI setup and examples in `API.md`, the Docker
+  development loop, and the pinned v1-to-v2 rollout rehearsal runbook.

--- a/docs/api-cli-roadmap.md
+++ b/docs/api-cli-roadmap.md
@@ -38,7 +38,7 @@ but it should not become a generic `curl` clone.
 
 ## P2 - Local Smoke Workflows
 
-- [ ] Add `jetmon2 api smoke` to run a local end-to-end sanity pass against Docker:
+- [x] Add `jetmon2 api smoke` to run a local end-to-end sanity pass against Docker:
   health, auth, create a site, trigger a check, read events, and exercise a
   webhook or alert-contact test path.
 - [ ] Add `jetmon2 api sites simulate-failure` to intentionally mutate one or
@@ -50,7 +50,7 @@ but it should not become a generic `curl` clone.
 - [ ] Track CLI-created test-site batches with a stable label or metadata marker
   so smoke tests and failure simulations can operate on `--batch <id>`,
   `--count <n>`, or explicit site IDs without touching unrelated local data.
-- [ ] Add cleanup behavior for resources created by smoke runs.
+- [x] Add cleanup behavior for resources created by smoke runs.
 - [ ] Return non-zero exit codes and concise failure summaries suitable for CI.
 
 ## Test Site Source Ideas
@@ -125,3 +125,7 @@ but it should not become a generic `curl` clone.
 - [x] 2026-04-28: Added the embedded `cmd/jetmon2/testdata/api-cli-sites.json`
   fixture with always-up, redirect, slow, HTTP error, TLS error, custom-header,
   and keyword-check examples.
+- [x] 2026-04-28: Added `jetmon2 api smoke` for Docker-local end-to-end API
+  sanity checks covering health, auth identity, site creation, trigger-now,
+  event listing, alert-contact creation, alert-contact send-test, JSON step
+  summaries, and best-effort cleanup of created resources.

--- a/docs/api-cli-roadmap.md
+++ b/docs/api-cli-roadmap.md
@@ -25,13 +25,13 @@ but it should not become a generic `curl` clone.
 - [x] Add `events list|get|transitions|close`.
 - [x] Add `webhooks list|get|create|update|delete|rotate-secret|deliveries|retry`.
 - [x] Add `alert-contacts list|get|create|update|delete|test|deliveries|retry`.
-- [ ] Keep typed command payloads close to the OpenAPI component schemas or shared
+- [x] Keep typed command payloads close to the OpenAPI component schemas or shared
   request structs so CLI examples do not drift from the server contract.
-- [ ] Add `sites bulk-add --count <n>` for creating a bounded batch of real
+- [x] Add `sites bulk-add --count <n>` for creating a bounded batch of real
   monitored URLs for local testing. Support `--source fixture|file|stdin` so the
   default is repeatable but operators can supply their own CSV/JSON/newline
   list without recompiling the CLI.
-- [ ] Add a curated local fixture of real public URLs with mixed behavior:
+- [x] Add a curated local fixture of real public URLs with mixed behavior:
   always-up examples, redirects, slow responses, client/server error responses,
   TLS edge cases, and keyword-check candidates. Keep the fixture small,
   documented, and safe for local-only test data generation.
@@ -115,3 +115,13 @@ but it should not become a generic `curl` clone.
   transport-specific destination shortcuts, raw destination JSON support, site
   filter clearing, delivery status filters, idempotency support for POST
   actions, and focused path/body tests.
+- [x] 2026-04-28: Kept typed command payloads aligned with the implemented API
+  schemas through local request structs, JSON body builders, and focused
+  path/body tests for sites, events, webhooks, and alert contacts.
+- [x] 2026-04-28: Added `jetmon2 api sites bulk-add --count <n>` with a
+  bounded 200-site cap, fixture/file/stdin sources, JSON/CSV/newline parsing,
+  dry-run output, per-site idempotency-key prefixes, and deterministic
+  sequential blog IDs for local Docker data generation.
+- [x] 2026-04-28: Added the embedded `cmd/jetmon2/testdata/api-cli-sites.json`
+  fixture with always-up, redirect, slow, HTTP error, TLS error, custom-header,
+  and keyword-check examples.

--- a/docs/api-cli-roadmap.md
+++ b/docs/api-cli-roadmap.md
@@ -243,7 +243,7 @@ but it should not become a generic `curl` clone.
   wording.
 - [x] 2026-04-28: Added `--allow-remote` guardrails for API CLI test-data
   workflows. Non-local API targets now refuse smoke, bulk-add, cleanup, and
-  failure simulation writes without the explicit flag; remote bulk-add,
+  failure simulation writes without the explicit flag; remote smoke, bulk-add,
   cleanup, and simulation also require `--batch`, and remote cleanup/simulation
   keep marker verification mandatory.
 - [x] 2026-04-28: Extended `api-fixture` with `/webhook` and

--- a/docs/api-cli-roadmap.md
+++ b/docs/api-cli-roadmap.md
@@ -241,6 +241,11 @@ but it should not become a generic `curl` clone.
   explicit `--auth-policy any-origin` opt-in, keeping `cli_batch` out of the
   canonical site response, and clarifying the `sites create` command catalog
   wording.
+- [x] 2026-04-28: Added `--allow-remote` guardrails for API CLI test-data
+  workflows. Non-local API targets now refuse smoke, bulk-add, cleanup, and
+  failure simulation writes without the explicit flag; remote bulk-add,
+  cleanup, and simulation also require `--batch`, and remote cleanup/simulation
+  keep marker verification mandatory.
 - [x] 2026-04-28: Extended `api-fixture` with `/webhook` and
   `/webhook/requests` endpoints that record deliveries, expose captured
   signature headers, clear recorded requests, and verify signatures when a

--- a/docs/api-cli-roadmap.md
+++ b/docs/api-cli-roadmap.md
@@ -22,7 +22,7 @@ but it should not become a generic `curl` clone.
 ## P1 - Typed Resource Commands
 
 - [x] Add `sites list|get|create|update|delete|pause|resume|trigger-now`.
-- [ ] Add `events list|get|transitions|close`.
+- [x] Add `events list|get|transitions|close`.
 - [ ] Add `webhooks list|get|create|update|delete|rotate-secret|deliveries|retry`.
 - [ ] Add `alert-contacts list|get|create|update|delete|test|deliveries|retry`.
 - [ ] Keep typed command payloads close to the OpenAPI component schemas or shared
@@ -101,3 +101,7 @@ but it should not become a generic `curl` clone.
   `list|get|create|update|delete|pause|resume|trigger-now` commands with
   query flags, typed create/update payload builders, idempotency support for
   POST actions, and focused helper tests.
+- [x] 2026-04-28: Added typed `jetmon2 api events`
+  `list|get|transitions|close` commands with site-scoped list/transition/close
+  paths, direct or site-scoped event lookup, close payload flags, idempotency
+  support, and focused path/body tests.

--- a/docs/api-cli-roadmap.md
+++ b/docs/api-cli-roadmap.md
@@ -126,7 +126,7 @@ but it should not become a generic `curl` clone.
   `jetmon2 api` command tree.
 - [ ] Extend `api-fixture` into a local webhook receiver so smoke tests can
   verify outbound webhook delivery and signing behavior end-to-end.
-- [ ] Add a local API-token convenience target or wrapper for creating and
+- [x] Add a local API-token convenience target or wrapper for creating and
   revoking Docker-local API CLI tokens during rehearsals.
 
 ## Completed
@@ -219,3 +219,5 @@ but it should not become a generic `curl` clone.
 - [x] 2026-04-28: Improved workflow table output by surfacing failure
   simulation trigger status, event IDs, event states, event severities,
   transition counts, and smoke cleanup rows in stable table columns.
+- [x] 2026-04-28: Added Docker-local API token convenience targets for
+  creating, listing, and revoking rehearsal tokens from the repository root.

--- a/docs/api-cli-roadmap.md
+++ b/docs/api-cli-roadmap.md
@@ -114,7 +114,7 @@ but it should not become a generic `curl` clone.
 
 - [x] Allow API CLI flags before or after positional arguments so examples like
   `sites get 123 --pretty` work the way operators naturally type them.
-- [ ] Add batch ownership safety checks for destructive or mutating batch
+- [x] Add batch ownership safety checks for destructive or mutating batch
   workflows. `sites cleanup --batch` and `sites simulate-failure --batch`
   should verify the target still belongs to the requested CLI batch unless the
   operator explicitly opts out.
@@ -223,3 +223,6 @@ but it should not become a generic `curl` clone.
   creating, listing, and revoking rehearsal tokens from the repository root.
 - [x] 2026-04-28: Added `jetmon2 api commands` as a table-first command
   catalog with descriptions and examples for the expanded API CLI tree.
+- [x] 2026-04-28: Added derived site `cli_batch` responses and batch marker
+  checks for `sites cleanup --batch` and `sites simulate-failure --batch`, with
+  `--allow-unmarked` as the explicit legacy opt-out.

--- a/docs/api-cli-roadmap.md
+++ b/docs/api-cli-roadmap.md
@@ -137,6 +137,9 @@ but it should not become a generic `curl` clone.
 - [x] 2026-04-28: Refreshed the root README into a shorter Jetmon 2 project
   front door and moved dense setup, operations, data-model, and support
   material into focused docs.
+- [x] 2026-04-28: Added the consolidated v1-to-v2 migration runbook, linked it
+  from README and the docs index, and updated migration references that had
+  pointed at the older pinned-rollout checklist.
 - [x] 2026-04-28: Created the `feature/api-cli` branch and initial roadmap.
 - [x] 2026-04-28: Added the `jetmon2 api` command group with `health`, `me`,
   and generic `request` subcommands.
@@ -192,7 +195,7 @@ but it should not become a generic `curl` clone.
   for API list responses and CLI workflow summaries while keeping JSON as the
   default script-friendly output.
 - [x] 2026-04-28: Documented API CLI setup and examples in `API.md`, the Docker
-  development loop, and the pinned v1-to-v2 rollout rehearsal runbook.
+  development loop, and the v1-to-v2 migration rehearsal runbook.
 - [x] 2026-04-28: Added `jetmon2 api sites cleanup` with deterministic
   batch-derived IDs, explicit site IDs, dry-run output, 404-tolerant cleanup,
   and JSON/table summaries for removing local CLI test data.

--- a/docs/api-cli-roadmap.md
+++ b/docs/api-cli-roadmap.md
@@ -232,9 +232,15 @@ but it should not become a generic `curl` clone.
   creating, listing, and revoking rehearsal tokens from the repository root.
 - [x] 2026-04-28: Added `jetmon2 api commands` as a table-first command
   catalog with descriptions and examples for the expanded API CLI tree.
-- [x] 2026-04-28: Added derived site `cli_batch` responses and batch marker
-  checks for `sites cleanup --batch` and `sites simulate-failure --batch`, with
-  `--allow-unmarked` as the explicit legacy opt-out.
+- [x] 2026-04-28: Added opt-in derived site `cli_batch` responses and batch
+  marker checks for `sites cleanup --batch` and
+  `sites simulate-failure --batch`, with `--allow-unmarked` as the explicit
+  legacy opt-out.
+- [x] 2026-04-28: Addressed API CLI review feedback by redacting sensitive
+  verbose headers, defaulting automatic auth to same-origin requests, adding an
+  explicit `--auth-policy any-origin` opt-in, keeping `cli_batch` out of the
+  canonical site response, and clarifying the `sites create` command catalog
+  wording.
 - [x] 2026-04-28: Extended `api-fixture` with `/webhook` and
   `/webhook/requests` endpoints that record deliveries, expose captured
   signature headers, clear recorded requests, and verify signatures when a

--- a/docs/api-cli-roadmap.md
+++ b/docs/api-cli-roadmap.md
@@ -21,7 +21,7 @@ but it should not become a generic `curl` clone.
 
 ## P1 - Typed Resource Commands
 
-- [ ] Add `sites list|get|create|update|delete|pause|resume|trigger-now`.
+- [x] Add `sites list|get|create|update|delete|pause|resume|trigger-now`.
 - [ ] Add `events list|get|transitions|close`.
 - [ ] Add `webhooks list|get|create|update|delete|rotate-secret|deliveries|retry`.
 - [ ] Add `alert-contacts list|get|create|update|delete|test|deliveries|retry`.
@@ -97,3 +97,7 @@ but it should not become a generic `curl` clone.
   and verbose request/response header logging.
 - [x] 2026-04-28: Added focused tests for URL resolution, auth/idempotency
   headers, verbose output, pretty JSON output, and HTTP error handling.
+- [x] 2026-04-28: Added typed `jetmon2 api sites`
+  `list|get|create|update|delete|pause|resume|trigger-now` commands with
+  query flags, typed create/update payload builders, idempotency support for
+  POST actions, and focused helper tests.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,147 @@
+# Data Model
+
+Jetmon 2 keeps the legacy site table as the configuration source during
+migration and adds event-sourced incident tables around it. New schema changes
+are additive and applied by `./jetmon2 migrate`.
+
+## Legacy Site Table
+
+The primary site table remains `jetpack_monitor_sites`.
+
+```sql
+CREATE TABLE `jetpack_monitor_sites` (
+  `jetpack_monitor_site_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `blog_id` bigint(20) unsigned NOT NULL,
+  `bucket_no` smallint(2) unsigned NOT NULL,
+  `monitor_url` varchar(300) NOT NULL,
+  `monitor_active` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `site_status` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `last_status_change` timestamp NULL DEFAULT current_timestamp(),
+  `check_interval` tinyint(1) unsigned NOT NULL DEFAULT 5,
+  INDEX `blog_id_monitor_url` (`blog_id`, `monitor_url`),
+  INDEX `bucket_no_monitor_active_check_interval`
+    (`bucket_no`, `monitor_active`, `check_interval`)
+);
+```
+
+Jetmon 2 adds these columns:
+
+| Column | Type | Purpose |
+|---|---|---|
+| `ssl_expiry_date` | `DATE NULL` | Last observed HTTPS certificate expiry |
+| `check_keyword` | `VARCHAR(500) NULL` | Required response-body string |
+| `maintenance_start` | `DATETIME NULL` | Maintenance window start |
+| `maintenance_end` | `DATETIME NULL` | Maintenance window end |
+| `custom_headers` | `JSON NULL` | Per-site request headers |
+| `timeout_seconds` | `TINYINT NULL` | Per-site timeout override |
+| `redirect_policy` | `ENUM NULL` | `follow`, `alert`, or `fail` |
+| `alert_cooldown_minutes` | `SMALLINT NULL` | Per-site alert cooldown override |
+
+The API can expose a derived `cli_batch` field for local API CLI test data when
+`custom_headers` contains `X-Jetmon-CLI-Batch`; it is not a dedicated database
+column.
+
+## New Tables
+
+| Table | Purpose |
+|---|---|
+| `jetmon_schema_migrations` | Applied migration tracking |
+| `jetmon_hosts` | MySQL-coordinated bucket ownership and heartbeat |
+| `jetmon_events` | Authoritative current state of every incident |
+| `jetmon_event_transitions` | Append-only mutation history for events |
+| `jetmon_audit_log` | Operational trail for checks, retries, WPCOM calls, suppression, API access, and reloads |
+| `jetmon_check_history` | RTT and timing samples for trending |
+| `jetmon_false_positives` | Veriflier non-confirmation records |
+| `jetmon_api_keys` | Internal REST API Bearer-token registry |
+| `jetmon_webhooks` | Webhook registrations and HMAC signing secrets |
+| `jetmon_webhook_deliveries` | Outbound webhook delivery attempts and retry state |
+| `jetmon_webhook_dispatch_progress` | Webhook worker high-water marks over transitions |
+| `jetmon_alert_contacts` | Managed destinations such as email, PagerDuty, Slack, and Teams |
+| `jetmon_alert_deliveries` | Outbound alert-contact attempts and retry state |
+| `jetmon_alert_dispatch_progress` | Alert worker high-water marks over transitions |
+| `jetmon_site_tenants` | Tenant-to-site mapping for gateway-scoped API access |
+
+## Event Source Of Truth
+
+Incident state is authoritative in:
+
+- `jetmon_events`: one mutable row per live incident identity, frozen after
+  close.
+- `jetmon_event_transitions`: one append-only row for every mutation.
+
+Every open, severity change, state change, cause-link change, and close writes a
+transition row in the same transaction as the event update. The `eventstore`
+package is the only writer for these tables.
+
+The lifecycle is:
+
+```text
+Up -> Seems Down -> Down -> Resolved
+         |
+         +-> Up (false alarm or probe-cleared)
+```
+
+`Seems Down` is first-class. It opens on the first local failure so incident
+duration starts when the user impact began, not when Verifliers later confirmed
+the outage.
+
+## Legacy Projection
+
+During the shadow-state migration, `jetpack_monitor_sites.site_status` and
+`last_status_change` are compatibility projections. With
+`LEGACY_STATUS_PROJECTION_ENABLE` enabled, every v2 event mutation also updates
+the legacy fields in the same transaction.
+
+Projection mapping:
+
+| v2 state | Legacy `site_status` |
+|---|---:|
+| Open `Seems Down` | `0` (`SITE_DOWN`) |
+| Open `Down` | `2` (`SITE_CONFIRMED_DOWN`) |
+| Closed or no open incident | `1` (`SITE_RUNNING`) |
+
+If drift is suspected, inspect mismatches with:
+
+```bash
+./jetmon2 rollout projection-drift
+./jetmon2 rollout projection-drift --bucket-min=0 --bucket-max=99 --limit=100
+```
+
+After legacy readers move to the v2 API or event tables, disable the projection.
+
+## Status And Failure Types
+
+Legacy status values:
+
+| Value | Meaning |
+|---:|---|
+| `0` | Local checks failed, retry or verification in progress |
+| `1` | Site is running |
+| `2` | Verifliers confirmed the site down |
+
+Failure classifications:
+
+| Type | Meaning |
+|---|---|
+| `server` | 5xx response |
+| `blocked` | 403 response |
+| `client` | 4xx response other than 403 |
+| `https` | SSL/TLS problem |
+| `intermittent` | Request timeout |
+| `redirect` | Redirect policy failure |
+| `ssl_expiry` | Certificate expiration threshold crossed |
+| `tls_deprecated` | TLS 1.0 or 1.1 |
+| `keyword_missing` | Required keyword was not present |
+| `success` | Recovery |
+
+## Tenant Mapping
+
+`jetmon_site_tenants` maps gateway tenant IDs to `blog_id` values. The import
+tool upserts known mappings and intentionally does not delete missing mappings:
+
+```bash
+./jetmon2 site-tenants import --file site-tenants.csv --dry-run
+./jetmon2 site-tenants import --file site-tenants.csv --source gateway
+```
+
+The CSV format is `tenant_id,blog_id` with an optional header row.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -39,8 +39,8 @@ Jetmon 2 adds these columns:
 | `alert_cooldown_minutes` | `SMALLINT NULL` | Per-site alert cooldown override |
 
 The API can expose a derived `cli_batch` field for local API CLI test data when
-`custom_headers` contains `X-Jetmon-CLI-Batch`; it is not a dedicated database
-column.
+`include_cli_metadata=true` is requested and `custom_headers` contains
+`X-Jetmon-CLI-Batch`; it is not a dedicated database column.
 
 ## New Tables
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,8 +1,9 @@
 # Data Model
 
-Jetmon 2 keeps the legacy site table as the configuration source during
-migration and adds event-sourced incident tables around it. New schema changes
-are additive and applied by `./jetmon2 migrate`.
+Jetmon 2 keeps the legacy site table as the configuration source during the
+[v1-to-v2 migration](v1-to-v2-migration.md) and adds event-sourced incident
+tables around it. New schema changes are additive and applied by
+`./jetmon2 migrate`.
 
 ## Legacy Site Table
 
@@ -87,10 +88,11 @@ the outage.
 
 ## Legacy Projection
 
-During the shadow-state migration, `jetpack_monitor_sites.site_status` and
-`last_status_change` are compatibility projections. With
-`LEGACY_STATUS_PROJECTION_ENABLE` enabled, every v2 event mutation also updates
-the legacy fields in the same transaction.
+During the shadow-state portion of the
+[v1-to-v2 migration](v1-to-v2-migration.md),
+`jetpack_monitor_sites.site_status` and `last_status_change` are compatibility
+projections. With `LEGACY_STATUS_PROJECTION_ENABLE` enabled, every v2 event
+mutation also updates the legacy fields in the same transaction.
 
 Projection mapping:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,161 @@
+# Getting Started
+
+This guide is for local development and smoke testing. Production rollout steps
+live in [operations-guide.md](operations-guide.md).
+
+## Requirements
+
+- Go 1.22 or newer
+- Docker and Docker Compose
+- `make`
+
+The Docker environment provides MySQL, StatsD/Graphite, Mailpit, the monitor,
+the Go Veriflier, and the API failure fixture.
+
+## Start Docker
+
+```bash
+cd docker
+cp .env-sample .env
+docker compose up --build -d
+```
+
+Useful follow-up commands:
+
+```bash
+docker compose logs -f jetmon
+docker compose exec jetmon bash
+docker compose down
+docker compose down --remove-orphans
+```
+
+Mailpit captures local alert-contact email. Open it at
+`http://localhost:8025` by default, or at the `BIND_ADDR` /
+`MAILPIT_HOST_PORT` values from `docker/.env`.
+
+## Build And Test
+
+From the repository root:
+
+```bash
+make all
+make test
+make test-race
+make lint
+```
+
+Build individual binaries when the full build is not needed:
+
+```bash
+make build
+make build-deliverer
+make build-veriflier
+```
+
+If `go` is not on `PATH`, the Makefile falls back to `/usr/local/go/bin/go`
+when present. Override with `make GO=/path/to/go ...` for other layouts.
+
+## Validate Config
+
+```bash
+./bin/jetmon2 validate-config
+```
+
+Validation checks required keys, value ranges, MySQL connectivity, legacy
+projection mode, email transport mode, and configured Verifliers. Veriflier
+reachability is reported as operational context rather than a hard validation
+failure.
+
+## API CLI Smoke
+
+Build the binary, create a local API key, and point the CLI at the exposed API:
+
+```bash
+make build
+make api-cli-token-create
+
+export JETMON_API_URL=http://localhost:${API_HOST_PORT:-8090}
+export JETMON_API_TOKEN=jm_replace_with_the_printed_token
+
+./bin/jetmon2 api health --pretty
+./bin/jetmon2 api me --pretty
+./bin/jetmon2 api commands --output table
+./bin/jetmon2 api sites list --output table
+```
+
+Run the standard smoke sequence:
+
+```bash
+make api-cli-smoke
+```
+
+Run the fuller live validation pass against the guide examples and local failure
+fixture:
+
+```bash
+make api-cli-validate
+```
+
+Use these helper targets to manage local rehearsal tokens:
+
+```bash
+make api-cli-token-list
+API_CLI_TOKEN_ID=<id> make api-cli-token-revoke
+```
+
+## Simulate A Failure
+
+The Docker Compose environment includes `api-fixture`, a deterministic local
+site fixture. Jetmon containers reach it at `http://api-fixture:8091` and
+`https://api-fixture:8443`; the host can inspect it at
+`http://localhost:18091` and `https://localhost:18443` by default.
+
+The fixture exposes endpoints for response codes, redirects, keyword mismatch,
+slow responses, TLS, and webhook capture.
+
+```bash
+./bin/jetmon2 api sites bulk-add --count 3 --batch local-smoke --dry-run --pretty
+./bin/jetmon2 api smoke --batch local-smoke --pretty
+./bin/jetmon2 api sites simulate-failure \
+  --batch local-smoke \
+  --mode http-500 \
+  --wait 30s \
+  --expect-event-state 'Seems Down' \
+  --expect-transition-reason opened \
+  --pretty
+./bin/jetmon2 api sites cleanup --batch local-smoke --count 3 --output table
+```
+
+Set `--fixture-url=off` to force public endpoint fallback behavior.
+
+## Add Manual Test Sites
+
+```bash
+cd docker
+docker compose exec mysqldb mysql -u jetmon -pjetmon_dev_password jetmon_db
+```
+
+```sql
+INSERT INTO jetpack_monitor_sites
+  (blog_id, bucket_no, monitor_url, monitor_active, site_status)
+VALUES
+  (1, 0, 'https://wordpress.com', 1, 1),
+  (2, 0, 'https://httpstat.us/200', 1, 1),
+  (3, 0, 'https://httpstat.us/500', 1, 1),
+  (4, 0, 'https://httpstat.us/200?sleep=15000', 1, 1);
+```
+
+## Import Tenant Mapping
+
+Gateway-routed site reads and writes are scoped through
+`jetmon_site_tenants`. Import the gateway or customer source of truth before
+customer traffic depends on Jetmon-side tenant enforcement:
+
+```bash
+./bin/jetmon2 site-tenants import --file site-tenants.csv --dry-run
+./bin/jetmon2 site-tenants import --file site-tenants.csv --source gateway
+```
+
+The CSV format is `tenant_id,blog_id` with an optional header row. Imports
+upsert mappings and skip duplicate input rows; they do not delete missing
+mappings.

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -27,9 +27,9 @@ Key settings:
 | `BUCKET_TOTAL` | 1000 | Total bucket range across all hosts |
 | `BUCKET_TARGET` | 500 | Maximum buckets this host should own |
 | `BUCKET_HEARTBEAT_GRACE_SEC` | 600 | Seconds before a silent host's buckets are reclaimed |
-| `PINNED_BUCKET_MIN` / `PINNED_BUCKET_MAX` | unset | Migration-only static bucket range |
+| `PINNED_BUCKET_MIN` / `PINNED_BUCKET_MAX` | unset | Static bucket range used by the [v1-to-v2 migration runbook](v1-to-v2-migration.md) |
 | `ALERT_COOLDOWN_MINUTES` | 30 | Default cooldown between repeated alerts per site |
-| `LEGACY_STATUS_PROJECTION_ENABLE` | true | Keep v1 status fields projected during migration |
+| `LEGACY_STATUS_PROJECTION_ENABLE` | true | Keep v1 status fields projected during the [v1-to-v2 migration](v1-to-v2-migration.md) |
 | `LOG_FORMAT` | `text` | `text` or `json` |
 | `DASHBOARD_PORT` | 8080 | Internal operator dashboard port, 0 disables it |
 | `API_PORT` | 0 | Internal REST API port, 0 disables it |
@@ -60,51 +60,12 @@ same `DB_*` environment that systemd reads from
 `/opt/jetmon2/config/jetmon2.env`; systemd's `EnvironmentFile` is not loaded for
 commands run directly from a shell.
 
-## First v1 To v2 Migration
+## v1 To v2 Migration
 
-For the first production migration, replace one v1 host at a time with a v2 host
-pinned to the same inclusive bucket range. This avoids mixed v1/v2 ownership and
-keeps rollback simple.
-
-1. Pre-apply additive migrations during a quiet period:
-
-   ```bash
-   ./jetmon2 migrate
-   ```
-
-2. Configure the v2 host with the same bucket range:
-
-   ```json
-   {
-     "PINNED_BUCKET_MIN": 0,
-     "PINNED_BUCKET_MAX": 99,
-     "LEGACY_STATUS_PROJECTION_ENABLE": true,
-     "API_PORT": 0
-   }
-   ```
-
-3. Run validation and pinned rollout checks:
-
-   ```bash
-   ./jetmon2 validate-config
-   ./jetmon2 rollout pinned-check
-   ```
-
-4. Stop the v1 process for that range, start v2, and verify checks, Veriflier
-   confirmations, WPCOM notifications, audit rows, and legacy projection.
-
-5. If rollback is needed, stop v2 and restart the original v1 process with the
-   same bucket config.
-
-6. After the fleet is on v2, remove `PINNED_BUCKET_*`, restart during the
-   approved window, and run:
-
-   ```bash
-   ./jetmon2 rollout dynamic-check
-   ```
-
-See [v1-to-v2-pinned-rollout.md](v1-to-v2-pinned-rollout.md) for the full
-checklist.
+Use [v1-to-v2-migration.md](v1-to-v2-migration.md) for the full production
+migration process. It covers preparation, additive migrations, pinned bucket
+mode, replacing v1 on the same server, moving a range to a fresh v2 server,
+monitoring, revert paths, dynamic ownership cutover, and v1 teardown.
 
 ## v2 Rolling Updates
 

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -1,0 +1,236 @@
+# Operations Guide
+
+This guide collects production-facing details that used to live in the root
+README: configuration, rollout, dashboard checks, delivery workers, metrics, and
+debugging.
+
+## Configuration
+
+Jetmon configuration lives in `config/config.json`. Copy
+`config/config-sample.json` to get started. Docker can generate this file from
+`config-sample.json` and `docker/.env` when it is not present.
+
+Use `SIGHUP` or `./jetmon2 reload` to reload configuration without restarting.
+
+Key settings:
+
+| Key | Default | Description |
+|---|---:|---|
+| `NUM_WORKERS` | 60 | Goroutine pool size |
+| `NUM_TO_PROCESS` | 40 | Parallel checks per pool slot |
+| `NUM_OF_CHECKS` | 3 | Local failures before Veriflier escalation |
+| `TIME_BETWEEN_CHECKS_SEC` | 30 | Delay between local retry checks |
+| `MIN_TIME_BETWEEN_ROUNDS_SEC` | 300 | Minimum seconds between check rounds |
+| `NET_COMMS_TIMEOUT` | 10 | Default per-check HTTP timeout in seconds |
+| `PEER_OFFLINE_LIMIT` | 3 | Veriflier agreements required to confirm downtime |
+| `WORKER_MAX_MEM_MB` | 53 | RSS threshold that triggers worker-pool drain |
+| `BUCKET_TOTAL` | 1000 | Total bucket range across all hosts |
+| `BUCKET_TARGET` | 500 | Maximum buckets this host should own |
+| `BUCKET_HEARTBEAT_GRACE_SEC` | 600 | Seconds before a silent host's buckets are reclaimed |
+| `PINNED_BUCKET_MIN` / `PINNED_BUCKET_MAX` | unset | Migration-only static bucket range |
+| `ALERT_COOLDOWN_MINUTES` | 30 | Default cooldown between repeated alerts per site |
+| `LEGACY_STATUS_PROJECTION_ENABLE` | true | Keep v1 status fields projected during migration |
+| `LOG_FORMAT` | `text` | `text` or `json` |
+| `DASHBOARD_PORT` | 8080 | Internal operator dashboard port, 0 disables it |
+| `API_PORT` | 0 | Internal REST API port, 0 disables it |
+| `DELIVERY_OWNER_HOST` | empty | Optional host allowed to run embedded delivery workers |
+| `DEBUG_PORT` | 6060 | localhost-only pprof port, 0 disables it |
+| `EMAIL_TRANSPORT` | `stub` | `stub`, `smtp`, or `wpcom` |
+
+See [../config/config.readme](../config/config.readme) for the full option
+reference.
+
+## Production Host Setup
+
+1. Install `jetmon2` to `/opt/jetmon2/`.
+2. Install `systemd/jetmon2.service` to `/etc/systemd/system/` and run
+   `systemctl daemon-reload`.
+3. Install `systemd/jetmon2-logrotate` to `/etc/logrotate.d/jetmon2`.
+4. Create `/opt/jetmon2/logs` and `/opt/jetmon2/stats`, owned by the `jetmon`
+   service user.
+5. Create `/opt/jetmon2/config/jetmon2.env` with database credentials and auth
+   tokens. See `config/db-config-sample.conf`.
+6. Copy or generate `config/config.json`.
+7. Set `BUCKET_TARGET` to the desired maximum bucket count for the host.
+8. Run `./jetmon2 migrate`.
+9. Start the service with `systemctl enable --now jetmon2`.
+
+Manual commands such as `migrate`, `validate-config`, and `rollout` need the
+same `DB_*` environment that systemd reads from
+`/opt/jetmon2/config/jetmon2.env`; systemd's `EnvironmentFile` is not loaded for
+commands run directly from a shell.
+
+## First v1 To v2 Migration
+
+For the first production migration, replace one v1 host at a time with a v2 host
+pinned to the same inclusive bucket range. This avoids mixed v1/v2 ownership and
+keeps rollback simple.
+
+1. Pre-apply additive migrations during a quiet period:
+
+   ```bash
+   ./jetmon2 migrate
+   ```
+
+2. Configure the v2 host with the same bucket range:
+
+   ```json
+   {
+     "PINNED_BUCKET_MIN": 0,
+     "PINNED_BUCKET_MAX": 99,
+     "LEGACY_STATUS_PROJECTION_ENABLE": true,
+     "API_PORT": 0
+   }
+   ```
+
+3. Run validation and pinned rollout checks:
+
+   ```bash
+   ./jetmon2 validate-config
+   ./jetmon2 rollout pinned-check
+   ```
+
+4. Stop the v1 process for that range, start v2, and verify checks, Veriflier
+   confirmations, WPCOM notifications, audit rows, and legacy projection.
+
+5. If rollback is needed, stop v2 and restart the original v1 process with the
+   same bucket config.
+
+6. After the fleet is on v2, remove `PINNED_BUCKET_*`, restart during the
+   approved window, and run:
+
+   ```bash
+   ./jetmon2 rollout dynamic-check
+   ```
+
+See [v1-to-v2-pinned-rollout.md](v1-to-v2-pinned-rollout.md) for the full
+checklist.
+
+## v2 Rolling Updates
+
+After all monitor hosts are on v2 dynamic bucket ownership, update one host at a
+time. Surviving hosts absorb the draining host's buckets during the update
+window.
+
+```bash
+systemctl stop jetmon2
+./jetmon2 migrate
+systemctl start jetmon2
+./jetmon2 status
+```
+
+Repeat for the next host.
+
+## Delivery Workers
+
+In the embedded deployment, setting `API_PORT` to a non-zero value starts the
+internal API and makes webhook and alert-contact delivery workers eligible to
+run inside `jetmon2`.
+
+Use `DELIVERY_OWNER_HOST` when only one API-enabled host should dispatch
+outbound deliveries during rollout. If it is empty, delivery workers start on
+any host with `API_PORT` enabled.
+
+`bin/jetmon-deliverer` is the standalone process boundary for outbound delivery.
+It starts the same webhook and alert-contact workers without starting the
+monitor, API, dashboard, or bucket ownership loop. Delivery rows are claimed
+transactionally, so multiple workers do not claim the same pending row.
+
+See [jetmon-deliverer-rollout.md](jetmon-deliverer-rollout.md) for the rollout
+and rollback path.
+
+## Runtime Checks
+
+Status and reload commands:
+
+```bash
+./jetmon2 status
+./jetmon2 reload
+./jetmon2 drain
+```
+
+The operator dashboard is available on `DASHBOARD_PORT` when enabled. It shows
+worker count, active checks, queue depth, retry queue depth, throughput, round
+time, owned buckets, rollout guard state, RSS, WPCOM circuit-breaker state, and
+dependency health for MySQL, Verifliers, WPCOM, StatsD, and local log/stats
+writes.
+
+Bucket coverage can be inspected directly:
+
+```sql
+SELECT host_id, bucket_min, bucket_max, last_heartbeat, status
+FROM jetmon_hosts
+ORDER BY bucket_min;
+```
+
+A host whose heartbeat is older than `BUCKET_HEARTBEAT_GRACE_SEC` will have its
+buckets reclaimed by peers on their next round.
+
+## Metrics And Logs
+
+StatsD metrics retain the v1 prefix:
+
+```text
+com.jetpack.jetmon.<hostname>
+```
+
+Important metric groups include:
+
+- Worker pool capacity and active goroutines
+- Sites processed per second
+- Round completion time
+- WPCOM API attempts, deliveries, retries, errors, and failures
+- Veriflier response times and vote counters
+- Detection flow timing from first failure to escalation, confirmation,
+  recovery, or false alarm
+- Detection outcome counters by local failure class
+- Legacy projection drift
+- Memory usage
+
+StatsD is the primary metrics transport. Expose Graphite/StatsD data through the
+existing metrics pipeline when external systems need it.
+
+Use `LOG_FORMAT=json` for structured logs during investigations.
+
+## Debugging
+
+Enable debug logging:
+
+```json
+{ "DEBUG": true }
+```
+
+Attach pprof locally:
+
+```bash
+curl http://localhost:6060/debug/pprof/
+curl http://localhost:6060/debug/pprof/heap > heap.prof
+go tool pprof heap.prof
+```
+
+The debug listener binds to localhost only. Set `DEBUG_PORT` to 0 to disable it.
+
+If RSS exceeds `WORKER_MAX_MEM_MB`, the goroutine pool shrinks by 10 percent via
+graceful drain. Sustained memory pressure should be investigated with pprof
+before increasing the limit.
+
+## Veriflier Health
+
+Verifliers that fail to respond are excluded from confirmation requests. If the
+healthy set drops below `PEER_OFFLINE_LIMIT`, Jetmon cannot issue new downtime
+confirmations.
+
+Manual check:
+
+```bash
+curl http://<veriflier-host>:7803/status
+```
+
+## Docker Cleanup
+
+```bash
+cd docker
+docker compose down -v
+rm -f ../config/config.json
+rm -rf ../logs/*.log ../stats/*
+```

--- a/docs/support-guide.md
+++ b/docs/support-guide.md
@@ -44,6 +44,17 @@ the monitor and then recover before Verifliers confirm it. That closes as a
 false alarm or probe-cleared event instead of sending a customer-facing outage
 notification.
 
+## Explain The GET Change
+
+Jetmon 1 used `HEAD` requests to decide whether a site was reachable. Some
+customer stacks block `HEAD`, route it differently, or return a status that does
+not match a real page load. Jetmon 2 uses `GET` for local checks and Veriflier
+checks, which better matches what visitors and customer-facing uptime tools see.
+
+When an alert differs from old v1 behavior, this is often the first thing to
+check: v2 may be surfacing a real GET-path issue that v1's HEAD-only probe did
+not exercise.
+
 ## Understand Alert Types
 
 | Type | Meaning |

--- a/docs/support-guide.md
+++ b/docs/support-guide.md
@@ -1,0 +1,158 @@
+# Support Guide
+
+This guide is for people explaining Jetmon behavior to customers and internal
+teams. It focuses on the questions v1 made hard to answer:
+
+- Why did Jetmon say the site was down?
+- Why was there no notification?
+- Why did the site recover before a customer noticed?
+- Was this a false positive, a real outage, or a monitor-side issue?
+
+## Start With The Audit Timeline
+
+Use the audit CLI to reconstruct a site's recent monitoring history:
+
+```bash
+./jetmon2 audit --blog-id 12345 --since 24h
+```
+
+For a specific incident window:
+
+```bash
+./jetmon2 audit \
+  --blog-id 12345 \
+  --since 2026-04-01T10:00:00 \
+  --until 2026-04-01T11:00:00
+```
+
+The timeline shows local checks, retry attempts, Veriflier requests and results,
+WPCOM notifications, status transitions, maintenance-window suppression, and
+other operational notes.
+
+## Explain The Incident State
+
+Jetmon 2 separates detection from confirmation:
+
+| State | Meaning |
+|---|---|
+| `Seems Down` | Local checks failed and Jetmon is retrying or asking Verifliers |
+| `Down` | Verifliers confirmed the outage |
+| `Resolved` | The incident closed after recovery or manual action |
+
+This matters for customer conversations. A site can be briefly unreachable from
+the monitor and then recover before Verifliers confirm it. That closes as a
+false alarm or probe-cleared event instead of sending a customer-facing outage
+notification.
+
+## Understand Alert Types
+
+| Type | Meaning |
+|---|---|
+| `server` | Site returned a 5xx response |
+| `blocked` | Site returned 403, often because monitoring is blocked |
+| `client` | Site returned a 4xx response other than 403 |
+| `https` | SSL/TLS problem |
+| `intermittent` | Request timed out |
+| `redirect` | Redirect policy failure |
+| `ssl_expiry` | Certificate expires within the configured threshold |
+| `tls_deprecated` | Site is serving TLS 1.0 or 1.1 |
+| `keyword_missing` | Response body did not contain the expected keyword |
+| `success` | Site recovered |
+
+## Check SSL Certificate Status
+
+```sql
+SELECT blog_id, monitor_url, ssl_expiry_date
+FROM jetpack_monitor_sites
+WHERE blog_id = 12345;
+```
+
+`ssl_expiry_date` is updated on HTTPS checks. Alerts fire at the configured
+expiry thresholds, currently 30, 14, and 7 days before expiry.
+
+## Check For False Positives
+
+```sql
+SELECT *
+FROM jetmon_false_positives
+WHERE blog_id = 12345
+ORDER BY created_at DESC
+LIMIT 20;
+```
+
+A false positive is recorded when Jetmon escalates a local failure to Veriflier
+confirmation and the Verifliers do not confirm the site as down. A high rate for
+one site usually means the site has transient network, redirect, firewall, or
+performance behavior worth tuning.
+
+## Maintenance Windows
+
+Use maintenance windows for planned work:
+
+```sql
+UPDATE jetpack_monitor_sites
+SET maintenance_start = '2026-04-20 02:00:00',
+    maintenance_end   = '2026-04-20 04:00:00'
+WHERE blog_id = 12345;
+```
+
+Checks continue and results are recorded during the window, but alerts are
+suppressed. Always set an explicit `maintenance_end`; an open-ended window can
+silently suppress alerts indefinitely.
+
+Clear a window after maintenance:
+
+```sql
+UPDATE jetpack_monitor_sites
+SET maintenance_start = NULL,
+    maintenance_end = NULL
+WHERE blog_id = 12345;
+```
+
+## Alert Sensitivity
+
+Use per-site cooldowns to reduce repeated alerts from a flapping site:
+
+```sql
+UPDATE jetpack_monitor_sites
+SET alert_cooldown_minutes = 60
+WHERE blog_id = 12345;
+```
+
+Global retry behavior is controlled by `NUM_OF_CHECKS` and
+`TIME_BETWEEN_CHECKS_SEC`. Per-site retry overrides are planned separately; do
+not promise per-site retry tuning unless the deployed schema includes it.
+
+## WPCOM Notification Data
+
+Every status-change notification sent to WPCOM includes:
+
+| Field | Description |
+|---|---|
+| `blog_id` | The site's WPCOM ID |
+| `monitor_url` | URL that was checked |
+| `status_id` | `0` down, `1` running, `2` confirmed down |
+| `last_check` | Datetime of the last check |
+| `last_status_change` | Datetime of the last status change |
+| `checks` | Local and Veriflier check results |
+
+Each `checks` entry includes:
+
+| Field | Description |
+|---|---|
+| `type` | `1` local Jetmon check, `2` Veriflier check |
+| `host` | Hostname of the checker |
+| `status` | `0` down, `1` running, `2` confirmed down |
+| `rtt` | Round-trip time in milliseconds |
+| `code` | HTTP response code |
+
+## Useful Customer Framing
+
+- "Jetmon saw local failures, retried, then asked Verifliers before notifying."
+- "The site recovered before quorum confirmation, so Jetmon recorded the event
+  but did not send a confirmed-down notification."
+- "The alert was suppressed because a maintenance window was active."
+- "The site blocked the monitor with a 403, which is different from the site
+  being down for visitors."
+- "The audit trail shows exactly which checkers saw the failure and what status
+  code or timeout they received."

--- a/docs/v1-to-v2-migration.md
+++ b/docs/v1-to-v2-migration.md
@@ -1,0 +1,406 @@
+# v1 to v2 Migration Runbook
+
+This is the source-of-truth runbook for the first production migration from
+Jetmon 1 to Jetmon 2.
+
+Use this document for:
+
+- preparing the fleet before any production change
+- replacing v1 on the same server
+- moving a v1 bucket range to a fresh v2 server
+- monitoring the cutover
+- reverting safely
+- completing the move from pinned buckets to dynamic v2 ownership
+- removing old v1 software after signoff
+
+## What Changes For Customers
+
+The important product fix is the probe method.
+
+Jetmon 1 verified sites with `HEAD` requests. That caused real customer pain:
+some production stacks block `HEAD`, route it differently, skip application
+logic, or return a status that does not match a visitor's real page load.
+Jetmon 2 uses `GET` requests for local monitor checks and Veriflier checks, so
+it validates the same class of request a browser or customer-facing uptime
+check normally makes.
+
+This is why v2 can support keyword checks, richer redirect behavior, and better
+VIP/Agency explanations. It is also why the rollout should be watched closely:
+GET-based checks are more correct, but they can expose sites whose `HEAD`
+behavior used to hide a real application issue.
+
+## Success Criteria
+
+The migration is complete only when:
+
+- every active v1 bucket range is covered by exactly one v2 host
+- no v1 monitor process is checking production buckets
+- `./jetmon2 rollout dynamic-check` passes after pinned mode is removed
+- legacy projection drift is zero while `LEGACY_STATUS_PROJECTION_ENABLE` is on
+- WPCOM notifications retain the v1 payload shape
+- check throughput, round timing, WPCOM delivery, Veriflier health, StatsD, and
+  log/stats writes are stable for the agreed observation window
+- old v1 software is retained until rollback signoff, then removed deliberately
+
+## Rollout Invariants
+
+Do not violate these during the migration:
+
+- Do not run v1 and v2 against the same bucket range at the same time.
+- Do not run unpinned dynamic v2 while any v1 host still owns static buckets.
+- Keep `LEGACY_STATUS_PROJECTION_ENABLE=true` until legacy readers have moved to
+  the v2 API or event tables.
+- Keep `API_PORT=0` on production monitor hosts during initial replacement
+  unless the API and delivery-owner plan has been explicitly approved.
+- Do not remove v1 binaries, configs, service units, or dependencies until the
+  rollback window is closed.
+- Treat `./jetmon2 migrate` as forward-only. Migrations are additive, so revert
+  by restarting v1, not by rolling the schema back.
+
+## Phase 0: Prepare Before Production Changes
+
+### Inventory The Current Fleet
+
+Record, for every v1 host:
+
+- hostname
+- service manager name and start/stop commands
+- v1 binary or checkout path
+- v1 config path
+- `BUCKET_NO_MIN` and `BUCKET_NO_MAX`
+- log and stats paths
+- WPCOM credentials source
+- Veriflier list
+- expected sites-per-round or sites-per-second baseline
+- current alert volume and any known noisy sites
+
+Confirm the bucket ranges are complete and non-overlapping:
+
+```sql
+SELECT bucket_no, COUNT(*) AS sites
+FROM jetpack_monitor_sites
+WHERE monitor_active = 1
+GROUP BY bucket_no
+ORDER BY bucket_no;
+```
+
+### Prepare Database And Rollback Safety
+
+1. Confirm a recent MySQL backup exists and restore has been tested according
+   to normal production policy.
+2. Review pending migrations with the release owner.
+3. Apply additive migrations before the first host cutover:
+
+   ```bash
+   ./jetmon2 migrate
+   ```
+
+4. Confirm v1 continues to run normally after migrations are applied.
+5. Do not plan a schema rollback. If v2 must be reverted, v1 can keep running
+   with the additive v2 tables and columns present.
+
+### Build And Stage Artifacts
+
+Build and verify the release:
+
+```bash
+make all
+make test
+make test-race
+```
+
+Stage these artifacts for each target host:
+
+- `jetmon2`
+- `veriflier2` when that host also owns a Veriflier deployment
+- `systemd/jetmon2.service`
+- `systemd/jetmon2-logrotate`
+- `config/config.json`
+- `/opt/jetmon2/config/jetmon2.env` from `config/db-config-sample.conf`
+
+Keep v2 files in `/opt/jetmon2` or another v2-specific directory. Do not
+overwrite the v1 install until rollback signoff.
+
+### Prepare Pinned v2 Config
+
+For each replacement host, configure the exact v1 bucket range:
+
+```json
+{
+  "PINNED_BUCKET_MIN": 0,
+  "PINNED_BUCKET_MAX": 99,
+  "LEGACY_STATUS_PROJECTION_ENABLE": true,
+  "API_PORT": 0
+}
+```
+
+The legacy v1 names `BUCKET_NO_MIN` and `BUCKET_NO_MAX` are accepted as aliases,
+but prefer `PINNED_BUCKET_MIN` and `PINNED_BUCKET_MAX` in v2 configs so the
+deployment mode is explicit.
+
+While pinned:
+
+- the host checks only the configured inclusive bucket range
+- the host does not claim or heartbeat `jetmon_hosts`
+- shutdown does not release a `jetmon_hosts` row
+- `BUCKET_TOTAL`, `BUCKET_TARGET`, and `BUCKET_HEARTBEAT_GRACE_SEC` still
+  validate, but dynamic ownership does not use them on that host
+
+### Validate Before Cutover
+
+Run validation with the same `DB_*` environment the service will use:
+
+```bash
+./jetmon2 validate-config
+```
+
+Confirm it reports:
+
+- `legacy_status_projection=enabled`
+- `bucket_ownership=pinned range=<min>-<max>`
+- `rollout_preflight=./jetmon2 rollout pinned-check`
+- `rollout_drift_report=./jetmon2 rollout projection-drift`
+
+Run the pinned preflight when the host identity and config are final:
+
+```bash
+./jetmon2 rollout pinned-check
+```
+
+If checking a config before it is running on the final hostname, pass the
+expected host id:
+
+```bash
+./jetmon2 rollout pinned-check --host=<v2-hostname>
+```
+
+### Rehearse API CLI Workflows Outside Production
+
+Use the API CLI in Docker, staging, or a dedicated rehearsal database with
+disposable sites. Do not enable `API_PORT` on initial production monitor hosts
+unless the delivery-owner plan has been approved.
+
+```bash
+./jetmon2 keys create --consumer api-cli-rehearsal --scope admin --created-by rollout-rehearsal
+
+export JETMON_API_URL=http://<rehearsal-host>:8090
+export JETMON_API_TOKEN=jm_replace_with_the_printed_token
+
+./bin/jetmon2 api health --pretty
+./bin/jetmon2 api me --pretty
+./bin/jetmon2 api smoke --batch rollout-rehearsal --pretty
+./bin/jetmon2 api sites simulate-failure \
+  --batch rollout-rehearsal \
+  --mode http-500 \
+  --wait 30s \
+  --expect-event-state 'Seems Down' \
+  --expect-transition-reason opened \
+  --pretty
+./bin/jetmon2 api sites cleanup --batch rollout-rehearsal --count 3 --output table
+```
+
+## Phase 1A: Replace v1 On The Existing Server
+
+Use this path when the same server currently running v1 will run v2 for the
+same bucket range.
+
+1. Confirm v2 files and config are staged beside, not on top of, v1.
+2. Confirm v1 service start commands and config are documented for rollback.
+3. Run `./jetmon2 validate-config`.
+4. Run `./jetmon2 rollout pinned-check`.
+5. Start a terminal watching v1 logs and a terminal ready to watch v2 logs.
+6. Stop v1 cleanly with the existing production command.
+7. Confirm the v1 process is no longer running.
+8. Start v2:
+
+   ```bash
+   systemctl enable --now jetmon2
+   ```
+
+9. Confirm v2 logs show:
+
+   - `legacy_status_projection=enabled`
+   - `bucket_ownership=pinned range=<min>-<max>`
+   - `orchestrator: using pinned buckets <min>-<max>`
+
+10. Run:
+
+    ```bash
+    ./jetmon2 rollout pinned-check
+    ./jetmon2 status
+    ```
+
+11. Watch one full check round before moving to the next host.
+
+## Phase 1B: Move A v1 Range To A Fresh Server
+
+Use this path when a new server will take over a bucket range from an existing
+v1 server.
+
+1. Provision the new server and install v2 artifacts.
+2. Configure `PINNED_BUCKET_MIN` and `PINNED_BUCKET_MAX` to match the old v1
+   host's `BUCKET_NO_MIN` and `BUCKET_NO_MAX`.
+3. Keep the v2 service stopped.
+4. Run `./jetmon2 validate-config` on the new server.
+5. Run `./jetmon2 rollout pinned-check --host=<new-v2-hostname>` if the final
+   hostname needs to be checked before service start.
+6. Confirm network access from the new server to MySQL, Verifliers, WPCOM,
+   StatsD, and log/stats directories.
+7. Stop v1 on the old server.
+8. Confirm the old v1 process is no longer running.
+9. Start v2 on the new server:
+
+   ```bash
+   systemctl enable --now jetmon2
+   ```
+
+10. Run `./jetmon2 rollout pinned-check` and `./jetmon2 status` on the new
+    server.
+11. Watch one full check round before moving to the next host.
+
+Do not leave the old v1 server running as a warm standby for the same range. A
+standby is safe only when the monitor process is stopped.
+
+## Phase 2: Monitor Each Cutover
+
+For every replaced range, verify:
+
+- checks run only for the pinned range
+- round time and sites-per-second are within the expected envelope
+- local checks use GET semantics against customer sites
+- Veriflier confirmation works
+- WPCOM notifications retain the v1 payload shape
+- `jetmon_events` receives event rows
+- `jetmon_event_transitions` receives transition rows for each mutation
+- `jetpack_monitor_sites.site_status` and `last_status_change` update while
+  legacy projection is enabled
+- no unexpected row is claimed in `jetmon_hosts` by a pinned host
+- no projection drift is reported:
+
+  ```bash
+  ./jetmon2 rollout projection-drift --limit=100
+  ```
+
+If `DASHBOARD_PORT` is enabled, confirm:
+
+- bucket ownership mode is pinned
+- dependency health is green for MySQL, configured Verifliers, WPCOM, StatsD,
+  and log/stats directory writes
+- WPCOM circuit breaker is closed
+- retry queue depth is not growing unexpectedly
+- RSS stays below the configured guardrail
+- delivery workers are disabled unless explicitly approved
+
+Useful direct checks:
+
+```bash
+./jetmon2 status
+tail -f logs/jetmon.log
+tail -f logs/status-change.log
+cat stats/sitespersec
+cat stats/sitesqueue
+cat stats/totals
+```
+
+## Phase 3: Revert Safely
+
+### Revert On The Existing Server
+
+Use this when v2 replaced v1 on the same server.
+
+1. Stop v2:
+
+   ```bash
+   systemctl stop jetmon2
+   ```
+
+2. Confirm the v2 process is stopped.
+3. Restart the original v1 service with its original `BUCKET_NO_MIN` /
+   `BUCKET_NO_MAX` config.
+4. Verify v1 checks the range again.
+5. Watch WPCOM notifications and legacy logs for one full v1 check round.
+6. Leave v2 schema in place. Do not attempt schema rollback.
+
+### Revert A Fresh-Server Takeover
+
+Use this when v2 was started on a new server and the old v1 server was stopped.
+
+1. Stop v2 on the new server:
+
+   ```bash
+   systemctl stop jetmon2
+   ```
+
+2. Confirm the new v2 process is stopped.
+3. Restart v1 on the old server with its original bucket config.
+4. Verify v1 checks the range again.
+5. Keep the new v2 server disabled until the next approved attempt.
+
+Never start the old v1 process until the new v2 process is stopped for that
+range.
+
+## Phase 4: Complete The Fleet Rollout
+
+After every monitor host is on v2 and stable in pinned mode:
+
+1. Confirm no v1 monitor process remains active.
+2. Confirm every v2 host passes:
+
+   ```bash
+   ./jetmon2 rollout pinned-check
+   ./jetmon2 rollout projection-drift --limit=100
+   ```
+
+3. Observe the fleet for the agreed stabilization window.
+4. Plan a coordinated dynamic-ownership cutover. Pinned hosts do not write
+   `jetmon_hosts`, so do not leave a long-lived mix of pinned and dynamic v2
+   hosts.
+5. Remove `PINNED_BUCKET_MIN` / `PINNED_BUCKET_MAX` and any legacy
+   `BUCKET_NO_MIN` / `BUCKET_NO_MAX` aliases from every v2 monitor config.
+6. Restart the v2 monitor fleet in the approved window.
+7. Run:
+
+   ```bash
+   ./jetmon2 validate-config
+   ./jetmon2 rollout dynamic-check
+   ./jetmon2 rollout projection-drift --limit=100
+   ```
+
+8. Confirm `jetmon_hosts` coverage is active, fresh, gap-free, and
+   overlap-free.
+9. Continue with normal v2 rolling updates: stop one host, deploy, start it,
+   verify `./jetmon2 status`, then move to the next host.
+
+## Phase 5: Tear Down v1
+
+Only remove v1 after rollout signoff.
+
+1. Archive final v1 configs, service units, and deployment metadata according
+   to normal retention policy.
+2. Confirm no process manager references the v1 service.
+3. Remove old v1 service units or disable them permanently.
+4. Remove old Node.js application checkouts, `node_modules`, compiled native
+   addons, Qt Veriflier artifacts, and v1-only logrotate files.
+5. Remove v1-only deployment hooks from host automation.
+6. Keep shared log and stats paths only if v2 still writes to them.
+7. Keep v2 additive database schema. Do not remove compatibility columns while
+   legacy consumers still read them.
+8. Keep `LEGACY_STATUS_PROJECTION_ENABLE=true` until legacy readers have moved
+   to v2 state surfaces. Retiring that projection is a separate project.
+
+## Final Checklist
+
+- [ ] v1 host inventory complete
+- [ ] bucket ranges complete and non-overlapping
+- [ ] DB backup and restore path confirmed
+- [ ] v2 binaries built and tested
+- [ ] additive migrations applied
+- [ ] pinned configs prepared for every range
+- [ ] rollback commands documented for every host
+- [ ] first host cutover observed for one full round
+- [ ] all hosts running v2 pinned
+- [ ] dynamic ownership cutover completed
+- [ ] `rollout dynamic-check` passes
+- [ ] projection drift is zero
+- [ ] v1 artifacts retained through rollback window
+- [ ] v1 artifacts removed after signoff

--- a/docs/v1-to-v2-pinned-rollout.md
+++ b/docs/v1-to-v2-pinned-rollout.md
@@ -1,212 +1,22 @@
 # v1 to v2 Pinned Bucket Rollout
 
-**Status:** Production migration runbook for the first v1-to-v2 cutover.
+This document has moved.
 
-This rollout replaces one v1 static-bucket host with one v2 host pinned to the
-same inclusive bucket range. It avoids mixed ownership between v1 static config
-and v2 `jetmon_hosts` dynamic ownership during the riskiest part of the
-migration.
+Use [v1-to-v2-migration.md](v1-to-v2-migration.md) for the complete production
+migration runbook, including pinned bucket mode, same-server replacement,
+fresh-server takeover, monitoring, revert paths, dynamic ownership cutover, and
+v1 teardown.
 
-## Why Pinned Mode Exists
+Pinned mode still means:
 
-v1 and v2 do not share a bucket ownership protocol:
+- configure `PINNED_BUCKET_MIN` and `PINNED_BUCKET_MAX` to match the v1 host's
+  static bucket range
+- keep `LEGACY_STATUS_PROJECTION_ENABLE=true`
+- keep `API_PORT=0` during initial production monitor replacement unless an API
+  and delivery-owner plan has been approved
+- run `./jetmon2 validate-config`
+- run `./jetmon2 rollout pinned-check`
 
-- v1 uses static `BUCKET_NO_MIN` / `BUCKET_NO_MAX` config per host.
-- v2 normally uses the `jetmon_hosts` table with heartbeat and reclaim.
-
-During a mixed fleet rollout, dynamic v2 ownership cannot know which buckets are
-still covered by v1. Pinned mode keeps each replacement host on the exact range
-its v1 predecessor owned and disables `jetmon_hosts` ownership for that v2 host.
-
-## Configuration
-
-Prefer explicit pinned keys in v2 config:
-
-```json
-{
-  "PINNED_BUCKET_MIN": 0,
-  "PINNED_BUCKET_MAX": 99,
-  "LEGACY_STATUS_PROJECTION_ENABLE": true,
-  "API_PORT": 0
-}
-```
-
-The legacy v1 names `BUCKET_NO_MIN` and `BUCKET_NO_MAX` are accepted as aliases
-for pinned mode. If both forms are present, they must describe the same range.
-
-While pinned:
-
-- the host checks only `PINNED_BUCKET_MIN <= bucket_no <= PINNED_BUCKET_MAX`
-- the host does not claim or heartbeat `jetmon_hosts`
-- shutdown does not release a `jetmon_hosts` row
-- `BUCKET_TOTAL`, `BUCKET_TARGET`, and `BUCKET_HEARTBEAT_GRACE_SEC` still
-  validate, but dynamic ownership does not use them on that host
-
-## Preflight
-
-1. Confirm the v1 fleet's static bucket ranges are complete and non-overlapping.
-2. Build all v2 binaries and run `make test`, `make test-race`, and `make all`.
-3. Apply additive migrations before the cutover:
-
-   ```bash
-   ./jetmon2 migrate
-   ```
-
-4. Keep `LEGACY_STATUS_PROJECTION_ENABLE=true` so legacy readers continue to see
-   `jetpack_monitor_sites.site_status` and `last_status_change`.
-5. Keep `API_PORT=0` on monitor hosts during initial replacement unless the API
-   and delivery owner plan has been explicitly approved.
-6. Run `./jetmon2 validate-config` with the prepared v2 config and confirm it
-   prints the pinned rollout preflight command plus the projection-drift command.
-7. Verify Veriflier endpoints, WPCOM auth, StatsD, log paths, and config reload
-   behavior in staging.
-
-## API CLI Rehearsal
-
-Use this only in staging, Docker, or a dedicated rehearsal database with
-disposable sites. The initial production pinned rollout should still keep
-`API_PORT=0` on monitor hosts unless the API and delivery owner plan has been
-approved.
-
-1. Enable `API_PORT=8090` on the rehearsal host and use `DELIVERY_OWNER_HOST`
-   if the rehearsal environment has more than one API-enabled process.
-2. Create an API key with write permissions:
-
-   ```bash
-   ./jetmon2 keys create --consumer api-cli-rehearsal --scope admin --created-by rollout-rehearsal
-   ```
-
-3. From the operator workstation, point the API CLI at the rehearsal host:
-
-   ```bash
-   export JETMON_API_URL=http://<rehearsal-host>:8090
-   export JETMON_API_TOKEN=jm_replace_with_the_printed_token
-   ./bin/jetmon2 api health --pretty
-   ./bin/jetmon2 api me --pretty
-   ./bin/jetmon2 api sites list --output table
-   ```
-
-4. Exercise a disposable batch and a known failure mode:
-
-   ```bash
-   ./bin/jetmon2 api smoke --batch rollout-rehearsal --pretty
-   ./bin/jetmon2 api sites simulate-failure --batch rollout-rehearsal --mode http-500 --wait 15s --pretty
-   ./bin/jetmon2 api sites simulate-failure --batch rollout-rehearsal --mode http-500 --wait 30s --expect-event-state 'Seems Down' --expect-transition-reason opened --pretty
-   ./bin/jetmon2 api sites cleanup --batch rollout-rehearsal --count 3 --output table
-   ```
-
-   In Docker Compose, failure simulation automatically uses the deterministic
-   `api-fixture` service when `http://localhost:18091/health` is reachable.
-   The expectation flags make the rehearsal fail fast if the API never reports
-   the expected active event and transition reason before `--wait` expires.
-
-5. Confirm the smoke output, event IDs, transitions, API audit rows, fixture
-   probe behavior, and any cleanup results match the rehearsal plan before
-   carrying the monitor binary into the per-host cutover.
-
-## Per-Host Cutover
-
-For each v1 host:
-
-1. Record the host name and v1 bucket range.
-2. Prepare the v2 config with the same pinned range.
-3. Before stopping v1, run `./jetmon2 validate-config` and confirm it reports:
-   - `legacy_status_projection=enabled`
-   - `bucket_ownership=pinned range=<min>-<max>`
-   - `rollout_preflight=./jetmon2 rollout pinned-check`
-   - `rollout_drift_report=./jetmon2 rollout projection-drift`
-4. Stop the v1 process for that host.
-5. Start the v2 process.
-6. Run the pinned rollout preflight:
-
-   ```bash
-   ./jetmon2 rollout pinned-check
-   ```
-
-   This check fails if the host is not in pinned mode, legacy projection writes
-   are disabled, the current host still has a `jetmon_hosts` ownership row, or
-   the active sites in the pinned range have projection drift. It also prints the
-   active site count for the range. If projection drift is reported, list the
-   mismatched rows before continuing:
-
-   ```bash
-   ./jetmon2 rollout projection-drift
-   ```
-
-   If checking a config before running on the final hostname, pass the expected
-   host id explicitly:
-
-   ```bash
-   ./jetmon2 rollout pinned-check --host=<v2-hostname>
-   ```
-
-7. Verify the process logs:
-   - `legacy_status_projection=enabled`
-   - `bucket_ownership=pinned range=<min>-<max>`
-   - `orchestrator: using pinned buckets <min>-<max>`
-8. If `DASHBOARD_PORT` is enabled, open the operator dashboard and confirm:
-   - rollout ownership shows the pinned range
-   - legacy projection is enabled
-   - delivery workers are disabled unless the delivery owner plan explicitly
-     enables them on this host
-   - dependency health is green for MySQL, configured Verifliers, log/stats
-     directory writes, and StatsD initialization; WPCOM must not show an open
-     circuit
-9. Watch one full check round for that bucket range.
-10. Confirm:
-   - checks are running only for the pinned range
-   - Veriflier confirmation works
-   - WPCOM notifications retain the v1 payload shape
-   - `jetmon_events` and `jetmon_event_transitions` receive event mutations
-   - `jetpack_monitor_sites.site_status` projection updates when enabled
-   - no unexpected rows are claimed in `jetmon_hosts` by the pinned host
-
-## Rollback
-
-Rollback is host-local:
-
-1. Stop the v2 process.
-2. Restart the original v1 process with the same `BUCKET_NO_MIN` /
-   `BUCKET_NO_MAX` config.
-3. Verify v1 checks the range again.
-
-The v2 migrations are additive, and legacy projection writes keep the old status
-fields meaningful while `LEGACY_STATUS_PROJECTION_ENABLE=true`, so rollback does
-not require schema rollback.
-
-## Transition to Dynamic v2 Ownership
-
-After every monitor host is on v2 and stable in pinned mode:
-
-1. Confirm no v1 monitor hosts remain active.
-2. Plan a coordinated dynamic-ownership cutover. Pinned hosts do not write
-   `jetmon_hosts`, so avoid leaving a long-lived mixed fleet where some v2
-   hosts are pinned and others use dynamic ownership.
-3. Remove `PINNED_BUCKET_MIN` / `PINNED_BUCKET_MAX` (and any legacy
-   `BUCKET_NO_MIN` / `BUCKET_NO_MAX` aliases) from the v2 monitor configs.
-4. Restart the v2 monitor hosts in the approved deployment window.
-5. Run `./jetmon2 validate-config` and confirm it reports
-   `rollout_preflight=./jetmon2 rollout dynamic-check`.
-6. Run the dynamic ownership preflight:
-
-   ```bash
-   ./jetmon2 rollout dynamic-check
-   ```
-
-   This check fails if pinned mode is still configured, legacy projection writes
-   are disabled, `jetmon_hosts` rows are missing, stale, inactive, overlapping,
-   or gapped, or the legacy projection has drifted.
-
-   To inspect projection drift details across the dynamic range:
-
-   ```bash
-   ./jetmon2 rollout projection-drift --limit=100
-   ```
-
-7. Continue using the normal v2 rolling-update process from `README.md`.
-
-Do not run a mixed configuration where some v1 hosts still own static ranges
-while unpinned v2 hosts use dynamic `jetmon_hosts` ownership. Also avoid a
-long-lived pinned-v2/dynamic-v2 mix: dynamic hosts cannot see pinned hosts in
-`jetmon_hosts`, so the fleet can overlap checks even though it should not create
-coverage gaps.
+The old detailed checklist was consolidated into
+[v1-to-v2-migration.md](v1-to-v2-migration.md) so migration guidance does not
+drift across multiple docs.

--- a/docs/v1-to-v2-pinned-rollout.md
+++ b/docs/v1-to-v2-pinned-rollout.md
@@ -91,6 +91,7 @@ approved.
    ```bash
    ./bin/jetmon2 api smoke --batch rollout-rehearsal --pretty
    ./bin/jetmon2 api sites simulate-failure --batch rollout-rehearsal --mode http-500 --wait 15s --pretty
+   ./bin/jetmon2 api sites cleanup --batch rollout-rehearsal --count 3 --output table
    ```
 
 5. Confirm the smoke output, event IDs, transitions, API audit rows, and any

--- a/docs/v1-to-v2-pinned-rollout.md
+++ b/docs/v1-to-v2-pinned-rollout.md
@@ -91,12 +91,18 @@ approved.
    ```bash
    ./bin/jetmon2 api smoke --batch rollout-rehearsal --pretty
    ./bin/jetmon2 api sites simulate-failure --batch rollout-rehearsal --mode http-500 --wait 15s --pretty
+   ./bin/jetmon2 api sites simulate-failure --batch rollout-rehearsal --mode http-500 --wait 30s --expect-event-state 'Seems Down' --expect-transition-reason opened --pretty
    ./bin/jetmon2 api sites cleanup --batch rollout-rehearsal --count 3 --output table
    ```
 
-5. Confirm the smoke output, event IDs, transitions, API audit rows, and any
-   cleanup results match the rehearsal plan before carrying the monitor binary
-   into the per-host cutover.
+   In Docker Compose, failure simulation automatically uses the deterministic
+   `api-fixture` service when `http://localhost:18091/health` is reachable.
+   The expectation flags make the rehearsal fail fast if the API never reports
+   the expected active event and transition reason before `--wait` expires.
+
+5. Confirm the smoke output, event IDs, transitions, API audit rows, fixture
+   probe behavior, and any cleanup results match the rehearsal plan before
+   carrying the monitor binary into the per-host cutover.
 
 ## Per-Host Cutover
 

--- a/docs/v1-to-v2-pinned-rollout.md
+++ b/docs/v1-to-v2-pinned-rollout.md
@@ -61,6 +61,42 @@ While pinned:
 7. Verify Veriflier endpoints, WPCOM auth, StatsD, log paths, and config reload
    behavior in staging.
 
+## API CLI Rehearsal
+
+Use this only in staging, Docker, or a dedicated rehearsal database with
+disposable sites. The initial production pinned rollout should still keep
+`API_PORT=0` on monitor hosts unless the API and delivery owner plan has been
+approved.
+
+1. Enable `API_PORT=8090` on the rehearsal host and use `DELIVERY_OWNER_HOST`
+   if the rehearsal environment has more than one API-enabled process.
+2. Create an API key with write permissions:
+
+   ```bash
+   ./jetmon2 keys create --consumer api-cli-rehearsal --scope admin --created-by rollout-rehearsal
+   ```
+
+3. From the operator workstation, point the API CLI at the rehearsal host:
+
+   ```bash
+   export JETMON_API_URL=http://<rehearsal-host>:8090
+   export JETMON_API_TOKEN=jm_replace_with_the_printed_token
+   ./bin/jetmon2 api health --pretty
+   ./bin/jetmon2 api me --pretty
+   ./bin/jetmon2 api sites list --output table
+   ```
+
+4. Exercise a disposable batch and a known failure mode:
+
+   ```bash
+   ./bin/jetmon2 api smoke --batch rollout-rehearsal --pretty
+   ./bin/jetmon2 api sites simulate-failure --batch rollout-rehearsal --mode http-500 --wait 15s --pretty
+   ```
+
+5. Confirm the smoke output, event IDs, transitions, API audit rows, and any
+   cleanup results match the rehearsal plan before carrying the monitor binary
+   into the per-host cutover.
+
 ## Per-Host Cutover
 
 For each v1 host:

--- a/docs/v3-probe-agent-architecture-options.md
+++ b/docs/v3-probe-agent-architecture-options.md
@@ -3,7 +3,7 @@
 ## Status
 
 Planning note. This is not an accepted architecture decision and should not
-block the v2 production migration.
+block the [v2 production migration](v1-to-v2-migration.md).
 
 The intended migration order is:
 

--- a/internal/api/handlers_sites.go
+++ b/internal/api/handlers_sites.go
@@ -38,7 +38,15 @@ type siteResponse struct {
 	MaintenanceStart     *string `json:"maintenance_start"`
 	MaintenanceEnd       *string `json:"maintenance_end"`
 	AlertCooldownMinutes *int    `json:"alert_cooldown_minutes"`
-	CLIBatch             string  `json:"cli_batch,omitempty"`
+	cliBatch             string
+}
+
+// siteCLIResponse is an explicit local-tooling projection used only when
+// ?include_cli_metadata=true is supplied. It keeps the canonical Site schema
+// free of API CLI implementation details.
+type siteCLIResponse struct {
+	siteResponse
+	CLIBatch string `json:"cli_batch,omitempty"`
 }
 
 // activeEventSummary is the compact event shape embedded in single-site
@@ -58,6 +66,12 @@ type singleSiteResponse struct {
 	ActiveEvents []activeEventSummary `json:"active_events"`
 }
 
+type singleSiteCLIResponse struct {
+	siteResponse
+	CLIBatch     string               `json:"cli_batch,omitempty"`
+	ActiveEvents []activeEventSummary `json:"active_events"`
+}
+
 // handleListSites implements GET /api/v1/sites with cursor pagination.
 //
 // Cursor encodes the (id) of the last row on the previous page; we use id
@@ -66,6 +80,11 @@ type singleSiteResponse struct {
 // they read.
 func (s *Server) handleListSites(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
+	includeCLIMetadata, err := parseIncludeCLIMetadata(q.Get("include_cli_metadata"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_include_cli_metadata", err.Error())
+		return
+	}
 
 	limit, err := parseLimit(q.Get("limit"), 50, 200)
 	if err != nil {
@@ -102,22 +121,14 @@ func (s *Server) handleListSites(w http.ResponseWriter, r *http.Request) {
 	if tenantScoped {
 		args = append(args, tenantID, cursor)
 		sb.WriteString(`
-		SELECT s.blog_id, s.blog_id AS public_id, s.monitor_url, s.monitor_active,
-		       s.bucket_no, s.check_interval, s.site_status, s.last_checked_at,
-		       s.last_status_change, s.ssl_expiry_date, s.check_keyword, s.redirect_policy,
-		       s.maintenance_start, s.maintenance_end, s.alert_cooldown_minutes,
-		       s.custom_headers
+		SELECT ` + siteSelectColumns("s.", includeCLIMetadata) + `
 		  FROM jetpack_monitor_sites s
 		  JOIN jetmon_site_tenants st ON st.blog_id = s.blog_id AND st.tenant_id = ?
 		 WHERE s.blog_id > ?`)
 	} else {
 		args = append(args, cursor)
 		sb.WriteString(`
-		SELECT blog_id, blog_id AS public_id, monitor_url, monitor_active,
-		       bucket_no, check_interval, site_status, last_checked_at,
-		       last_status_change, ssl_expiry_date, check_keyword, redirect_policy,
-		       maintenance_start, maintenance_end, alert_cooldown_minutes,
-		       custom_headers
+		SELECT ` + siteSelectColumns("", includeCLIMetadata) + `
 		  FROM jetpack_monitor_sites
 		 WHERE blog_id > ?`)
 	}
@@ -170,7 +181,7 @@ func (s *Server) handleListSites(w http.ResponseWriter, r *http.Request) {
 	results := make([]siteResponse, 0, limit)
 	var lastID int64
 	for rows.Next() {
-		s, err := scanSiteRow(rows)
+		s, err := scanSiteRow(rows, includeCLIMetadata)
 		if err != nil {
 			writeError(w, r, http.StatusInternalServerError, "db_error",
 				"site row scan failed: "+err.Error())
@@ -207,7 +218,7 @@ func (s *Server) handleListSites(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, ListEnvelope{
-		Data: results,
+		Data: siteListResponseData(results, includeCLIMetadata),
 		Page: Page{Next: nextCursor, Limit: limit},
 	})
 }
@@ -222,20 +233,22 @@ func (s *Server) handleGetSite(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	includeCLIMetadata, err := parseIncludeCLIMetadata(r.URL.Query().Get("include_cli_metadata"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_include_cli_metadata", err.Error())
+		return
+	}
+
 	ctx := r.Context()
 	if !s.ensureSiteVisibleForRequest(w, r, id) {
 		return
 	}
 	row := s.db.QueryRowContext(ctx, `
-		SELECT blog_id, blog_id AS public_id, monitor_url, monitor_active,
-		       bucket_no, check_interval, site_status, last_checked_at,
-		       last_status_change, ssl_expiry_date, check_keyword, redirect_policy,
-		       maintenance_start, maintenance_end, alert_cooldown_minutes,
-		       custom_headers
+		SELECT `+siteSelectColumns("", includeCLIMetadata)+`
 		  FROM jetpack_monitor_sites
 		 WHERE blog_id = ?`, id)
 
-	site, err := scanSiteRow(row)
+	site, err := scanSiteRow(row, includeCLIMetadata)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			writeSiteNotFound(w, r, id)
@@ -265,10 +278,61 @@ func (s *Server) handleGetSite(w http.ResponseWriter, r *http.Request) {
 		site.ActiveEventID = &eventID
 	}
 
-	writeJSON(w, http.StatusOK, singleSiteResponse{
-		siteResponse: site,
-		ActiveEvents: active,
-	})
+	if includeCLIMetadata {
+		writeJSON(w, http.StatusOK, singleSiteCLIResponse{
+			siteResponse: site,
+			CLIBatch:     site.cliBatch,
+			ActiveEvents: active,
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, singleSiteResponse{siteResponse: site, ActiveEvents: active})
+}
+
+func siteSelectColumns(prefix string, includeCLIMetadata bool) string {
+	cols := []string{
+		prefix + "blog_id",
+		prefix + "blog_id AS public_id",
+		prefix + "monitor_url",
+		prefix + "monitor_active",
+		prefix + "bucket_no",
+		prefix + "check_interval",
+		prefix + "site_status",
+		prefix + "last_checked_at",
+		prefix + "last_status_change",
+		prefix + "ssl_expiry_date",
+		prefix + "check_keyword",
+		prefix + "redirect_policy",
+		prefix + "maintenance_start",
+		prefix + "maintenance_end",
+		prefix + "alert_cooldown_minutes",
+	}
+	if includeCLIMetadata {
+		cols = append(cols, prefix+"custom_headers")
+	}
+	return strings.Join(cols, ", ")
+}
+
+func parseIncludeCLIMetadata(value string) (bool, error) {
+	switch value {
+	case "", "false", "0":
+		return false, nil
+	case "true", "1":
+		return true, nil
+	default:
+		return false, fmt.Errorf("include_cli_metadata must be 'true' or 'false'")
+	}
+}
+
+func siteListResponseData(sites []siteResponse, includeCLIMetadata bool) any {
+	if !includeCLIMetadata {
+		return sites
+	}
+	out := make([]siteCLIResponse, 0, len(sites))
+	for _, site := range sites {
+		out = append(out, siteCLIResponse{siteResponse: site, CLIBatch: site.cliBatch})
+	}
+	return out
 }
 
 // queryActiveEvents returns all open events for a site, ordered by severity
@@ -374,7 +438,7 @@ type rowScanner interface {
 // scanSiteRow scans the columns selected by the site queries into a
 // siteResponse. SiteStatus is not exposed directly; it is used only as a
 // fallback for sites with no active v2 event during the shadow migration.
-func scanSiteRow(s rowScanner) (siteResponse, error) {
+func scanSiteRow(s rowScanner, includeCLIMetadata bool) (siteResponse, error) {
 	var (
 		out            siteResponse
 		monitorActive  uint8
@@ -387,14 +451,18 @@ func scanSiteRow(s rowScanner) (siteResponse, error) {
 		maintStart     sql.NullTime
 		maintEnd       sql.NullTime
 		alertCooldown  sql.NullInt64
-		customHeaders  sql.NullString
 	)
-	if err := s.Scan(
+	dest := []any{
 		&out.ID, &out.BlogID, &out.MonitorURL, &monitorActive,
 		&out.BucketNo, &out.CheckInterval, &siteStatus,
 		&lastCheckedAt, &lastStatusChg, &sslExpiry, &checkKeyword,
-		&redirectPolicy, &maintStart, &maintEnd, &alertCooldown, &customHeaders,
-	); err != nil {
+		&redirectPolicy, &maintStart, &maintEnd, &alertCooldown,
+	}
+	var customHeaders sql.NullString
+	if includeCLIMetadata {
+		dest = append(dest, &customHeaders)
+	}
+	if err := s.Scan(dest...); err != nil {
 		return out, err
 	}
 	out.MonitorActive = monitorActive == 1
@@ -435,8 +503,8 @@ func scanSiteRow(s rowScanner) (siteResponse, error) {
 		v := int(alertCooldown.Int64)
 		out.AlertCooldownMinutes = &v
 	}
-	if customHeaders.Valid {
-		out.CLIBatch = cliBatchFromCustomHeaders(customHeaders.String)
+	if includeCLIMetadata && customHeaders.Valid {
+		out.cliBatch = cliBatchFromCustomHeaders(customHeaders.String)
 	}
 	return out, nil
 }

--- a/internal/api/handlers_sites.go
+++ b/internal/api/handlers_sites.go
@@ -15,6 +15,8 @@ import (
 	"github.com/Automattic/jetmon/internal/eventstore"
 )
 
+const cliBatchHeader = "X-Jetmon-CLI-Batch"
+
 // siteResponse is the JSON shape for a site in list and single-site responses.
 // Field ordering kept human-friendly (id and url first, configuration fields
 // after, computed fields last). See API.md "Family 1: Sites and current state".
@@ -36,6 +38,7 @@ type siteResponse struct {
 	MaintenanceStart     *string `json:"maintenance_start"`
 	MaintenanceEnd       *string `json:"maintenance_end"`
 	AlertCooldownMinutes *int    `json:"alert_cooldown_minutes"`
+	CLIBatch             string  `json:"cli_batch,omitempty"`
 }
 
 // activeEventSummary is the compact event shape embedded in single-site
@@ -102,7 +105,8 @@ func (s *Server) handleListSites(w http.ResponseWriter, r *http.Request) {
 		SELECT s.blog_id, s.blog_id AS public_id, s.monitor_url, s.monitor_active,
 		       s.bucket_no, s.check_interval, s.site_status, s.last_checked_at,
 		       s.last_status_change, s.ssl_expiry_date, s.check_keyword, s.redirect_policy,
-		       s.maintenance_start, s.maintenance_end, s.alert_cooldown_minutes
+		       s.maintenance_start, s.maintenance_end, s.alert_cooldown_minutes,
+		       s.custom_headers
 		  FROM jetpack_monitor_sites s
 		  JOIN jetmon_site_tenants st ON st.blog_id = s.blog_id AND st.tenant_id = ?
 		 WHERE s.blog_id > ?`)
@@ -112,7 +116,8 @@ func (s *Server) handleListSites(w http.ResponseWriter, r *http.Request) {
 		SELECT blog_id, blog_id AS public_id, monitor_url, monitor_active,
 		       bucket_no, check_interval, site_status, last_checked_at,
 		       last_status_change, ssl_expiry_date, check_keyword, redirect_policy,
-		       maintenance_start, maintenance_end, alert_cooldown_minutes
+		       maintenance_start, maintenance_end, alert_cooldown_minutes,
+		       custom_headers
 		  FROM jetpack_monitor_sites
 		 WHERE blog_id > ?`)
 	}
@@ -225,7 +230,8 @@ func (s *Server) handleGetSite(w http.ResponseWriter, r *http.Request) {
 		SELECT blog_id, blog_id AS public_id, monitor_url, monitor_active,
 		       bucket_no, check_interval, site_status, last_checked_at,
 		       last_status_change, ssl_expiry_date, check_keyword, redirect_policy,
-		       maintenance_start, maintenance_end, alert_cooldown_minutes
+		       maintenance_start, maintenance_end, alert_cooldown_minutes,
+		       custom_headers
 		  FROM jetpack_monitor_sites
 		 WHERE blog_id = ?`, id)
 
@@ -381,12 +387,13 @@ func scanSiteRow(s rowScanner) (siteResponse, error) {
 		maintStart     sql.NullTime
 		maintEnd       sql.NullTime
 		alertCooldown  sql.NullInt64
+		customHeaders  sql.NullString
 	)
 	if err := s.Scan(
 		&out.ID, &out.BlogID, &out.MonitorURL, &monitorActive,
 		&out.BucketNo, &out.CheckInterval, &siteStatus,
 		&lastCheckedAt, &lastStatusChg, &sslExpiry, &checkKeyword,
-		&redirectPolicy, &maintStart, &maintEnd, &alertCooldown,
+		&redirectPolicy, &maintStart, &maintEnd, &alertCooldown, &customHeaders,
 	); err != nil {
 		return out, err
 	}
@@ -428,7 +435,26 @@ func scanSiteRow(s rowScanner) (siteResponse, error) {
 		v := int(alertCooldown.Int64)
 		out.AlertCooldownMinutes = &v
 	}
+	if customHeaders.Valid {
+		out.CLIBatch = cliBatchFromCustomHeaders(customHeaders.String)
+	}
 	return out, nil
+}
+
+func cliBatchFromCustomHeaders(raw string) string {
+	var headers map[string]any
+	if err := json.Unmarshal([]byte(raw), &headers); err != nil {
+		return ""
+	}
+	for name, value := range headers {
+		if !strings.EqualFold(name, cliBatchHeader) {
+			continue
+		}
+		if s, ok := value.(string); ok {
+			return s
+		}
+	}
+	return ""
 }
 
 // deriveStateFromSiteStatus maps the v1 site_status integer to the v2

--- a/internal/api/handlers_sites_test.go
+++ b/internal/api/handlers_sites_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 )
 
-const sitesListSQL = ` SELECT blog_id, blog_id AS public_id, monitor_url, monitor_active, bucket_no, check_interval, site_status, last_checked_at, last_status_change, ssl_expiry_date, check_keyword, redirect_policy, maintenance_start, maintenance_end, alert_cooldown_minutes FROM jetpack_monitor_sites WHERE blog_id > ? ORDER BY blog_id ASC LIMIT ?`
+const sitesListSQL = ` SELECT blog_id, blog_id AS public_id, monitor_url, monitor_active, bucket_no, check_interval, site_status, last_checked_at, last_status_change, ssl_expiry_date, check_keyword, redirect_policy, maintenance_start, maintenance_end, alert_cooldown_minutes, custom_headers FROM jetpack_monitor_sites WHERE blog_id > ? ORDER BY blog_id ASC LIMIT ?`
 
-const sitesListForTenantSQL = ` SELECT s.blog_id, s.blog_id AS public_id, s.monitor_url, s.monitor_active, s.bucket_no, s.check_interval, s.site_status, s.last_checked_at, s.last_status_change, s.ssl_expiry_date, s.check_keyword, s.redirect_policy, s.maintenance_start, s.maintenance_end, s.alert_cooldown_minutes FROM jetpack_monitor_sites s JOIN jetmon_site_tenants st ON st.blog_id = s.blog_id AND st.tenant_id = ? WHERE s.blog_id > ? ORDER BY s.blog_id ASC LIMIT ?`
+const sitesListForTenantSQL = ` SELECT s.blog_id, s.blog_id AS public_id, s.monitor_url, s.monitor_active, s.bucket_no, s.check_interval, s.site_status, s.last_checked_at, s.last_status_change, s.ssl_expiry_date, s.check_keyword, s.redirect_policy, s.maintenance_start, s.maintenance_end, s.alert_cooldown_minutes, s.custom_headers FROM jetpack_monitor_sites s JOIN jetmon_site_tenants st ON st.blog_id = s.blog_id AND st.tenant_id = ? WHERE s.blog_id > ? ORDER BY s.blog_id ASC LIMIT ?`
 
-const singleSiteSQL = ` SELECT blog_id, blog_id AS public_id, monitor_url, monitor_active, bucket_no, check_interval, site_status, last_checked_at, last_status_change, ssl_expiry_date, check_keyword, redirect_policy, maintenance_start, maintenance_end, alert_cooldown_minutes FROM jetpack_monitor_sites WHERE blog_id = ?`
+const singleSiteSQL = ` SELECT blog_id, blog_id AS public_id, monitor_url, monitor_active, bucket_no, check_interval, site_status, last_checked_at, last_status_change, ssl_expiry_date, check_keyword, redirect_policy, maintenance_start, maintenance_end, alert_cooldown_minutes, custom_headers FROM jetpack_monitor_sites WHERE blog_id = ?`
 
 const activeEventsSQL = ` SELECT id, check_type, severity, state, started_at FROM jetmon_events WHERE blog_id = ? AND ended_at IS NULL ORDER BY severity DESC, started_at ASC`
 
@@ -35,7 +35,7 @@ func makeSiteRowWithSchedule(blogID int64, monitorURL string, siteStatus int, bu
 	return sqlmock.NewRows(columnsSite).AddRow(
 		blogID, blogID, monitorURL, 1, bucketNo, checkInterval, siteStatus,
 		nil, nil, nil, nil,
-		"follow", nil, nil, nil,
+		"follow", nil, nil, nil, nil,
 	)
 }
 
@@ -72,7 +72,7 @@ func TestListSitesReturnsRows(t *testing.T) {
 
 	rows := makeSiteRow(101, "https://example.com", 1)
 	rows.AddRow(102, 102, "https://other.com", 1, 7, 3, 1,
-		nil, nil, nil, nil, "follow", nil, nil, nil)
+		nil, nil, nil, nil, "follow", nil, nil, nil, nil)
 
 	mock.ExpectQuery(sitesListSQL).
 		WithArgs(int64(0), 51).
@@ -236,8 +236,8 @@ func TestListSitesAppliesPaginationCursor(t *testing.T) {
 
 	// Three rows; limit=2 → should return 2 + a next cursor.
 	rows := makeSiteRow(10, "a", 1)
-	rows.AddRow(20, 20, "b", 1, 0, 5, 1, nil, nil, nil, nil, "follow", nil, nil, nil)
-	rows.AddRow(30, 30, "c", 1, 0, 5, 1, nil, nil, nil, nil, "follow", nil, nil, nil)
+	rows.AddRow(20, 20, "b", 1, 0, 5, 1, nil, nil, nil, nil, "follow", nil, nil, nil, nil)
+	rows.AddRow(30, 30, "c", 1, 0, 5, 1, nil, nil, nil, nil, "follow", nil, nil, nil, nil)
 
 	mock.ExpectQuery(sitesListSQL).
 		WithArgs(int64(0), 3). // limit+1 = 3
@@ -282,8 +282,8 @@ func TestListSitesKeepsCursorWhenFilteredPageHasMoreRows(t *testing.T) {
 	// pagination must advance past the sentinel row instead of reporting
 	// page.next=null.
 	rows := makeSiteRow(10, "a", 1)
-	rows.AddRow(20, 20, "b", 1, 0, 5, 1, nil, nil, nil, nil, "follow", nil, nil, nil)
-	rows.AddRow(30, 30, "c", 1, 0, 5, 2, nil, nil, nil, nil, "follow", nil, nil, nil)
+	rows.AddRow(20, 20, "b", 1, 0, 5, 1, nil, nil, nil, nil, "follow", nil, nil, nil, nil)
+	rows.AddRow(30, 30, "c", 1, 0, 5, 2, nil, nil, nil, nil, "follow", nil, nil, nil, nil)
 
 	mock.ExpectQuery(sitesListSQL).
 		WithArgs(int64(0), 3).
@@ -325,7 +325,7 @@ func TestListSitesFiltersByMonitorActive(t *testing.T) {
 	s, mock, key, cleanup := newTestServer(t)
 	defer cleanup()
 
-	expected := ` SELECT blog_id, blog_id AS public_id, monitor_url, monitor_active, bucket_no, check_interval, site_status, last_checked_at, last_status_change, ssl_expiry_date, check_keyword, redirect_policy, maintenance_start, maintenance_end, alert_cooldown_minutes FROM jetpack_monitor_sites WHERE blog_id > ? AND monitor_active = 1 ORDER BY blog_id ASC LIMIT ?`
+	expected := ` SELECT blog_id, blog_id AS public_id, monitor_url, monitor_active, bucket_no, check_interval, site_status, last_checked_at, last_status_change, ssl_expiry_date, check_keyword, redirect_policy, maintenance_start, maintenance_end, alert_cooldown_minutes, custom_headers FROM jetpack_monitor_sites WHERE blog_id > ? AND monitor_active = 1 ORDER BY blog_id ASC LIMIT ?`
 	mock.ExpectQuery(expected).
 		WithArgs(int64(0), 51).
 		WillReturnRows(sqlmock.NewRows(columnsSite))
@@ -445,7 +445,13 @@ func TestGetSiteFound(t *testing.T) {
 	s, mock, key, cleanup := newTestServer(t)
 	defer cleanup()
 
-	mock.ExpectQuery(singleSiteSQL).WithArgs(int64(42)).WillReturnRows(makeSiteRow(42, "https://x", 2))
+	mock.ExpectQuery(singleSiteSQL).WithArgs(int64(42)).WillReturnRows(
+		sqlmock.NewRows(columnsSite).AddRow(
+			42, 42, "https://x", 1, 0, 5, 2,
+			nil, nil, nil, nil, "follow", nil, nil, nil,
+			`{"X-Jetmon-CLI-Batch":"local-smoke"}`,
+		),
+	)
 
 	// active_events query — return one active event.
 	startedAt := time.Date(2026, 4, 25, 3, 18, 38, 329_000_000, time.UTC)
@@ -468,6 +474,9 @@ func TestGetSiteFound(t *testing.T) {
 	}
 	if resp.BucketNo != 0 || resp.CheckInterval != 5 {
 		t.Errorf("scheduling fields = (%d, %d), want (0, 5)", resp.BucketNo, resp.CheckInterval)
+	}
+	if resp.CLIBatch != "local-smoke" {
+		t.Errorf("cli_batch = %q, want local-smoke", resp.CLIBatch)
 	}
 	if len(resp.ActiveEvents) != 1 || resp.ActiveEvents[0].ID != 7 {
 		t.Fatalf("active_events = %+v, want one with id=7", resp.ActiveEvents)

--- a/internal/api/handlers_sites_test.go
+++ b/internal/api/handlers_sites_test.go
@@ -11,11 +11,15 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 )
 
-const sitesListSQL = ` SELECT blog_id, blog_id AS public_id, monitor_url, monitor_active, bucket_no, check_interval, site_status, last_checked_at, last_status_change, ssl_expiry_date, check_keyword, redirect_policy, maintenance_start, maintenance_end, alert_cooldown_minutes, custom_headers FROM jetpack_monitor_sites WHERE blog_id > ? ORDER BY blog_id ASC LIMIT ?`
+const sitesListSQL = ` SELECT blog_id, blog_id AS public_id, monitor_url, monitor_active, bucket_no, check_interval, site_status, last_checked_at, last_status_change, ssl_expiry_date, check_keyword, redirect_policy, maintenance_start, maintenance_end, alert_cooldown_minutes FROM jetpack_monitor_sites WHERE blog_id > ? ORDER BY blog_id ASC LIMIT ?`
 
-const sitesListForTenantSQL = ` SELECT s.blog_id, s.blog_id AS public_id, s.monitor_url, s.monitor_active, s.bucket_no, s.check_interval, s.site_status, s.last_checked_at, s.last_status_change, s.ssl_expiry_date, s.check_keyword, s.redirect_policy, s.maintenance_start, s.maintenance_end, s.alert_cooldown_minutes, s.custom_headers FROM jetpack_monitor_sites s JOIN jetmon_site_tenants st ON st.blog_id = s.blog_id AND st.tenant_id = ? WHERE s.blog_id > ? ORDER BY s.blog_id ASC LIMIT ?`
+const sitesListForTenantSQL = ` SELECT s.blog_id, s.blog_id AS public_id, s.monitor_url, s.monitor_active, s.bucket_no, s.check_interval, s.site_status, s.last_checked_at, s.last_status_change, s.ssl_expiry_date, s.check_keyword, s.redirect_policy, s.maintenance_start, s.maintenance_end, s.alert_cooldown_minutes FROM jetpack_monitor_sites s JOIN jetmon_site_tenants st ON st.blog_id = s.blog_id AND st.tenant_id = ? WHERE s.blog_id > ? ORDER BY s.blog_id ASC LIMIT ?`
 
-const singleSiteSQL = ` SELECT blog_id, blog_id AS public_id, monitor_url, monitor_active, bucket_no, check_interval, site_status, last_checked_at, last_status_change, ssl_expiry_date, check_keyword, redirect_policy, maintenance_start, maintenance_end, alert_cooldown_minutes, custom_headers FROM jetpack_monitor_sites WHERE blog_id = ?`
+const sitesListWithCLIMetadataSQL = ` SELECT blog_id, blog_id AS public_id, monitor_url, monitor_active, bucket_no, check_interval, site_status, last_checked_at, last_status_change, ssl_expiry_date, check_keyword, redirect_policy, maintenance_start, maintenance_end, alert_cooldown_minutes, custom_headers FROM jetpack_monitor_sites WHERE blog_id > ? ORDER BY blog_id ASC LIMIT ?`
+
+const singleSiteSQL = ` SELECT blog_id, blog_id AS public_id, monitor_url, monitor_active, bucket_no, check_interval, site_status, last_checked_at, last_status_change, ssl_expiry_date, check_keyword, redirect_policy, maintenance_start, maintenance_end, alert_cooldown_minutes FROM jetpack_monitor_sites WHERE blog_id = ?`
+
+const singleSiteWithCLIMetadataSQL = ` SELECT blog_id, blog_id AS public_id, monitor_url, monitor_active, bucket_no, check_interval, site_status, last_checked_at, last_status_change, ssl_expiry_date, check_keyword, redirect_policy, maintenance_start, maintenance_end, alert_cooldown_minutes, custom_headers FROM jetpack_monitor_sites WHERE blog_id = ?`
 
 const activeEventsSQL = ` SELECT id, check_type, severity, state, started_at FROM jetmon_events WHERE blog_id = ? AND ended_at IS NULL ORDER BY severity DESC, started_at ASC`
 
@@ -35,7 +39,7 @@ func makeSiteRowWithSchedule(blogID int64, monitorURL string, siteStatus int, bu
 	return sqlmock.NewRows(columnsSite).AddRow(
 		blogID, blogID, monitorURL, 1, bucketNo, checkInterval, siteStatus,
 		nil, nil, nil, nil,
-		"follow", nil, nil, nil, nil,
+		"follow", nil, nil, nil,
 	)
 }
 
@@ -72,7 +76,7 @@ func TestListSitesReturnsRows(t *testing.T) {
 
 	rows := makeSiteRow(101, "https://example.com", 1)
 	rows.AddRow(102, 102, "https://other.com", 1, 7, 3, 1,
-		nil, nil, nil, nil, "follow", nil, nil, nil, nil)
+		nil, nil, nil, nil, "follow", nil, nil, nil)
 
 	mock.ExpectQuery(sitesListSQL).
 		WithArgs(int64(0), 51).
@@ -87,6 +91,9 @@ func TestListSitesReturnsRows(t *testing.T) {
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if contains(rec.Body.String(), "cli_batch") {
+		t.Fatalf("canonical list response unexpectedly included cli_batch: %s", rec.Body.String())
 	}
 	var resp struct {
 		Data []siteResponse `json:"data"`
@@ -142,6 +149,38 @@ func TestListSitesWithGatewayTenantScopesRows(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestListSitesIncludesCLIBatchOnlyWhenRequested(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(sitesListWithCLIMetadataSQL).
+		WithArgs(int64(0), 51).
+		WillReturnRows(sqlmock.NewRows(columnsSiteWithCLIMetadata).AddRow(
+			101, 101, "https://example.com", 1, 0, 5, 1,
+			nil, nil, nil, nil, "follow", nil, nil, nil,
+			`{"X-Jetmon-CLI-Batch":"local-smoke"}`,
+		))
+	mock.ExpectQuery(activeEventRollupsSQL("?")).
+		WithArgs(int64(101)).
+		WillReturnRows(sqlmock.NewRows(activeEventRollupColumns))
+
+	req := requestWithKey("GET", "/api/v1/sites?include_cli_metadata=true", key)
+	rec := invokeAuthed(s, req, s.handleListSites)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Data []struct {
+			ID       int64  `json:"id"`
+			CLIBatch string `json:"cli_batch"`
+		} `json:"data"`
+	}
+	readJSON(t, rec.Body, &resp)
+	if len(resp.Data) != 1 || resp.Data[0].ID != 101 || resp.Data[0].CLIBatch != "local-smoke" {
+		t.Fatalf("data = %+v, want site 101 cli_batch=local-smoke", resp.Data)
 	}
 }
 
@@ -236,8 +275,8 @@ func TestListSitesAppliesPaginationCursor(t *testing.T) {
 
 	// Three rows; limit=2 → should return 2 + a next cursor.
 	rows := makeSiteRow(10, "a", 1)
-	rows.AddRow(20, 20, "b", 1, 0, 5, 1, nil, nil, nil, nil, "follow", nil, nil, nil, nil)
-	rows.AddRow(30, 30, "c", 1, 0, 5, 1, nil, nil, nil, nil, "follow", nil, nil, nil, nil)
+	rows.AddRow(20, 20, "b", 1, 0, 5, 1, nil, nil, nil, nil, "follow", nil, nil, nil)
+	rows.AddRow(30, 30, "c", 1, 0, 5, 1, nil, nil, nil, nil, "follow", nil, nil, nil)
 
 	mock.ExpectQuery(sitesListSQL).
 		WithArgs(int64(0), 3). // limit+1 = 3
@@ -282,8 +321,8 @@ func TestListSitesKeepsCursorWhenFilteredPageHasMoreRows(t *testing.T) {
 	// pagination must advance past the sentinel row instead of reporting
 	// page.next=null.
 	rows := makeSiteRow(10, "a", 1)
-	rows.AddRow(20, 20, "b", 1, 0, 5, 1, nil, nil, nil, nil, "follow", nil, nil, nil, nil)
-	rows.AddRow(30, 30, "c", 1, 0, 5, 2, nil, nil, nil, nil, "follow", nil, nil, nil, nil)
+	rows.AddRow(20, 20, "b", 1, 0, 5, 1, nil, nil, nil, nil, "follow", nil, nil, nil)
+	rows.AddRow(30, 30, "c", 1, 0, 5, 2, nil, nil, nil, nil, "follow", nil, nil, nil)
 
 	mock.ExpectQuery(sitesListSQL).
 		WithArgs(int64(0), 3).
@@ -325,7 +364,7 @@ func TestListSitesFiltersByMonitorActive(t *testing.T) {
 	s, mock, key, cleanup := newTestServer(t)
 	defer cleanup()
 
-	expected := ` SELECT blog_id, blog_id AS public_id, monitor_url, monitor_active, bucket_no, check_interval, site_status, last_checked_at, last_status_change, ssl_expiry_date, check_keyword, redirect_policy, maintenance_start, maintenance_end, alert_cooldown_minutes, custom_headers FROM jetpack_monitor_sites WHERE blog_id > ? AND monitor_active = 1 ORDER BY blog_id ASC LIMIT ?`
+	expected := ` SELECT blog_id, blog_id AS public_id, monitor_url, monitor_active, bucket_no, check_interval, site_status, last_checked_at, last_status_change, ssl_expiry_date, check_keyword, redirect_policy, maintenance_start, maintenance_end, alert_cooldown_minutes FROM jetpack_monitor_sites WHERE blog_id > ? AND monitor_active = 1 ORDER BY blog_id ASC LIMIT ?`
 	mock.ExpectQuery(expected).
 		WithArgs(int64(0), 51).
 		WillReturnRows(sqlmock.NewRows(columnsSite))
@@ -381,6 +420,9 @@ func TestScanSiteRowIgnoresLegacyStatusWhenProjectionDisabled(t *testing.T) {
 	rec := invokeAuthed(s, req, s.handleGetSite)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if contains(rec.Body.String(), "cli_batch") {
+		t.Fatalf("canonical single-site response unexpectedly included cli_batch: %s", rec.Body.String())
 	}
 	var resp singleSiteResponse
 	readJSON(t, rec.Body, &resp)
@@ -445,13 +487,7 @@ func TestGetSiteFound(t *testing.T) {
 	s, mock, key, cleanup := newTestServer(t)
 	defer cleanup()
 
-	mock.ExpectQuery(singleSiteSQL).WithArgs(int64(42)).WillReturnRows(
-		sqlmock.NewRows(columnsSite).AddRow(
-			42, 42, "https://x", 1, 0, 5, 2,
-			nil, nil, nil, nil, "follow", nil, nil, nil,
-			`{"X-Jetmon-CLI-Batch":"local-smoke"}`,
-		),
-	)
+	mock.ExpectQuery(singleSiteSQL).WithArgs(int64(42)).WillReturnRows(makeSiteRow(42, "https://x", 2))
 
 	// active_events query — return one active event.
 	startedAt := time.Date(2026, 4, 25, 3, 18, 38, 329_000_000, time.UTC)
@@ -475,9 +511,6 @@ func TestGetSiteFound(t *testing.T) {
 	if resp.BucketNo != 0 || resp.CheckInterval != 5 {
 		t.Errorf("scheduling fields = (%d, %d), want (0, 5)", resp.BucketNo, resp.CheckInterval)
 	}
-	if resp.CLIBatch != "local-smoke" {
-		t.Errorf("cli_batch = %q, want local-smoke", resp.CLIBatch)
-	}
 	if len(resp.ActiveEvents) != 1 || resp.ActiveEvents[0].ID != 7 {
 		t.Fatalf("active_events = %+v, want one with id=7", resp.ActiveEvents)
 	}
@@ -487,6 +520,36 @@ func TestGetSiteFound(t *testing.T) {
 	// Worst event should be reflected on the projection.
 	if resp.CurrentState != "Down" || resp.CurrentSeverity != 4 {
 		t.Errorf("projection = (%q, %d), want (Down, 4)", resp.CurrentState, resp.CurrentSeverity)
+	}
+}
+
+func TestGetSiteIncludesCLIBatchOnlyWhenRequested(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(singleSiteWithCLIMetadataSQL).WithArgs(int64(42)).WillReturnRows(
+		sqlmock.NewRows(columnsSiteWithCLIMetadata).AddRow(
+			42, 42, "https://x", 1, 0, 5, 1,
+			nil, nil, nil, nil, "follow", nil, nil, nil,
+			`{"X-Jetmon-CLI-Batch":"local-smoke"}`,
+		),
+	)
+	mock.ExpectQuery(activeEventsSQL).WithArgs(int64(42)).
+		WillReturnRows(sqlmock.NewRows(columnsActiveEvent))
+
+	req := requestWithKey("GET", "/api/v1/sites/42?include_cli_metadata=true", key)
+	req.SetPathValue("id", "42")
+	rec := invokeAuthed(s, req, s.handleGetSite)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		ID       int64  `json:"id"`
+		CLIBatch string `json:"cli_batch"`
+	}
+	readJSON(t, rec.Body, &resp)
+	if resp.ID != 42 || resp.CLIBatch != "local-smoke" {
+		t.Fatalf("response = %+v, want id=42 cli_batch=local-smoke", resp)
 	}
 }
 

--- a/internal/api/handlers_sites_write.go
+++ b/internal/api/handlers_sites_write.go
@@ -495,14 +495,10 @@ func (s *Server) closeEvent(ctx context.Context, eventID, blogID int64, reason s
 // write handlers' read-back step.
 func (s *Server) readSite(ctx context.Context, blogID int64) (siteResponse, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT blog_id, blog_id AS public_id, monitor_url, monitor_active,
-		       bucket_no, check_interval, site_status, last_checked_at,
-		       last_status_change, ssl_expiry_date, check_keyword, redirect_policy,
-		       maintenance_start, maintenance_end, alert_cooldown_minutes,
-		       custom_headers
+		SELECT `+siteSelectColumns("", false)+`
 		  FROM jetpack_monitor_sites
 		 WHERE blog_id = ?`, blogID)
-	return scanSiteRow(row)
+	return scanSiteRow(row, false)
 }
 
 // validateMonitorURL accepts only http and https URLs with a non-empty host.

--- a/internal/api/handlers_sites_write.go
+++ b/internal/api/handlers_sites_write.go
@@ -498,7 +498,8 @@ func (s *Server) readSite(ctx context.Context, blogID int64) (siteResponse, erro
 		SELECT blog_id, blog_id AS public_id, monitor_url, monitor_active,
 		       bucket_no, check_interval, site_status, last_checked_at,
 		       last_status_change, ssl_expiry_date, check_keyword, redirect_policy,
-		       maintenance_start, maintenance_end, alert_cooldown_minutes
+		       maintenance_start, maintenance_end, alert_cooldown_minutes,
+		       custom_headers
 		  FROM jetpack_monitor_sites
 		 WHERE blog_id = ?`, blogID)
 	return scanSiteRow(row)

--- a/internal/api/testhelp_test.go
+++ b/internal/api/testhelp_test.go
@@ -122,7 +122,7 @@ var columnsSite = []string{
 	"blog_id", "public_id", "monitor_url", "monitor_active", "bucket_no",
 	"check_interval", "site_status", "last_checked_at", "last_status_change",
 	"ssl_expiry_date", "check_keyword", "redirect_policy", "maintenance_start",
-	"maintenance_end", "alert_cooldown_minutes",
+	"maintenance_end", "alert_cooldown_minutes", "custom_headers",
 }
 
 // columnsActiveEvent is the column set returned by queryActiveEvents.

--- a/internal/api/testhelp_test.go
+++ b/internal/api/testhelp_test.go
@@ -122,8 +122,10 @@ var columnsSite = []string{
 	"blog_id", "public_id", "monitor_url", "monitor_active", "bucket_no",
 	"check_interval", "site_status", "last_checked_at", "last_status_change",
 	"ssl_expiry_date", "check_keyword", "redirect_policy", "maintenance_start",
-	"maintenance_end", "alert_cooldown_minutes", "custom_headers",
+	"maintenance_end", "alert_cooldown_minutes",
 }
+
+var columnsSiteWithCLIMetadata = append(append([]string{}, columnsSite...), "custom_headers")
 
 // columnsActiveEvent is the column set returned by queryActiveEvents.
 var columnsActiveEvent = []string{

--- a/scripts/api-cli-validate.sh
+++ b/scripts/api-cli-validate.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+binary="${API_CLI_BINARY:-./bin/jetmon2}"
+batch="${API_VALIDATE_BATCH:-api-cli-validate}"
+smoke_batch="${batch}-smoke"
+failure_batch="${batch}-failure"
+failure_count="${API_VALIDATE_COUNT:-1}"
+failure_mode="${API_VALIDATE_MODE:-http-500}"
+failure_wait="${API_VALIDATE_WAIT:-30s}"
+
+if [[ -z "${JETMON_API_TOKEN:-}" ]]; then
+	echo "JETMON_API_TOKEN is required" >&2
+	exit 1
+fi
+
+export JETMON_API_URL="${JETMON_API_URL:-http://localhost:${API_HOST_PORT:-8090}}"
+
+cleanup() {
+	"$binary" api sites cleanup --batch "$smoke_batch" --count 3 --output table >/dev/null 2>&1 || true
+	"$binary" api sites cleanup --batch "$failure_batch" --count "$failure_count" --output table >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+step() {
+	printf '\n== %s ==\n' "$1"
+	shift
+	"$@"
+}
+
+step "health" "$binary" api health --pretty
+step "identity" "$binary" api me --pretty
+step "request escape hatch" "$binary" api request --output table GET "/api/v1/sites?limit=1"
+step "bulk-add dry run" "$binary" api sites bulk-add --count 3 --batch "$smoke_batch" --dry-run --pretty
+step "smoke workflow" "$binary" api smoke --batch "$smoke_batch" --pretty
+
+if [[ "${API_VALIDATE_SKIP_FAILURE:-0}" != "1" ]]; then
+	step "failure simulation assertions" "$binary" api sites simulate-failure \
+		--batch "$failure_batch" \
+		--count "$failure_count" \
+		--create-missing \
+		--mode "$failure_mode" \
+		--wait "$failure_wait" \
+		--expect-event-state "Seems Down" \
+		--expect-event-severity 3 \
+		--require-transition \
+		--expect-transition-reason opened \
+		--pretty
+fi


### PR DESCRIPTION
## Summary

Adds the `jetmon2 api` helper CLI for exercising Jetmon's internal `/api/v1` API from local Docker, rollout rehearsals, and CI smoke checks.

This branch includes:
- API request foundation: `health`, `me`, generic `request`, local env defaults, Bearer auth, custom headers, idempotency keys, verbose header logging, JSON/table output.
- Typed resources: `sites`, `events`, `webhooks`, and `alert-contacts` commands covering list/get/create/update/delete/actions/retry paths.
- Local workflows: `api smoke`, `sites bulk-add`, `sites cleanup`, and `sites simulate-failure`.
- Deterministic Docker fixture: `api-fixture` / `jetmon-testsite` for local HTTP 500/403, redirects, keyword mismatch, slow response, and self-signed TLS scenarios.
- Docs: API CLI roadmap and feature guide with examples.

## Highlighted Examples

```bash
# Verify the API and token identity
./bin/jetmon2 api health --pretty
./bin/jetmon2 api me --pretty

# Use the generic escape hatch before a typed command exists
./bin/jetmon2 api request --output table GET '/api/v1/sites?limit=5'

# Create repeatable local test data
./bin/jetmon2 api sites bulk-add --count 3 --batch local-smoke --dry-run --pretty
./bin/jetmon2 api sites bulk-add --count 3 --batch local-smoke --idempotency-key-prefix local-smoke --pretty

# Run the documented Docker-local smoke workflow
JETMON_API_URL=http://localhost:${API_HOST_PORT:-8090} \
JETMON_API_TOKEN=jm_replace_with_the_printed_token \
make api-cli-smoke

# Simulate a known failure using the Docker-local fixture when available
./bin/jetmon2 api sites simulate-failure \
  --batch local-smoke \
  --mode http-500 \
  --wait 30s \
  --expect-event-state 'Seems Down' \
  --expect-event-severity 3 \
  --require-transition \
  --expect-transition-reason opened \
  --pretty

# Clean up disposable local data
./bin/jetmon2 api sites cleanup --batch local-smoke --count 3 --output table
```

## Validation

- `make build`
- `/usr/local/go/bin/go test ./...`
- `/usr/local/go/bin/go vet ./...`
- `docker compose config --services`
- `DASHBOARD_HOST_PORT=18080 API_HOST_PORT=18090 docker compose up --build -d`
- Live Docker-local API CLI validation covering: `health`, `me`, generic `request`, `sites bulk-add`, `sites list/get/update/pause/resume/trigger-now`, `events list`, `webhooks create/list/get/update/rotate-secret/deliveries`, `alert-contacts create/list/get/test/deliveries`, `sites simulate-failure`, and `sites cleanup`.
- `JETMON_API_URL=http://localhost:18090 JETMON_API_TOKEN=<temp-token> API_SMOKE_BATCH=docs-pr-smoke make api-cli-smoke`

Temporary validation resources were cleaned up and the temporary API key was revoked.
