### PR TITLE
Simplify v2 rollout rehearsal and operator checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,7 @@ go run -race ./cmd/jetmon2/
 ./jetmon2 status
 ./jetmon2 audit --blog-id 12345 --since 2h
 ./jetmon2 rollout pinned-check
+./jetmon2 rollout cutover-check
 ./jetmon2 rollout dynamic-check
 ./jetmon2 rollout projection-drift
 ./jetmon2 site-tenants import --file site-tenants.csv --dry-run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,7 @@ go run -race ./cmd/jetmon2/
 ./jetmon2 rollout cutover-check
 ./jetmon2 rollout dynamic-check
 ./jetmon2 rollout projection-drift
+./jetmon2 rollout state-report
 ./jetmon2 site-tenants import --file site-tenants.csv --dry-run
 ./jetmon2 drain
 ./jetmon2 reload

--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,13 @@ API_CLI_TOKEN_TTL ?= 0
 API_CLI_TOKEN_ID ?=
 GO          ?= $(shell if command -v go >/dev/null 2>&1; then command -v go; elif [ -x /usr/local/go/bin/go ]; then printf /usr/local/go/bin/go; else printf go; fi)
 GOCACHE     ?= /tmp/jetmon-go-cache
-GO_ENV      := GOCACHE=$(GOCACHE)
+GOMODCACHE  ?= /tmp/jetmon-gomod-cache
+GO_ENV      := GOCACHE=$(GOCACHE) GOMODCACHE=$(GOMODCACHE)
 BUILD_FLAGS := -ldflags "-X main.version=$(shell git describe --tags --always --dirty) \
                          -X main.buildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ) \
                          -X main.goVersion=$(shell $(GO) version | awk '{print $$3}')"
 
-.PHONY: all build build-deliverer build-veriflier generate test test-race lint api-cli-smoke api-cli-validate api-cli-token-create api-cli-token-list api-cli-token-revoke clean
+.PHONY: all build build-deliverer build-veriflier generate test test-race lint rollout-docs-verify api-cli-smoke api-cli-validate api-cli-token-create api-cli-token-list api-cli-token-revoke clean
 
 all: build build-deliverer build-veriflier
 
@@ -53,6 +54,9 @@ test-race:
 
 lint:
 	$(GO_ENV) $(GO) vet ./...
+
+rollout-docs-verify: all test lint
+	scripts/rollout-docs-verify.sh
 
 api-cli-smoke: build
 	@test -n "$$JETMON_API_TOKEN" || { echo "JETMON_API_TOKEN is required"; exit 1; }

--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ is in [docs/v1-to-v2-migration.md](docs/v1-to-v2-migration.md):
 - Use pinned bucket mode for the first v1-to-v2 migration so one v1 host can be
   replaced by one v2 host with the same bucket range.
 - Use `rollout static-plan-check`, `rollout pinned-check`,
-  `rollout activity-check`, `rollout rollback-check`, and
-  `rollout projection-drift` from the migration runbook before changing the
-  next host.
+  `rollout cutover-check`, `rollout rollback-check`, and targeted
+  `rollout activity-check` / `rollout projection-drift` from the migration
+  runbook before changing the next host.
 - Keep `LEGACY_STATUS_PROJECTION_ENABLE` on until legacy readers have moved to
   the v2 API or event tables.
 - Use `SIGINT` or `./jetmon2 drain` for graceful shutdown.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,9 @@ Longer design decisions live in [docs/adr/](docs/adr/).
 ## Production Posture
 
 Jetmon 2 is designed for a cautious host-by-host rollout. The complete process
-is in [docs/v1-to-v2-migration.md](docs/v1-to-v2-migration.md):
+is in [docs/v1-to-v2-migration.md](docs/v1-to-v2-migration.md). Use
+[docs/rollout-quick-reference.md](docs/rollout-quick-reference.md) as the
+one-page command checklist during rehearsals and rollout windows:
 
 - Run `./jetmon2 migrate` before first start. Migrations are embedded and
   additive.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ make build-veriflier  # Build only veriflier2
 make test             # Run the Go test suite
 make test-race        # Run tests with the race detector
 make lint             # Run lint checks
+make rollout-docs-verify  # Verify rollout docs/tooling alignment
 ```
 
 `make generate` is intentionally separate. It requires `protoc` and Go protobuf

--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ one-page command checklist during rehearsals and rollout windows:
 - Use `rollout static-plan-check`, `rollout pinned-check`,
   `rollout cutover-check`, `rollout rollback-check`, and targeted
   `rollout activity-check` / `rollout projection-drift` from the migration
-  runbook before changing the next host.
+  runbook before changing the next host. Use `rollout state-report` for a
+  quick handoff snapshot.
 - Keep `LEGACY_STATUS_PROJECTION_ENABLE` on until legacy readers have moved to
   the v2 API or event tables.
 - Use `SIGINT` or `./jetmon2 drain` for graceful shutdown.

--- a/cmd/jetmon2/main.go
+++ b/cmd/jetmon2/main.go
@@ -322,6 +322,9 @@ func rolloutAdviceLines(cfg *config.Config) []string {
 		"INFO rollout_preflight="+rolloutPreflightCommand(cfg),
 		"INFO rollout_activity_check="+rolloutActivityCommand(),
 	)
+	if cmd := cutoverCheckCommand(cfg); cmd != "" {
+		lines = append(lines, "INFO rollout_cutover_check="+cmd)
+	}
 	if cmd := rollbackCheckCommand(cfg); cmd != "" {
 		lines = append(lines, "INFO rollout_rollback_check="+cmd)
 	}
@@ -342,6 +345,13 @@ func rolloutPreflightCommand(cfg *config.Config) string {
 
 func rolloutActivityCommand() string {
 	return "./jetmon2 rollout activity-check --since=15m"
+}
+
+func cutoverCheckCommand(cfg *config.Config) string {
+	if _, _, ok := cfg.PinnedBucketRange(); ok {
+		return "./jetmon2 rollout cutover-check --since=15m"
+	}
+	return ""
 }
 
 func rollbackCheckCommand(cfg *config.Config) string {

--- a/cmd/jetmon2/main_test.go
+++ b/cmd/jetmon2/main_test.go
@@ -282,8 +282,8 @@ func TestRolloutAdviceLines(t *testing.T) {
 
 	min, max := 12, 34
 	pinned := rolloutAdviceLines(&config.Config{PinnedBucketMin: &min, PinnedBucketMax: &max})
-	if len(pinned) != 5 {
-		t.Fatalf("pinned advice len = %d, want 5", len(pinned))
+	if len(pinned) != 6 {
+		t.Fatalf("pinned advice len = %d, want 6", len(pinned))
 	}
 	if !strings.Contains(pinned[0], "rollout static-plan-check") {
 		t.Fatalf("pinned static-plan advice = %q", pinned[0])
@@ -294,11 +294,14 @@ func TestRolloutAdviceLines(t *testing.T) {
 	if !strings.Contains(pinned[2], "rollout activity-check") {
 		t.Fatalf("pinned activity advice = %q", pinned[2])
 	}
-	if !strings.Contains(pinned[3], "rollout rollback-check") {
-		t.Fatalf("pinned rollback advice = %q", pinned[3])
+	if !strings.Contains(pinned[3], "rollout cutover-check") {
+		t.Fatalf("pinned cutover advice = %q", pinned[3])
 	}
-	if !strings.Contains(pinned[4], "rollout projection-drift") {
-		t.Fatalf("pinned drift advice = %q", pinned[4])
+	if !strings.Contains(pinned[4], "rollout rollback-check") {
+		t.Fatalf("pinned rollback advice = %q", pinned[4])
+	}
+	if !strings.Contains(pinned[5], "rollout projection-drift") {
+		t.Fatalf("pinned drift advice = %q", pinned[5])
 	}
 }
 
@@ -316,6 +319,12 @@ func TestRolloutCommandHelpers(t *testing.T) {
 	}
 	if got := rolloutActivityCommand(); got != "./jetmon2 rollout activity-check --since=15m" {
 		t.Fatalf("rolloutActivityCommand() = %q", got)
+	}
+	if got := cutoverCheckCommand(&config.Config{}); got != "" {
+		t.Fatalf("cutoverCheckCommand(dynamic) = %q, want empty", got)
+	}
+	if got := cutoverCheckCommand(cfg); got != "./jetmon2 rollout cutover-check --since=15m" {
+		t.Fatalf("cutoverCheckCommand(pinned) = %q", got)
 	}
 	if got := rollbackCheckCommand(&config.Config{}); got != "" {
 		t.Fatalf("rollbackCheckCommand(dynamic) = %q, want empty", got)

--- a/cmd/jetmon2/rollout.go
+++ b/cmd/jetmon2/rollout.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/csv"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -81,6 +83,103 @@ func cmdRollout(args []string) {
 	}
 }
 
+type rolloutJSONLine struct {
+	Level   string `json:"level"`
+	Message string `json:"message"`
+}
+
+type rolloutJSONReport struct {
+	OK          bool              `json:"ok"`
+	Command     string            `json:"command"`
+	GeneratedAt time.Time         `json:"generated_at"`
+	Lines       []rolloutJSONLine `json:"lines,omitempty"`
+	Failures    []string          `json:"failures,omitempty"`
+}
+
+func rolloutOutputFlag(fs *flag.FlagSet) *string {
+	return fs.String("output", "text", "output format: text or json")
+}
+
+func normalizeRolloutOutput(output string) (string, error) {
+	output = strings.ToLower(strings.TrimSpace(output))
+	if output == "" {
+		output = "text"
+	}
+	if output != "text" && output != "json" {
+		return "", errors.New("--output must be text or json")
+	}
+	return output, nil
+}
+
+func runRolloutCommandOutput(stdout io.Writer, command, output string, run func(io.Writer) error) error {
+	if stdout == nil {
+		stdout = io.Discard
+	}
+	if output != "json" {
+		return run(stdout)
+	}
+
+	var text bytes.Buffer
+	err := run(&text)
+	report := buildRolloutJSONReport(command, text.String(), err)
+	if renderErr := renderRolloutJSONReport(stdout, report); renderErr != nil {
+		return renderErr
+	}
+	return err
+}
+
+func buildRolloutJSONReport(command, text string, err error) rolloutJSONReport {
+	report := rolloutJSONReport{
+		OK:          err == nil,
+		Command:     command,
+		GeneratedAt: time.Now().UTC(),
+		Lines:       parseRolloutOutputLines(text),
+	}
+	if err != nil {
+		report.Failures = []string{err.Error()}
+	}
+	return report
+}
+
+func parseRolloutOutputLines(text string) []rolloutJSONLine {
+	var lines []rolloutJSONLine
+	for _, raw := range strings.Split(strings.TrimRight(text, "\n"), "\n") {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		level, message := parseRolloutOutputLine(raw)
+		lines = append(lines, rolloutJSONLine{Level: level, Message: message})
+	}
+	return lines
+}
+
+func parseRolloutOutputLine(line string) (string, string) {
+	if strings.HasPrefix(line, "## ") {
+		return "section", strings.TrimSpace(strings.TrimPrefix(line, "## "))
+	}
+	for _, level := range []string{"PASS", "WARN", "INFO", "FAIL"} {
+		prefix := level + " "
+		if strings.HasPrefix(line, prefix) {
+			return strings.ToLower(level), strings.TrimSpace(strings.TrimPrefix(line, prefix))
+		}
+	}
+	return "output", line
+}
+
+func renderRolloutJSONReport(out io.Writer, report rolloutJSONReport) error {
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	return enc.Encode(report)
+}
+
+func exitRolloutCommandError(err error, output string) {
+	if output != "json" {
+		fmt.Fprintf(os.Stderr, "FAIL %v\n", err)
+	}
+	os.Exit(1)
+}
+
 func cmdRolloutRehearsalPlan(args []string) {
 	fs := flag.NewFlagSet("rollout rehearsal-plan", flag.ExitOnError)
 	file := fs.String("file", "", "CSV file with host,bucket_min,bucket_max rows")
@@ -150,10 +249,16 @@ func cmdRolloutStaticPlanCheck(args []string) {
 	host := fs.String("host", "", "optional host id that must appear in the plan")
 	bucketMin := fs.Int("bucket-min", -1, "expected bucket minimum for --host")
 	bucketMax := fs.Int("bucket-max", -1, "expected bucket maximum for --host")
+	output := rolloutOutputFlag(fs)
 	_ = fs.Parse(args)
 	if fs.NArg() != 0 || strings.TrimSpace(*file) == "" {
-		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout static-plan-check --file=<ranges.csv> [--bucket-total=N] [--host=<host> --bucket-min=N --bucket-max=N]")
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout static-plan-check --file=<ranges.csv> [--bucket-total=N] [--host=<host> --bucket-min=N --bucket-max=N] [--output=text|json]")
 		os.Exit(1)
+	}
+	outputFormat, err := normalizeRolloutOutput(*output)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL %v\n", err)
+		os.Exit(2)
 	}
 	assertion, err := staticPlanAssertionFromFlags(*host, *bucketMin, *bucketMax)
 	if err != nil {
@@ -161,75 +266,78 @@ func cmdRolloutStaticPlanCheck(args []string) {
 		os.Exit(1)
 	}
 
-	resolvedBucketTotal := *bucketTotal
-	if resolvedBucketTotal < 0 {
-		fmt.Fprintln(os.Stderr, "FAIL bucket-total must be > 0")
-		os.Exit(1)
-	}
-	if resolvedBucketTotal == 0 {
-		configPath := envOrDefault("JETMON_CONFIG", "config/config.json")
-		if err := config.Load(configPath); err != nil {
-			fmt.Fprintf(os.Stderr, "FAIL config parse: %v\n", err)
-			os.Exit(1)
+	if err := runRolloutCommandOutput(os.Stdout, "rollout static-plan-check", outputFormat, func(out io.Writer) error {
+		resolvedBucketTotal := *bucketTotal
+		if resolvedBucketTotal < 0 {
+			return errors.New("bucket-total must be > 0")
 		}
-		resolvedBucketTotal = config.Get().BucketTotal
-	}
-
-	inputName := strings.TrimSpace(*file)
-	input := io.Reader(os.Stdin)
-	var opened *os.File
-	if inputName != "-" {
-		f, err := os.Open(inputName)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "FAIL open static bucket plan: %v\n", err)
-			os.Exit(1)
+		if resolvedBucketTotal == 0 {
+			configPath := envOrDefault("JETMON_CONFIG", "config/config.json")
+			if err := config.Load(configPath); err != nil {
+				return fmt.Errorf("config parse: %w", err)
+			}
+			resolvedBucketTotal = config.Get().BucketTotal
 		}
-		opened = f
-		input = f
-	}
-	if opened != nil {
-		defer opened.Close()
-	}
 
-	if err := runStaticPlanCheck(os.Stdout, inputName, input, resolvedBucketTotal, assertion); err != nil {
-		fmt.Fprintf(os.Stderr, "FAIL %v\n", err)
-		os.Exit(1)
+		inputName := strings.TrimSpace(*file)
+		input := io.Reader(os.Stdin)
+		var opened *os.File
+		if inputName != "-" {
+			f, err := os.Open(inputName)
+			if err != nil {
+				return fmt.Errorf("open static bucket plan: %w", err)
+			}
+			opened = f
+			input = f
+		}
+		if opened != nil {
+			defer opened.Close()
+		}
+
+		return runStaticPlanCheck(out, inputName, input, resolvedBucketTotal, assertion)
+	}); err != nil {
+		exitRolloutCommandError(err, outputFormat)
 	}
 }
 
 func cmdRolloutPinnedCheck(args []string) {
 	fs := flag.NewFlagSet("rollout pinned-check", flag.ExitOnError)
 	host := fs.String("host", "", "host id to check (default current hostname)")
+	output := rolloutOutputFlag(fs)
 	_ = fs.Parse(args)
 	if fs.NArg() != 0 {
-		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout pinned-check [--host=<host_id>]")
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout pinned-check [--host=<host_id>] [--output=text|json]")
 		os.Exit(1)
 	}
-
-	configPath := envOrDefault("JETMON_CONFIG", "config/config.json")
-	if err := config.Load(configPath); err != nil {
-		fmt.Fprintf(os.Stderr, "FAIL config parse: %v\n", err)
-		os.Exit(1)
-	}
-	fmt.Println("PASS config parse")
-
-	config.LoadDB()
-	if err := db.ConnectWithRetry(3); err != nil {
-		fmt.Fprintf(os.Stderr, "FAIL db connect: %v\n", err)
-		os.Exit(1)
-	}
-	fmt.Println("PASS db connect")
-
-	deps := pinnedRolloutCheckDeps{
-		Hostname:                       db.Hostname,
-		HostRowExists:                  db.HostRowExists,
-		ListOverlappingHostRows:        db.ListHostRowsOverlappingBucketRange,
-		CountActiveSitesForBucketRange: db.CountActiveSitesForBucketRange,
-		CountLegacyProjectionDrift:     db.CountLegacyProjectionDrift,
-	}
-	if err := runPinnedRolloutCheck(context.Background(), os.Stdout, config.Get(), *host, deps); err != nil {
+	outputFormat, err := normalizeRolloutOutput(*output)
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "FAIL %v\n", err)
-		os.Exit(1)
+		os.Exit(2)
+	}
+
+	if err := runRolloutCommandOutput(os.Stdout, "rollout pinned-check", outputFormat, func(out io.Writer) error {
+		configPath := envOrDefault("JETMON_CONFIG", "config/config.json")
+		if err := config.Load(configPath); err != nil {
+			return fmt.Errorf("config parse: %w", err)
+		}
+		fmt.Fprintln(out, "PASS config parse")
+
+		config.LoadDB()
+		if err := db.ConnectWithRetry(3); err != nil {
+			return fmt.Errorf("db connect: %w", err)
+		}
+		fmt.Fprintln(out, "PASS db connect")
+
+		deps := pinnedRolloutCheckDeps{
+			Hostname:                       db.Hostname,
+			HostRowExists:                  db.HostRowExists,
+			ListOverlappingHostRows:        db.ListHostRowsOverlappingBucketRange,
+			CountActiveSitesForBucketRange: db.CountActiveSitesForBucketRange,
+			CountLegacyProjectionDrift:     db.CountLegacyProjectionDrift,
+		}
+		return runPinnedRolloutCheck(context.Background(), out, config.Get(), *host, deps)
+	}); err != nil {
+		exitRolloutCommandError(err, outputFormat)
 	}
 }
 
@@ -243,58 +351,63 @@ func cmdRolloutCutoverCheck(args []string) {
 	limit := fs.Int("limit", 100, "maximum projection drift rows to print")
 	statusPort := fs.Int("status-port", -1, "dashboard port for status check (default DASHBOARD_PORT from config)")
 	skipStatus := fs.Bool("skip-status", false, "skip dashboard status check")
+	output := rolloutOutputFlag(fs)
 	_ = fs.Parse(args)
 	if fs.NArg() != 0 {
-		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout cutover-check [--host=<host_id>] [--bucket-min=N --bucket-max=N] [--since=15m] [--require-all] [--limit=N] [--status-port=N] [--skip-status]")
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout cutover-check [--host=<host_id>] [--bucket-min=N --bucket-max=N] [--since=15m] [--require-all] [--limit=N] [--status-port=N] [--skip-status] [--output=text|json]")
 		os.Exit(1)
 	}
-
-	configPath := envOrDefault("JETMON_CONFIG", "config/config.json")
-	if err := config.Load(configPath); err != nil {
-		fmt.Fprintf(os.Stderr, "FAIL config parse: %v\n", err)
-		os.Exit(1)
-	}
-	fmt.Println("PASS config parse")
-
-	config.LoadDB()
-	if err := db.ConnectWithRetry(3); err != nil {
-		fmt.Fprintf(os.Stderr, "FAIL db connect: %v\n", err)
-		os.Exit(1)
-	}
-	fmt.Println("PASS db connect")
-
-	deps := cutoverCheckDeps{
-		Pinned: pinnedRolloutCheckDeps{
-			Hostname:                       db.Hostname,
-			HostRowExists:                  db.HostRowExists,
-			ListOverlappingHostRows:        db.ListHostRowsOverlappingBucketRange,
-			CountActiveSitesForBucketRange: db.CountActiveSitesForBucketRange,
-			CountLegacyProjectionDrift:     db.CountLegacyProjectionDrift,
-		},
-		Activity: activityCheckDeps{
-			Now:                                     time.Now,
-			CountActiveSitesForBucketRange:          db.CountActiveSitesForBucketRange,
-			CountRecentlyCheckedActiveSitesForRange: db.CountRecentlyCheckedActiveSitesForBucketRange,
-		},
-		Projection: projectionDriftDeps{
-			CountLegacyProjectionDrift: db.CountLegacyProjectionDrift,
-			ListLegacyProjectionDrift:  db.ListLegacyProjectionDrift,
-		},
-		Status: dashboardStatus,
-	}
-	opts := cutoverCheckOptions{
-		HostOverride: *host,
-		BucketMin:    *bucketMin,
-		BucketMax:    *bucketMax,
-		Since:        *since,
-		RequireAll:   *requireAll,
-		Limit:        *limit,
-		StatusPort:   *statusPort,
-		SkipStatus:   *skipStatus,
-	}
-	if err := runCutoverCheck(context.Background(), os.Stdout, config.Get(), opts, deps); err != nil {
+	outputFormat, err := normalizeRolloutOutput(*output)
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "FAIL %v\n", err)
-		os.Exit(1)
+		os.Exit(2)
+	}
+
+	if err := runRolloutCommandOutput(os.Stdout, "rollout cutover-check", outputFormat, func(out io.Writer) error {
+		configPath := envOrDefault("JETMON_CONFIG", "config/config.json")
+		if err := config.Load(configPath); err != nil {
+			return fmt.Errorf("config parse: %w", err)
+		}
+		fmt.Fprintln(out, "PASS config parse")
+
+		config.LoadDB()
+		if err := db.ConnectWithRetry(3); err != nil {
+			return fmt.Errorf("db connect: %w", err)
+		}
+		fmt.Fprintln(out, "PASS db connect")
+
+		deps := cutoverCheckDeps{
+			Pinned: pinnedRolloutCheckDeps{
+				Hostname:                       db.Hostname,
+				HostRowExists:                  db.HostRowExists,
+				ListOverlappingHostRows:        db.ListHostRowsOverlappingBucketRange,
+				CountActiveSitesForBucketRange: db.CountActiveSitesForBucketRange,
+				CountLegacyProjectionDrift:     db.CountLegacyProjectionDrift,
+			},
+			Activity: activityCheckDeps{
+				Now:                                     time.Now,
+				CountActiveSitesForBucketRange:          db.CountActiveSitesForBucketRange,
+				CountRecentlyCheckedActiveSitesForRange: db.CountRecentlyCheckedActiveSitesForBucketRange,
+			},
+			Projection: projectionDriftDeps{
+				CountLegacyProjectionDrift: db.CountLegacyProjectionDrift,
+				ListLegacyProjectionDrift:  db.ListLegacyProjectionDrift,
+			},
+			Status: dashboardStatus,
+		}
+		opts := cutoverCheckOptions{
+			HostOverride: *host,
+			BucketMin:    *bucketMin,
+			BucketMax:    *bucketMax,
+			Since:        *since,
+			RequireAll:   *requireAll,
+			Limit:        *limit,
+			StatusPort:   *statusPort,
+			SkipStatus:   *skipStatus,
+		}
+		return runCutoverCheck(context.Background(), out, config.Get(), opts, deps)
+	}); err != nil {
+		exitRolloutCommandError(err, outputFormat)
 	}
 }
 
@@ -303,70 +416,80 @@ func cmdRolloutRollbackCheck(args []string) {
 	host := fs.String("host", "", "v2 host id that must not own dynamic buckets (default current hostname)")
 	bucketMin := fs.Int("bucket-min", -1, "inclusive rollback bucket minimum (default pinned range)")
 	bucketMax := fs.Int("bucket-max", -1, "inclusive rollback bucket maximum (default pinned range)")
+	output := rolloutOutputFlag(fs)
 	_ = fs.Parse(args)
 	if fs.NArg() != 0 {
-		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout rollback-check [--host=<host_id>] [--bucket-min=N --bucket-max=N]")
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout rollback-check [--host=<host_id>] [--bucket-min=N --bucket-max=N] [--output=text|json]")
 		os.Exit(1)
 	}
-
-	configPath := envOrDefault("JETMON_CONFIG", "config/config.json")
-	if err := config.Load(configPath); err != nil {
-		fmt.Fprintf(os.Stderr, "FAIL config parse: %v\n", err)
-		os.Exit(1)
-	}
-	fmt.Println("PASS config parse")
-
-	config.LoadDB()
-	if err := db.ConnectWithRetry(3); err != nil {
-		fmt.Fprintf(os.Stderr, "FAIL db connect: %v\n", err)
-		os.Exit(1)
-	}
-	fmt.Println("PASS db connect")
-
-	deps := rollbackCheckDeps{
-		Hostname:                       db.Hostname,
-		HostRowExists:                  db.HostRowExists,
-		ListOverlappingHostRows:        db.ListHostRowsOverlappingBucketRange,
-		CountActiveSitesForBucketRange: db.CountActiveSitesForBucketRange,
-		CountLegacyProjectionDrift:     db.CountLegacyProjectionDrift,
-	}
-	if err := runRollbackCheck(context.Background(), os.Stdout, config.Get(), *host, *bucketMin, *bucketMax, deps); err != nil {
+	outputFormat, err := normalizeRolloutOutput(*output)
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "FAIL %v\n", err)
-		os.Exit(1)
+		os.Exit(2)
+	}
+
+	if err := runRolloutCommandOutput(os.Stdout, "rollout rollback-check", outputFormat, func(out io.Writer) error {
+		configPath := envOrDefault("JETMON_CONFIG", "config/config.json")
+		if err := config.Load(configPath); err != nil {
+			return fmt.Errorf("config parse: %w", err)
+		}
+		fmt.Fprintln(out, "PASS config parse")
+
+		config.LoadDB()
+		if err := db.ConnectWithRetry(3); err != nil {
+			return fmt.Errorf("db connect: %w", err)
+		}
+		fmt.Fprintln(out, "PASS db connect")
+
+		deps := rollbackCheckDeps{
+			Hostname:                       db.Hostname,
+			HostRowExists:                  db.HostRowExists,
+			ListOverlappingHostRows:        db.ListHostRowsOverlappingBucketRange,
+			CountActiveSitesForBucketRange: db.CountActiveSitesForBucketRange,
+			CountLegacyProjectionDrift:     db.CountLegacyProjectionDrift,
+		}
+		return runRollbackCheck(context.Background(), out, config.Get(), *host, *bucketMin, *bucketMax, deps)
+	}); err != nil {
+		exitRolloutCommandError(err, outputFormat)
 	}
 }
 
 func cmdRolloutDynamicCheck(args []string) {
 	fs := flag.NewFlagSet("rollout dynamic-check", flag.ExitOnError)
+	output := rolloutOutputFlag(fs)
 	_ = fs.Parse(args)
 	if fs.NArg() != 0 {
-		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout dynamic-check")
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout dynamic-check [--output=text|json]")
 		os.Exit(1)
 	}
-
-	configPath := envOrDefault("JETMON_CONFIG", "config/config.json")
-	if err := config.Load(configPath); err != nil {
-		fmt.Fprintf(os.Stderr, "FAIL config parse: %v\n", err)
-		os.Exit(1)
-	}
-	fmt.Println("PASS config parse")
-
-	config.LoadDB()
-	if err := db.ConnectWithRetry(3); err != nil {
-		fmt.Fprintf(os.Stderr, "FAIL db connect: %v\n", err)
-		os.Exit(1)
-	}
-	fmt.Println("PASS db connect")
-
-	deps := dynamicRolloutCheckDeps{
-		Now:                            time.Now,
-		GetAllHosts:                    db.GetAllHosts,
-		CountActiveSitesForBucketRange: db.CountActiveSitesForBucketRange,
-		CountLegacyProjectionDrift:     db.CountLegacyProjectionDrift,
-	}
-	if err := runDynamicRolloutCheck(context.Background(), os.Stdout, config.Get(), deps); err != nil {
+	outputFormat, err := normalizeRolloutOutput(*output)
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "FAIL %v\n", err)
-		os.Exit(1)
+		os.Exit(2)
+	}
+
+	if err := runRolloutCommandOutput(os.Stdout, "rollout dynamic-check", outputFormat, func(out io.Writer) error {
+		configPath := envOrDefault("JETMON_CONFIG", "config/config.json")
+		if err := config.Load(configPath); err != nil {
+			return fmt.Errorf("config parse: %w", err)
+		}
+		fmt.Fprintln(out, "PASS config parse")
+
+		config.LoadDB()
+		if err := db.ConnectWithRetry(3); err != nil {
+			return fmt.Errorf("db connect: %w", err)
+		}
+		fmt.Fprintln(out, "PASS db connect")
+
+		deps := dynamicRolloutCheckDeps{
+			Now:                            time.Now,
+			GetAllHosts:                    db.GetAllHosts,
+			CountActiveSitesForBucketRange: db.CountActiveSitesForBucketRange,
+			CountLegacyProjectionDrift:     db.CountLegacyProjectionDrift,
+		}
+		return runDynamicRolloutCheck(context.Background(), out, config.Get(), deps)
+	}); err != nil {
+		exitRolloutCommandError(err, outputFormat)
 	}
 }
 
@@ -376,34 +499,39 @@ func cmdRolloutActivityCheck(args []string) {
 	bucketMax := fs.Int("bucket-max", -1, "inclusive bucket maximum (default pinned range or BUCKET_TOTAL-1)")
 	since := fs.String("since", "15m", "activity cutoff as duration like 15m or RFC3339 timestamp")
 	requireAll := fs.Bool("require-all", false, "fail unless every active site in range was checked since the cutoff")
+	output := rolloutOutputFlag(fs)
 	_ = fs.Parse(args)
 	if fs.NArg() != 0 {
-		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout activity-check [--bucket-min=N --bucket-max=N] [--since=15m] [--require-all]")
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout activity-check [--bucket-min=N --bucket-max=N] [--since=15m] [--require-all] [--output=text|json]")
 		os.Exit(1)
 	}
-
-	configPath := envOrDefault("JETMON_CONFIG", "config/config.json")
-	if err := config.Load(configPath); err != nil {
-		fmt.Fprintf(os.Stderr, "FAIL config parse: %v\n", err)
-		os.Exit(1)
-	}
-	fmt.Println("PASS config parse")
-
-	config.LoadDB()
-	if err := db.ConnectWithRetry(3); err != nil {
-		fmt.Fprintf(os.Stderr, "FAIL db connect: %v\n", err)
-		os.Exit(1)
-	}
-	fmt.Println("PASS db connect")
-
-	deps := activityCheckDeps{
-		Now:                                     time.Now,
-		CountActiveSitesForBucketRange:          db.CountActiveSitesForBucketRange,
-		CountRecentlyCheckedActiveSitesForRange: db.CountRecentlyCheckedActiveSitesForBucketRange,
-	}
-	if err := runActivityCheck(context.Background(), os.Stdout, config.Get(), *bucketMin, *bucketMax, *since, *requireAll, deps); err != nil {
+	outputFormat, err := normalizeRolloutOutput(*output)
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "FAIL %v\n", err)
-		os.Exit(1)
+		os.Exit(2)
+	}
+
+	if err := runRolloutCommandOutput(os.Stdout, "rollout activity-check", outputFormat, func(out io.Writer) error {
+		configPath := envOrDefault("JETMON_CONFIG", "config/config.json")
+		if err := config.Load(configPath); err != nil {
+			return fmt.Errorf("config parse: %w", err)
+		}
+		fmt.Fprintln(out, "PASS config parse")
+
+		config.LoadDB()
+		if err := db.ConnectWithRetry(3); err != nil {
+			return fmt.Errorf("db connect: %w", err)
+		}
+		fmt.Fprintln(out, "PASS db connect")
+
+		deps := activityCheckDeps{
+			Now:                                     time.Now,
+			CountActiveSitesForBucketRange:          db.CountActiveSitesForBucketRange,
+			CountRecentlyCheckedActiveSitesForRange: db.CountRecentlyCheckedActiveSitesForBucketRange,
+		}
+		return runActivityCheck(context.Background(), out, config.Get(), *bucketMin, *bucketMax, *since, *requireAll, deps)
+	}); err != nil {
+		exitRolloutCommandError(err, outputFormat)
 	}
 }
 
@@ -412,33 +540,38 @@ func cmdRolloutProjectionDrift(args []string) {
 	bucketMin := fs.Int("bucket-min", -1, "inclusive bucket minimum (default pinned range or 0)")
 	bucketMax := fs.Int("bucket-max", -1, "inclusive bucket maximum (default pinned range or BUCKET_TOTAL-1)")
 	limit := fs.Int("limit", 50, "maximum drift rows to print")
+	output := rolloutOutputFlag(fs)
 	_ = fs.Parse(args)
 	if fs.NArg() != 0 {
-		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout projection-drift [--bucket-min=N --bucket-max=N] [--limit=N]")
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout projection-drift [--bucket-min=N --bucket-max=N] [--limit=N] [--output=text|json]")
 		os.Exit(1)
 	}
-
-	configPath := envOrDefault("JETMON_CONFIG", "config/config.json")
-	if err := config.Load(configPath); err != nil {
-		fmt.Fprintf(os.Stderr, "FAIL config parse: %v\n", err)
-		os.Exit(1)
-	}
-	fmt.Println("PASS config parse")
-
-	config.LoadDB()
-	if err := db.ConnectWithRetry(3); err != nil {
-		fmt.Fprintf(os.Stderr, "FAIL db connect: %v\n", err)
-		os.Exit(1)
-	}
-	fmt.Println("PASS db connect")
-
-	deps := projectionDriftDeps{
-		CountLegacyProjectionDrift: db.CountLegacyProjectionDrift,
-		ListLegacyProjectionDrift:  db.ListLegacyProjectionDrift,
-	}
-	if err := runProjectionDriftReport(context.Background(), os.Stdout, config.Get(), *bucketMin, *bucketMax, *limit, deps); err != nil {
+	outputFormat, err := normalizeRolloutOutput(*output)
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "FAIL %v\n", err)
-		os.Exit(1)
+		os.Exit(2)
+	}
+
+	if err := runRolloutCommandOutput(os.Stdout, "rollout projection-drift", outputFormat, func(out io.Writer) error {
+		configPath := envOrDefault("JETMON_CONFIG", "config/config.json")
+		if err := config.Load(configPath); err != nil {
+			return fmt.Errorf("config parse: %w", err)
+		}
+		fmt.Fprintln(out, "PASS config parse")
+
+		config.LoadDB()
+		if err := db.ConnectWithRetry(3); err != nil {
+			return fmt.Errorf("db connect: %w", err)
+		}
+		fmt.Fprintln(out, "PASS db connect")
+
+		deps := projectionDriftDeps{
+			CountLegacyProjectionDrift: db.CountLegacyProjectionDrift,
+			ListLegacyProjectionDrift:  db.ListLegacyProjectionDrift,
+		}
+		return runProjectionDriftReport(context.Background(), out, config.Get(), *bucketMin, *bucketMax, *limit, deps)
+	}); err != nil {
+		exitRolloutCommandError(err, outputFormat)
 	}
 }
 

--- a/cmd/jetmon2/rollout.go
+++ b/cmd/jetmon2/rollout.go
@@ -54,9 +54,18 @@ type cutoverCheckDeps struct {
 	Status     func(int) (string, error)
 }
 
+type rolloutStateReportDeps struct {
+	Now                                     func() time.Time
+	Hostname                                func() string
+	GetAllHosts                             func() ([]db.HostRow, error)
+	CountActiveSitesForBucketRange          func(context.Context, int, int) (int, error)
+	CountRecentlyCheckedActiveSitesForRange func(context.Context, int, int, time.Time) (int, error)
+	CountLegacyProjectionDrift              func(context.Context, int, int) (int, error)
+}
+
 func cmdRollout(args []string) {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout <rehearsal-plan|static-plan-check|pinned-check|cutover-check|rollback-check|dynamic-check|activity-check|projection-drift> [args]")
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout <rehearsal-plan|static-plan-check|pinned-check|cutover-check|rollback-check|dynamic-check|activity-check|projection-drift|state-report> [args]")
 		os.Exit(1)
 	}
 
@@ -77,8 +86,10 @@ func cmdRollout(args []string) {
 		cmdRolloutActivityCheck(args[1:])
 	case "projection-drift":
 		cmdRolloutProjectionDrift(args[1:])
+	case "state-report":
+		cmdRolloutStateReport(args[1:])
 	default:
-		fmt.Fprintf(os.Stderr, "unknown rollout subcommand %q (want: rehearsal-plan, static-plan-check, pinned-check, cutover-check, rollback-check, dynamic-check, activity-check, projection-drift)\n", args[0])
+		fmt.Fprintf(os.Stderr, "unknown rollout subcommand %q (want: rehearsal-plan, static-plan-check, pinned-check, cutover-check, rollback-check, dynamic-check, activity-check, projection-drift, state-report)\n", args[0])
 		os.Exit(1)
 	}
 }
@@ -575,6 +586,88 @@ func cmdRolloutProjectionDrift(args []string) {
 	}
 }
 
+func cmdRolloutStateReport(args []string) {
+	fs := flag.NewFlagSet("rollout state-report", flag.ExitOnError)
+	since := fs.String("since", "15m", "activity cutoff as duration like 15m or RFC3339 timestamp")
+	output := rolloutOutputFlag(fs)
+	_ = fs.Parse(args)
+	if fs.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout state-report [--since=15m] [--output=text|json]")
+		os.Exit(1)
+	}
+	outputFormat, err := normalizeRolloutOutput(*output)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL %v\n", err)
+		os.Exit(2)
+	}
+
+	configPath := envOrDefault("JETMON_CONFIG", "config/config.json")
+	if err := config.Load(configPath); err != nil {
+		if outputFormat == "json" {
+			report := rolloutStateReport{
+				OK:          false,
+				Command:     "rollout state-report",
+				GeneratedAt: time.Now().UTC(),
+				Issues:      []string{fmt.Sprintf("config parse: %v", err)},
+			}
+			_ = renderRolloutStateReport(os.Stdout, report, outputFormat)
+		} else {
+			fmt.Fprintf(os.Stderr, "FAIL config parse: %v\n", err)
+		}
+		os.Exit(1)
+	}
+	if outputFormat != "json" {
+		fmt.Println("PASS config parse")
+	}
+
+	config.LoadDB()
+	if err := db.ConnectWithRetry(3); err != nil {
+		if outputFormat == "json" {
+			report := rolloutStateReport{
+				OK:          false,
+				Command:     "rollout state-report",
+				GeneratedAt: time.Now().UTC(),
+				Issues:      []string{fmt.Sprintf("db connect: %v", err)},
+			}
+			_ = renderRolloutStateReport(os.Stdout, report, outputFormat)
+		} else {
+			fmt.Fprintf(os.Stderr, "FAIL db connect: %v\n", err)
+		}
+		os.Exit(1)
+	}
+	if outputFormat != "json" {
+		fmt.Println("PASS db connect")
+	}
+
+	deps := rolloutStateReportDeps{
+		Now:                                     time.Now,
+		Hostname:                                db.Hostname,
+		GetAllHosts:                             db.GetAllHosts,
+		CountActiveSitesForBucketRange:          db.CountActiveSitesForBucketRange,
+		CountRecentlyCheckedActiveSitesForRange: db.CountRecentlyCheckedActiveSitesForBucketRange,
+		CountLegacyProjectionDrift:              db.CountLegacyProjectionDrift,
+	}
+	report, err := buildRolloutStateReport(context.Background(), config.Get(), rolloutStateReportOptions{Since: *since}, deps)
+	if err != nil {
+		if outputFormat == "json" {
+			failed := rolloutStateReport{
+				OK:          false,
+				Command:     "rollout state-report",
+				GeneratedAt: time.Now().UTC(),
+				Issues:      []string{err.Error()},
+			}
+			_ = renderRolloutStateReport(os.Stdout, failed, outputFormat)
+		} else {
+			fmt.Fprintf(os.Stderr, "FAIL %v\n", err)
+		}
+		os.Exit(1)
+	}
+	if err := renderRolloutStateReport(os.Stdout, report, outputFormat); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL render rollout state report: %v\n", err)
+		os.Exit(1)
+	}
+}
+
 type staticBucketRange struct {
 	HostID    string
 	BucketMin int
@@ -787,6 +880,280 @@ func runCutoverStatusCheck(out io.Writer, cfg *config.Config, opts cutoverCheckO
 
 func dashboardStatus(port int) (string, error) {
 	return httpGet(fmt.Sprintf("http://localhost:%d/api/state", port))
+}
+
+type rolloutStateReportOptions struct {
+	Since string
+}
+
+type rolloutStateReport struct {
+	OK                  bool                       `json:"ok"`
+	Command             string                     `json:"command"`
+	GeneratedAt         time.Time                  `json:"generated_at"`
+	Host                string                     `json:"host,omitempty"`
+	Ownership           rolloutStateOwnership      `json:"ownership"`
+	BucketCoverage      rolloutStateBucketCoverage `json:"bucket_coverage"`
+	Activity            rolloutStateActivity       `json:"activity"`
+	ProjectionDrift     rolloutStateDrift          `json:"projection_drift"`
+	DeliveryOwner       rolloutStateDeliveryOwner  `json:"delivery_owner"`
+	SuggestedNextAction string                     `json:"suggested_next_action,omitempty"`
+	Issues              []string                   `json:"issues,omitempty"`
+}
+
+type rolloutStateOwnership struct {
+	Mode      string `json:"mode"`
+	BucketMin int    `json:"bucket_min"`
+	BucketMax int    `json:"bucket_max"`
+}
+
+type rolloutStateBucketCoverage struct {
+	Status      string                `json:"status"`
+	BucketTotal int                   `json:"bucket_total"`
+	HostCount   int                   `json:"host_count"`
+	Error       string                `json:"error,omitempty"`
+	Hosts       []rolloutStateHostRow `json:"hosts,omitempty"`
+}
+
+type rolloutStateHostRow struct {
+	HostID              string    `json:"host_id"`
+	BucketMin           int       `json:"bucket_min"`
+	BucketMax           int       `json:"bucket_max"`
+	Status              string    `json:"status"`
+	LastHeartbeat       time.Time `json:"last_heartbeat"`
+	LastHeartbeatAgeSec int64     `json:"last_heartbeat_age_sec"`
+}
+
+type rolloutStateActivity struct {
+	Since          time.Time `json:"since"`
+	ActiveSites    int       `json:"active_sites"`
+	CheckedSince   int       `json:"checked_since"`
+	UncheckedSince int       `json:"unchecked_since"`
+	CheckedPercent float64   `json:"checked_percent"`
+}
+
+type rolloutStateDrift struct {
+	Count int `json:"count"`
+}
+
+type rolloutStateDeliveryOwner struct {
+	Level   string `json:"level"`
+	Message string `json:"message"`
+}
+
+func buildRolloutStateReport(ctx context.Context, cfg *config.Config, opts rolloutStateReportOptions, deps rolloutStateReportDeps) (rolloutStateReport, error) {
+	if cfg == nil {
+		return rolloutStateReport{}, errors.New("config is not loaded")
+	}
+	now := time.Now().UTC()
+	if deps.Now != nil {
+		now = deps.Now().UTC()
+	}
+	cutoff, err := resolveActivityCutoff(now, opts.Since)
+	if err != nil {
+		return rolloutStateReport{}, err
+	}
+
+	hostID := ""
+	if deps.Hostname != nil {
+		hostID = strings.TrimSpace(deps.Hostname())
+	}
+	if hostID == "" {
+		hostID = "unknown"
+	}
+
+	minBucket, maxBucket, ownershipMode, err := rolloutStateRange(cfg)
+	if err != nil {
+		return rolloutStateReport{}, err
+	}
+
+	report := rolloutStateReport{
+		Command:     "rollout state-report",
+		GeneratedAt: now,
+		Host:        hostID,
+		Ownership: rolloutStateOwnership{
+			Mode:      ownershipMode,
+			BucketMin: minBucket,
+			BucketMax: maxBucket,
+		},
+		BucketCoverage: rolloutStateBucketCoverage{
+			BucketTotal: cfg.BucketTotal,
+		},
+		Activity: rolloutStateActivity{
+			Since: cutoff,
+		},
+	}
+
+	if ownershipMode == "pinned" {
+		report.BucketCoverage.Status = "pinned_config"
+	} else {
+		if deps.GetAllHosts == nil {
+			return rolloutStateReport{}, errors.New("host list query is not configured")
+		}
+		hosts, err := deps.GetAllHosts()
+		if err != nil {
+			return rolloutStateReport{}, fmt.Errorf("query jetmon_hosts: %w", err)
+		}
+		report.BucketCoverage.HostCount = len(hosts)
+		report.BucketCoverage.Hosts = summarizeRolloutHosts(hosts, now)
+		if err := validateDynamicBucketCoverage(hosts, cfg.BucketTotal, time.Duration(cfg.BucketHeartbeatGraceSec)*time.Second, now); err != nil {
+			report.BucketCoverage.Status = "invalid"
+			report.BucketCoverage.Error = err.Error()
+			report.Issues = append(report.Issues, err.Error())
+		} else {
+			report.BucketCoverage.Status = "complete"
+		}
+	}
+
+	if deps.CountActiveSitesForBucketRange == nil {
+		return rolloutStateReport{}, errors.New("active site counter is not configured")
+	}
+	activeSites, err := deps.CountActiveSitesForBucketRange(ctx, minBucket, maxBucket)
+	if err != nil {
+		return rolloutStateReport{}, fmt.Errorf("count active sites in range %d-%d: %w", minBucket, maxBucket, err)
+	}
+	report.Activity.ActiveSites = activeSites
+
+	if deps.CountRecentlyCheckedActiveSitesForRange == nil {
+		return rolloutStateReport{}, errors.New("recently checked active site counter is not configured")
+	}
+	checkedSince, err := deps.CountRecentlyCheckedActiveSitesForRange(ctx, minBucket, maxBucket, cutoff)
+	if err != nil {
+		return rolloutStateReport{}, fmt.Errorf("count recently checked active sites in range %d-%d since %s: %w", minBucket, maxBucket, cutoff.Format(time.RFC3339), err)
+	}
+	report.Activity.CheckedSince = checkedSince
+	report.Activity.UncheckedSince = maxInt(0, activeSites-checkedSince)
+	if activeSites > 0 {
+		report.Activity.CheckedPercent = float64(checkedSince) * 100 / float64(activeSites)
+	}
+
+	if deps.CountLegacyProjectionDrift == nil {
+		return rolloutStateReport{}, errors.New("projection drift counter is not configured")
+	}
+	drift, err := deps.CountLegacyProjectionDrift(ctx, minBucket, maxBucket)
+	if err != nil {
+		return rolloutStateReport{}, fmt.Errorf("count legacy projection drift in range %d-%d: %w", minBucket, maxBucket, err)
+	}
+	report.ProjectionDrift.Count = drift
+
+	level, message := deliveryOwnerStatus(cfg, hostID)
+	report.DeliveryOwner = rolloutStateDeliveryOwner{Level: level, Message: message}
+
+	report.Issues = append(report.Issues, rolloutStateIssues(report)...)
+	report.SuggestedNextAction = suggestRolloutNextAction(report)
+	report.OK = len(report.Issues) == 0
+	return report, nil
+}
+
+func rolloutStateRange(cfg *config.Config) (int, int, string, error) {
+	if minBucket, maxBucket, ok := cfg.PinnedBucketRange(); ok {
+		return minBucket, maxBucket, "pinned", nil
+	}
+	if cfg.BucketTotal <= 0 {
+		return 0, 0, "", errors.New("BUCKET_TOTAL must be > 0")
+	}
+	return 0, cfg.BucketTotal - 1, "dynamic", nil
+}
+
+func summarizeRolloutHosts(hosts []db.HostRow, now time.Time) []rolloutStateHostRow {
+	out := make([]rolloutStateHostRow, 0, len(hosts))
+	for _, host := range hosts {
+		age := now.Sub(host.LastHeartbeat)
+		if age < 0 {
+			age = 0
+		}
+		out = append(out, rolloutStateHostRow{
+			HostID:              host.HostID,
+			BucketMin:           host.BucketMin,
+			BucketMax:           host.BucketMax,
+			Status:              host.Status,
+			LastHeartbeat:       host.LastHeartbeat,
+			LastHeartbeatAgeSec: int64(age.Round(time.Second) / time.Second),
+		})
+	}
+	return out
+}
+
+func rolloutStateIssues(report rolloutStateReport) []string {
+	var issues []string
+	if report.ProjectionDrift.Count > 0 {
+		issues = append(issues, fmt.Sprintf("legacy projection drift=%d", report.ProjectionDrift.Count))
+	}
+	if report.Activity.ActiveSites > 0 && report.Activity.CheckedSince == 0 {
+		issues = append(issues, fmt.Sprintf("no active sites checked since %s", report.Activity.Since.Format(time.RFC3339)))
+	} else if report.Activity.UncheckedSince > 0 {
+		issues = append(issues, fmt.Sprintf("%d/%d active sites checked since %s", report.Activity.CheckedSince, report.Activity.ActiveSites, report.Activity.Since.Format(time.RFC3339)))
+	}
+	if report.DeliveryOwner.Level == "WARN" {
+		issues = append(issues, report.DeliveryOwner.Message)
+	}
+	return issues
+}
+
+func suggestRolloutNextAction(report rolloutStateReport) string {
+	if report.BucketCoverage.Status == "invalid" {
+		return "Fix jetmon_hosts bucket coverage before relying on dynamic ownership."
+	}
+	if report.ProjectionDrift.Count > 0 {
+		return "Run rollout projection-drift --limit=100 and fix legacy projection drift before continuing."
+	}
+	if report.Activity.ActiveSites == 0 {
+		return "Confirm this range is intentionally empty before continuing."
+	}
+	if report.Activity.CheckedSince == 0 {
+		return "Investigate the check loop; no active sites have fresh last_checked_at writes."
+	}
+	if report.Activity.UncheckedSince > 0 {
+		return "Wait one full expected round, then run rollout cutover-check --require-all before moving on."
+	}
+	if report.DeliveryOwner.Level == "WARN" {
+		return "Set DELIVERY_OWNER_HOST or explicitly approve multi-owner delivery before enabling API delivery workers."
+	}
+	if report.Ownership.Mode == "pinned" {
+		return "Continue with the next pinned host; after every host is on v2, plan dynamic ownership cutover."
+	}
+	return "Dynamic ownership looks healthy; continue normal v2 rolling updates and monitoring."
+}
+
+func renderRolloutStateReport(out io.Writer, report rolloutStateReport, output string) error {
+	if output == "json" {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	}
+	renderRolloutStateText(out, report)
+	return nil
+}
+
+func renderRolloutStateText(out io.Writer, report rolloutStateReport) {
+	fmt.Fprintf(out, "INFO rollout_state_generated_at=%s\n", report.GeneratedAt.Format(time.RFC3339))
+	fmt.Fprintf(out, "INFO host=%q\n", report.Host)
+	fmt.Fprintf(out, "INFO ownership_mode=%s bucket_range=%d-%d\n", report.Ownership.Mode, report.Ownership.BucketMin, report.Ownership.BucketMax)
+	if report.BucketCoverage.Status == "invalid" {
+		fmt.Fprintf(out, "WARN bucket_coverage=%s error=%q\n", report.BucketCoverage.Status, report.BucketCoverage.Error)
+	} else {
+		fmt.Fprintf(out, "PASS bucket_coverage=%s bucket_total=%d host_count=%d\n", report.BucketCoverage.Status, report.BucketCoverage.BucketTotal, report.BucketCoverage.HostCount)
+	}
+	fmt.Fprintf(out, "INFO activity_since=%s\n", report.Activity.Since.Format(time.RFC3339))
+	fmt.Fprintf(out, "INFO active_sites=%d checked_since=%d unchecked_since=%d checked_percent=%.1f\n", report.Activity.ActiveSites, report.Activity.CheckedSince, report.Activity.UncheckedSince, report.Activity.CheckedPercent)
+	if report.ProjectionDrift.Count > 0 {
+		fmt.Fprintf(out, "WARN legacy_projection_drift=%d\n", report.ProjectionDrift.Count)
+	} else {
+		fmt.Fprintln(out, "PASS legacy_projection_drift=0")
+	}
+	if report.DeliveryOwner.Message != "" {
+		fmt.Fprintf(out, "%s %s\n", report.DeliveryOwner.Level, report.DeliveryOwner.Message)
+	}
+	for _, issue := range report.Issues {
+		fmt.Fprintf(out, "WARN rollout_state_issue=%q\n", issue)
+	}
+	fmt.Fprintf(out, "INFO suggested_next_action=%q\n", report.SuggestedNextAction)
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 func writeRolloutPlanSection(out io.Writer, title string, lines ...string) {

--- a/cmd/jetmon2/rollout.go
+++ b/cmd/jetmon2/rollout.go
@@ -47,11 +47,13 @@ type projectionDriftDeps struct {
 
 func cmdRollout(args []string) {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout <static-plan-check|pinned-check|rollback-check|dynamic-check|activity-check|projection-drift> [args]")
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout <rehearsal-plan|static-plan-check|pinned-check|rollback-check|dynamic-check|activity-check|projection-drift> [args]")
 		os.Exit(1)
 	}
 
 	switch args[0] {
+	case "rehearsal-plan":
+		cmdRolloutRehearsalPlan(args[1:])
 	case "static-plan-check":
 		cmdRolloutStaticPlanCheck(args[1:])
 	case "pinned-check":
@@ -65,7 +67,69 @@ func cmdRollout(args []string) {
 	case "projection-drift":
 		cmdRolloutProjectionDrift(args[1:])
 	default:
-		fmt.Fprintf(os.Stderr, "unknown rollout subcommand %q (want: static-plan-check, pinned-check, rollback-check, dynamic-check, activity-check, projection-drift)\n", args[0])
+		fmt.Fprintf(os.Stderr, "unknown rollout subcommand %q (want: rehearsal-plan, static-plan-check, pinned-check, rollback-check, dynamic-check, activity-check, projection-drift)\n", args[0])
+		os.Exit(1)
+	}
+}
+
+func cmdRolloutRehearsalPlan(args []string) {
+	fs := flag.NewFlagSet("rollout rehearsal-plan", flag.ExitOnError)
+	file := fs.String("file", "", "CSV file with host,bucket_min,bucket_max rows")
+	mode := fs.String("mode", "same-server", "rollout mode: same-server or fresh-server")
+	host := fs.String("host", "", "host id that must appear in the static plan")
+	runtimeHost := fs.String("runtime-host", "", "v2 host id for pinned/rollback checks (default --host)")
+	bucketMin := fs.Int("bucket-min", -1, "expected bucket minimum for --host")
+	bucketMax := fs.Int("bucket-max", -1, "expected bucket maximum for --host")
+	bucketTotal := fs.Int("bucket-total", 0, "total bucket count (default BUCKET_TOTAL from config)")
+	binary := fs.String("binary", "./jetmon2", "jetmon2 command path to print")
+	service := fs.String("service", "jetmon2", "systemd service name to print for v2")
+	since := fs.String("since", "15m", "activity cutoff to print for post-cutover checks")
+	_ = fs.Parse(args)
+	if fs.NArg() != 0 || strings.TrimSpace(*file) == "" {
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout rehearsal-plan --file=<ranges.csv> --host=<host> --bucket-min=N --bucket-max=N [--mode=same-server|fresh-server] [--runtime-host=<v2-host>] [--bucket-total=N]")
+		os.Exit(1)
+	}
+
+	resolvedBucketTotal := *bucketTotal
+	if resolvedBucketTotal < 0 {
+		fmt.Fprintln(os.Stderr, "FAIL bucket-total must be > 0")
+		os.Exit(1)
+	}
+	if resolvedBucketTotal == 0 {
+		configPath := envOrDefault("JETMON_CONFIG", "config/config.json")
+		if err := config.Load(configPath); err != nil {
+			fmt.Fprintf(os.Stderr, "FAIL config parse: %v\n", err)
+			os.Exit(1)
+		}
+		resolvedBucketTotal = config.Get().BucketTotal
+	}
+
+	inputName := strings.TrimSpace(*file)
+	if inputName == "-" {
+		fmt.Fprintln(os.Stderr, "FAIL --file=- is not supported for rehearsal-plan; pass a reusable CSV path so the printed commands are repeatable")
+		os.Exit(1)
+	}
+	f, err := os.Open(inputName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL open static bucket plan: %v\n", err)
+		os.Exit(1)
+	}
+	defer f.Close()
+
+	opts := rolloutRehearsalPlanOptions{
+		Mode:        *mode,
+		PlanFile:    inputName,
+		HostID:      *host,
+		RuntimeHost: *runtimeHost,
+		BucketMin:   *bucketMin,
+		BucketMax:   *bucketMax,
+		BucketTotal: resolvedBucketTotal,
+		Binary:      *binary,
+		Service:     *service,
+		Since:       *since,
+	}
+	if err := runRolloutRehearsalPlan(os.Stdout, f, opts); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL %v\n", err)
 		os.Exit(1)
 	}
 }
@@ -308,6 +372,176 @@ type staticBucketRange struct {
 	HostID    string
 	BucketMin int
 	BucketMax int
+}
+
+type rolloutRehearsalPlanOptions struct {
+	Mode        string
+	PlanFile    string
+	HostID      string
+	RuntimeHost string
+	BucketMin   int
+	BucketMax   int
+	BucketTotal int
+	Binary      string
+	Service     string
+	Since       string
+}
+
+func runRolloutRehearsalPlan(out io.Writer, input io.Reader, opts rolloutRehearsalPlanOptions) error {
+	if out == nil {
+		out = io.Discard
+	}
+	mode := strings.ToLower(strings.TrimSpace(opts.Mode))
+	switch mode {
+	case "", "same-server":
+		mode = "same-server"
+	case "fresh-server":
+	default:
+		return fmt.Errorf("--mode must be same-server or fresh-server, got %q", opts.Mode)
+	}
+
+	planFile := strings.TrimSpace(opts.PlanFile)
+	if planFile == "" || planFile == "-" {
+		return errors.New("--file must be a reusable CSV path")
+	}
+	hostID := strings.TrimSpace(opts.HostID)
+	if hostID == "" {
+		return errors.New("--host is required")
+	}
+	runtimeHost := strings.TrimSpace(opts.RuntimeHost)
+	if runtimeHost == "" {
+		runtimeHost = hostID
+	}
+	if opts.BucketMin < 0 || opts.BucketMax < 0 {
+		return errors.New("--bucket-min and --bucket-max are required")
+	}
+	if opts.BucketMax < opts.BucketMin {
+		return errors.New("--bucket-max must be >= --bucket-min")
+	}
+	if opts.BucketTotal <= 0 {
+		return errors.New("BUCKET_TOTAL must be > 0")
+	}
+	binary := strings.TrimSpace(opts.Binary)
+	if binary == "" {
+		binary = "./jetmon2"
+	}
+	service := strings.TrimSpace(opts.Service)
+	if service == "" {
+		service = "jetmon2"
+	}
+	since := strings.TrimSpace(opts.Since)
+	if since == "" {
+		since = "15m"
+	}
+
+	ranges, err := parseStaticBucketPlanCSV(input)
+	if err != nil {
+		return err
+	}
+	if err := validateStaticBucketPlan(ranges, opts.BucketTotal); err != nil {
+		return err
+	}
+	assertion := staticPlanAssertion{HostID: hostID, BucketMin: opts.BucketMin, BucketMax: opts.BucketMax}
+	assertedRange, err := validateStaticPlanAssertion(ranges, assertion)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(out, "# Jetmon v2 rollout rehearsal plan")
+	fmt.Fprintf(out, "INFO mode=%s\n", mode)
+	fmt.Fprintf(out, "INFO static_plan_file=%s ranges=%d\n", planFile, len(ranges))
+	fmt.Fprintf(out, "INFO plan_host=%q runtime_host=%q range=%d-%d\n", assertedRange.HostID, runtimeHost, assertedRange.BucketMin, assertedRange.BucketMax)
+	fmt.Fprintln(out)
+
+	writeRolloutPlanSection(out, "1. Validate the copied static bucket plan",
+		rolloutCommand(binary, "rollout", "static-plan-check", "--file", planFile, "--host", hostID, "--bucket-min", strconv.Itoa(opts.BucketMin), "--bucket-max", strconv.Itoa(opts.BucketMax)),
+	)
+	writeRolloutPlanSection(out, "2. Validate the staged v2 config and service unit",
+		rolloutCommand(binary, "validate-config"),
+		"systemd-analyze verify "+shellQuote("/etc/systemd/system/"+service+".service"),
+	)
+	writeRolloutPlanSection(out, "3. Run the pinned preflight before stopping v1",
+		rolloutCommand(binary, "rollout", "pinned-check", "--host", runtimeHost),
+	)
+
+	if mode == "fresh-server" {
+		writeRolloutPlanSection(out, "4. Cut over from the old v1 host to the fresh v2 host",
+			"# Keep v2 stopped on the fresh server until the old v1 monitor process is stopped.",
+			"# Stop v1 on "+shellQuote(hostID)+" with the documented production command.",
+			"systemctl enable --now "+shellQuote(service),
+		)
+	} else {
+		writeRolloutPlanSection(out, "4. Cut over the same server from v1 to v2",
+			"# Stop the v1 service with the documented production command.",
+			"systemctl enable --now "+shellQuote(service),
+		)
+	}
+
+	rangeArgs := []string{"--bucket-min", strconv.Itoa(opts.BucketMin), "--bucket-max", strconv.Itoa(opts.BucketMax)}
+	writeRolloutPlanSection(out, "5. Verify the v2 host after start",
+		rolloutCommand(binary, "rollout", "pinned-check", "--host", runtimeHost),
+		rolloutCommand(append([]string{binary, "rollout", "activity-check"}, append(rangeArgs, "--since", since)...)...),
+		rolloutCommand(binary, "status"),
+		"# After one full expected check round:",
+		rolloutCommand(append([]string{binary, "rollout", "activity-check"}, append(append([]string{}, rangeArgs...), "--since", since, "--require-all")...)...),
+		rolloutCommand(append([]string{binary, "rollout", "projection-drift"}, append(rangeArgs, "--limit", "100")...)...),
+	)
+
+	rollbackComment := "# Restart the original v1 service with its original BUCKET_NO_MIN/BUCKET_NO_MAX config."
+	if mode == "fresh-server" {
+		rollbackComment = "# Restart v1 on " + shellQuote(hostID) + " with its original BUCKET_NO_MIN/BUCKET_NO_MAX config."
+	}
+	writeRolloutPlanSection(out, "6. Rehearse the rollback path before the rollback window closes",
+		"systemctl stop "+shellQuote(service),
+		rolloutCommand(append([]string{binary, "rollout", "rollback-check", "--host", runtimeHost}, rangeArgs...)...),
+		rollbackComment,
+	)
+
+	writeRolloutPlanSection(out, "7. Complete fleet-level pinned and dynamic checks after every host is on v2",
+		rolloutCommand(binary, "rollout", "pinned-check", "--host", runtimeHost),
+		rolloutCommand(append([]string{binary, "rollout", "activity-check"}, append(append([]string{}, rangeArgs...), "--since", since, "--require-all")...)...),
+		rolloutCommand(append([]string{binary, "rollout", "projection-drift"}, append(rangeArgs, "--limit", "100")...)...),
+		"# After PINNED_BUCKET_* is removed from every v2 monitor config and the fleet is restarted:",
+		rolloutCommand(binary, "validate-config"),
+		rolloutCommand(binary, "rollout", "dynamic-check"),
+		rolloutCommand(binary, "rollout", "activity-check", "--since", since, "--require-all"),
+		rolloutCommand(binary, "rollout", "projection-drift", "--limit", "100"),
+	)
+	return nil
+}
+
+func writeRolloutPlanSection(out io.Writer, title string, lines ...string) {
+	fmt.Fprintf(out, "## %s\n", title)
+	for _, line := range lines {
+		fmt.Fprintln(out, line)
+	}
+	fmt.Fprintln(out)
+}
+
+func rolloutCommand(parts ...string) string {
+	quoted := make([]string, 0, len(parts))
+	for _, part := range parts {
+		quoted = append(quoted, shellQuote(part))
+	}
+	return strings.Join(quoted, " ")
+}
+
+func shellQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			continue
+		}
+		switch r {
+		case '_', '-', '.', '/', ':', '=', '+', ',', '@':
+			continue
+		default:
+			return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+		}
+	}
+	return value
 }
 
 type staticPlanAssertion struct {

--- a/cmd/jetmon2/rollout.go
+++ b/cmd/jetmon2/rollout.go
@@ -45,9 +45,16 @@ type projectionDriftDeps struct {
 	ListLegacyProjectionDrift  func(context.Context, int, int, int) ([]db.ProjectionDriftRow, error)
 }
 
+type cutoverCheckDeps struct {
+	Pinned     pinnedRolloutCheckDeps
+	Activity   activityCheckDeps
+	Projection projectionDriftDeps
+	Status     func(int) (string, error)
+}
+
 func cmdRollout(args []string) {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout <rehearsal-plan|static-plan-check|pinned-check|rollback-check|dynamic-check|activity-check|projection-drift> [args]")
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout <rehearsal-plan|static-plan-check|pinned-check|cutover-check|rollback-check|dynamic-check|activity-check|projection-drift> [args]")
 		os.Exit(1)
 	}
 
@@ -58,6 +65,8 @@ func cmdRollout(args []string) {
 		cmdRolloutStaticPlanCheck(args[1:])
 	case "pinned-check":
 		cmdRolloutPinnedCheck(args[1:])
+	case "cutover-check":
+		cmdRolloutCutoverCheck(args[1:])
 	case "rollback-check":
 		cmdRolloutRollbackCheck(args[1:])
 	case "dynamic-check":
@@ -67,7 +76,7 @@ func cmdRollout(args []string) {
 	case "projection-drift":
 		cmdRolloutProjectionDrift(args[1:])
 	default:
-		fmt.Fprintf(os.Stderr, "unknown rollout subcommand %q (want: rehearsal-plan, static-plan-check, pinned-check, rollback-check, dynamic-check, activity-check, projection-drift)\n", args[0])
+		fmt.Fprintf(os.Stderr, "unknown rollout subcommand %q (want: rehearsal-plan, static-plan-check, pinned-check, cutover-check, rollback-check, dynamic-check, activity-check, projection-drift)\n", args[0])
 		os.Exit(1)
 	}
 }
@@ -219,6 +228,71 @@ func cmdRolloutPinnedCheck(args []string) {
 		CountLegacyProjectionDrift:     db.CountLegacyProjectionDrift,
 	}
 	if err := runPinnedRolloutCheck(context.Background(), os.Stdout, config.Get(), *host, deps); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func cmdRolloutCutoverCheck(args []string) {
+	fs := flag.NewFlagSet("rollout cutover-check", flag.ExitOnError)
+	host := fs.String("host", "", "host id to check (default current hostname)")
+	bucketMin := fs.Int("bucket-min", -1, "inclusive bucket minimum (default pinned range)")
+	bucketMax := fs.Int("bucket-max", -1, "inclusive bucket maximum (default pinned range)")
+	since := fs.String("since", "15m", "activity cutoff as duration like 15m or RFC3339 timestamp")
+	requireAll := fs.Bool("require-all", false, "fail unless every active site in range was checked since the cutoff")
+	limit := fs.Int("limit", 100, "maximum projection drift rows to print")
+	statusPort := fs.Int("status-port", -1, "dashboard port for status check (default DASHBOARD_PORT from config)")
+	skipStatus := fs.Bool("skip-status", false, "skip dashboard status check")
+	_ = fs.Parse(args)
+	if fs.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout cutover-check [--host=<host_id>] [--bucket-min=N --bucket-max=N] [--since=15m] [--require-all] [--limit=N] [--status-port=N] [--skip-status]")
+		os.Exit(1)
+	}
+
+	configPath := envOrDefault("JETMON_CONFIG", "config/config.json")
+	if err := config.Load(configPath); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL config parse: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("PASS config parse")
+
+	config.LoadDB()
+	if err := db.ConnectWithRetry(3); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL db connect: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("PASS db connect")
+
+	deps := cutoverCheckDeps{
+		Pinned: pinnedRolloutCheckDeps{
+			Hostname:                       db.Hostname,
+			HostRowExists:                  db.HostRowExists,
+			ListOverlappingHostRows:        db.ListHostRowsOverlappingBucketRange,
+			CountActiveSitesForBucketRange: db.CountActiveSitesForBucketRange,
+			CountLegacyProjectionDrift:     db.CountLegacyProjectionDrift,
+		},
+		Activity: activityCheckDeps{
+			Now:                                     time.Now,
+			CountActiveSitesForBucketRange:          db.CountActiveSitesForBucketRange,
+			CountRecentlyCheckedActiveSitesForRange: db.CountRecentlyCheckedActiveSitesForBucketRange,
+		},
+		Projection: projectionDriftDeps{
+			CountLegacyProjectionDrift: db.CountLegacyProjectionDrift,
+			ListLegacyProjectionDrift:  db.ListLegacyProjectionDrift,
+		},
+		Status: dashboardStatus,
+	}
+	opts := cutoverCheckOptions{
+		HostOverride: *host,
+		BucketMin:    *bucketMin,
+		BucketMax:    *bucketMax,
+		Since:        *since,
+		RequireAll:   *requireAll,
+		Limit:        *limit,
+		StatusPort:   *statusPort,
+		SkipStatus:   *skipStatus,
+	}
+	if err := runCutoverCheck(context.Background(), os.Stdout, config.Get(), opts, deps); err != nil {
 		fmt.Fprintf(os.Stderr, "FAIL %v\n", err)
 		os.Exit(1)
 	}
@@ -479,12 +553,9 @@ func runRolloutRehearsalPlan(out io.Writer, input io.Reader, opts rolloutRehears
 
 	rangeArgs := []string{"--bucket-min", strconv.Itoa(opts.BucketMin), "--bucket-max", strconv.Itoa(opts.BucketMax)}
 	writeRolloutPlanSection(out, "5. Verify the v2 host after start",
-		rolloutCommand(binary, "rollout", "pinned-check", "--host", runtimeHost),
-		rolloutCommand(append([]string{binary, "rollout", "activity-check"}, append(rangeArgs, "--since", since)...)...),
-		rolloutCommand(binary, "status"),
+		rolloutCommand(append([]string{binary, "rollout", "cutover-check", "--host", runtimeHost}, append(append([]string{}, rangeArgs...), "--since", since)...)...),
 		"# After one full expected check round:",
-		rolloutCommand(append([]string{binary, "rollout", "activity-check"}, append(append([]string{}, rangeArgs...), "--since", since, "--require-all")...)...),
-		rolloutCommand(append([]string{binary, "rollout", "projection-drift"}, append(rangeArgs, "--limit", "100")...)...),
+		rolloutCommand(append([]string{binary, "rollout", "cutover-check", "--host", runtimeHost}, append(append([]string{}, rangeArgs...), "--since", since, "--require-all")...)...),
 	)
 
 	rollbackComment := "# Restart the original v1 service with its original BUCKET_NO_MIN/BUCKET_NO_MAX config."
@@ -498,9 +569,7 @@ func runRolloutRehearsalPlan(out io.Writer, input io.Reader, opts rolloutRehears
 	)
 
 	writeRolloutPlanSection(out, "7. Complete fleet-level pinned and dynamic checks after every host is on v2",
-		rolloutCommand(binary, "rollout", "pinned-check", "--host", runtimeHost),
-		rolloutCommand(append([]string{binary, "rollout", "activity-check"}, append(append([]string{}, rangeArgs...), "--since", since, "--require-all")...)...),
-		rolloutCommand(append([]string{binary, "rollout", "projection-drift"}, append(rangeArgs, "--limit", "100")...)...),
+		rolloutCommand(append([]string{binary, "rollout", "cutover-check", "--host", runtimeHost}, append(append([]string{}, rangeArgs...), "--since", since, "--require-all")...)...),
 		"# After PINNED_BUCKET_* is removed from every v2 monitor config and the fleet is restarted:",
 		rolloutCommand(binary, "validate-config"),
 		rolloutCommand(binary, "rollout", "dynamic-check"),
@@ -508,6 +577,83 @@ func runRolloutRehearsalPlan(out io.Writer, input io.Reader, opts rolloutRehears
 		rolloutCommand(binary, "rollout", "projection-drift", "--limit", "100"),
 	)
 	return nil
+}
+
+type cutoverCheckOptions struct {
+	HostOverride string
+	BucketMin    int
+	BucketMax    int
+	Since        string
+	RequireAll   bool
+	Limit        int
+	StatusPort   int
+	SkipStatus   bool
+}
+
+func runCutoverCheck(ctx context.Context, out io.Writer, cfg *config.Config, opts cutoverCheckOptions, deps cutoverCheckDeps) error {
+	if cfg == nil {
+		return errors.New("config is not loaded")
+	}
+	if out == nil {
+		out = io.Discard
+	}
+
+	writeRolloutPlanSection(out, "pinned preflight")
+	if err := runPinnedRolloutCheck(ctx, out, cfg, opts.HostOverride, deps.Pinned); err != nil {
+		return err
+	}
+
+	writeRolloutPlanSection(out, "activity check")
+	if err := runActivityCheck(ctx, out, cfg, opts.BucketMin, opts.BucketMax, opts.Since, opts.RequireAll, deps.Activity); err != nil {
+		return err
+	}
+
+	writeRolloutPlanSection(out, "dashboard status")
+	if err := runCutoverStatusCheck(out, cfg, opts, deps); err != nil {
+		return err
+	}
+
+	writeRolloutPlanSection(out, "projection drift")
+	if err := runProjectionDriftReport(ctx, out, cfg, opts.BucketMin, opts.BucketMax, opts.Limit, deps.Projection); err != nil {
+		return err
+	}
+
+	fmt.Fprintln(out, "cutover check passed")
+	return nil
+}
+
+func runCutoverStatusCheck(out io.Writer, cfg *config.Config, opts cutoverCheckOptions, deps cutoverCheckDeps) error {
+	if opts.SkipStatus {
+		fmt.Fprintln(out, "INFO dashboard_status=skipped reason=operator")
+		return nil
+	}
+	port := opts.StatusPort
+	if port == -1 {
+		port = cfg.DashboardPort
+	}
+	if port < 0 {
+		return errors.New("status-port must be >= 0")
+	}
+	if port == 0 {
+		fmt.Fprintln(out, "INFO dashboard_status=skipped dashboard_port=disabled")
+		return nil
+	}
+	if deps.Status == nil {
+		return errors.New("dashboard status checker is not configured")
+	}
+	body, err := deps.Status(port)
+	if err != nil {
+		return fmt.Errorf("dashboard status check on port %d: %w", port, err)
+	}
+	fmt.Fprintf(out, "PASS dashboard_status=http://localhost:%d/api/state\n", port)
+	if body = strings.TrimSpace(body); body != "" {
+		fmt.Fprintf(out, "INFO dashboard_state=%s\n", strings.Join(strings.Fields(body), " "))
+	}
+	return nil
+}
+
+func dashboardStatus(port int) (string, error) {
+	return httpGet(fmt.Sprintf("http://localhost:%d/api/state", port))
 }
 
 func writeRolloutPlanSection(out io.Writer, title string, lines ...string) {

--- a/cmd/jetmon2/rollout_test.go
+++ b/cmd/jetmon2/rollout_test.go
@@ -896,6 +896,105 @@ func TestRunCutoverCheckFailures(t *testing.T) {
 	}
 }
 
+func TestBuildRolloutStateReportPinned(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := pinnedRolloutTestConfig(12, 34)
+	cfg.APIPort = 0
+
+	report, err := buildRolloutStateReport(context.Background(), cfg, rolloutStateReportOptions{Since: "15m"}, rolloutStateReportDeps{
+		Now:      func() time.Time { return now },
+		Hostname: func() string { return "host-a" },
+		CountActiveSitesForBucketRange: func(_ context.Context, min, max int) (int, error) {
+			if min != 12 || max != 34 {
+				t.Fatalf("active range = %d-%d, want 12-34", min, max)
+			}
+			return 3, nil
+		},
+		CountRecentlyCheckedActiveSitesForRange: func(_ context.Context, min, max int, cutoff time.Time) (int, error) {
+			if min != 12 || max != 34 {
+				t.Fatalf("activity range = %d-%d, want 12-34", min, max)
+			}
+			if !cutoff.Equal(now.Add(-15 * time.Minute)) {
+				t.Fatalf("cutoff = %s, want %s", cutoff, now.Add(-15*time.Minute))
+			}
+			return 3, nil
+		},
+		CountLegacyProjectionDrift: func(_ context.Context, min, max int) (int, error) {
+			if min != 12 || max != 34 {
+				t.Fatalf("drift range = %d-%d, want 12-34", min, max)
+			}
+			return 0, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildRolloutStateReport: %v", err)
+	}
+	if !report.OK {
+		t.Fatalf("report.OK = false issues=%v", report.Issues)
+	}
+	if report.Ownership.Mode != "pinned" || report.BucketCoverage.Status != "pinned_config" {
+		t.Fatalf("ownership/coverage = %s/%s", report.Ownership.Mode, report.BucketCoverage.Status)
+	}
+	if report.Activity.CheckedPercent != 100 {
+		t.Fatalf("checked percent = %f, want 100", report.Activity.CheckedPercent)
+	}
+	if !strings.Contains(report.SuggestedNextAction, "next pinned host") {
+		t.Fatalf("suggested action = %q", report.SuggestedNextAction)
+	}
+}
+
+func TestBuildRolloutStateReportDynamicIssues(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := &config.Config{
+		BucketTotal:                  10,
+		BucketHeartbeatGraceSec:      60,
+		LegacyStatusProjectionEnable: true,
+		APIPort:                      8090,
+	}
+
+	report, err := buildRolloutStateReport(context.Background(), cfg, rolloutStateReportOptions{Since: "15m"}, rolloutStateReportDeps{
+		Now:      func() time.Time { return now },
+		Hostname: func() string { return "host-a" },
+		GetAllHosts: func() ([]db.HostRow, error) {
+			return []db.HostRow{
+				{HostID: "host-a", BucketMin: 0, BucketMax: 4, LastHeartbeat: now, Status: "active"},
+				{HostID: "host-b", BucketMin: 6, BucketMax: 9, LastHeartbeat: now, Status: "active"},
+			}, nil
+		},
+		CountActiveSitesForBucketRange: func(context.Context, int, int) (int, error) {
+			return 4, nil
+		},
+		CountRecentlyCheckedActiveSitesForRange: func(context.Context, int, int, time.Time) (int, error) {
+			return 1, nil
+		},
+		CountLegacyProjectionDrift: func(context.Context, int, int) (int, error) {
+			return 2, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildRolloutStateReport: %v", err)
+	}
+	if report.OK {
+		t.Fatal("report.OK = true, want false")
+	}
+	for _, want := range []string{
+		"dynamic bucket coverage has gap",
+		"legacy projection drift=2",
+		"1/4 active sites checked",
+		"delivery_owner_host is unset",
+	} {
+		if !strings.Contains(strings.Join(report.Issues, "\n"), want) {
+			t.Fatalf("issues missing %q: %#v", want, report.Issues)
+		}
+	}
+	if report.BucketCoverage.Status != "invalid" {
+		t.Fatalf("coverage status = %q, want invalid", report.BucketCoverage.Status)
+	}
+	if !strings.Contains(report.SuggestedNextAction, "Fix jetmon_hosts bucket coverage") {
+		t.Fatalf("suggested action = %q", report.SuggestedNextAction)
+	}
+}
+
 func pinnedRolloutTestConfig(minBucket, maxBucket int) *config.Config {
 	return &config.Config{
 		PinnedBucketMin:              &minBucket,

--- a/cmd/jetmon2/rollout_test.go
+++ b/cmd/jetmon2/rollout_test.go
@@ -316,7 +316,8 @@ jetmon-v1-b,5,9
 		"systemd-analyze verify /etc/systemd/system/jetmon2.service",
 		"./jetmon2 rollout pinned-check --host jetmon-v1-a",
 		"systemctl enable --now jetmon2",
-		"./jetmon2 rollout activity-check --bucket-min 0 --bucket-max 4 --since 15m --require-all",
+		"./jetmon2 rollout cutover-check --host jetmon-v1-a --bucket-min 0 --bucket-max 4 --since 15m",
+		"./jetmon2 rollout cutover-check --host jetmon-v1-a --bucket-min 0 --bucket-max 4 --since 15m --require-all",
 		"./jetmon2 rollout rollback-check --host jetmon-v1-a --bucket-min 0 --bucket-max 4",
 		"./jetmon2 rollout dynamic-check",
 	} {
@@ -353,7 +354,7 @@ jetmon-v1-a,0,9
 		`INFO plan_host="jetmon-v1-a" runtime_host="jetmon-v2-a" range=0-9`,
 		"/opt/jetmon2/jetmon2 rollout pinned-check --host jetmon-v2-a",
 		"# Stop v1 on jetmon-v1-a with the documented production command.",
-		"/opt/jetmon2/jetmon2 rollout activity-check --bucket-min 0 --bucket-max 9 --since 20m",
+		"/opt/jetmon2/jetmon2 rollout cutover-check --host jetmon-v2-a --bucket-min 0 --bucket-max 9 --since 20m",
 		"/opt/jetmon2/jetmon2 rollout rollback-check --host jetmon-v2-a --bucket-min 0 --bucket-max 9",
 	} {
 		if !strings.Contains(out.String(), want) {
@@ -682,12 +683,202 @@ func TestRunPinnedRolloutCheckFailures(t *testing.T) {
 	}
 }
 
+func TestRunCutoverCheckSuccess(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := pinnedRolloutTestConfig(12, 34)
+	cfg.DashboardPort = 8080
+
+	deps := successfulCutoverCheckDeps(now)
+	var gotStatusPort int
+	deps.Status = func(port int) (string, error) {
+		gotStatusPort = port
+		return "{\n  \"state\": \"ok\"\n}", nil
+	}
+
+	var out bytes.Buffer
+	err := runCutoverCheck(context.Background(), &out, cfg, cutoverCheckOptions{
+		HostOverride: "host-a",
+		BucketMin:    -1,
+		BucketMax:    -1,
+		Since:        "15m",
+		Limit:        100,
+		StatusPort:   -1,
+	}, deps)
+	if err != nil {
+		t.Fatalf("runCutoverCheck: %v", err)
+	}
+	if gotStatusPort != 8080 {
+		t.Fatalf("status port = %d, want 8080", gotStatusPort)
+	}
+	for _, want := range []string{
+		"## pinned preflight",
+		"pinned rollout check passed",
+		"## activity check",
+		"PASS rollout_activity=recent_checks_present",
+		"## dashboard status",
+		"PASS dashboard_status=http://localhost:8080/api/state",
+		`INFO dashboard_state={ "state": "ok" }`,
+		"## projection drift",
+		"PASS legacy_projection_drift=0",
+		"cutover check passed",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestRunCutoverCheckRequireAllAndSkipStatus(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := pinnedRolloutTestConfig(12, 34)
+	deps := successfulCutoverCheckDeps(now)
+	deps.Status = func(int) (string, error) {
+		t.Fatal("status should not be called")
+		return "", nil
+	}
+
+	var out bytes.Buffer
+	err := runCutoverCheck(context.Background(), &out, cfg, cutoverCheckOptions{
+		BucketMin:  -1,
+		BucketMax:  -1,
+		Since:      "15m",
+		RequireAll: true,
+		Limit:      100,
+		StatusPort: -1,
+		SkipStatus: true,
+	}, deps)
+	if err != nil {
+		t.Fatalf("runCutoverCheck: %v", err)
+	}
+	for _, want := range []string{
+		"PASS rollout_activity=all_active_sites_checked",
+		"INFO dashboard_status=skipped reason=operator",
+		"cutover check passed",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestRunCutoverCheckSkipsDisabledDashboard(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := pinnedRolloutTestConfig(12, 34)
+	cfg.DashboardPort = 0
+	deps := successfulCutoverCheckDeps(now)
+	deps.Status = func(int) (string, error) {
+		t.Fatal("status should not be called")
+		return "", nil
+	}
+
+	var out bytes.Buffer
+	if err := runCutoverCheck(context.Background(), &out, cfg, cutoverCheckOptions{BucketMin: -1, BucketMax: -1, Since: "15m", Limit: 100, StatusPort: -1}, deps); err != nil {
+		t.Fatalf("runCutoverCheck: %v", err)
+	}
+	if !strings.Contains(out.String(), "INFO dashboard_status=skipped dashboard_port=disabled") {
+		t.Fatalf("output missing disabled dashboard skip:\n%s", out.String())
+	}
+}
+
+func TestRunCutoverCheckFailures(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := pinnedRolloutTestConfig(12, 34)
+	cfg.DashboardPort = 8080
+
+	tests := []struct {
+		name string
+		opts cutoverCheckOptions
+		deps cutoverCheckDeps
+		want string
+	}{
+		{
+			name: "status error",
+			opts: cutoverCheckOptions{BucketMin: -1, BucketMax: -1, Since: "15m", Limit: 100, StatusPort: -1},
+			deps: func() cutoverCheckDeps {
+				deps := successfulCutoverCheckDeps(now)
+				deps.Status = func(int) (string, error) {
+					return "", errors.New("connection refused")
+				}
+				return deps
+			}(),
+			want: "connection refused",
+		},
+		{
+			name: "activity require all failure",
+			opts: cutoverCheckOptions{BucketMin: -1, BucketMax: -1, Since: "15m", RequireAll: true, Limit: 100, StatusPort: -1, SkipStatus: true},
+			deps: func() cutoverCheckDeps {
+				deps := successfulCutoverCheckDeps(now)
+				deps.Activity.CountRecentlyCheckedActiveSitesForRange = func(context.Context, int, int, time.Time) (int, error) {
+					return 1, nil
+				}
+				return deps
+			}(),
+			want: "only 1/3 active sites",
+		},
+		{
+			name: "projection drift",
+			opts: cutoverCheckOptions{BucketMin: -1, BucketMax: -1, Since: "15m", Limit: 100, StatusPort: -1, SkipStatus: true},
+			deps: func() cutoverCheckDeps {
+				deps := successfulCutoverCheckDeps(now)
+				deps.Projection.CountLegacyProjectionDrift = func(context.Context, int, int) (int, error) {
+					return 2, nil
+				}
+				deps.Projection.ListLegacyProjectionDrift = func(context.Context, int, int, int) ([]db.ProjectionDriftRow, error) {
+					return nil, nil
+				}
+				return deps
+			}(),
+			want: "legacy projection drift=2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			err := runCutoverCheck(context.Background(), &out, cfg, tt.opts, tt.deps)
+			if err == nil {
+				t.Fatal("runCutoverCheck succeeded")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), tt.want)
+			}
+		})
+	}
+}
+
 func pinnedRolloutTestConfig(minBucket, maxBucket int) *config.Config {
 	return &config.Config{
 		PinnedBucketMin:              &minBucket,
 		PinnedBucketMax:              &maxBucket,
 		LegacyStatusProjectionEnable: true,
 	}
+}
+
+func successfulCutoverCheckDeps(now time.Time) cutoverCheckDeps {
+	deps := cutoverCheckDeps{
+		Pinned: successfulPinnedRolloutDeps(),
+		Activity: activityCheckDeps{
+			Now: func() time.Time { return now },
+			CountActiveSitesForBucketRange: func(context.Context, int, int) (int, error) {
+				return 3, nil
+			},
+			CountRecentlyCheckedActiveSitesForRange: func(context.Context, int, int, time.Time) (int, error) {
+				return 3, nil
+			},
+		},
+		Projection: projectionDriftDeps{
+			CountLegacyProjectionDrift: func(context.Context, int, int) (int, error) {
+				return 0, nil
+			},
+			ListLegacyProjectionDrift: func(context.Context, int, int, int) ([]db.ProjectionDriftRow, error) {
+				return nil, nil
+			},
+		},
+		Status: func(int) (string, error) {
+			return `{"state":"ok"}`, nil
+		},
+	}
+	return deps
 }
 
 func successfulPinnedRolloutDeps() pinnedRolloutCheckDeps {

--- a/cmd/jetmon2/rollout_test.go
+++ b/cmd/jetmon2/rollout_test.go
@@ -3,7 +3,10 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -11,6 +14,53 @@ import (
 	"github.com/Automattic/jetmon/internal/config"
 	"github.com/Automattic/jetmon/internal/db"
 )
+
+func TestRunRolloutCommandOutputJSON(t *testing.T) {
+	var out bytes.Buffer
+	err := runRolloutCommandOutput(&out, "rollout test-check", "json", func(w io.Writer) error {
+		fmt.Fprintln(w, "PASS config parse")
+		fmt.Fprintln(w, "## activity check")
+		fmt.Fprintln(w, "INFO active_sites=3")
+		return errors.New("activity failed")
+	})
+	if err == nil {
+		t.Fatal("runRolloutCommandOutput returned nil error")
+	}
+
+	var report rolloutJSONReport
+	if decodeErr := json.Unmarshal(out.Bytes(), &report); decodeErr != nil {
+		t.Fatalf("decode rollout JSON report: %v\n%s", decodeErr, out.String())
+	}
+	if report.OK {
+		t.Fatal("report.OK = true, want false")
+	}
+	if report.Command != "rollout test-check" {
+		t.Fatalf("command = %q", report.Command)
+	}
+	if len(report.Failures) != 1 || report.Failures[0] != "activity failed" {
+		t.Fatalf("failures = %#v", report.Failures)
+	}
+	wantLevels := []string{"pass", "section", "info"}
+	if len(report.Lines) != len(wantLevels) {
+		t.Fatalf("line count = %d, want %d: %#v", len(report.Lines), len(wantLevels), report.Lines)
+	}
+	for i, want := range wantLevels {
+		if report.Lines[i].Level != want {
+			t.Fatalf("line %d level = %q, want %q", i, report.Lines[i].Level, want)
+		}
+	}
+}
+
+func TestNormalizeRolloutOutput(t *testing.T) {
+	for _, raw := range []string{"", "text", "TEXT", " json "} {
+		if _, err := normalizeRolloutOutput(raw); err != nil {
+			t.Fatalf("normalizeRolloutOutput(%q): %v", raw, err)
+		}
+	}
+	if _, err := normalizeRolloutOutput("yaml"); err == nil {
+		t.Fatal("normalizeRolloutOutput(yaml) error = nil")
+	}
+}
 
 func TestRunStaticPlanCheckSuccess(t *testing.T) {
 	input := strings.NewReader(`

--- a/cmd/jetmon2/rollout_test.go
+++ b/cmd/jetmon2/rollout_test.go
@@ -286,6 +286,160 @@ func TestValidateStaticBucketPlanFailures(t *testing.T) {
 	}
 }
 
+func TestRunRolloutRehearsalPlanSameServer(t *testing.T) {
+	input := strings.NewReader(`
+host,bucket_min,bucket_max
+jetmon-v1-a,0,4
+jetmon-v1-b,5,9
+`)
+	opts := rolloutRehearsalPlanOptions{
+		Mode:        "same-server",
+		PlanFile:    "rollout-buckets.csv",
+		HostID:      "jetmon-v1-a",
+		BucketMin:   0,
+		BucketMax:   4,
+		BucketTotal: 10,
+		Binary:      "./jetmon2",
+		Service:     "jetmon2",
+		Since:       "15m",
+	}
+
+	var out bytes.Buffer
+	if err := runRolloutRehearsalPlan(&out, input, opts); err != nil {
+		t.Fatalf("runRolloutRehearsalPlan: %v", err)
+	}
+	for _, want := range []string{
+		"INFO mode=same-server",
+		`INFO plan_host="jetmon-v1-a" runtime_host="jetmon-v1-a" range=0-4`,
+		"./jetmon2 rollout static-plan-check --file rollout-buckets.csv --host jetmon-v1-a --bucket-min 0 --bucket-max 4",
+		"./jetmon2 validate-config",
+		"systemd-analyze verify /etc/systemd/system/jetmon2.service",
+		"./jetmon2 rollout pinned-check --host jetmon-v1-a",
+		"systemctl enable --now jetmon2",
+		"./jetmon2 rollout activity-check --bucket-min 0 --bucket-max 4 --since 15m --require-all",
+		"./jetmon2 rollout rollback-check --host jetmon-v1-a --bucket-min 0 --bucket-max 4",
+		"./jetmon2 rollout dynamic-check",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestRunRolloutRehearsalPlanFreshServerRuntimeHost(t *testing.T) {
+	input := strings.NewReader(`
+host,bucket_min,bucket_max
+jetmon-v1-a,0,9
+`)
+	opts := rolloutRehearsalPlanOptions{
+		Mode:        "fresh-server",
+		PlanFile:    "rollout-buckets.csv",
+		HostID:      "jetmon-v1-a",
+		RuntimeHost: "jetmon-v2-a",
+		BucketMin:   0,
+		BucketMax:   9,
+		BucketTotal: 10,
+		Binary:      "/opt/jetmon2/jetmon2",
+		Service:     "jetmon2",
+		Since:       "20m",
+	}
+
+	var out bytes.Buffer
+	if err := runRolloutRehearsalPlan(&out, input, opts); err != nil {
+		t.Fatalf("runRolloutRehearsalPlan: %v", err)
+	}
+	for _, want := range []string{
+		"INFO mode=fresh-server",
+		`INFO plan_host="jetmon-v1-a" runtime_host="jetmon-v2-a" range=0-9`,
+		"/opt/jetmon2/jetmon2 rollout pinned-check --host jetmon-v2-a",
+		"# Stop v1 on jetmon-v1-a with the documented production command.",
+		"/opt/jetmon2/jetmon2 rollout activity-check --bucket-min 0 --bucket-max 9 --since 20m",
+		"/opt/jetmon2/jetmon2 rollout rollback-check --host jetmon-v2-a --bucket-min 0 --bucket-max 9",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestRunRolloutRehearsalPlanFailures(t *testing.T) {
+	validInput := `host,bucket_min,bucket_max
+jetmon-v1-a,0,9
+`
+	tests := []struct {
+		name  string
+		input string
+		opts  rolloutRehearsalPlanOptions
+		want  string
+	}{
+		{
+			name:  "bad mode",
+			input: validInput,
+			opts: rolloutRehearsalPlanOptions{
+				Mode:        "auto",
+				PlanFile:    "rollout-buckets.csv",
+				HostID:      "jetmon-v1-a",
+				BucketMin:   0,
+				BucketMax:   9,
+				BucketTotal: 10,
+			},
+			want: "--mode must be",
+		},
+		{
+			name:  "missing range",
+			input: validInput,
+			opts: rolloutRehearsalPlanOptions{
+				Mode:        "same-server",
+				PlanFile:    "rollout-buckets.csv",
+				HostID:      "jetmon-v1-a",
+				BucketMin:   -1,
+				BucketMax:   9,
+				BucketTotal: 10,
+			},
+			want: "--bucket-min and --bucket-max are required",
+		},
+		{
+			name:  "host not in plan",
+			input: validInput,
+			opts: rolloutRehearsalPlanOptions{
+				Mode:        "same-server",
+				PlanFile:    "rollout-buckets.csv",
+				HostID:      "jetmon-v1-b",
+				BucketMin:   0,
+				BucketMax:   9,
+				BucketTotal: 10,
+			},
+			want: "not present",
+		},
+		{
+			name:  "range mismatch",
+			input: validInput,
+			opts: rolloutRehearsalPlanOptions{
+				Mode:        "same-server",
+				PlanFile:    "rollout-buckets.csv",
+				HostID:      "jetmon-v1-a",
+				BucketMin:   1,
+				BucketMax:   9,
+				BucketTotal: 10,
+			},
+			want: "want 1-9",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			err := runRolloutRehearsalPlan(&out, strings.NewReader(tt.input), tt.opts)
+			if err == nil {
+				t.Fatal("runRolloutRehearsalPlan succeeded")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), tt.want)
+			}
+		})
+	}
+}
+
 func TestRunPinnedRolloutCheckSuccess(t *testing.T) {
 	minBucket, maxBucket := 12, 34
 	cfg := &config.Config{

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ Start with [`adr/README.md`](adr/README.md) for the ADR format and index.
 | [`taxonomy.md`](taxonomy.md) | Severity, state, cause, rollup, and test taxonomy. |
 | [`getting-started.md`](getting-started.md) | Local Docker setup, build/test commands, API CLI smoke runs, fixture failure simulation, and tenant import basics. |
 | [`operations-guide.md`](operations-guide.md) | Production configuration, host setup, rollout modes, delivery workers, metrics, dashboard checks, and debugging. |
+| [`rollout-quick-reference.md`](rollout-quick-reference.md) | One-page operator checklist for the v1-to-v2 rollout, linked back to the full migration runbook. |
 | [`data-model.md`](data-model.md) | Legacy and v2 tables, additive migrations, event-sourced incident state, legacy projection, and tenant mapping. |
 | [`support-guide.md`](support-guide.md) | Happiness Engineer workflows for explaining alerts, missed alerts, false positives, maintenance windows, and WPCOM payloads. |
 | [`api-cli-guide.md`](api-cli-guide.md) | Feature guide and examples for using `jetmon2 api` against the internal REST API during local testing, rehearsals, and CI smoke runs. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ accepted architecture decisions.
 | Document | Purpose |
 |---|---|
 | [`roadmap.md`](roadmap.md) | Broader v2/v3 planning, deferred feature work, and public API prerequisites. |
-| [`api-cli-roadmap.md`](api-cli-roadmap.md) | Prioritized plan for a local `jetmon2 api` helper CLI that exercises the internal REST API during Docker and rollout testing. |
+| [`api-cli-roadmap.md`](api-cli-roadmap.md) | Completed implementation history for the local `jetmon2 api` helper CLI used during Docker and rollout testing. |
 | [`jetmon-deliverer-rollout.md`](jetmon-deliverer-rollout.md) | Operational rollout policy for moving outbound dispatch from embedded `jetmon2` workers to standalone `jetmon-deliverer`. |
 | [`outbound-credential-encryption-plan.md`](outbound-credential-encryption-plan.md) | Migration plan for encrypting webhook secrets and alert-contact destination credentials after the current plaintext v2 model. |
 | [`public-api-gateway-tenant-contract.md`](public-api-gateway-tenant-contract.md) | Gateway boundary contract, implemented Jetmon-side tenant ownership checks, and remaining public-exposure prerequisites. |

--- a/docs/api-cli-roadmap.md
+++ b/docs/api-cli-roadmap.md
@@ -1,11 +1,13 @@
 # API CLI Roadmap
 
-Status: active on `feature/api-cli`.
+Status: complete and merged into `v2`.
 
-This roadmap tracks a local developer/operator CLI for exercising the internal
-Jetmon `/api/v1` surface without remembering endpoint paths, auth headers, and
-payload shapes by hand. The CLI should make local Docker testing repeatable,
-but it should not become a generic `curl` clone.
+This roadmap is retained as implementation history for the local
+developer/operator CLI that exercises the internal Jetmon `/api/v1` surface
+without remembering endpoint paths, auth headers, and payload shapes by hand.
+New API CLI follow-up ideas should be tracked in
+[`roadmap.md`](roadmap.md) unless they are small enough to land with adjacent
+feature work.
 
 ## P0 - Request Foundation
 

--- a/docs/jetmon-deliverer-rollout.md
+++ b/docs/jetmon-deliverer-rollout.md
@@ -163,8 +163,10 @@ Before enabling standalone delivery:
   is expected.
 - `JETMON_CONFIG=/opt/jetmon2/config/deliverer.json bin/jetmon-deliverer
   delivery-check --since=15m --output=json` returns clean JSON for automation.
-- `systemd-analyze verify systemd/jetmon-deliverer.service` passes, or the
-  deployment-system equivalent validates the service definition.
+- `systemd-analyze verify /etc/systemd/system/jetmon-deliverer.service` passes
+  on a staged host, or against an alternate deployment root, after
+  `/opt/jetmon2/bin/jetmon-deliverer` exists. The repository copy can report
+  missing `ExecStart` paths before packaging.
 - The process can connect to MySQL using the same schema as `jetmon2`.
 - `EMAIL_TRANSPORT` is set to `wpcom` or `smtp` in any environment where real
   alert-contact emails should be delivered; `stub` is safe for dry runs.

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -76,6 +76,11 @@ sequence for one host replacement. Use `--mode=fresh-server` plus
 `--runtime-host=<new-v2-hostname>` when the new v2 hostname differs from the v1
 host recorded in the static bucket plan.
 
+After a pinned v2 host starts, use `./jetmon2 rollout cutover-check --since=15m`
+to run the post-start pinned preflight, recent activity check, dashboard status
+check, and projection-drift report together. After one full expected check
+round, rerun it with `--require-all` before moving to the next host.
+
 ## v2 Rolling Updates
 
 After all monitor hosts are on v2 dynamic bucket ownership, update one host at a

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -86,6 +86,9 @@ round, rerun it with `--require-all` before moving to the next host.
 Use `--output=json` on rollout gate commands when wiring them into Systems
 automation. The command still exits non-zero on failed checks, and stdout
 contains `ok`, the command name, parsed output lines, and failure messages.
+Use `./jetmon2 rollout state-report --since=15m` for an operator snapshot of
+ownership mode, bucket coverage, activity freshness, projection drift, delivery
+owner state, and the suggested next action.
 
 ## v2 Rolling Updates
 

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -70,6 +70,12 @@ migration process. It covers preparation, additive migrations, pinned bucket
 mode, replacing v1 on the same server, moving a range to a fresh v2 server,
 monitoring, revert paths, dynamic ownership cutover, and v1 teardown.
 
+Use `./jetmon2 rollout rehearsal-plan --file=<ranges.csv> --host=<host>
+--bucket-min=N --bucket-max=N --mode=same-server` to print the ordered command
+sequence for one host replacement. Use `--mode=fresh-server` plus
+`--runtime-host=<new-v2-hostname>` when the new v2 hostname differs from the v1
+host recorded in the static bucket plan.
+
 ## v2 Rolling Updates
 
 After all monitor hosts are on v2 dynamic bucket ownership, update one host at a

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -42,7 +42,8 @@ reference.
 
 ## Production Host Setup
 
-1. Install `jetmon2` to `/opt/jetmon2/`.
+1. Install `bin/jetmon2` as `/opt/jetmon2/jetmon2`, or update the service unit
+   if your deployment system uses a different path.
 2. Install `systemd/jetmon2.service` to `/etc/systemd/system/` and run
    `systemctl daemon-reload`.
 3. Install `systemd/jetmon2-logrotate` to `/etc/logrotate.d/jetmon2`.
@@ -53,7 +54,9 @@ reference.
 6. Copy or generate `config/config.json`.
 7. Set `BUCKET_TARGET` to the desired maximum bucket count for the host.
 8. Run `./jetmon2 migrate`.
-9. Start the service with `systemctl enable --now jetmon2`.
+9. Run `systemd-analyze verify /etc/systemd/system/jetmon2.service` after the
+   binary exists at the path used by `ExecStart`.
+10. Start the service with `systemctl enable --now jetmon2`.
 
 Manual commands such as `migrate`, `validate-config`, and `rollout` need the
 same `DB_*` environment that systemd reads from
@@ -109,6 +112,11 @@ JETMON_CONFIG=/opt/jetmon2/config/deliverer.json \
 
 Add `--require-email-delivery` when real alert-contact email delivery is
 expected in that environment.
+
+Run `systemd-analyze verify /etc/systemd/system/jetmon-deliverer.service` after
+`/opt/jetmon2/bin/jetmon-deliverer` exists, or against an equivalent staged
+deployment root where the service's `ExecStart` and `ExecStartPre` paths are
+present.
 
 During rollout, inspect the shared webhook and alert-contact delivery queues
 from the same environment the service uses:

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -69,6 +69,8 @@ Use [v1-to-v2-migration.md](v1-to-v2-migration.md) for the full production
 migration process. It covers preparation, additive migrations, pinned bucket
 mode, replacing v1 on the same server, moving a range to a fresh v2 server,
 monitoring, revert paths, dynamic ownership cutover, and v1 teardown.
+Use [rollout-quick-reference.md](rollout-quick-reference.md) as the one-page
+operator command checklist during rehearsals and rollout windows.
 
 Use `./jetmon2 rollout rehearsal-plan --file=<ranges.csv> --host=<host>
 --bucket-min=N --bucket-max=N --mode=same-server` to print the ordered command

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -81,6 +81,10 @@ to run the post-start pinned preflight, recent activity check, dashboard status
 check, and projection-drift report together. After one full expected check
 round, rerun it with `--require-all` before moving to the next host.
 
+Use `--output=json` on rollout gate commands when wiring them into Systems
+automation. The command still exits non-zero on failed checks, and stdout
+contains `ok`, the command name, parsed output lines, and failure messages.
+
 ## v2 Rolling Updates
 
 After all monitor hosts are on v2 dynamic bucket ownership, update one host at a

--- a/docs/project.md
+++ b/docs/project.md
@@ -280,6 +280,11 @@ Queryable by `blog_id` and time range via a CLI tool (`jetmon2 audit --blog-id 1
 - `jetmon2 drain --worker N` — gracefully removes one worker pool slot, waiting for in-flight checks to complete before reducing concurrency
 - `jetmon2 reload` — sends SIGHUP to the running process (convenience wrapper)
 
+Rollout gate commands accept `--output=json` for Systems automation. JSON output
+keeps the command's pass/fail state, generated timestamp, parsed output lines,
+and failure messages on stdout while preserving non-zero exit status on failed
+checks.
+
 The complete v1-to-v2 production process is documented in
 [`v1-to-v2-migration.md`](v1-to-v2-migration.md).
 

--- a/docs/project.md
+++ b/docs/project.md
@@ -158,20 +158,22 @@ Add a `redirect_policy` column to `jetpack_monitor_sites` with three options: `f
 ## Tooling and Developer Experience
 
 **Docker Compose Environment**
-The existing Docker Compose setup is updated for the Go binary. A single `docker compose up` starts MySQL, the Jetmon 2 binary, one or more Veriflier instances, Mailpit for local email capture, StatsD + Graphite, and the operator dashboard. No npm, no node-gyp, no manual build steps. `docker compose up --build` rebuilds the Go binary in a reproducible multi-stage Docker build. A simulated site server remains a planned addition for deterministic local failure scenarios.
+The existing Docker Compose setup is updated for the Go binary. A single `docker compose up` starts MySQL, the Jetmon 2 binary, one or more Veriflier instances, Mailpit for local email capture, StatsD + Graphite, the operator dashboard, and the deterministic API fixture. No npm, no node-gyp, no manual build steps. `docker compose up --build` rebuilds the Go binaries in a reproducible multi-stage Docker build.
 
-**Planned Simulated Site Server**
-A dedicated HTTP service should be added to the Docker Compose environment to simulate configurable site states without requiring real external sites:
+**Docker-Local API Fixture**
+The Docker Compose environment includes an `api-fixture` service for deterministic local API CLI and event-flow rehearsals without depending on public endpoint timing. It exposes:
 
-- Static response codes (200, 404, 500, 503)
-- Configurable response delay (simulates slow sites and timeouts)
-- Flapping mode (alternates between up and down on a configurable schedule)
-- SSL with a self-signed certificate (for TLS path testing)
-- Keyword presence/absence for content check testing
-- Redirect chains (tests the redirect-following logic)
-- Abrupt TCP close (tests connection reset handling)
+- static response-code endpoints for success, client error, and server error cases
+- configurable slow responses for timeout paths
+- keyword-present and keyword-missing responses
+- redirect paths for redirect-policy checks
+- HTTPS with a self-signed certificate for TLS failure paths
+- webhook capture endpoints that record deliveries and verify
+  `X-Jetmon-Signature` when a shared secret is supplied
 
-States should be toggled via a simple HTTP API so integration tests can script site behaviour programmatically.
+`make api-cli-smoke` exercises the normal local API smoke path, and
+`make api-cli-validate` runs the broader guide validation with fixture-backed
+failure simulation and optional webhook signature verification.
 
 **Structured Logging**
 All log output is available in two formats: the existing plain-text line format (for drop-in compatibility with current log consumers) and an optional structured JSON format enabled via `config.json`. The JSON format emits the same fields — level, timestamp, message, blog_id, http_code, error_code, RTT — as a machine-readable object, making log ingestion into Elasticsearch, Loki, or any log aggregation platform straightforward without a custom parser. Both formats write to the same log file paths.
@@ -267,7 +269,10 @@ Queryable by `blog_id` and time range via a CLI tool (`jetmon2 audit --blog-id 1
 - `jetmon2 version` — prints binary version, build date, Go version, and git commit hash
 - `jetmon2 migrate` — applies pending DB schema migrations idempotently
 - `jetmon2 status` — connects to a running instance's internal API and prints a one-line health summary (equivalent to reading `stats/totals` but richer)
+- `jetmon2 rollout static-plan-check` — validates a CSV host-to-bucket plan before any v1 host is stopped
 - `jetmon2 rollout pinned-check` — validates a pinned v1-to-v2 cutover host before or during host replacement
+- `jetmon2 rollout activity-check` — verifies recent check activity for a bucket range after cutover
+- `jetmon2 rollout rollback-check` — verifies a pinned v2 range is safe to hand back to v1
 - `jetmon2 rollout dynamic-check` — validates full `jetmon_hosts` coverage after the fleet transitions from pinned to dynamic ownership
 - `jetmon2 rollout projection-drift` — lists active sites whose legacy `site_status` projection disagrees with the authoritative event state
 - `jetmon2 drain --worker N` — gracefully removes one worker pool slot, waiting for in-flight checks to complete before reducing concurrency

--- a/docs/project.md
+++ b/docs/project.md
@@ -277,6 +277,7 @@ Queryable by `blog_id` and time range via a CLI tool (`jetmon2 audit --blog-id 1
 - `jetmon2 rollout rollback-check` — verifies a pinned v2 range is safe to hand back to v1
 - `jetmon2 rollout dynamic-check` — validates full `jetmon_hosts` coverage after the fleet transitions from pinned to dynamic ownership
 - `jetmon2 rollout projection-drift` — lists active sites whose legacy `site_status` projection disagrees with the authoritative event state
+- `jetmon2 rollout state-report` — summarizes ownership mode, bucket coverage, recent activity, projection drift, delivery-owner state, and the suggested next action
 - `jetmon2 drain --worker N` — gracefully removes one worker pool slot, waiting for in-flight checks to complete before reducing concurrency
 - `jetmon2 reload` — sends SIGHUP to the running process (convenience wrapper)
 

--- a/docs/project.md
+++ b/docs/project.md
@@ -269,6 +269,7 @@ Queryable by `blog_id` and time range via a CLI tool (`jetmon2 audit --blog-id 1
 - `jetmon2 version` — prints binary version, build date, Go version, and git commit hash
 - `jetmon2 migrate` — applies pending DB schema migrations idempotently
 - `jetmon2 status` — connects to a running instance's internal API and prints a one-line health summary (equivalent to reading `stats/totals` but richer)
+- `jetmon2 rollout rehearsal-plan` — prints the ordered same-server or fresh-server command sequence for a host replacement from the approved bucket CSV
 - `jetmon2 rollout static-plan-check` — validates a CSV host-to-bucket plan before any v1 host is stopped
 - `jetmon2 rollout pinned-check` — validates a pinned v1-to-v2 cutover host before or during host replacement
 - `jetmon2 rollout activity-check` — verifies recent check activity for a bucket range after cutover

--- a/docs/project.md
+++ b/docs/project.md
@@ -272,6 +272,7 @@ Queryable by `blog_id` and time range via a CLI tool (`jetmon2 audit --blog-id 1
 - `jetmon2 rollout rehearsal-plan` — prints the ordered same-server or fresh-server command sequence for a host replacement from the approved bucket CSV
 - `jetmon2 rollout static-plan-check` — validates a CSV host-to-bucket plan before any v1 host is stopped
 - `jetmon2 rollout pinned-check` — validates a pinned v1-to-v2 cutover host before or during host replacement
+- `jetmon2 rollout cutover-check` — bundles the read-only post-start pinned preflight, activity, dashboard status, and projection-drift checks
 - `jetmon2 rollout activity-check` — verifies recent check activity for a bucket range after cutover
 - `jetmon2 rollout rollback-check` — verifies a pinned v2 range is safe to hand back to v1
 - `jetmon2 rollout dynamic-check` — validates full `jetmon_hosts` coverage after the fleet transitions from pinned to dynamic ownership

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -43,7 +43,7 @@ preflight, deliverer hardening, and API CLI fixture workflow branches:
 - [x] Add JSON output to rollout checks for Systems automation gates.
 - [x] Create a one-page rollout quick reference that links to the full
   migration runbook.
-- [ ] Add a rollout state report that summarizes ownership mode, bucket
+- [x] Add a rollout state report that summarizes ownership mode, bucket
   coverage, drift, recent activity, delivery owner state, and suggested next
   action.
 
@@ -712,6 +712,9 @@ where to look, and what each item unlocked.
   operators a one-page command checklist for rehearsal, per-host cutover,
   rollback, fleet completion, and JSON automation while linking back to the
   full migration runbook as source of truth.
+- **Rollout state report.** `./jetmon2 rollout state-report` summarizes the
+  current ownership mode, bucket coverage, recent activity, projection drift,
+  delivery-owner state, and suggested next action for operator handoffs.
 - **Dynamic ownership preflight.** `./jetmon2 rollout dynamic-check` verifies
   that pinned ranges are removed, `jetmon_hosts` rows cover the full bucket
   range without gaps/overlaps, heartbeats are fresh, and projection drift is

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,28 +12,34 @@ migration and the operating data needed to make larger architecture decisions.
 
 ### Candidate follow-up branches
 
-These are scoped branches worth considering after the API CLI work and rollout
-preflight hardening settle:
+These are scoped branches worth considering after the merged API CLI, rollout
+preflight, deliverer hardening, and API CLI fixture workflow branches:
 
-- **`feature/rollout-preflight-hardening`** - finish and merge the in-flight
-  branch that adds static bucket plan validation, post-cutover activity checks,
-  rollback checks, and operator-visible rollout safety commands.
-- **`feature/deliverer-rollout-hardening`** - make the standalone
-  `jetmon-deliverer` rollout safer with stronger config validation, ownership
-  checks, delivery backlog checks, service docs, and explicit rollback
-  rehearsal.
 - **`feature/operator-dashboard-polish`** - turn the dashboard into a clearer
   production rollout cockpit: stronger warning states, dependency health
   details, rollout-command visibility, and event/API pointers for operators.
-- **`feature/api-cli-fixture-workflows`** - extend the merged API CLI with
-  richer seeded data, additional deterministic failure modes, cleanup helpers,
-  and safer batch-owned staging workflows.
 - **`feature/projection-drift-tooling`** - expand drift diagnostics beyond
   count/list output with range summaries, likely causes, rehearsal reports, and
   dry-run repair guidance if repair becomes safe enough to automate.
+- **`feature/production-telemetry-reports`** - turn existing StatsD and event
+  data into repeatable reports for first-failure timing, verifier agreement,
+  false-alarm classes, WPCOM parity, and operator explanation gaps after v2 has
+  enough traffic.
 - **`feature/v2-rollout-docs-rehearsal`** - walk the migration docs through a
   full rehearsal and keep README, operations docs, migration docs, config
   samples, service units, and CLI output aligned.
+
+Recently completed candidate branches:
+
+- **`feature/rollout-preflight-hardening`** - merged rollout safety commands
+  for static bucket plans, pinned checks, activity checks, rollback checks,
+  projection drift, and operator-visible rollout guidance.
+- **`feature/deliverer-rollout-hardening`** - merged standalone deliverer
+  validation, owner checks, delivery backlog checks, service docs, rollback
+  guidance, and service-file cleanup.
+- **`feature/api-cli-fixture-workflows`** - merged deterministic fixture-backed
+  API CLI validation, webhook smoke, signature checks, remote-write guardrails,
+  batch-owned cleanup, and command discovery.
 
 ### P0 - v2 production hardening
 
@@ -721,6 +727,18 @@ where to look, and what each item unlocked.
   and Veriflier binaries without requiring generated gRPC code, and Makefile
   targets use an explicit Go path and writable build cache.
   This keeps normal build/test workflows reliable in local and CI-like shells.
+- **API CLI and deterministic rehearsal workflows.** `jetmon2 api` now has
+  typed commands, smoke workflows, batch-owned test data, remote-write
+  guardrails, a Docker-local failure/webhook fixture, `make api-cli-smoke`,
+  and `make api-cli-validate`.
+  This gives local, staging, and CI rehearsals a repeatable way to exercise the
+  internal API without hand-written curl scripts.
+- **Rollout preflight and deliverer hardening branches.** The v2 branch now has
+  static bucket plan validation, pinned/dynamic/activity/rollback/drift rollout
+  checks, standalone `jetmon-deliverer` validation, delivery queue checks, and
+  matching operator docs.
+  These are the guardrails needed before replacing the first v1 production
+  monitor host or splitting outbound delivery.
 - **Coverage and race-test expansion.** Core packages gained coverage for
   list handlers, lifecycle helpers, API audit paths, delivery behavior,
   startup helpers, and previously racy tests.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -37,7 +37,7 @@ preflight, deliverer hardening, and API CLI fixture workflow branches:
 - [x] Add `make rollout-docs-verify` so docs/tooling drift checks, command help
   checks, staged systemd validation, build, test, and lint can run as one
   repeatable gate.
-- [ ] Add `jetmon2 rollout cutover-check` to bundle the read-only post-start
+- [x] Add `jetmon2 rollout cutover-check` to bundle the read-only post-start
   pinned preflight, activity, status, and projection-drift checks used after
   each host replacement.
 - [ ] Add JSON output to rollout checks for Systems automation gates.
@@ -86,7 +86,7 @@ Recently completed candidate branches:
 - **Run a production rollout rehearsal pass.** Validate that README,
   `v1-to-v2-migration.md`, config samples, systemd units,
   `validate-config`, `rollout static-plan-check`, `rollout pinned-check`,
-  `rollout activity-check`, `rollout rollback-check`,
+  `rollout cutover-check`, `rollout activity-check`, `rollout rollback-check`,
   `rollout projection-drift`, and rollback steps line up exactly before the
   first production host replacement.
 - **Instrument the data needed for the v3 decision.** During v2 production,
@@ -700,6 +700,11 @@ where to look, and what each item unlocked.
   Example: `./jetmon2 rollout pinned-check` verifies pinned config, projection
   writes, dynamic-ownership absence, active-site coverage, and projection drift
   before cutover.
+- **Post-start cutover check.** `./jetmon2 rollout cutover-check` bundles the
+  read-only pinned preflight, recent activity check, dashboard status check,
+  and projection-drift report used after each v1 host replacement.
+  Operators can run it immediately after start, then again with `--require-all`
+  after one full expected check round.
 - **Dynamic ownership preflight.** `./jetmon2 rollout dynamic-check` verifies
   that pinned ranges are removed, `jetmon_hosts` rows cover the full bucket
   range without gaps/overlaps, heartbeats are fresh, and projection drift is
@@ -752,9 +757,9 @@ where to look, and what each item unlocked.
   This gives local, staging, and CI rehearsals a repeatable way to exercise the
   internal API without hand-written curl scripts.
 - **Rollout preflight and deliverer hardening branches.** The v2 branch now has
-  static bucket plan validation, pinned/dynamic/activity/rollback/drift rollout
-  checks, standalone `jetmon-deliverer` validation, delivery queue checks, and
-  matching operator docs.
+  static bucket plan validation, pinned/dynamic/cutover/activity/rollback/drift
+  rollout checks, standalone `jetmon-deliverer` validation, delivery queue
+  checks, and matching operator docs.
   These are the guardrails needed before replacing the first v1 production
   monitor host or splitting outbound delivery.
 - **Coverage and race-test expansion.** Core packages gained coverage for

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,7 +40,7 @@ preflight, deliverer hardening, and API CLI fixture workflow branches:
 - [x] Add `jetmon2 rollout cutover-check` to bundle the read-only post-start
   pinned preflight, activity, status, and projection-drift checks used after
   each host replacement.
-- [ ] Add JSON output to rollout checks for Systems automation gates.
+- [x] Add JSON output to rollout checks for Systems automation gates.
 - [ ] Create a one-page rollout quick reference that links to the full
   migration runbook.
 - [ ] Add a rollout state report that summarizes ownership mode, bucket
@@ -705,6 +705,9 @@ where to look, and what each item unlocked.
   and projection-drift report used after each v1 host replacement.
   Operators can run it immediately after start, then again with `--require-all`
   after one full expected check round.
+- **Rollout check JSON output.** Rollout gate commands accept `--output=json`
+  so Systems automation can parse a stable pass/fail envelope while retaining
+  the same non-zero exit behavior as text mode.
 - **Dynamic ownership preflight.** `./jetmon2 rollout dynamic-check` verifies
   that pinned ranges are removed, `jetmon_hosts` rows cover the full bucket
   range without gaps/overlaps, heartbeats are fresh, and projection drift is

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -29,6 +29,24 @@ preflight, deliverer hardening, and API CLI fixture workflow branches:
   full rehearsal and keep README, operations docs, migration docs, config
   samples, service units, and CLI output aligned.
 
+### Rollout Simplification TODO
+
+- [x] Add `jetmon2 rollout rehearsal-plan` so operators can generate the exact
+  same-server or fresh-server command sequence from a bucket CSV, host, bucket
+  range, and rollout mode.
+- [x] Add `make rollout-docs-verify` so docs/tooling drift checks, command help
+  checks, staged systemd validation, build, test, and lint can run as one
+  repeatable gate.
+- [ ] Add `jetmon2 rollout cutover-check` to bundle the read-only post-start
+  pinned preflight, activity, status, and projection-drift checks used after
+  each host replacement.
+- [ ] Add JSON output to rollout checks for Systems automation gates.
+- [ ] Create a one-page rollout quick reference that links to the full
+  migration runbook.
+- [ ] Add a rollout state report that summarizes ownership mode, bucket
+  coverage, drift, recent activity, delivery owner state, and suggested next
+  action.
+
 Recently completed candidate branches:
 
 - **`feature/rollout-preflight-hardening`** - merged rollout safety commands

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -41,7 +41,7 @@ preflight, deliverer hardening, and API CLI fixture workflow branches:
   pinned preflight, activity, status, and projection-drift checks used after
   each host replacement.
 - [x] Add JSON output to rollout checks for Systems automation gates.
-- [ ] Create a one-page rollout quick reference that links to the full
+- [x] Create a one-page rollout quick reference that links to the full
   migration runbook.
 - [ ] Add a rollout state report that summarizes ownership mode, bucket
   coverage, drift, recent activity, delivery owner state, and suggested next
@@ -708,6 +708,10 @@ where to look, and what each item unlocked.
 - **Rollout check JSON output.** Rollout gate commands accept `--output=json`
   so Systems automation can parse a stable pass/fail envelope while retaining
   the same non-zero exit behavior as text mode.
+- **Rollout quick reference.** `docs/rollout-quick-reference.md` gives
+  operators a one-page command checklist for rehearsal, per-host cutover,
+  rollback, fleet completion, and JSON automation while linking back to the
+  full migration runbook as source of truth.
 - **Dynamic ownership preflight.** `./jetmon2 rollout dynamic-check` verifies
   that pinned ranges are removed, `jetmon_hosts` rows cover the full bucket
   range without gaps/overlaps, heartbeats are fresh, and projection drift is

--- a/docs/rollout-quick-reference.md
+++ b/docs/rollout-quick-reference.md
@@ -109,3 +109,12 @@ Rollout gate commands support JSON output:
 
 Automation should gate on both the process exit code and the JSON `ok` field.
 The human runbook remains the source of truth for what to do when a gate fails.
+
+For a quick operator snapshot, run:
+
+```bash
+./jetmon2 rollout state-report --since=15m
+```
+
+This summarizes ownership mode, bucket coverage, activity freshness, projection
+drift, delivery-owner state, and the suggested next action.

--- a/docs/rollout-quick-reference.md
+++ b/docs/rollout-quick-reference.md
@@ -1,0 +1,111 @@
+# v1 to v2 Rollout Quick Reference
+
+This is the short operator checklist for a production v1-to-v2 monitor rollout.
+Use the full [migration runbook](v1-to-v2-migration.md) for preparation,
+approval, troubleshooting, revert details, and final v1 teardown.
+
+## Before The First Host
+
+1. Confirm the approved static bucket plan exists as a reusable CSV:
+
+   ```bash
+   ./jetmon2 rollout static-plan-check \
+     --file=<ranges.csv> \
+     --host=<v1-hostname> \
+     --bucket-min=<min> \
+     --bucket-max=<max>
+   ```
+
+2. Generate the exact host command sequence:
+
+   ```bash
+   ./jetmon2 rollout rehearsal-plan \
+     --file=<ranges.csv> \
+     --host=<v1-hostname> \
+     --bucket-min=<min> \
+     --bucket-max=<max> \
+     --mode=same-server
+   ```
+
+   Use `--mode=fresh-server --runtime-host=<new-v2-hostname>` for a fresh v2
+   server taking over from an existing v1 server.
+
+3. Validate config, migrations, and the staged systemd service:
+
+   ```bash
+   ./jetmon2 validate-config
+   ./jetmon2 migrate
+   systemd-analyze verify /etc/systemd/system/jetmon2.service
+   ```
+
+## Per-Host Cutover
+
+1. Confirm the v2 host is pinned to the v1 range and not participating in
+   dynamic bucket ownership:
+
+   ```bash
+   ./jetmon2 rollout pinned-check --host=<v2-hostname>
+   ```
+
+2. Stop the v1 monitor for that bucket range.
+3. Start v2:
+
+   ```bash
+   systemctl enable --now jetmon2
+   ```
+
+4. Immediately run:
+
+   ```bash
+   ./jetmon2 rollout cutover-check --host=<v2-hostname> --since=15m
+   ```
+
+5. After one full expected check round, run:
+
+   ```bash
+   ./jetmon2 rollout cutover-check --host=<v2-hostname> --since=15m --require-all
+   ```
+
+6. Watch logs, dashboard health, WPCOM notification parity, event rows, and
+   projection drift before moving to the next host.
+
+## Rollback Gate
+
+Before restarting v1 for a range, stop v2 and run:
+
+```bash
+./jetmon2 rollout rollback-check --host=<v2-hostname>
+```
+
+Only restart v1 after the v2 process is stopped and the rollback check passes.
+Do not roll back schema migrations.
+
+## Fleet Completion
+
+After every monitor host is stable on v2 pinned mode:
+
+```bash
+./jetmon2 rollout cutover-check --since=15m --require-all
+```
+
+Then remove `PINNED_BUCKET_MIN` / `PINNED_BUCKET_MAX` and legacy
+`BUCKET_NO_MIN` / `BUCKET_NO_MAX` aliases from every v2 monitor config,
+restart the fleet in the approved window, and run:
+
+```bash
+./jetmon2 validate-config
+./jetmon2 rollout dynamic-check
+./jetmon2 rollout activity-check --since=15m --require-all
+./jetmon2 rollout projection-drift --limit=100
+```
+
+## Automation
+
+Rollout gate commands support JSON output:
+
+```bash
+./jetmon2 rollout cutover-check --since=15m --require-all --output=json
+```
+
+Automation should gate on both the process exit code and the JSON `ok` field.
+The human runbook remains the source of truth for what to do when a gate fails.

--- a/docs/v1-to-v2-migration.md
+++ b/docs/v1-to-v2-migration.md
@@ -113,6 +113,21 @@ approved plan:
   --host=jetmon-v1-a --bucket-min=0 --bucket-max=99
 ```
 
+Generate the host-specific command sequence operators will rehearse and run:
+
+```bash
+./jetmon2 rollout rehearsal-plan \
+  --file rollout-buckets.csv \
+  --host=jetmon-v1-a \
+  --bucket-min=0 \
+  --bucket-max=99 \
+  --mode=same-server
+```
+
+For a fresh-server takeover where the v2 hostname differs from the v1 host in
+the static plan, add `--runtime-host=<new-v2-hostname>` and use
+`--mode=fresh-server`.
+
 ### Prepare Database And Rollback Safety
 
 1. Confirm a recent MySQL backup exists and restore has been tested according
@@ -137,6 +152,7 @@ make all
 make test
 make test-race
 make lint
+make rollout-docs-verify
 ```
 
 Stage these artifacts for each target host:

--- a/docs/v1-to-v2-migration.md
+++ b/docs/v1-to-v2-migration.md
@@ -136,12 +136,14 @@ Build and verify the release:
 make all
 make test
 make test-race
+make lint
 ```
 
 Stage these artifacts for each target host:
 
-- `jetmon2`
-- `veriflier2` when that host also owns a Veriflier deployment
+- `bin/jetmon2`, installed at the path expected by the service unit
+  (`/opt/jetmon2/jetmon2` for the sample unit)
+- `bin/veriflier2` when that host also owns a Veriflier deployment
 - `systemd/jetmon2.service`
 - `systemd/jetmon2-logrotate`
 - `config/config.json`
@@ -149,6 +151,22 @@ Stage these artifacts for each target host:
 
 Keep v2 files in `/opt/jetmon2` or another v2-specific directory. Do not
 overwrite the v1 install until rollback signoff.
+
+Do not start `bin/jetmon-deliverer` during the initial monitor replacement
+unless standalone delivery is part of the approved rollout plan. Use
+[`jetmon-deliverer-rollout.md`](jetmon-deliverer-rollout.md) for that separate
+process cutover.
+
+After the binary and service files are staged, verify the service definition
+from that staged host or deployment root:
+
+```bash
+systemd-analyze verify /etc/systemd/system/jetmon2.service
+```
+
+If this check is run directly against the repository copy before installing the
+binary to `/opt/jetmon2`, systemd can report missing `ExecStart` paths. Treat
+that as a packaging reminder and re-run the check after the final paths exist.
 
 ### Prepare Pinned v2 Config
 
@@ -234,6 +252,25 @@ export JETMON_API_TOKEN=jm_replace_with_the_printed_token
   --pretty
 ./bin/jetmon2 api sites cleanup --batch rollout-rehearsal --count 3 --output table
 ```
+
+When the Docker-local fixture and delivery workers are enabled, also exercise
+the webhook path:
+
+```bash
+./bin/jetmon2 api smoke --batch rollout-webhook --exercise webhook --pretty
+```
+
+For a fuller Docker-local pass against the feature-guide examples, failure
+fixture, webhook receiver, signature verification, and cleanup path, run:
+
+```bash
+make api-cli-validate
+```
+
+Set `API_VALIDATE_SKIP_WEBHOOK=1` when the environment does not have outbound
+delivery workers enabled. Any API CLI write against a non-local API URL must
+use `--allow-remote`, and remote smoke, bulk-add, cleanup, and failure
+simulation must also use `--batch`.
 
 ## Phase 1A: Replace v1 On The Existing Server
 

--- a/docs/v1-to-v2-migration.md
+++ b/docs/v1-to-v2-migration.md
@@ -3,6 +3,10 @@
 This is the source-of-truth runbook for the first production migration from
 Jetmon 1 to Jetmon 2.
 
+Use [rollout-quick-reference.md](rollout-quick-reference.md) as the condensed
+command checklist during rehearsals and rollout windows. If it conflicts with
+this runbook, this runbook wins.
+
 Use this document for:
 
 - preparing the fleet before any production change

--- a/docs/v1-to-v2-migration.md
+++ b/docs/v1-to-v2-migration.md
@@ -224,6 +224,7 @@ Confirm it reports:
 - `rollout_static_plan=./jetmon2 rollout static-plan-check --file=<ranges.csv>`
 - `rollout_preflight=./jetmon2 rollout pinned-check`
 - `rollout_activity_check=./jetmon2 rollout activity-check --since=15m`
+- `rollout_cutover_check=./jetmon2 rollout cutover-check --since=15m`
 - `rollout_rollback_check=./jetmon2 rollout rollback-check`
 - `rollout_drift_report=./jetmon2 rollout projection-drift`
 
@@ -315,18 +316,18 @@ same bucket range.
 10. Run:
 
     ```bash
-    ./jetmon2 rollout pinned-check
-    ./jetmon2 rollout activity-check --since=15m
-    ./jetmon2 status
+    ./jetmon2 rollout cutover-check --since=15m
     ```
 
-    `activity-check` proves the range has fresh `last_checked_at` writes, not
-    which process wrote them. Keep v1 stopped and use logs or the dashboard to
-    confirm v2 is checking only the pinned range.
+    `cutover-check` runs the pinned preflight, recent activity check,
+    dashboard status check, and projection-drift report. Its activity section
+    proves the range has fresh `last_checked_at` writes, not which process
+    wrote them. Keep v1 stopped and use logs or the dashboard to confirm v2 is
+    checking only the pinned range.
 11. After one full expected round, run:
 
     ```bash
-    ./jetmon2 rollout activity-check --since=15m --require-all
+    ./jetmon2 rollout cutover-check --since=15m --require-all
     ```
 
 12. Watch one full check round before moving to the next host.
@@ -353,11 +354,9 @@ v1 server.
    systemctl enable --now jetmon2
    ```
 
-10. Run `./jetmon2 rollout pinned-check`,
-    `./jetmon2 rollout activity-check --since=15m`, and `./jetmon2 status` on
-    the new server.
+10. Run `./jetmon2 rollout cutover-check --since=15m` on the new server.
 11. After one full expected round, run
-    `./jetmon2 rollout activity-check --since=15m --require-all`.
+    `./jetmon2 rollout cutover-check --since=15m --require-all`.
 12. Watch one full check round before moving to the next host.
 
 Do not leave the old v1 server running as a warm standby for the same range. A
@@ -394,6 +393,14 @@ For every replaced range, verify:
 
   ```bash
   ./jetmon2 rollout activity-check --since=15m --require-all
+  ```
+
+  The bundled cutover check runs the pinned preflight, activity check,
+  dashboard status check, and projection-drift report together:
+
+  ```bash
+  ./jetmon2 rollout cutover-check --since=15m
+  ./jetmon2 rollout cutover-check --since=15m --require-all
   ```
 
 If `DASHBOARD_PORT` is enabled, confirm:
@@ -479,9 +486,7 @@ After every monitor host is on v2 and stable in pinned mode:
 2. Confirm every v2 host passes:
 
    ```bash
-   ./jetmon2 rollout pinned-check
-   ./jetmon2 rollout activity-check --since=15m --require-all
-   ./jetmon2 rollout projection-drift --limit=100
+   ./jetmon2 rollout cutover-check --since=15m --require-all
    ```
 
 3. Observe the fleet for the agreed stabilization window.
@@ -533,7 +538,7 @@ Only remove v1 after rollout signoff.
 - [ ] pinned configs prepared for every range
 - [ ] rollback commands documented for every host
 - [ ] first host cutover observed for one full round
-- [ ] `rollout activity-check --require-all` passes for replaced ranges
+- [ ] `rollout cutover-check --require-all` passes for replaced ranges
 - [ ] `rollout rollback-check` exercised during rehearsal
 - [ ] all hosts running v2 pinned
 - [ ] dynamic ownership cutover completed

--- a/docs/v1-to-v2-pinned-rollout.md
+++ b/docs/v1-to-v2-pinned-rollout.md
@@ -17,6 +17,8 @@ Pinned mode still means:
   and delivery-owner plan has been approved
 - run `./jetmon2 validate-config`
 - run `./jetmon2 rollout pinned-check`
+- after v2 starts, run `./jetmon2 rollout cutover-check --since=15m`, then
+  rerun it with `--require-all` after one full expected check round
 
 The old detailed checklist was consolidated into
 [v1-to-v2-migration.md](v1-to-v2-migration.md) so migration guidance does not

--- a/scripts/rollout-docs-verify.sh
+++ b/scripts/rollout-docs-verify.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+jetmon_binary="${ROLLOUT_DOCS_JETMON2:-./bin/jetmon2}"
+deliverer_binary="${ROLLOUT_DOCS_DELIVERER:-./bin/jetmon-deliverer}"
+
+step() {
+	printf '\n== %s ==\n' "$1"
+}
+
+fail() {
+	printf 'FAIL %s\n' "$1" >&2
+	exit 1
+}
+
+run_help_check() {
+	local output status
+	set +e
+	output="$("$@" 2>&1)"
+	status=$?
+	set -e
+	printf '%s\n' "$output"
+	if [[ "$status" -ne 0 && "$status" -ne 2 ]]; then
+		fail "help command failed with status $status: $*"
+	fi
+	if ! grep -qi 'usage' <<<"$output"; then
+		fail "help output did not contain usage: $*"
+	fi
+}
+
+step "stale rollout docs scan"
+stale_pattern='Status: active on|after the API CLI work|rollout preflight hardening settle|Planned Simulated|simulated site server remains a planned|systemd-analyze verify systemd/|API.md|ROADMAP.md|PROJECT.md|TAXONOMY.md|EVENTS.md'
+if rg -n "$stale_pattern" README.md AGENTS.md docs config systemd; then
+	fail "stale documentation references found"
+fi
+
+step "diff whitespace"
+git diff --check
+
+step "rollout command help"
+run_help_check "$jetmon_binary" rollout rehearsal-plan --help
+run_help_check "$jetmon_binary" rollout static-plan-check --help
+run_help_check "$jetmon_binary" rollout pinned-check --help
+run_help_check "$jetmon_binary" rollout rollback-check --help
+run_help_check "$jetmon_binary" rollout dynamic-check --help
+run_help_check "$jetmon_binary" rollout activity-check --help
+run_help_check "$jetmon_binary" rollout projection-drift --help
+
+step "deliverer command help"
+run_help_check "$deliverer_binary" validate-config --help
+run_help_check "$deliverer_binary" delivery-check --help
+
+step "rehearsal-plan smoke"
+plan_file="${ROLLOUT_DOCS_PLAN_FILE:-/tmp/jetmon-rollout-docs-verify-buckets.csv}"
+printf '%s\n' \
+	'host,bucket_min,bucket_max' \
+	'jetmon-v1-a,0,4' \
+	'jetmon-v1-b,5,9' \
+	>"$plan_file"
+plan_output="$("$jetmon_binary" rollout rehearsal-plan \
+	--file "$plan_file" \
+	--bucket-total 10 \
+	--host jetmon-v1-a \
+	--bucket-min 0 \
+	--bucket-max 4 \
+	--mode same-server)"
+printf '%s\n' "$plan_output"
+grep -q 'rollout static-plan-check' <<<"$plan_output" || fail "rehearsal plan omitted static-plan-check"
+grep -q 'rollout pinned-check' <<<"$plan_output" || fail "rehearsal plan omitted pinned-check"
+grep -q 'rollout rollback-check' <<<"$plan_output" || fail "rehearsal plan omitted rollback-check"
+grep -q 'rollout dynamic-check' <<<"$plan_output" || fail "rehearsal plan omitted dynamic-check"
+
+step "staged systemd verify"
+if ! command -v systemd-analyze >/dev/null 2>&1; then
+	printf 'WARN systemd-analyze not found; skipping service-unit verification\n'
+	exit 0
+fi
+
+staged_root="${ROLLOUT_DOCS_SYSTEMD_ROOT:-/tmp/jetmon-rollout-docs-verify-root}"
+mkdir -p \
+	"$staged_root/opt/jetmon2/bin" \
+	"$staged_root/etc/systemd/system" \
+	"$staged_root/bin" \
+	"$staged_root/usr/lib/systemd/system"
+cp "$jetmon_binary" "$staged_root/opt/jetmon2/jetmon2"
+cp "$deliverer_binary" "$staged_root/opt/jetmon2/bin/jetmon-deliverer"
+cp systemd/jetmon2.service "$staged_root/etc/systemd/system/jetmon2.service"
+cp systemd/jetmon-deliverer.service "$staged_root/etc/systemd/system/jetmon-deliverer.service"
+
+if [[ -x /bin/kill ]]; then
+	cp /bin/kill "$staged_root/bin/kill"
+else
+	printf 'WARN /bin/kill not found; skipping service-unit verification\n'
+	exit 0
+fi
+
+if [[ -f /usr/lib/systemd/system/sysinit.target ]]; then
+	cp /usr/lib/systemd/system/sysinit.target "$staged_root/usr/lib/systemd/system/sysinit.target"
+elif [[ -f /lib/systemd/system/sysinit.target ]]; then
+	cp /lib/systemd/system/sysinit.target "$staged_root/usr/lib/systemd/system/sysinit.target"
+else
+	printf 'WARN sysinit.target not found; skipping service-unit verification\n'
+	exit 0
+fi
+
+set +e
+systemd_output="$(systemd-analyze --root="$staged_root" verify /etc/systemd/system/jetmon2.service /etc/systemd/system/jetmon-deliverer.service 2>&1)"
+systemd_status=$?
+set -e
+printf '%s\n' "$systemd_output"
+if [[ "$systemd_status" -ne 0 ]]; then
+	if grep -qiE 'SO_PASSCRED|Operation not permitted' <<<"$systemd_output"; then
+		printf 'WARN systemd-analyze was blocked by the local sandbox; rerun on an unrestricted host for service-unit verification\n'
+	else
+		exit "$systemd_status"
+	fi
+fi
+
+printf '\nrollout docs verification passed\n'

--- a/scripts/rollout-docs-verify.sh
+++ b/scripts/rollout-docs-verify.sh
@@ -44,6 +44,7 @@ step "rollout command help"
 run_help_check "$jetmon_binary" rollout rehearsal-plan --help
 run_help_check "$jetmon_binary" rollout static-plan-check --help
 run_help_check "$jetmon_binary" rollout pinned-check --help
+run_help_check "$jetmon_binary" rollout cutover-check --help
 run_help_check "$jetmon_binary" rollout rollback-check --help
 run_help_check "$jetmon_binary" rollout dynamic-check --help
 run_help_check "$jetmon_binary" rollout activity-check --help
@@ -70,6 +71,7 @@ plan_output="$("$jetmon_binary" rollout rehearsal-plan \
 printf '%s\n' "$plan_output"
 grep -q 'rollout static-plan-check' <<<"$plan_output" || fail "rehearsal plan omitted static-plan-check"
 grep -q 'rollout pinned-check' <<<"$plan_output" || fail "rehearsal plan omitted pinned-check"
+grep -q 'rollout cutover-check' <<<"$plan_output" || fail "rehearsal plan omitted cutover-check"
 grep -q 'rollout rollback-check' <<<"$plan_output" || fail "rehearsal plan omitted rollback-check"
 grep -q 'rollout dynamic-check' <<<"$plan_output" || fail "rehearsal plan omitted dynamic-check"
 

--- a/scripts/rollout-docs-verify.sh
+++ b/scripts/rollout-docs-verify.sh
@@ -75,6 +75,15 @@ grep -q 'rollout cutover-check' <<<"$plan_output" || fail "rehearsal plan omitte
 grep -q 'rollout rollback-check' <<<"$plan_output" || fail "rehearsal plan omitted rollback-check"
 grep -q 'rollout dynamic-check' <<<"$plan_output" || fail "rehearsal plan omitted dynamic-check"
 
+step "rollout json smoke"
+json_output="$("$jetmon_binary" rollout static-plan-check \
+	--file "$plan_file" \
+	--bucket-total 10 \
+	--output=json)"
+printf '%s\n' "$json_output"
+grep -q '"ok": true' <<<"$json_output" || fail "static-plan-check JSON did not report ok=true"
+grep -q '"command": "rollout static-plan-check"' <<<"$json_output" || fail "static-plan-check JSON omitted command name"
+
 step "staged systemd verify"
 if ! command -v systemd-analyze >/dev/null 2>&1; then
 	printf 'WARN systemd-analyze not found; skipping service-unit verification\n'

--- a/scripts/rollout-docs-verify.sh
+++ b/scripts/rollout-docs-verify.sh
@@ -49,6 +49,7 @@ run_help_check "$jetmon_binary" rollout rollback-check --help
 run_help_check "$jetmon_binary" rollout dynamic-check --help
 run_help_check "$jetmon_binary" rollout activity-check --help
 run_help_check "$jetmon_binary" rollout projection-drift --help
+run_help_check "$jetmon_binary" rollout state-report --help
 
 step "deliverer command help"
 run_help_check "$deliverer_binary" validate-config --help


### PR DESCRIPTION
## Summary

This PR tightens the v1-to-v2 rollout workflow so Systems has fewer manual
steps, clearer hold points, and better automation hooks during production host
replacement.

It adds a focused rollout rehearsal and verification layer around the existing
migration runbook:

- `jetmon2 rollout rehearsal-plan` prints an ordered same-server or fresh-server
  command sequence from a bucket CSV, host, range, and rollout mode.
- `make rollout-docs-verify` builds the binaries, runs tests/vet, checks
  rollout help output, validates stale doc references, smokes rehearsal-plan
  output, validates JSON output, and verifies staged systemd units.
- `jetmon2 rollout cutover-check` bundles the post-start pinned preflight,
  recent activity check, dashboard status probe, and projection-drift report.
- rollout gate commands now accept `--output=json` for Systems automation while
  preserving non-zero exit behavior on failures.
- `docs/rollout-quick-reference.md` provides a one-page operator checklist
  linked back to the full migration runbook.
- `jetmon2 rollout state-report` summarizes ownership mode, bucket coverage,
  recent activity, projection drift, delivery-owner state, and suggested next
  action for handoffs.

## Why

The migration runbook is detailed, but the riskiest rollout moments are still
operational: stopping v1, starting v2, proving the right range is active,
confirming drift is clean, and deciding whether to move forward or pause. This
PR turns those checks into repeatable commands and keeps the docs/tooling
aligned so operators do not have to stitch together several manual commands
under pressure.

## Highlighted examples

Generate a per-host command sequence:

```bash
./jetmon2 rollout rehearsal-plan \
  --file=<ranges.csv> \
  --host=<v1-hostname> \
  --bucket-min=<min> \
  --bucket-max=<max> \
  --mode=same-server
```

Run the bundled post-start gate:

```bash
./jetmon2 rollout cutover-check --host=<v2-hostname> --since=15m
./jetmon2 rollout cutover-check --host=<v2-hostname> --since=15m --require-all
```

Use JSON output for automation:

```bash
./jetmon2 rollout cutover-check --since=15m --require-all --output=json
```

Get an operator handoff snapshot:

```bash
./jetmon2 rollout state-report --since=15m
```

Run the rollout docs/tooling verification gate:

```bash
make rollout-docs-verify
```

## Validation

- `/usr/local/go/bin/go test ./cmd/jetmon2`
- `make rollout-docs-verify`
- `make test-race`
