### PR TITLE
Add rollout VM lab coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ BUILD_FLAGS := -ldflags "-X main.version=$(shell git describe --tags --always --
                          -X main.buildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ) \
                          -X main.goVersion=$(shell $(GO) version | awk '{print $$3}')"
 
-.PHONY: all build build-deliverer build-veriflier generate test test-race lint rollout-docs-verify rollout-vm-lab-sync rollout-vm-lab-sync-artifacts rollout-vm-lab-doctor rollout-vm-lab-prepare rollout-vm-lab-smoke rollout-vm-lab-execute-smoke rollout-vm-lab-failure-smoke rollout-vm-lab-resume-smoke rollout-vm-lab-post-start-rollback-smoke rollout-vm-lab-bad-ssh-smoke rollout-vm-lab-snapshot-execute-smoke api-cli-smoke api-cli-validate api-cli-token-create api-cli-token-list api-cli-token-revoke clean
+.PHONY: all build build-deliverer build-veriflier generate test test-race lint rollout-docs-verify rollout-vm-lab-sync rollout-vm-lab-sync-artifacts rollout-vm-lab-doctor rollout-vm-lab-prepare rollout-vm-lab-smoke rollout-vm-lab-execute-smoke rollout-vm-lab-failure-smoke rollout-vm-lab-resume-smoke rollout-vm-lab-post-start-rollback-smoke rollout-vm-lab-bad-ssh-smoke rollout-vm-lab-v2-start-failure-smoke rollout-vm-lab-runtime-guard-smoke rollout-vm-lab-real-activity-smoke rollout-vm-lab-snapshot-execute-smoke rollout-vm-lab-snapshot-all-smoke api-cli-smoke api-cli-validate api-cli-token-create api-cli-token-list api-cli-token-revoke clean
 
 all: build build-deliverer build-veriflier
 
@@ -97,8 +97,20 @@ rollout-vm-lab-post-start-rollback-smoke: rollout-vm-lab-sync-artifacts
 rollout-vm-lab-bad-ssh-smoke: rollout-vm-lab-sync-artifacts
 	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh smoke-bad-ssh'
 
+rollout-vm-lab-v2-start-failure-smoke: rollout-vm-lab-sync-artifacts
+	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh smoke-v2-start-failure'
+
+rollout-vm-lab-runtime-guard-smoke: rollout-vm-lab-sync-artifacts
+	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh smoke-runtime-guards'
+
+rollout-vm-lab-real-activity-smoke: rollout-vm-lab-sync-artifacts
+	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh smoke-real-activity'
+
 rollout-vm-lab-snapshot-execute-smoke: rollout-vm-lab-sync-artifacts
 	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh snapshot-run $(ROLLOUT_VM_LAB_SNAPSHOT) execute-rollback'
+
+rollout-vm-lab-snapshot-all-smoke: rollout-vm-lab-sync-artifacts
+	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh snapshot-run-all $(ROLLOUT_VM_LAB_SNAPSHOT)'
 
 api-cli-smoke: build
 	@test -n "$$JETMON_API_TOKEN" || { echo "JETMON_API_TOKEN is required"; exit 1; }

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ API_CLI_TOKEN_TTL ?= 0
 API_CLI_TOKEN_ID ?=
 ROLLOUT_VM_LAB_HOST ?= jetmon-deploy-test
 ROLLOUT_VM_LAB_SSH ?= ssh -F $(HOME)/.ssh/config -o ControlMaster=no -o ControlPath=none -o BatchMode=yes -o ConnectTimeout=10
+ROLLOUT_VM_LAB_SNAPSHOT ?= pre-guided-flow
 GO          ?= $(shell if command -v go >/dev/null 2>&1; then command -v go; elif [ -x /usr/local/go/bin/go ]; then printf /usr/local/go/bin/go; else printf go; fi)
 GOCACHE     ?= /tmp/jetmon-go-cache
 GOMODCACHE  ?= /tmp/jetmon-gomod-cache
@@ -26,7 +27,7 @@ BUILD_FLAGS := -ldflags "-X main.version=$(shell git describe --tags --always --
                          -X main.buildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ) \
                          -X main.goVersion=$(shell $(GO) version | awk '{print $$3}')"
 
-.PHONY: all build build-deliverer build-veriflier generate test test-race lint rollout-docs-verify rollout-vm-lab-sync rollout-vm-lab-sync-artifacts rollout-vm-lab-doctor rollout-vm-lab-prepare rollout-vm-lab-smoke rollout-vm-lab-execute-smoke rollout-vm-lab-failure-smoke api-cli-smoke api-cli-validate api-cli-token-create api-cli-token-list api-cli-token-revoke clean
+.PHONY: all build build-deliverer build-veriflier generate test test-race lint rollout-docs-verify rollout-vm-lab-sync rollout-vm-lab-sync-artifacts rollout-vm-lab-doctor rollout-vm-lab-prepare rollout-vm-lab-smoke rollout-vm-lab-execute-smoke rollout-vm-lab-failure-smoke rollout-vm-lab-resume-smoke rollout-vm-lab-post-start-rollback-smoke rollout-vm-lab-bad-ssh-smoke rollout-vm-lab-snapshot-execute-smoke api-cli-smoke api-cli-validate api-cli-token-create api-cli-token-list api-cli-token-revoke clean
 
 all: build build-deliverer build-veriflier
 
@@ -86,6 +87,18 @@ rollout-vm-lab-execute-smoke: rollout-vm-lab-sync-artifacts
 
 rollout-vm-lab-failure-smoke: rollout-vm-lab-sync-artifacts
 	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh smoke-failure-gates'
+
+rollout-vm-lab-resume-smoke: rollout-vm-lab-sync-artifacts
+	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh smoke-interrupted-resume'
+
+rollout-vm-lab-post-start-rollback-smoke: rollout-vm-lab-sync-artifacts
+	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh smoke-post-start-rollback'
+
+rollout-vm-lab-bad-ssh-smoke: rollout-vm-lab-sync-artifacts
+	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh smoke-bad-ssh'
+
+rollout-vm-lab-snapshot-execute-smoke: rollout-vm-lab-sync-artifacts
+	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh snapshot-run $(ROLLOUT_VM_LAB_SNAPSHOT) execute-rollback'
 
 api-cli-smoke: build
 	@test -n "$$JETMON_API_TOKEN" || { echo "JETMON_API_TOKEN is required"; exit 1; }

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ API_CLI_TOKEN_SCOPE ?= admin
 API_CLI_TOKEN_CREATED_BY ?= docker-local
 API_CLI_TOKEN_TTL ?= 0
 API_CLI_TOKEN_ID ?=
+ROLLOUT_VM_LAB_HOST ?= jetmon-deploy-test
+ROLLOUT_VM_LAB_SSH ?= ssh -F $(HOME)/.ssh/config -o ControlMaster=no -o ControlPath=none -o BatchMode=yes -o ConnectTimeout=10
 GO          ?= $(shell if command -v go >/dev/null 2>&1; then command -v go; elif [ -x /usr/local/go/bin/go ]; then printf /usr/local/go/bin/go; else printf go; fi)
 GOCACHE     ?= /tmp/jetmon-go-cache
 GOMODCACHE  ?= /tmp/jetmon-gomod-cache
@@ -24,7 +26,7 @@ BUILD_FLAGS := -ldflags "-X main.version=$(shell git describe --tags --always --
                          -X main.buildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ) \
                          -X main.goVersion=$(shell $(GO) version | awk '{print $$3}')"
 
-.PHONY: all build build-deliverer build-veriflier generate test test-race lint rollout-docs-verify api-cli-smoke api-cli-validate api-cli-token-create api-cli-token-list api-cli-token-revoke clean
+.PHONY: all build build-deliverer build-veriflier generate test test-race lint rollout-docs-verify rollout-vm-lab-sync rollout-vm-lab-sync-artifacts rollout-vm-lab-doctor rollout-vm-lab-prepare rollout-vm-lab-smoke rollout-vm-lab-execute-smoke rollout-vm-lab-failure-smoke api-cli-smoke api-cli-validate api-cli-token-create api-cli-token-list api-cli-token-revoke clean
 
 all: build build-deliverer build-veriflier
 
@@ -57,6 +59,33 @@ lint:
 
 rollout-docs-verify: all test lint
 	scripts/rollout-docs-verify.sh
+
+rollout-vm-lab-sync:
+	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'mkdir -p ~/jetmon-rollout-tools/scripts ~/jetmon-rollout-tools/docs'
+	rsync -e "$(ROLLOUT_VM_LAB_SSH)" -a scripts/rollout-vm-lab.sh $(ROLLOUT_VM_LAB_HOST):~/jetmon-rollout-tools/scripts/
+	rsync -e "$(ROLLOUT_VM_LAB_SSH)" -a docs/rollout-vm-lab.md $(ROLLOUT_VM_LAB_HOST):~/jetmon-rollout-tools/docs/
+
+rollout-vm-lab-sync-artifacts: build rollout-vm-lab-sync
+	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'mkdir -p ~/jetmon-rollout-tools/bin ~/jetmon-rollout-tools/systemd ~/jetmon-rollout-tools/config'
+	rsync -e "$(ROLLOUT_VM_LAB_SSH)" -a bin/jetmon2 $(ROLLOUT_VM_LAB_HOST):~/jetmon-rollout-tools/bin/
+	rsync -e "$(ROLLOUT_VM_LAB_SSH)" -a systemd/jetmon2.service systemd/jetmon2-logrotate $(ROLLOUT_VM_LAB_HOST):~/jetmon-rollout-tools/systemd/
+	rsync -e "$(ROLLOUT_VM_LAB_SSH)" -a config/config-sample.json config/db-config-sample.conf $(ROLLOUT_VM_LAB_HOST):~/jetmon-rollout-tools/config/
+
+rollout-vm-lab-doctor: rollout-vm-lab-sync
+	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh doctor'
+
+rollout-vm-lab-prepare: rollout-vm-lab-sync-artifacts
+	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh prepare-topology'
+
+rollout-vm-lab-smoke: rollout-vm-lab-sync-artifacts
+	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh smoke-preflight'
+	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh smoke-guided-dry-run'
+
+rollout-vm-lab-execute-smoke: rollout-vm-lab-sync-artifacts
+	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh smoke-guided-execute-rollback'
+
+rollout-vm-lab-failure-smoke: rollout-vm-lab-sync-artifacts
+	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh smoke-failure-gates'
 
 api-cli-smoke: build
 	@test -n "$$JETMON_API_TOKEN" || { echo "JETMON_API_TOKEN is required"; exit 1; }

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ BUILD_FLAGS := -ldflags "-X main.version=$(shell git describe --tags --always --
                          -X main.buildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ) \
                          -X main.goVersion=$(shell $(GO) version | awk '{print $$3}')"
 
-.PHONY: all build build-deliverer build-veriflier generate test test-race lint rollout-docs-verify rollout-vm-lab-sync rollout-vm-lab-sync-artifacts rollout-vm-lab-doctor rollout-vm-lab-prepare rollout-vm-lab-smoke rollout-vm-lab-execute-smoke rollout-vm-lab-failure-smoke rollout-vm-lab-resume-smoke rollout-vm-lab-post-start-rollback-smoke rollout-vm-lab-bad-ssh-smoke rollout-vm-lab-v2-start-failure-smoke rollout-vm-lab-runtime-guard-smoke rollout-vm-lab-real-activity-smoke rollout-vm-lab-snapshot-execute-smoke rollout-vm-lab-snapshot-all-smoke api-cli-smoke api-cli-validate api-cli-token-create api-cli-token-list api-cli-token-revoke clean
+.PHONY: all build build-deliverer build-veriflier generate test test-race lint rollout-docs-verify rollout-vm-lab-sync rollout-vm-lab-sync-artifacts rollout-vm-lab-stage-v2 rollout-vm-lab-doctor rollout-vm-lab-prepare rollout-vm-lab-smoke rollout-vm-lab-execute-smoke rollout-vm-lab-failure-smoke rollout-vm-lab-resume-smoke rollout-vm-lab-post-start-rollback-smoke rollout-vm-lab-bad-ssh-smoke rollout-vm-lab-v2-start-failure-smoke rollout-vm-lab-runtime-guard-smoke rollout-vm-lab-real-activity-smoke rollout-vm-lab-snapshot-execute-smoke rollout-vm-lab-snapshot-all-smoke api-cli-smoke api-cli-validate api-cli-token-create api-cli-token-list api-cli-token-revoke clean
 
 all: build build-deliverer build-veriflier
 
@@ -72,44 +72,47 @@ rollout-vm-lab-sync-artifacts: build rollout-vm-lab-sync
 	rsync -e "$(ROLLOUT_VM_LAB_SSH)" -a systemd/jetmon2.service systemd/jetmon2-logrotate $(ROLLOUT_VM_LAB_HOST):~/jetmon-rollout-tools/systemd/
 	rsync -e "$(ROLLOUT_VM_LAB_SSH)" -a config/config-sample.json config/db-config-sample.conf $(ROLLOUT_VM_LAB_HOST):~/jetmon-rollout-tools/config/
 
+rollout-vm-lab-stage-v2: rollout-vm-lab-sync-artifacts
+	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh install-v2'
+
 rollout-vm-lab-doctor: rollout-vm-lab-sync
 	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh doctor'
 
 rollout-vm-lab-prepare: rollout-vm-lab-sync-artifacts
 	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh prepare-topology'
 
-rollout-vm-lab-smoke: rollout-vm-lab-sync-artifacts
+rollout-vm-lab-smoke: rollout-vm-lab-stage-v2
 	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh smoke-preflight'
 	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh smoke-guided-dry-run'
 
-rollout-vm-lab-execute-smoke: rollout-vm-lab-sync-artifacts
+rollout-vm-lab-execute-smoke: rollout-vm-lab-stage-v2
 	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh smoke-guided-execute-rollback'
 
-rollout-vm-lab-failure-smoke: rollout-vm-lab-sync-artifacts
+rollout-vm-lab-failure-smoke: rollout-vm-lab-stage-v2
 	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh smoke-failure-gates'
 
-rollout-vm-lab-resume-smoke: rollout-vm-lab-sync-artifacts
+rollout-vm-lab-resume-smoke: rollout-vm-lab-stage-v2
 	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh smoke-interrupted-resume'
 
-rollout-vm-lab-post-start-rollback-smoke: rollout-vm-lab-sync-artifacts
+rollout-vm-lab-post-start-rollback-smoke: rollout-vm-lab-stage-v2
 	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh smoke-post-start-rollback'
 
-rollout-vm-lab-bad-ssh-smoke: rollout-vm-lab-sync-artifacts
+rollout-vm-lab-bad-ssh-smoke: rollout-vm-lab-stage-v2
 	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh smoke-bad-ssh'
 
-rollout-vm-lab-v2-start-failure-smoke: rollout-vm-lab-sync-artifacts
+rollout-vm-lab-v2-start-failure-smoke: rollout-vm-lab-stage-v2
 	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh smoke-v2-start-failure'
 
-rollout-vm-lab-runtime-guard-smoke: rollout-vm-lab-sync-artifacts
+rollout-vm-lab-runtime-guard-smoke: rollout-vm-lab-stage-v2
 	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh smoke-runtime-guards'
 
-rollout-vm-lab-real-activity-smoke: rollout-vm-lab-sync-artifacts
+rollout-vm-lab-real-activity-smoke: rollout-vm-lab-stage-v2
 	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh smoke-real-activity'
 
-rollout-vm-lab-snapshot-execute-smoke: rollout-vm-lab-sync-artifacts
+rollout-vm-lab-snapshot-execute-smoke: rollout-vm-lab-stage-v2
 	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh snapshot-run $(ROLLOUT_VM_LAB_SNAPSHOT) execute-rollback'
 
-rollout-vm-lab-snapshot-all-smoke: rollout-vm-lab-sync-artifacts
+rollout-vm-lab-snapshot-all-smoke: rollout-vm-lab-stage-v2
 	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'cd ~/jetmon-rollout-tools && scripts/rollout-vm-lab.sh snapshot-run-all $(ROLLOUT_VM_LAB_SNAPSHOT)'
 
 api-cli-smoke: build

--- a/cmd/jetmon2/rollout.go
+++ b/cmd/jetmon2/rollout.go
@@ -1569,9 +1569,9 @@ func (s *guidedRolloutSession) dryRunCommandForStep(stepID string) string {
 	case "stop-v1":
 		return s.opts.V1StopCmd
 	case "start-v2":
-		return "systemctl enable --now " + shellQuote(s.opts.Service)
+		return startSystemdServiceCommand(s.opts.Service)
 	case "rollback-stop-v2":
-		return "systemctl stop " + shellQuote(s.opts.Service)
+		return stopSystemdServiceCommand(s.opts.Service)
 	case "rollback-start-v1":
 		return s.opts.V1StartCmd
 	default:
@@ -1667,7 +1667,7 @@ func forwardGuidedSteps() []guidedStep {
 				if err := s.runOperatorCommand(
 					ctx,
 					"Start v2",
-					"systemctl enable --now "+shellQuote(s.opts.Service),
+					startSystemdServiceCommand(s.opts.Service),
 					"Starting v2 begins production checks for this range.",
 					phrase,
 					"Type DONE after v2 is started and logs show the pinned range.",
@@ -1712,7 +1712,7 @@ func rollbackGuidedSteps() []guidedStep {
 				if err := s.runOperatorCommand(
 					ctx,
 					"Stop v2",
-					"systemctl stop "+shellQuote(s.opts.Service),
+					stopSystemdServiceCommand(s.opts.Service),
 					"Stopping v2 is required before v1 can be restarted.",
 					phrase,
 					"Type DONE after v2 is stopped and you have confirmed the process is no longer running.",
@@ -2078,13 +2078,13 @@ func runRolloutRehearsalPlan(out io.Writer, input io.Reader, opts rolloutRehears
 			"# HOLD: keep v2 stopped on the fresh server until the old v1 monitor process is stopped.",
 			v1StopLine,
 			"# HOLD: confirm v1 on "+shellQuote(hostID)+" is stopped before starting v2 on "+shellQuote(runtimeHost)+".",
-			"systemctl enable --now "+shellQuote(service),
+			startSystemdServiceCommand(service),
 		)
 	} else {
 		writeRolloutPlanSection(out, "4. Cut over the same server from v1 to v2",
 			v1StopLine,
 			"# HOLD: confirm v1 is stopped before starting v2.",
-			"systemctl enable --now "+shellQuote(service),
+			startSystemdServiceCommand(service),
 		)
 	}
 
@@ -2102,7 +2102,7 @@ func runRolloutRehearsalPlan(out io.Writer, input io.Reader, opts rolloutRehears
 	}
 	v1StartLine := rolloutOperatorCommandOrComment(opts.V1StartCmd, strings.TrimPrefix(rollbackComment, "# "))
 	writeRolloutPlanSection(out, "6. Rehearse the rollback path before the rollback window closes",
-		"systemctl stop "+shellQuote(service),
+		stopSystemdServiceCommand(service),
 		"# HOLD: confirm the v2 process is stopped before restarting v1.",
 		rolloutCommand(append([]string{binary, "rollout", "rollback-check", "--host", runtimeHost}, rangeArgs...)...),
 		"# HOLD: do not restart v1 unless rollback-check passes.",
@@ -2502,6 +2502,16 @@ func rolloutCommand(parts ...string) string {
 		quoted = append(quoted, shellQuote(part))
 	}
 	return strings.Join(quoted, " ")
+}
+
+func startSystemdServiceCommand(service string) string {
+	quotedService := shellQuote(service)
+	return "systemctl enable --now " + quotedService + " && systemctl is-active --quiet " + quotedService
+}
+
+func stopSystemdServiceCommand(service string) string {
+	quotedService := shellQuote(service)
+	return "systemctl stop " + quotedService + " && ! systemctl is-active --quiet " + quotedService
 }
 
 func shellQuote(value string) string {

--- a/cmd/jetmon2/rollout_test.go
+++ b/cmd/jetmon2/rollout_test.go
@@ -372,7 +372,7 @@ jetmon-v1-b,5,9
 		"./jetmon2 rollout host-preflight --file rollout-buckets.csv --host jetmon-v1-a --runtime-host jetmon-v1-a --bucket-min 0 --bucket-max 4 --bucket-total 10 --service jetmon2",
 		"systemctl stop jetmon",
 		"# HOLD: confirm v1 is stopped before starting v2.",
-		"systemctl enable --now jetmon2",
+		"systemctl enable --now jetmon2 && systemctl is-active --quiet jetmon2",
 		"# Immediate smoke gate: checks startup and recent activity; recent writes can still include v1.",
 		"./jetmon2 rollout cutover-check --host jetmon-v1-a --bucket-min 0 --bucket-max 4 --since 15m",
 		"# Strong gate after one full v2 check round:",
@@ -756,7 +756,7 @@ func TestRunGuidedRolloutRollbackDryRunOnlyShowsRollbackPath(t *testing.T) {
 	}
 	for _, want := range []string{
 		"INFO selected_path=rollback",
-		`PLAN path=ROLLBACK step=rollback-stop-v2 command="systemctl stop jetmon2"`,
+		`PLAN path=ROLLBACK step=rollback-stop-v2 command="systemctl stop jetmon2 && ! systemctl is-active --quiet jetmon2"`,
 		`PLAN path=ROLLBACK step=rollback-start-v1 typed_confirmation="START V1 jetmon-v1-a 0-4"`,
 	} {
 		if !strings.Contains(out.String(), want) {
@@ -785,7 +785,7 @@ func TestRunGuidedRolloutDryRunExecuteModeDoesNotRunCommands(t *testing.T) {
 	for _, want := range []string{
 		"INFO operator_command_mode=execute-after-confirmation",
 		`PLAN path=FORWARD step=stop-v1 command="systemctl stop jetmon"`,
-		`PLAN path=FORWARD step=start-v2 command="systemctl enable --now jetmon2"`,
+		`PLAN path=FORWARD step=start-v2 command="systemctl enable --now jetmon2 && systemctl is-active --quiet jetmon2"`,
 	} {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("output missing %q:\n%s", want, out.String())
@@ -875,7 +875,7 @@ func TestRunGuidedRolloutForwardExecuteCommands(t *testing.T) {
 	if got, want := strings.Join(calls, ","), "static,validate,preflight,cutover-smoke,cutover-all"; got != want {
 		t.Fatalf("calls = %s, want %s", got, want)
 	}
-	if got, want := strings.Join(commands, ","), "systemctl stop jetmon,systemctl enable --now jetmon2"; got != want {
+	if got, want := strings.Join(commands, ","), "systemctl stop jetmon,systemctl enable --now jetmon2 && systemctl is-active --quiet jetmon2"; got != want {
 		t.Fatalf("commands = %s, want %s", got, want)
 	}
 	stopCommandAt := strings.Index(out.String(), "COMMAND systemctl stop jetmon")
@@ -927,7 +927,7 @@ func TestRunGuidedRolloutFreshServerManualFlowPrintsRemoteAndLocalCommands(t *te
 		`INFO guided_run_origin=runtime_host mode="fresh-server" v1_host="jetmon-v1-a" runtime_host="jetmon-v2-a"`,
 		`WARN remote_v1_access_required=true runtime_host="jetmon-v2-a" v1_host="jetmon-v1-a"`,
 		"COMMAND ssh jetmon-v1-a sudo systemctl stop jetmon",
-		"COMMAND systemctl enable --now jetmon2",
+		"COMMAND systemctl enable --now jetmon2 && systemctl is-active --quiet jetmon2",
 		"INFO executing_operator_command=false",
 		"PASS guided_rollout=complete",
 	} {
@@ -936,7 +936,7 @@ func TestRunGuidedRolloutFreshServerManualFlowPrintsRemoteAndLocalCommands(t *te
 		}
 	}
 	stopAt := strings.Index(out.String(), "COMMAND ssh jetmon-v1-a sudo systemctl stop jetmon")
-	startAt := strings.Index(out.String(), "COMMAND systemctl enable --now jetmon2")
+	startAt := strings.Index(out.String(), "COMMAND systemctl enable --now jetmon2 && systemctl is-active --quiet jetmon2")
 	if stopAt < 0 || startAt < 0 || stopAt > startAt {
 		t.Fatalf("fresh-server command order is wrong:\n%s", out.String())
 	}
@@ -974,7 +974,7 @@ func TestRunGuidedRolloutFreshServerExecuteFlowCommandOrder(t *testing.T) {
 	if err := runGuidedRollout(context.Background(), &out, strings.NewReader(input), opts, deps); err != nil {
 		t.Fatalf("runGuidedRollout: %v\n%s", err, out.String())
 	}
-	if got, want := strings.Join(commands, ","), "ssh jetmon-v1-a sudo systemctl stop jetmon,systemctl enable --now jetmon2"; got != want {
+	if got, want := strings.Join(commands, ","), "ssh jetmon-v1-a sudo systemctl stop jetmon,systemctl enable --now jetmon2 && systemctl is-active --quiet jetmon2"; got != want {
 		t.Fatalf("commands = %s, want %s", got, want)
 	}
 	if !strings.Contains(out.String(), "PASS guided_rollout=complete") {
@@ -1045,7 +1045,7 @@ func TestRunGuidedRolloutRollbackExecuteCommands(t *testing.T) {
 	if got, want := strings.Join(calls, ","), "rollback-check"; got != want {
 		t.Fatalf("calls = %s, want %s", got, want)
 	}
-	if got, want := strings.Join(commands, ","), "systemctl stop jetmon2,systemctl start jetmon"; got != want {
+	if got, want := strings.Join(commands, ","), "systemctl stop jetmon2 && ! systemctl is-active --quiet jetmon2,systemctl start jetmon"; got != want {
 		t.Fatalf("commands = %s, want %s", got, want)
 	}
 	if !strings.Contains(out.String(), "PASS guided_rollback=complete") {
@@ -1077,7 +1077,7 @@ func TestRunGuidedRolloutFreshServerRollbackExecuteCommands(t *testing.T) {
 	if err := runGuidedRollout(context.Background(), &out, strings.NewReader(input), opts, deps); err != nil {
 		t.Fatalf("runGuidedRollout: %v\n%s", err, out.String())
 	}
-	if got, want := strings.Join(commands, ","), "systemctl stop jetmon2,ssh jetmon-v1-a sudo systemctl start jetmon"; got != want {
+	if got, want := strings.Join(commands, ","), "systemctl stop jetmon2 && ! systemctl is-active --quiet jetmon2,ssh jetmon-v1-a sudo systemctl start jetmon"; got != want {
 		t.Fatalf("commands = %s, want %s", got, want)
 	}
 	if !strings.Contains(out.String(), `WARN remote_v1_access_required=true runtime_host="jetmon-v2-a" v1_host="jetmon-v1-a"`) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ Start with [`adr/README.md`](adr/README.md) for the ADR format and index.
 | [`getting-started.md`](getting-started.md) | Local Docker setup, build/test commands, API CLI smoke runs, fixture failure simulation, and tenant import basics. |
 | [`operations-guide.md`](operations-guide.md) | Production configuration, host setup, rollout modes, delivery workers, metrics, dashboard checks, and debugging. |
 | [`rollout-quick-reference.md`](rollout-quick-reference.md) | One-page operator checklist for the v1-to-v2 rollout, linked back to the full migration runbook. |
+| [`rollout-vm-lab.md`](rollout-vm-lab.md) | KVM/libvirt lab harness for rehearsing rollout flows with DB, v1, and fresh v2 VMs plus snapshots. |
 | [`data-model.md`](data-model.md) | Legacy and v2 tables, additive migrations, event-sourced incident state, legacy projection, and tenant mapping. |
 | [`support-guide.md`](support-guide.md) | Happiness Engineer workflows for explaining alerts, missed alerts, false positives, maintenance windows, and WPCOM payloads. |
 | [`api-cli-guide.md`](api-cli-guide.md) | Feature guide and examples for using `jetmon2 api` against the internal REST API during local testing, rehearsals, and CI smoke runs. |

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -56,7 +56,8 @@ reference.
 8. Run `./jetmon2 migrate`.
 9. Run `systemd-analyze verify /etc/systemd/system/jetmon2.service` after the
    binary exists at the path used by `ExecStart`.
-10. Start the service with `systemctl enable --now jetmon2`.
+10. Start the service with
+    `systemctl enable --now jetmon2 && systemctl is-active --quiet jetmon2`.
 
 Manual commands such as `migrate`, `validate-config`, and `rollout` need the
 same `DB_*` environment that systemd reads from
@@ -127,7 +128,7 @@ time. Surviving hosts absorb the draining host's buckets during the update
 window.
 
 ```bash
-systemctl stop jetmon2
+systemctl stop jetmon2 && ! systemctl is-active --quiet jetmon2
 ./jetmon2 migrate
 systemctl start jetmon2
 ./jetmon2 status

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -104,6 +104,10 @@ preflight, deliverer hardening, and API CLI fixture workflow branches:
   flows.
 - [x] Add snapshot-backed VM flow runners for full execute-mode cutover and
   rollback simulations.
+- [x] Automate v2 service start failure after v1 stops, unwritable rollout log
+  directory refusal, bad DB connection refusal, and real `last_checked_at`
+  activity from the `jetmon2` service.
+- [x] Add snapshot-backed replay for every named VM lab smoke flow.
 
 Recently completed candidate branches:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -100,9 +100,9 @@ preflight, deliverer hardening, and API CLI fixture workflow branches:
 - [x] Automate fresh-server execute-mode happy path and guided rollback smoke.
 - [x] Automate failed pre-stop dynamic-overlap and bad systemd-unit refusal
   flows.
-- [ ] Automate interrupted resume, failed post-start rollback, and bad SSH
+- [x] Automate interrupted resume, failed post-start rollback, and bad SSH
   flows.
-- [ ] Add snapshot-backed VM flow runners for full execute-mode cutover and
+- [x] Add snapshot-backed VM flow runners for full execute-mode cutover and
   rollback simulations.
 
 Recently completed candidate branches:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -82,6 +82,29 @@ preflight, deliverer hardening, and API CLI fixture workflow branches:
 - [x] Add fresh-server guided happy-path simulations for manual flow, execute
   flow, and direct rollback command ordering.
 
+### Rollout VM Lab TODO
+
+- [x] Prepare an in-house KVM/libvirt host with passwordless sudo, QEMU,
+  libvirt, cloud-init tooling, Ansible, Expect, Go, MariaDB client tools, and a
+  dedicated `jetmon-rollout` storage pool.
+- [x] Add a repo-owned `scripts/rollout-vm-lab.sh` harness with host `doctor`,
+  image fetch, VM create/destroy, topology create, SSH wait, and offline
+  snapshot/revert primitives.
+- [x] Document the VM lab workflow, environment overrides, topology, and
+  planned rollout flow coverage.
+- [x] Seed the DB VM with v1-compatible Jetmon data and v2 additive migrations.
+- [x] Install built `jetmon2` artifacts and staged systemd units onto the v2 VM.
+- [x] Add a v1 simulator service that models static bucket ownership and safe
+  stop/start behavior for guided rollout tests.
+- [x] Wire VM lab smoke targets into Makefile or a dedicated operator script.
+- [x] Automate fresh-server execute-mode happy path and guided rollback smoke.
+- [x] Automate failed pre-stop dynamic-overlap and bad systemd-unit refusal
+  flows.
+- [ ] Automate interrupted resume, failed post-start rollback, and bad SSH
+  flows.
+- [ ] Add snapshot-backed VM flow runners for full execute-mode cutover and
+  rollback simulations.
+
 Recently completed candidate branches:
 
 - **`feature/rollout-preflight-hardening`** - merged rollout safety commands

--- a/docs/rollout-quick-reference.md
+++ b/docs/rollout-quick-reference.md
@@ -134,7 +134,7 @@ to v1" and keep the transcript with the incident record.
 3. Confirm the v1 process is stopped, then start v2:
 
    ```bash
-   systemctl enable --now jetmon2
+   systemctl enable --now jetmon2 && systemctl is-active --quiet jetmon2
    ```
 
 4. Immediately run the smoke gate:

--- a/docs/rollout-vm-lab.md
+++ b/docs/rollout-vm-lab.md
@@ -214,9 +214,11 @@ Supported snapshot flow names are `execute-rollback`, `interrupted-resume`,
 `post-start-rollback`, `bad-ssh`, `v2-start-failure`, `runtime-guards`,
 `real-activity`, and `failure-gates`. Snapshot runners are useful when
 iterating on guided behavior because each run starts from the same VM, DB,
-service, and log state. At the end, the runner reverts to the snapshot and
-enforces the safe lab state: v1 simulator active, v2 `jetmon2` stopped and
-disabled. `snapshot-run-all` replays every named flow from the same snapshot.
+service, and log state. After each revert, the runner stages the current local
+`jetmon2` artifact into the v2 guest so snapshot-backed flows do not silently
+test an old binary. At the end, the runner reverts to the snapshot and enforces
+the safe lab state: v1 simulator active, v2 `jetmon2` stopped and disabled.
+`snapshot-run-all` replays every named flow from the same snapshot.
 
 Destroy the topology and its lab volumes:
 

--- a/docs/rollout-vm-lab.md
+++ b/docs/rollout-vm-lab.md
@@ -98,6 +98,9 @@ make rollout-vm-lab-prepare
 make rollout-vm-lab-smoke
 make rollout-vm-lab-execute-smoke
 make rollout-vm-lab-failure-smoke
+make rollout-vm-lab-resume-smoke
+make rollout-vm-lab-post-start-rollback-smoke
+make rollout-vm-lab-bad-ssh-smoke
 ```
 
 The harness keeps the v2 `jetmon2` service staged but stopped. That preserves
@@ -156,6 +159,21 @@ guided rollback to stop `jetmon2` and restart the v1 simulator:
 scripts/rollout-vm-lab.sh smoke-guided-execute-rollback
 ```
 
+Run targeted guided-flow smokes:
+
+```bash
+scripts/rollout-vm-lab.sh smoke-interrupted-resume
+scripts/rollout-vm-lab.sh smoke-post-start-rollback
+scripts/rollout-vm-lab.sh smoke-bad-ssh
+```
+
+- `smoke-interrupted-resume` stops v1, intentionally leaves the first guided
+  run at EOF, resumes from state, completes cutover, then rolls back to v1.
+- `smoke-post-start-rollback` starts v2, forces the post-start activity gate to
+  fail with a future cutoff, chooses guided rollback, and confirms v1 is active.
+- `smoke-bad-ssh` uses an invalid v1 SSH target and confirms the flow fails
+  before v1 is stopped or v2 is started.
+
 Run the failure-gate smoke:
 
 ```bash
@@ -165,6 +183,21 @@ scripts/rollout-vm-lab.sh smoke-failure-gates
 This injects an overlapping `jetmon_hosts` row and a broken staged systemd unit,
 then confirms `rollout host-preflight` refuses both before restoring the DB
 state.
+
+Run a flow from a named snapshot, then revert back and normalize the safe lab
+service state:
+
+```bash
+scripts/rollout-vm-lab.sh snapshot-all pre-guided-flow
+scripts/rollout-vm-lab.sh snapshot-run pre-guided-flow execute-rollback
+```
+
+Supported snapshot flow names are `execute-rollback`, `interrupted-resume`,
+`post-start-rollback`, `bad-ssh`, and `failure-gates`. Snapshot runners are
+useful when iterating on guided behavior because each run starts from the same
+VM, DB, service, and log state. At the end, the runner reverts to the snapshot
+and enforces the safe lab state: v1 simulator active, v2 `jetmon2` stopped and
+disabled.
 
 Destroy the topology and its lab volumes:
 
@@ -195,6 +228,7 @@ scripts/rollout-vm-lab.sh destroy-topology
 | `JETMON_ROLLOUT_JETMON2_BINARY` | `<repo>/bin/jetmon2` |
 | `JETMON_ROLLOUT_JETMON2_SERVICE` | `<repo>/systemd/jetmon2.service` |
 | `JETMON_ROLLOUT_JETMON2_LOGROTATE` | `<repo>/systemd/jetmon2-logrotate` |
+| `ROLLOUT_VM_LAB_SNAPSHOT` | `pre-guided-flow` for Makefile snapshot smoke |
 
 ## Planned Flow Coverage
 
@@ -211,9 +245,11 @@ The VM lab is intended to exercise these rollout scenarios:
 - bad staged systemd unit refusal
 - failed post-start smoke gate followed by guided rollback
 - bad SSH access from the v2 runtime host to the old v1 host
+- snapshot-backed flow reruns
 - bad systemd unit or unwritable rollout log directory
 
 The current harness provides VM lifecycle, DB seeding, v1/v2 service staging,
 preflight/dry-run smoke coverage, and a full execute-mode cutover plus guided
-rollback smoke. The next layer should drive interrupted resume and targeted
-failure cases automatically from snapshots.
+rollback smoke. It also exercises interrupted resume, post-start rollback, bad
+SSH, failure gates, and named-snapshot reruns. The next layer should add more
+specialized failure fixtures as new rollout bugs are discovered.

--- a/docs/rollout-vm-lab.md
+++ b/docs/rollout-vm-lab.md
@@ -25,7 +25,7 @@ The lab host needs:
 - an active libvirt storage pool, default `jetmon-rollout`
 - write access to the storage pool path for the operator user
 - `qemu-img`, `virt-install`, `cloud-localds`, `ssh`, `scp`, `curl`, `mysql`,
-  `sed`, `awk`, `ansible`, and `expect`
+  `sed`, and `awk`
 - a dedicated lab SSH key, default
   `~/.ssh/jetmon-rollout-lab_ed25519`
 

--- a/docs/rollout-vm-lab.md
+++ b/docs/rollout-vm-lab.md
@@ -89,12 +89,13 @@ files. It:
 - runs `jetmon2 migrate` from the v2 VM against the DB VM
 - runs `rollout host-preflight` and a guided fresh-server dry-run from the v2 VM
 
-From the local workstation, the Makefile wraps artifact sync and remote
-execution:
+From the local workstation, the Makefile wraps artifact sync, v2 VM artifact
+staging, and remote execution:
 
 ```bash
 make rollout-vm-lab-doctor
 make rollout-vm-lab-prepare
+make rollout-vm-lab-stage-v2
 make rollout-vm-lab-smoke
 make rollout-vm-lab-execute-smoke
 make rollout-vm-lab-failure-smoke

--- a/docs/rollout-vm-lab.md
+++ b/docs/rollout-vm-lab.md
@@ -1,0 +1,219 @@
+# Rollout VM Lab
+
+The rollout VM lab is a KVM/libvirt test bed for rehearsing the v1-to-v2 host
+rollout on real Linux guests instead of containers. It is meant to catch the
+host-level failures that are hard to validate in Docker: systemd unit state,
+SSH reachability between fresh-server hosts, service start/stop ordering,
+cloud-init provisioning, writable log paths, and snapshot-based rollback.
+
+The lab harness is [`scripts/rollout-vm-lab.sh`](../scripts/rollout-vm-lab.sh).
+Run it on the virtualization host itself. For the current in-house lab host:
+
+```bash
+ssh jetmon-deploy-test
+cd /path/to/jetmon
+scripts/rollout-vm-lab.sh doctor
+```
+
+## Host Requirements
+
+The lab host needs:
+
+- KVM available through `/dev/kvm`
+- `qemu:///system` libvirt access for the operator user
+- an active libvirt NAT network, default `default`
+- an active libvirt storage pool, default `jetmon-rollout`
+- write access to the storage pool path for the operator user
+- `qemu-img`, `virt-install`, `cloud-localds`, `ssh`, `scp`, `curl`, `mysql`,
+  `sed`, `awk`, `ansible`, and `expect`
+- a dedicated lab SSH key, default
+  `~/.ssh/jetmon-rollout-lab_ed25519`
+
+Validate the host:
+
+```bash
+scripts/rollout-vm-lab.sh doctor
+```
+
+The command is read-only except for checking local files and libvirt state.
+
+## First-Time Setup
+
+Fetch the Ubuntu cloud image once. By default the image is cached in the
+libvirt storage pool so QEMU can use it as a backing file:
+
+```bash
+scripts/rollout-vm-lab.sh fetch-image
+```
+
+Create the baseline topology:
+
+```bash
+scripts/rollout-vm-lab.sh create-topology
+scripts/rollout-vm-lab.sh wait-ssh db
+scripts/rollout-vm-lab.sh wait-ssh v1
+scripts/rollout-vm-lab.sh wait-ssh v2
+```
+
+This creates:
+
+| VM | Purpose |
+| --- | --- |
+| `jetmon-rollout-db` | MariaDB host for seeded v1-compatible data and v2 migrations. |
+| `jetmon-rollout-v1` | Old monitor host used to model v1 service ownership. |
+| `jetmon-rollout-v2` | Fresh v2 runtime host where guided rollout commands run. |
+
+The guests use cloud-init to create a `jetmon` user with passwordless sudo and
+the dedicated lab SSH key. The DB guest also installs MariaDB, listens on the
+libvirt network, creates `jetmon_db`, and grants `jetmon` / `jetmon`.
+
+## Prepare The Rollout Lab
+
+After the topology is reachable, prepare it for real rollout command testing:
+
+```bash
+scripts/rollout-vm-lab.sh prepare-topology
+```
+
+This command is intentionally idempotent for the lab data and staged service
+files. It:
+
+- seeds the DB VM with a v1-compatible `jetpack_monitor_sites` table and ten
+  active sites in buckets `0-99`
+- installs and starts `jetmon-v1-sim.service` on the v1 VM
+- stages `jetmon2`, `/opt/jetmon2/config/config.json`,
+  `/opt/jetmon2/config/jetmon2.env`, `systemd/jetmon2.service`, logrotate, and
+  `rollout-buckets.csv` on the v2 VM
+- installs the lab SSH key on the v2 VM so fresh-server stop/start commands can
+  reach the old v1 VM over SSH
+- runs `jetmon2 migrate` from the v2 VM against the DB VM
+- runs `rollout host-preflight` and a guided fresh-server dry-run from the v2 VM
+
+From the local workstation, the Makefile wraps artifact sync and remote
+execution:
+
+```bash
+make rollout-vm-lab-doctor
+make rollout-vm-lab-prepare
+make rollout-vm-lab-smoke
+make rollout-vm-lab-execute-smoke
+make rollout-vm-lab-failure-smoke
+```
+
+The harness keeps the v2 `jetmon2` service staged but stopped. That preserves
+the production rollout shape: v1 owns the range until the guided flow reaches
+the explicit stop-v1/start-v2 transition.
+
+## Snapshots
+
+Create a named snapshot after each known-good checkpoint:
+
+```bash
+scripts/rollout-vm-lab.sh snapshot-all base-installed
+scripts/rollout-vm-lab.sh snapshot-all db-seeded
+scripts/rollout-vm-lab.sh snapshot-all pre-cutover-ready
+```
+
+Return every VM to a checkpoint:
+
+```bash
+scripts/rollout-vm-lab.sh revert-all pre-cutover-ready
+scripts/rollout-vm-lab.sh wait-ssh db
+scripts/rollout-vm-lab.sh wait-ssh v1
+scripts/rollout-vm-lab.sh wait-ssh v2
+```
+
+Snapshots are intentionally offline snapshots. The harness shuts the VM down
+before creating or reverting snapshots so disk state is deterministic.
+
+## Useful Commands
+
+List current lab state:
+
+```bash
+scripts/rollout-vm-lab.sh list
+```
+
+SSH to a guest:
+
+```bash
+scripts/rollout-vm-lab.sh ssh v2
+scripts/rollout-vm-lab.sh ssh db 'sudo systemctl status mariadb --no-pager'
+```
+
+Run only the v2-side rollout smoke checks:
+
+```bash
+scripts/rollout-vm-lab.sh smoke-preflight
+scripts/rollout-vm-lab.sh smoke-guided-dry-run
+```
+
+Run the heavier execute-mode cutover and rollback smoke. This actually stops
+the v1 simulator, starts `jetmon2`, verifies the post-start gates, then resumes
+guided rollback to stop `jetmon2` and restart the v1 simulator:
+
+```bash
+scripts/rollout-vm-lab.sh smoke-guided-execute-rollback
+```
+
+Run the failure-gate smoke:
+
+```bash
+scripts/rollout-vm-lab.sh smoke-failure-gates
+```
+
+This injects an overlapping `jetmon_hosts` row and a broken staged systemd unit,
+then confirms `rollout host-preflight` refuses both before restoring the DB
+state.
+
+Destroy the topology and its lab volumes:
+
+```bash
+scripts/rollout-vm-lab.sh destroy-topology
+```
+
+## Environment Overrides
+
+| Variable | Default |
+| --- | --- |
+| `JETMON_ROLLOUT_LAB_DIR` | `~/rollout-lab` |
+| `JETMON_ROLLOUT_POOL` | `jetmon-rollout` |
+| `JETMON_ROLLOUT_NETWORK` | `default` |
+| `JETMON_ROLLOUT_PREFIX` | `jetmon-rollout` |
+| `JETMON_ROLLOUT_IMAGE_URL` | Ubuntu 24.04 noble amd64 cloud image |
+| `JETMON_ROLLOUT_IMAGE_PATH` | `<pool path>/noble-server-cloudimg-amd64.img` |
+| `JETMON_ROLLOUT_SSH_KEY` | `~/.ssh/jetmon-rollout-lab_ed25519` |
+| `JETMON_ROLLOUT_WAIT_TIMEOUT` | `600` seconds |
+| `JETMON_ROLLOUT_MEMORY_MIB` | `2048` |
+| `JETMON_ROLLOUT_VCPUS` | `2` |
+| `JETMON_ROLLOUT_DISK_GIB` | `20` |
+| `JETMON_ROLLOUT_DB_MEMORY_MIB` | `4096` |
+| `JETMON_ROLLOUT_DB_DISK_GIB` | `30` |
+| `JETMON_ROLLOUT_BUCKET_MIN` | `0` |
+| `JETMON_ROLLOUT_BUCKET_MAX` | `99` |
+| `JETMON_ROLLOUT_BUCKET_TOTAL` | `1000` |
+| `JETMON_ROLLOUT_JETMON2_BINARY` | `<repo>/bin/jetmon2` |
+| `JETMON_ROLLOUT_JETMON2_SERVICE` | `<repo>/systemd/jetmon2.service` |
+| `JETMON_ROLLOUT_JETMON2_LOGROTATE` | `<repo>/systemd/jetmon2-logrotate` |
+
+## Planned Flow Coverage
+
+The VM lab is intended to exercise these rollout scenarios:
+
+- DB seeded with the v1-compatible site table plus v2 additive migrations
+- v1 host active for one static bucket range
+- fresh v2 host staged with pinned config but stopped
+- `rollout guided --dry-run` from the v2 runtime host
+- successful fresh-server cutover with `--execute-operator-commands`
+- guided rollback after execute-mode cutover
+- interrupted guided flow and resume from state
+- failed pre-stop gate refusal
+- bad staged systemd unit refusal
+- failed post-start smoke gate followed by guided rollback
+- bad SSH access from the v2 runtime host to the old v1 host
+- bad systemd unit or unwritable rollout log directory
+
+The current harness provides VM lifecycle, DB seeding, v1/v2 service staging,
+preflight/dry-run smoke coverage, and a full execute-mode cutover plus guided
+rollback smoke. The next layer should drive interrupted resume and targeted
+failure cases automatically from snapshots.

--- a/docs/rollout-vm-lab.md
+++ b/docs/rollout-vm-lab.md
@@ -101,6 +101,10 @@ make rollout-vm-lab-failure-smoke
 make rollout-vm-lab-resume-smoke
 make rollout-vm-lab-post-start-rollback-smoke
 make rollout-vm-lab-bad-ssh-smoke
+make rollout-vm-lab-v2-start-failure-smoke
+make rollout-vm-lab-runtime-guard-smoke
+make rollout-vm-lab-real-activity-smoke
+make rollout-vm-lab-snapshot-all-smoke
 ```
 
 The harness keeps the v2 `jetmon2` service staged but stopped. That preserves
@@ -165,6 +169,9 @@ Run targeted guided-flow smokes:
 scripts/rollout-vm-lab.sh smoke-interrupted-resume
 scripts/rollout-vm-lab.sh smoke-post-start-rollback
 scripts/rollout-vm-lab.sh smoke-bad-ssh
+scripts/rollout-vm-lab.sh smoke-v2-start-failure
+scripts/rollout-vm-lab.sh smoke-runtime-guards
+scripts/rollout-vm-lab.sh smoke-real-activity
 ```
 
 - `smoke-interrupted-resume` stops v1, intentionally leaves the first guided
@@ -173,6 +180,15 @@ scripts/rollout-vm-lab.sh smoke-bad-ssh
   fail with a future cutoff, chooses guided rollback, and confirms v1 is active.
 - `smoke-bad-ssh` uses an invalid v1 SSH target and confirms the flow fails
   before v1 is stopped or v2 is started.
+- `smoke-v2-start-failure` corrupts only the staged v2 systemd start command,
+  confirms the guided flow stops after v1 is stopped and v2 fails to start,
+  then restores the unit and returns the range to v1.
+- `smoke-runtime-guards` confirms guided rollout refuses an unwritable log
+  directory before any rollout checks run, and confirms host preflight refuses
+  a broken DB connection before service state changes.
+- `smoke-real-activity` clears the seeded range's `last_checked_at`, stops the
+  v1 simulator, starts real `jetmon2`, and waits for every active seeded site
+  to receive a real check write before returning the range to v1.
 
 Run the failure-gate smoke:
 
@@ -190,14 +206,16 @@ service state:
 ```bash
 scripts/rollout-vm-lab.sh snapshot-all pre-guided-flow
 scripts/rollout-vm-lab.sh snapshot-run pre-guided-flow execute-rollback
+scripts/rollout-vm-lab.sh snapshot-run-all pre-guided-flow
 ```
 
 Supported snapshot flow names are `execute-rollback`, `interrupted-resume`,
-`post-start-rollback`, `bad-ssh`, and `failure-gates`. Snapshot runners are
-useful when iterating on guided behavior because each run starts from the same
-VM, DB, service, and log state. At the end, the runner reverts to the snapshot
-and enforces the safe lab state: v1 simulator active, v2 `jetmon2` stopped and
-disabled.
+`post-start-rollback`, `bad-ssh`, `v2-start-failure`, `runtime-guards`,
+`real-activity`, and `failure-gates`. Snapshot runners are useful when
+iterating on guided behavior because each run starts from the same VM, DB,
+service, and log state. At the end, the runner reverts to the snapshot and
+enforces the safe lab state: v1 simulator active, v2 `jetmon2` stopped and
+disabled. `snapshot-run-all` replays every named flow from the same snapshot.
 
 Destroy the topology and its lab volumes:
 
@@ -225,6 +243,7 @@ scripts/rollout-vm-lab.sh destroy-topology
 | `JETMON_ROLLOUT_BUCKET_MIN` | `0` |
 | `JETMON_ROLLOUT_BUCKET_MAX` | `99` |
 | `JETMON_ROLLOUT_BUCKET_TOTAL` | `1000` |
+| `JETMON_ROLLOUT_ACTIVITY_WAIT_TIMEOUT` | `240` seconds |
 | `JETMON_ROLLOUT_JETMON2_BINARY` | `<repo>/bin/jetmon2` |
 | `JETMON_ROLLOUT_JETMON2_SERVICE` | `<repo>/systemd/jetmon2.service` |
 | `JETMON_ROLLOUT_JETMON2_LOGROTATE` | `<repo>/systemd/jetmon2-logrotate` |
@@ -245,11 +264,18 @@ The VM lab is intended to exercise these rollout scenarios:
 - bad staged systemd unit refusal
 - failed post-start smoke gate followed by guided rollback
 - bad SSH access from the v2 runtime host to the old v1 host
+- failed v2 service start after v1 has stopped, preserving a resumable stopped
+  state and returning the lab to v1 after the fixture
+- unwritable rollout log directory refusal before any rollout checks or service
+  commands run
+- bad DB connection refusal during host preflight
+- real v2 monitor activity that writes seeded sites' `last_checked_at`
 - snapshot-backed flow reruns
-- bad systemd unit or unwritable rollout log directory
+- bad systemd unit refusal
 
 The current harness provides VM lifecycle, DB seeding, v1/v2 service staging,
 preflight/dry-run smoke coverage, and a full execute-mode cutover plus guided
 rollback smoke. It also exercises interrupted resume, post-start rollback, bad
-SSH, failure gates, and named-snapshot reruns. The next layer should add more
-specialized failure fixtures as new rollout bugs are discovered.
+SSH, v2 start failure, runtime guard failures, real activity, failure gates,
+and named-snapshot reruns. The next layer should add more specialized failure
+fixtures as new rollout bugs are discovered.

--- a/docs/v1-to-v2-migration.md
+++ b/docs/v1-to-v2-migration.md
@@ -398,7 +398,7 @@ are the fallback/reference path and match what the guided command walks through.
 8. Start v2:
 
    ```bash
-   systemctl enable --now jetmon2
+   systemctl enable --now jetmon2 && systemctl is-active --quiet jetmon2
    ```
 
 9. Confirm v2 logs show:
@@ -469,7 +469,7 @@ fallback/reference path.
 9. Start v2 on the new server:
 
    ```bash
-   systemctl enable --now jetmon2
+   systemctl enable --now jetmon2 && systemctl is-active --quiet jetmon2
    ```
 
 10. Run the cutover smoke gate on the new server:
@@ -590,7 +590,7 @@ start command. The manual steps below are the fallback/reference path.
 1. Stop v2:
 
    ```bash
-   systemctl stop jetmon2
+   systemctl stop jetmon2 && ! systemctl is-active --quiet jetmon2
    ```
 
 2. Confirm the v2 process is stopped. Do not restart v1 until this is true.
@@ -624,7 +624,7 @@ manual steps below are the fallback/reference path.
 1. Stop v2 on the new server:
 
    ```bash
-   systemctl stop jetmon2
+   systemctl stop jetmon2 && ! systemctl is-active --quiet jetmon2
    ```
 
 2. Confirm the new v2 process is stopped. Do not restart v1 until this is true.

--- a/scripts/rollout-vm-lab.sh
+++ b/scripts/rollout-vm-lab.sh
@@ -19,6 +19,7 @@ DEFAULT_VCPUS="${JETMON_ROLLOUT_VCPUS:-2}"
 DEFAULT_DISK_GIB="${JETMON_ROLLOUT_DISK_GIB:-20}"
 SSH_CONNECT_TIMEOUT="${JETMON_ROLLOUT_SSH_CONNECT_TIMEOUT:-5}"
 WAIT_TIMEOUT="${JETMON_ROLLOUT_WAIT_TIMEOUT:-600}"
+ACTIVITY_WAIT_TIMEOUT="${JETMON_ROLLOUT_ACTIVITY_WAIT_TIMEOUT:-240}"
 JETMON2_BINARY="${JETMON_ROLLOUT_JETMON2_BINARY:-$REPO_ROOT/bin/jetmon2}"
 JETMON2_SERVICE="${JETMON_ROLLOUT_JETMON2_SERVICE:-$REPO_ROOT/systemd/jetmon2.service}"
 JETMON2_LOGROTATE="${JETMON_ROLLOUT_JETMON2_LOGROTATE:-$REPO_ROOT/systemd/jetmon2-logrotate}"
@@ -47,7 +48,11 @@ Commands:
   smoke-interrupted-resume       Interrupt after v1 stop, resume, then roll back.
   smoke-post-start-rollback      Fail a post-start gate and verify guided rollback.
   smoke-bad-ssh                  Verify bad v1 SSH commands fail before stopping v1.
+  smoke-v2-start-failure         Verify v1 stays stopped when v2 service start fails.
+  smoke-runtime-guards           Verify bad DB config and unwritable log dir refusals.
+  smoke-real-activity            Start v2 and wait for real last_checked_at updates.
   snapshot-run <snapshot> <flow> Revert to snapshot, run flow, revert again.
+  snapshot-run-all <snapshot>    Run all named snapshot-backed smoke flows.
   wait-ssh <vm>                  Wait until a VM has an IP and accepts SSH.
   ssh <vm> [command...]          SSH into a VM or run a command.
   snapshot <vm> <snapshot>       Create an offline libvirt snapshot.
@@ -68,6 +73,8 @@ Environment:
   JETMON_ROLLOUT_BUCKET_MIN      Default: 0
   JETMON_ROLLOUT_BUCKET_MAX      Default: 99
   JETMON_ROLLOUT_BUCKET_TOTAL    Default: 1000
+  JETMON_ROLLOUT_ACTIVITY_WAIT_TIMEOUT
+                                  Default: 240 seconds
 USAGE
 }
 
@@ -654,6 +661,56 @@ mark_lab_activity() {
 	pass "lab_activity_marked bucket_range=$LAB_BUCKET_MIN-$LAB_BUCKET_MAX"
 }
 
+clear_lab_activity() {
+	local db_vm db_ip
+	db_vm="$(vm_name db)"
+	db_ip="$(vm_ip_required "$db_vm")"
+	mysql_lab "$db_ip" jetmon_db -e "UPDATE jetpack_monitor_sites SET last_checked_at = NULL WHERE bucket_no BETWEEN $LAB_BUCKET_MIN AND $LAB_BUCKET_MAX"
+	pass "lab_activity_cleared bucket_range=$LAB_BUCKET_MIN-$LAB_BUCKET_MAX"
+}
+
+lab_active_site_count() {
+	local db_ip="$1"
+	mysql_lab "$db_ip" --batch --skip-column-names jetmon_db -e "SELECT COUNT(*) FROM jetpack_monitor_sites WHERE monitor_active = 1 AND bucket_no BETWEEN $LAB_BUCKET_MIN AND $LAB_BUCKET_MAX" | tr -d '[:space:]'
+}
+
+lab_checked_site_count() {
+	local db_ip="$1"
+	mysql_lab "$db_ip" --batch --skip-column-names jetmon_db -e "SELECT COUNT(*) FROM jetpack_monitor_sites WHERE monitor_active = 1 AND bucket_no BETWEEN $LAB_BUCKET_MIN AND $LAB_BUCKET_MAX AND last_checked_at IS NOT NULL" | tr -d '[:space:]'
+}
+
+wait_for_real_lab_activity() {
+	local db_vm db_ip active checked deadline
+	db_vm="$(vm_name db)"
+	db_ip="$(vm_ip_required "$db_vm")"
+	active="$(lab_active_site_count "$db_ip")"
+	[[ "$active" =~ ^[0-9]+$ ]] || {
+		warn "invalid active site count: $active"
+		return 1
+	}
+	if (( active == 0 )); then
+		warn "no active lab sites in bucket range $LAB_BUCKET_MIN-$LAB_BUCKET_MAX"
+		return 1
+	fi
+
+	deadline=$((SECONDS + ACTIVITY_WAIT_TIMEOUT))
+	while (( SECONDS < deadline )); do
+		checked="$(lab_checked_site_count "$db_ip")"
+		[[ "$checked" =~ ^[0-9]+$ ]] || {
+			warn "invalid checked site count: $checked"
+			return 1
+		}
+		if (( checked >= active )); then
+			pass "real_activity_seen checked=$checked active=$active bucket_range=$LAB_BUCKET_MIN-$LAB_BUCKET_MAX"
+			return 0
+		fi
+		log "waiting_for_real_activity checked=$checked active=$active timeout_seconds=$ACTIVITY_WAIT_TIMEOUT"
+		sleep 5
+	done
+	warn "timed out waiting for real activity checked=$(lab_checked_site_count "$db_ip") active=$active bucket_range=$LAB_BUCKET_MIN-$LAB_BUCKET_MAX"
+	return 1
+}
+
 future_activity_cutoff() {
 	date -u -d '+1 hour' +%Y-%m-%dT%H:%M:%SZ
 }
@@ -1012,6 +1069,163 @@ REMOTE
 	pass "smoke_bad_ssh_passed v1=$v1_vm v2=$v2_vm output=$out"
 }
 
+smoke_v2_start_failure() {
+	local v1_vm v2_vm out run_status
+	v1_vm="$(vm_name v1)"
+	v2_vm="$(vm_name v2)"
+	ensure_lab_dirs
+	reset_guided_lab_state
+	mark_lab_activity
+
+	ssh_vm "$v2_vm" 'sudo cp /etc/systemd/system/jetmon2.service /tmp/jetmon2.service.rollout-lab-good; sudo sed -i "s#^ExecStart=.*#ExecStart=/bin/false#" /etc/systemd/system/jetmon2.service; sudo systemctl daemon-reload; sudo systemctl reset-failed jetmon2 >/dev/null 2>&1 || true'
+	out="$LAB_DIR/logs/v2-start-failure.out"
+	run_status=0
+	if ssh_vm "$v2_vm" 'bash -s' <<REMOTE >"$out" 2>&1; then
+set -euo pipefail
+cd /opt/jetmon2
+set -a
+. config/jetmon2.env
+set +a
+printf '%s\n%s\n%s\n%s\n%s\n%s\n' \\
+	'y' \\
+	'y' \\
+	'y' \\
+	'STOP $v1_vm $LAB_BUCKET_MIN-$LAB_BUCKET_MAX' \\
+	'START V2 $v2_vm $LAB_BUCKET_MIN-$LAB_BUCKET_MAX' \\
+	's' | sudo env \\
+	JETMON_CONFIG=/opt/jetmon2/config/config.json \\
+	DB_HOST="\$DB_HOST" DB_PORT="\$DB_PORT" DB_USER="\$DB_USER" DB_PASSWORD="\$DB_PASSWORD" DB_NAME="\$DB_NAME" \\
+	/opt/jetmon2/jetmon2 rollout guided \\
+	--file rollout-buckets.csv \\
+	--host $v1_vm \\
+	--runtime-host $v2_vm \\
+	--bucket-min $LAB_BUCKET_MIN \\
+	--bucket-max $LAB_BUCKET_MAX \\
+	--bucket-total $LAB_BUCKET_TOTAL \\
+	--mode fresh-server \\
+	--v1-stop-command 'sudo -u jetmon ssh $v1_vm sudo systemctl stop jetmon-v1-sim' \\
+	--v1-start-command 'sudo -u jetmon ssh $v1_vm sudo systemctl start jetmon-v1-sim' \\
+	--log-dir logs/rollout \\
+	--execute-operator-commands \\
+	--skip-status
+REMOTE
+		run_status=0
+	else
+		run_status=$?
+	fi
+	ssh_vm "$v2_vm" 'sudo mv /tmp/jetmon2.service.rollout-lab-good /etc/systemd/system/jetmon2.service; sudo systemctl daemon-reload; sudo systemctl reset-failed jetmon2 >/dev/null 2>&1 || true; sudo systemctl disable --now jetmon2 >/dev/null 2>&1 || true'
+	if (( run_status == 0 )); then
+		cat "$out"
+		fail "v2 start failure guided run unexpectedly passed"
+	fi
+	grep -q 'PASS guided_step=stop-v1' "$out" || {
+		cat "$out"
+		fail "v2 start failure flow did not stop v1 first"
+	}
+	grep -q 'FAIL step=start-v2' "$out" || {
+		cat "$out"
+		fail "v2 start failure flow did not fail at start-v2"
+	}
+	ssh_vm "$v1_vm" '! systemctl is-active --quiet jetmon-v1-sim'
+	ssh_vm "$v2_vm" '! systemctl is-active --quiet jetmon2'
+	ssh_vm "$v1_vm" 'sudo systemctl start jetmon-v1-sim; systemctl is-active --quiet jetmon-v1-sim'
+	ssh_vm "$v2_vm" 'sudo rm -f /opt/jetmon2/logs/rollout/*.state.json'
+	pass "smoke_v2_start_failure_passed v1=$v1_vm v2=$v2_vm output=$out"
+}
+
+smoke_runtime_guards() {
+	local v1_vm v2_vm out
+	v1_vm="$(vm_name v1)"
+	v2_vm="$(vm_name v2)"
+	ensure_lab_dirs
+	reset_guided_lab_state
+
+	out="$LAB_DIR/logs/unwritable-log-dir.out"
+	ssh_vm "$v2_vm" 'sudo rm -rf /tmp/jetmon-unwritable-rollout; sudo install -d -o root -g root -m 0500 /tmp/jetmon-unwritable-rollout'
+	if ssh_vm "$v2_vm" 'bash -s' <<REMOTE >"$out" 2>&1; then
+set -euo pipefail
+cd /opt/jetmon2
+set -a
+. config/jetmon2.env
+set +a
+sudo -u jetmon env \\
+	JETMON_CONFIG=/opt/jetmon2/config/config.json \\
+	DB_HOST="\$DB_HOST" DB_PORT="\$DB_PORT" DB_USER="\$DB_USER" DB_PASSWORD="\$DB_PASSWORD" DB_NAME="\$DB_NAME" \\
+	/opt/jetmon2/jetmon2 rollout guided \\
+	--file rollout-buckets.csv \\
+	--host $v1_vm \\
+	--runtime-host $v2_vm \\
+	--bucket-min $LAB_BUCKET_MIN \\
+	--bucket-max $LAB_BUCKET_MAX \\
+	--bucket-total $LAB_BUCKET_TOTAL \\
+	--mode fresh-server \\
+	--v1-stop-command 'ssh $v1_vm sudo systemctl stop jetmon-v1-sim' \\
+	--v1-start-command 'ssh $v1_vm sudo systemctl start jetmon-v1-sim' \\
+	--log-dir /tmp/jetmon-unwritable-rollout \\
+	--skip-status \\
+	--dry-run
+REMOTE
+		ssh_vm "$v2_vm" 'sudo rm -rf /tmp/jetmon-unwritable-rollout'
+		fail "unwritable log dir guided run unexpectedly passed"
+	fi
+	ssh_vm "$v2_vm" 'sudo rm -rf /tmp/jetmon-unwritable-rollout'
+	grep -q 'rollout log directory preflight failed' "$out" || {
+		cat "$out"
+		fail "unwritable log dir failed for an unexpected reason"
+	}
+	pass "runtime_guard_unwritable_log_dir_refused output=$out"
+
+	out="$LAB_DIR/logs/bad-db-preflight.out"
+	if ssh_vm "$v2_vm" 'bash -s' <<REMOTE >"$out" 2>&1; then
+set -euo pipefail
+cd /opt/jetmon2
+set -a
+. config/jetmon2.env
+set +a
+sudo -u jetmon env \\
+	JETMON_CONFIG=/opt/jetmon2/config/config.json \\
+	DB_HOST="\$DB_HOST" DB_PORT=1 DB_USER="\$DB_USER" DB_PASSWORD=wrong DB_NAME="\$DB_NAME" \\
+	timeout 20s /opt/jetmon2/jetmon2 rollout host-preflight \\
+	--file rollout-buckets.csv \\
+	--host $v1_vm \\
+	--runtime-host $v2_vm \\
+	--bucket-min $LAB_BUCKET_MIN \\
+	--bucket-max $LAB_BUCKET_MAX \\
+	--bucket-total $LAB_BUCKET_TOTAL
+REMOTE
+		fail "bad DB host-preflight unexpectedly passed"
+	fi
+	grep -q 'db connect' "$out" || {
+		cat "$out"
+		fail "bad DB host-preflight failed for an unexpected reason"
+	}
+	pass "runtime_guard_bad_db_refused output=$out"
+}
+
+smoke_real_activity() {
+	local v1_vm v2_vm
+	v1_vm="$(vm_name v1)"
+	v2_vm="$(vm_name v2)"
+	reset_guided_lab_state
+	clear_lab_activity
+	ssh_vm "$v1_vm" 'sudo systemctl stop jetmon-v1-sim; ! systemctl is-active --quiet jetmon-v1-sim'
+	if ! ssh_vm "$v2_vm" 'sudo systemctl enable --now jetmon2; systemctl is-active --quiet jetmon2'; then
+		ssh_vm "$v2_vm" 'sudo journalctl -u jetmon2 -n 80 --no-pager || true'
+		ssh_vm "$v2_vm" 'sudo systemctl disable --now jetmon2 >/dev/null 2>&1 || true'
+		ssh_vm "$v1_vm" 'sudo systemctl start jetmon-v1-sim'
+		fail "v2 service did not start for real activity smoke"
+	fi
+	if ! wait_for_real_lab_activity; then
+		ssh_vm "$v2_vm" 'sudo journalctl -u jetmon2 -n 120 --no-pager || true'
+		ssh_vm "$v2_vm" 'sudo systemctl disable --now jetmon2 >/dev/null 2>&1 || true'
+		ssh_vm "$v1_vm" 'sudo systemctl start jetmon-v1-sim'
+		fail "real activity smoke did not observe last_checked_at updates"
+	fi
+	ssh_vm "$v2_vm" 'sudo systemctl disable --now jetmon2 >/dev/null 2>&1 || true; ! systemctl is-enabled --quiet jetmon2'
+	ssh_vm "$v1_vm" 'sudo systemctl start jetmon-v1-sim; systemctl is-active --quiet jetmon-v1-sim'
+	pass "smoke_real_activity_passed v1=$v1_vm v2=$v2_vm"
+}
+
 smoke_failure_gates() {
 	local v2_vm db_vm db_ip out
 	v2_vm="$(vm_name v2)"
@@ -1073,8 +1287,11 @@ run_flow_by_name() {
 	interrupted-resume) smoke_interrupted_resume ;;
 	post-start-rollback) smoke_post_start_rollback ;;
 	bad-ssh) smoke_bad_ssh ;;
+	v2-start-failure) smoke_v2_start_failure ;;
+	runtime-guards) smoke_runtime_guards ;;
+	real-activity) smoke_real_activity ;;
 	failure-gates) smoke_failure_gates ;;
-	*) fail "unknown snapshot flow $1 (want: execute-rollback, interrupted-resume, post-start-rollback, bad-ssh, failure-gates)" ;;
+	*) fail "unknown snapshot flow $1 (want: execute-rollback, interrupted-resume, post-start-rollback, bad-ssh, v2-start-failure, runtime-guards, real-activity, failure-gates)" ;;
 	esac
 }
 
@@ -1105,6 +1322,15 @@ snapshot_run() {
 	SNAPSHOT_RUN_CLEANUP_NAME=""
 	trap - EXIT
 	pass "snapshot_flow_passed snapshot=$snapshot flow=$flow"
+}
+
+snapshot_run_all() {
+	local snapshot="$1"
+	local flow
+	for flow in execute-rollback interrupted-resume post-start-rollback bad-ssh v2-start-failure runtime-guards real-activity failure-gates; do
+		snapshot_run "$snapshot" "$flow"
+	done
+	pass "snapshot_all_flows_passed snapshot=$snapshot"
 }
 
 prepare_topology() {
@@ -1217,9 +1443,16 @@ main() {
 	smoke-interrupted-resume) smoke_interrupted_resume "$@" ;;
 	smoke-post-start-rollback) smoke_post_start_rollback "$@" ;;
 	smoke-bad-ssh) smoke_bad_ssh "$@" ;;
+	smoke-v2-start-failure) smoke_v2_start_failure "$@" ;;
+	smoke-runtime-guards) smoke_runtime_guards "$@" ;;
+	smoke-real-activity) smoke_real_activity "$@" ;;
 	snapshot-run)
 		[[ $# -eq 2 ]] || fail "snapshot-run requires snapshot and flow"
 		snapshot_run "$@"
+		;;
+	snapshot-run-all)
+		[[ $# -eq 1 ]] || fail "snapshot-run-all requires snapshot"
+		snapshot_run_all "$1"
 		;;
 	wait-ssh)
 		[[ $# -eq 1 ]] || fail "wait-ssh requires vm"

--- a/scripts/rollout-vm-lab.sh
+++ b/scripts/rollout-vm-lab.sh
@@ -1077,7 +1077,7 @@ smoke_v2_start_failure() {
 	reset_guided_lab_state
 	mark_lab_activity
 
-	ssh_vm "$v2_vm" 'sudo cp /etc/systemd/system/jetmon2.service /tmp/jetmon2.service.rollout-lab-good; sudo sed -i "s#^ExecStart=.*#ExecStart=/bin/false#" /etc/systemd/system/jetmon2.service; sudo systemctl daemon-reload; sudo systemctl reset-failed jetmon2 >/dev/null 2>&1 || true'
+	ssh_vm "$v2_vm" 'sudo cp /etc/systemd/system/jetmon2.service /tmp/jetmon2.service.rollout-lab-good; sudo sed -i "/^ExecStart=/i ExecStartPre=/bin/false" /etc/systemd/system/jetmon2.service; sudo systemctl daemon-reload; sudo systemctl reset-failed jetmon2 >/dev/null 2>&1 || true'
 	out="$LAB_DIR/logs/v2-start-failure.out"
 	run_status=0
 	if ssh_vm "$v2_vm" 'bash -s' <<REMOTE >"$out" 2>&1; then

--- a/scripts/rollout-vm-lab.sh
+++ b/scripts/rollout-vm-lab.sh
@@ -44,6 +44,10 @@ Commands:
   smoke-guided-dry-run           Print the guided fresh-server rollout plan on v2.
   smoke-guided-execute-rollback  Execute guided cutover, then guided rollback.
   smoke-failure-gates            Verify preflight refuses unsafe DB/systemd state.
+  smoke-interrupted-resume       Interrupt after v1 stop, resume, then roll back.
+  smoke-post-start-rollback      Fail a post-start gate and verify guided rollback.
+  smoke-bad-ssh                  Verify bad v1 SSH commands fail before stopping v1.
+  snapshot-run <snapshot> <flow> Revert to snapshot, run flow, revert again.
   wait-ssh <vm>                  Wait until a VM has an IP and accepts SSH.
   ssh <vm> [command...]          SSH into a VM or run a command.
   snapshot <vm> <snapshot>       Create an offline libvirt snapshot.
@@ -650,6 +654,10 @@ mark_lab_activity() {
 	pass "lab_activity_marked bucket_range=$LAB_BUCKET_MIN-$LAB_BUCKET_MAX"
 }
 
+future_activity_cutoff() {
+	date -u -d '+1 hour' +%Y-%m-%dT%H:%M:%SZ
+}
+
 smoke_preflight() {
 	local v2_vm
 	v2_vm="$(vm_name v2)"
@@ -691,8 +699,9 @@ reset_guided_lab_state() {
 	v2_vm="$(vm_name v2)"
 	wait_ssh "$v1_vm"
 	wait_ssh "$v2_vm"
-	ssh_vm "$v2_vm" 'sudo systemctl stop jetmon2 >/dev/null 2>&1 || true; sudo rm -f /opt/jetmon2/logs/rollout/*.state.json'
+	ssh_vm "$v2_vm" 'sudo systemctl disable --now jetmon2 >/dev/null 2>&1 || true; sudo rm -f /opt/jetmon2/logs/rollout/*.state.json'
 	ssh_vm "$v1_vm" 'sudo systemctl start jetmon-v1-sim; systemctl is-active --quiet jetmon-v1-sim'
+	ssh_vm "$v2_vm" '! systemctl is-enabled --quiet jetmon2'
 	pass "guided_lab_state_reset v1=$v1_vm v2=$v2_vm"
 }
 
@@ -765,7 +774,242 @@ printf '%s\n%s\n%s\n%s\n' \\
 REMOTE
 	ssh_vm "$v2_vm" '! systemctl is-active --quiet jetmon2'
 	ssh_vm "$v1_vm" 'systemctl is-active --quiet jetmon-v1-sim'
+	ssh_vm "$v2_vm" 'sudo systemctl disable jetmon2 >/dev/null 2>&1 || true'
 	pass "smoke_guided_execute_rollback_passed v1=$v1_vm v2=$v2_vm"
+}
+
+smoke_interrupted_resume() {
+	local v1_vm v2_vm out
+	v1_vm="$(vm_name v1)"
+	v2_vm="$(vm_name v2)"
+	ensure_lab_dirs
+	reset_guided_lab_state
+	mark_lab_activity
+
+	out="$LAB_DIR/logs/interrupted-resume-first.out"
+	if ssh_vm "$v2_vm" 'bash -s' <<REMOTE >"$out" 2>&1; then
+set -euo pipefail
+cd /opt/jetmon2
+set -a
+. config/jetmon2.env
+set +a
+printf '%s\n%s\n%s\n%s\n' \\
+	'y' \\
+	'y' \\
+	'y' \\
+	'STOP $v1_vm $LAB_BUCKET_MIN-$LAB_BUCKET_MAX' | sudo env \\
+	JETMON_CONFIG=/opt/jetmon2/config/config.json \\
+	DB_HOST="\$DB_HOST" DB_PORT="\$DB_PORT" DB_USER="\$DB_USER" DB_PASSWORD="\$DB_PASSWORD" DB_NAME="\$DB_NAME" \\
+	/opt/jetmon2/jetmon2 rollout guided \\
+	--file rollout-buckets.csv \\
+	--host $v1_vm \\
+	--runtime-host $v2_vm \\
+	--bucket-min $LAB_BUCKET_MIN \\
+	--bucket-max $LAB_BUCKET_MAX \\
+	--bucket-total $LAB_BUCKET_TOTAL \\
+	--mode fresh-server \\
+	--v1-stop-command 'sudo -u jetmon ssh $v1_vm sudo systemctl stop jetmon-v1-sim' \\
+	--v1-start-command 'sudo -u jetmon ssh $v1_vm sudo systemctl start jetmon-v1-sim' \\
+	--log-dir logs/rollout \\
+	--execute-operator-commands \\
+	--skip-status
+REMOTE
+		fail "interrupted guided run unexpectedly completed"
+	fi
+	grep -q 'PASS guided_step=stop-v1' "$out" || {
+		cat "$out"
+		fail "interrupted guided run did not complete stop-v1"
+	}
+	ssh_vm "$v1_vm" '! systemctl is-active --quiet jetmon-v1-sim'
+	ssh_vm "$v2_vm" '! systemctl is-active --quiet jetmon2'
+	pass "interrupted_after_v1_stop output=$out"
+
+	out="$LAB_DIR/logs/interrupted-resume-complete.out"
+	ssh_vm "$v2_vm" 'bash -s' <<REMOTE >"$out" 2>&1
+set -euo pipefail
+cd /opt/jetmon2
+set -a
+. config/jetmon2.env
+set +a
+printf '%s\n%s\n%s\n%s\n' \\
+	'RESUME' \\
+	'START V2 $v2_vm $LAB_BUCKET_MIN-$LAB_BUCKET_MAX' \\
+	'y' \\
+	'READY' | sudo env \\
+	JETMON_CONFIG=/opt/jetmon2/config/config.json \\
+	DB_HOST="\$DB_HOST" DB_PORT="\$DB_PORT" DB_USER="\$DB_USER" DB_PASSWORD="\$DB_PASSWORD" DB_NAME="\$DB_NAME" \\
+	/opt/jetmon2/jetmon2 rollout guided \\
+	--file rollout-buckets.csv \\
+	--host $v1_vm \\
+	--runtime-host $v2_vm \\
+	--bucket-min $LAB_BUCKET_MIN \\
+	--bucket-max $LAB_BUCKET_MAX \\
+	--bucket-total $LAB_BUCKET_TOTAL \\
+	--mode fresh-server \\
+	--v1-stop-command 'sudo -u jetmon ssh $v1_vm sudo systemctl stop jetmon-v1-sim' \\
+	--v1-start-command 'sudo -u jetmon ssh $v1_vm sudo systemctl start jetmon-v1-sim' \\
+	--log-dir logs/rollout \\
+	--execute-operator-commands \\
+	--skip-status
+REMOTE
+	grep -q 'previous_state=resumed' "$out" || {
+		cat "$out"
+		fail "resume run did not resume previous state"
+	}
+	grep -q 'SKIP step=stop-v1 reason=completed_from_state' "$out" || {
+		cat "$out"
+		fail "resume run did not skip completed stop-v1"
+	}
+	grep -q 'PASS guided_rollout=complete' "$out" || {
+		cat "$out"
+		fail "resume run did not complete guided rollout"
+	}
+	ssh_vm "$v1_vm" '! systemctl is-active --quiet jetmon-v1-sim'
+	ssh_vm "$v2_vm" 'systemctl is-active --quiet jetmon2'
+	pass "interrupted_resume_completed output=$out"
+
+	out="$LAB_DIR/logs/interrupted-resume-rollback.out"
+	ssh_vm "$v2_vm" 'bash -s' <<REMOTE >"$out" 2>&1
+set -euo pipefail
+cd /opt/jetmon2
+set -a
+. config/jetmon2.env
+set +a
+printf '%s\n%s\n%s\n%s\n' \\
+	'RESUME' \\
+	'STOP V2 $v2_vm $LAB_BUCKET_MIN-$LAB_BUCKET_MAX' \\
+	'y' \\
+	'START V1 $v1_vm $LAB_BUCKET_MIN-$LAB_BUCKET_MAX' | sudo env \\
+	JETMON_CONFIG=/opt/jetmon2/config/config.json \\
+	DB_HOST="\$DB_HOST" DB_PORT="\$DB_PORT" DB_USER="\$DB_USER" DB_PASSWORD="\$DB_PASSWORD" DB_NAME="\$DB_NAME" \\
+	/opt/jetmon2/jetmon2 rollout guided \\
+	--file rollout-buckets.csv \\
+	--host $v1_vm \\
+	--runtime-host $v2_vm \\
+	--bucket-min $LAB_BUCKET_MIN \\
+	--bucket-max $LAB_BUCKET_MAX \\
+	--bucket-total $LAB_BUCKET_TOTAL \\
+	--mode fresh-server \\
+	--v1-stop-command 'sudo -u jetmon ssh $v1_vm sudo systemctl stop jetmon-v1-sim' \\
+	--v1-start-command 'sudo -u jetmon ssh $v1_vm sudo systemctl start jetmon-v1-sim' \\
+	--log-dir logs/rollout \\
+	--execute-operator-commands \\
+	--skip-status \\
+	--rollback
+REMOTE
+	ssh_vm "$v2_vm" '! systemctl is-active --quiet jetmon2'
+	ssh_vm "$v1_vm" 'systemctl is-active --quiet jetmon-v1-sim'
+	ssh_vm "$v2_vm" 'sudo systemctl disable jetmon2 >/dev/null 2>&1 || true'
+	pass "smoke_interrupted_resume_passed v1=$v1_vm v2=$v2_vm"
+}
+
+smoke_post_start_rollback() {
+	local v1_vm v2_vm out future_since
+	v1_vm="$(vm_name v1)"
+	v2_vm="$(vm_name v2)"
+	ensure_lab_dirs
+	reset_guided_lab_state
+	future_since="$(future_activity_cutoff)"
+	out="$LAB_DIR/logs/post-start-rollback.out"
+	if ssh_vm "$v2_vm" 'bash -s' <<REMOTE >"$out" 2>&1; then
+set -euo pipefail
+cd /opt/jetmon2
+set -a
+. config/jetmon2.env
+set +a
+printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \\
+	'y' \\
+	'y' \\
+	'y' \\
+	'STOP $v1_vm $LAB_BUCKET_MIN-$LAB_BUCKET_MAX' \\
+	'START V2 $v2_vm $LAB_BUCKET_MIN-$LAB_BUCKET_MAX' \\
+	'y' \\
+	'b' \\
+	'STOP V2 $v2_vm $LAB_BUCKET_MIN-$LAB_BUCKET_MAX' \\
+	'y' \\
+	'START V1 $v1_vm $LAB_BUCKET_MIN-$LAB_BUCKET_MAX' | sudo env \\
+	JETMON_CONFIG=/opt/jetmon2/config/config.json \\
+	DB_HOST="\$DB_HOST" DB_PORT="\$DB_PORT" DB_USER="\$DB_USER" DB_PASSWORD="\$DB_PASSWORD" DB_NAME="\$DB_NAME" \\
+	/opt/jetmon2/jetmon2 rollout guided \\
+	--file rollout-buckets.csv \\
+	--host $v1_vm \\
+	--runtime-host $v2_vm \\
+	--bucket-min $LAB_BUCKET_MIN \\
+	--bucket-max $LAB_BUCKET_MAX \\
+	--bucket-total $LAB_BUCKET_TOTAL \\
+	--mode fresh-server \\
+	--since '$future_since' \\
+	--v1-stop-command 'sudo -u jetmon ssh $v1_vm sudo systemctl stop jetmon-v1-sim' \\
+	--v1-start-command 'sudo -u jetmon ssh $v1_vm sudo systemctl start jetmon-v1-sim' \\
+	--log-dir logs/rollout \\
+	--execute-operator-commands \\
+	--skip-status
+REMOTE
+		fail "post-start rollback flow unexpectedly exited successfully"
+	fi
+	grep -q 'PASS guided_step=start-v2' "$out" || {
+		cat "$out"
+		fail "post-start rollback flow did not reach start-v2"
+	}
+	grep -q 'PASS guided_rollback=complete' "$out" || {
+		cat "$out"
+		fail "post-start rollback flow did not complete rollback"
+	}
+	grep -q 'guided_rollout=rolled_back' "$out" || {
+		cat "$out"
+		fail "post-start rollback flow did not report rolled_back"
+	}
+	ssh_vm "$v2_vm" '! systemctl is-active --quiet jetmon2'
+	ssh_vm "$v1_vm" 'systemctl is-active --quiet jetmon-v1-sim'
+	ssh_vm "$v2_vm" 'sudo systemctl disable jetmon2 >/dev/null 2>&1 || true'
+	pass "smoke_post_start_rollback_passed v1=$v1_vm v2=$v2_vm output=$out"
+}
+
+smoke_bad_ssh() {
+	local v1_vm v2_vm out
+	v1_vm="$(vm_name v1)"
+	v2_vm="$(vm_name v2)"
+	ensure_lab_dirs
+	reset_guided_lab_state
+	mark_lab_activity
+	out="$LAB_DIR/logs/bad-ssh.out"
+	if ssh_vm "$v2_vm" 'bash -s' <<REMOTE >"$out" 2>&1; then
+set -euo pipefail
+cd /opt/jetmon2
+set -a
+. config/jetmon2.env
+set +a
+printf '%s\n%s\n%s\n%s\n%s\n' \\
+	'y' \\
+	'y' \\
+	'y' \\
+	'STOP $v1_vm $LAB_BUCKET_MIN-$LAB_BUCKET_MAX' \\
+	's' | sudo env \\
+	JETMON_CONFIG=/opt/jetmon2/config/config.json \\
+	DB_HOST="\$DB_HOST" DB_PORT="\$DB_PORT" DB_USER="\$DB_USER" DB_PASSWORD="\$DB_PASSWORD" DB_NAME="\$DB_NAME" \\
+	/opt/jetmon2/jetmon2 rollout guided \\
+	--file rollout-buckets.csv \\
+	--host $v1_vm \\
+	--runtime-host $v2_vm \\
+	--bucket-min $LAB_BUCKET_MIN \\
+	--bucket-max $LAB_BUCKET_MAX \\
+	--bucket-total $LAB_BUCKET_TOTAL \\
+	--mode fresh-server \\
+	--v1-stop-command 'sudo -u jetmon ssh $v1_vm-missing sudo systemctl stop jetmon-v1-sim' \\
+	--v1-start-command 'sudo -u jetmon ssh $v1_vm sudo systemctl start jetmon-v1-sim' \\
+	--log-dir logs/rollout \\
+	--execute-operator-commands \\
+	--skip-status
+REMOTE
+		fail "bad SSH guided run unexpectedly passed"
+	fi
+	grep -q 'FAIL step=stop-v1' "$out" || {
+		cat "$out"
+		fail "bad SSH flow failed before expected stop-v1 failure"
+	}
+	ssh_vm "$v1_vm" 'systemctl is-active --quiet jetmon-v1-sim'
+	ssh_vm "$v2_vm" '! systemctl is-active --quiet jetmon2'
+	pass "smoke_bad_ssh_passed v1=$v1_vm v2=$v2_vm output=$out"
 }
 
 smoke_failure_gates() {
@@ -800,6 +1044,67 @@ smoke_failure_gates() {
 		fail "bad systemd preflight failed for an unexpected reason"
 	}
 	pass "failure_gate_bad_systemd_refused output=$out"
+}
+
+wait_topology_ssh() {
+	wait_ssh "$(vm_name db)"
+	wait_ssh "$(vm_name v1)"
+	wait_ssh "$(vm_name v2)"
+}
+
+snapshot_exists() {
+	local vm="$1"
+	local snapshot="$2"
+	virsh_cmd snapshot-info "$vm" "$snapshot" >/dev/null 2>&1
+}
+
+validate_snapshot_all_exists() {
+	local snapshot="$1"
+	local role vm
+	for role in db v1 v2; do
+		vm="$(vm_name "$role")"
+		snapshot_exists "$vm" "$snapshot" || fail "missing snapshot $snapshot for $vm; create it with snapshot-all $snapshot"
+	done
+}
+
+run_flow_by_name() {
+	case "$1" in
+	execute-rollback) smoke_guided_execute_rollback ;;
+	interrupted-resume) smoke_interrupted_resume ;;
+	post-start-rollback) smoke_post_start_rollback ;;
+	bad-ssh) smoke_bad_ssh ;;
+	failure-gates) smoke_failure_gates ;;
+	*) fail "unknown snapshot flow $1 (want: execute-rollback, interrupted-resume, post-start-rollback, bad-ssh, failure-gates)" ;;
+	esac
+}
+
+SNAPSHOT_RUN_CLEANUP_ACTIVE=0
+SNAPSHOT_RUN_CLEANUP_NAME=""
+
+cleanup_snapshot_run() {
+	if [[ "$SNAPSHOT_RUN_CLEANUP_ACTIVE" == "1" && -n "$SNAPSHOT_RUN_CLEANUP_NAME" ]]; then
+		warn "snapshot_flow_cleanup snapshot=$SNAPSHOT_RUN_CLEANUP_NAME"
+		revert_all "$SNAPSHOT_RUN_CLEANUP_NAME" || true
+	fi
+}
+
+snapshot_run() {
+	local snapshot="$1"
+	local flow="$2"
+	validate_snapshot_all_exists "$snapshot"
+	SNAPSHOT_RUN_CLEANUP_ACTIVE=1
+	SNAPSHOT_RUN_CLEANUP_NAME="$snapshot"
+	trap cleanup_snapshot_run EXIT
+	revert_all "$snapshot"
+	wait_topology_ssh
+	run_flow_by_name "$flow"
+	revert_all "$snapshot"
+	wait_topology_ssh
+	reset_guided_lab_state
+	SNAPSHOT_RUN_CLEANUP_ACTIVE=0
+	SNAPSHOT_RUN_CLEANUP_NAME=""
+	trap - EXIT
+	pass "snapshot_flow_passed snapshot=$snapshot flow=$flow"
 }
 
 prepare_topology() {
@@ -909,6 +1214,13 @@ main() {
 	smoke-guided-dry-run) smoke_guided_dry_run "$@" ;;
 	smoke-guided-execute-rollback) smoke_guided_execute_rollback "$@" ;;
 	smoke-failure-gates) smoke_failure_gates "$@" ;;
+	smoke-interrupted-resume) smoke_interrupted_resume "$@" ;;
+	smoke-post-start-rollback) smoke_post_start_rollback "$@" ;;
+	smoke-bad-ssh) smoke_bad_ssh "$@" ;;
+	snapshot-run)
+		[[ $# -eq 2 ]] || fail "snapshot-run requires snapshot and flow"
+		snapshot_run "$@"
+		;;
 	wait-ssh)
 		[[ $# -eq 1 ]] || fail "wait-ssh requires vm"
 		wait_ssh "$(vm_name "$1")"

--- a/scripts/rollout-vm-lab.sh
+++ b/scripts/rollout-vm-lab.sh
@@ -1,0 +1,949 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
+LAB_DIR="${JETMON_ROLLOUT_LAB_DIR:-$HOME/rollout-lab}"
+POOL="${JETMON_ROLLOUT_POOL:-jetmon-rollout}"
+NETWORK="${JETMON_ROLLOUT_NETWORK:-default}"
+PREFIX="${JETMON_ROLLOUT_PREFIX:-jetmon-rollout}"
+IMAGE_URL="${JETMON_ROLLOUT_IMAGE_URL:-https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img}"
+IMAGE_NAME="${JETMON_ROLLOUT_IMAGE_NAME:-noble-server-cloudimg-amd64.img}"
+VM_USER="${JETMON_ROLLOUT_VM_USER:-jetmon}"
+SSH_KEY="${JETMON_ROLLOUT_SSH_KEY:-$HOME/.ssh/jetmon-rollout-lab_ed25519}"
+SSH_PUBKEY="${JETMON_ROLLOUT_SSH_PUBKEY:-$SSH_KEY.pub}"
+LIBVIRT_URI="${JETMON_ROLLOUT_LIBVIRT_URI:-qemu:///system}"
+DEFAULT_MEMORY_MIB="${JETMON_ROLLOUT_MEMORY_MIB:-2048}"
+DEFAULT_VCPUS="${JETMON_ROLLOUT_VCPUS:-2}"
+DEFAULT_DISK_GIB="${JETMON_ROLLOUT_DISK_GIB:-20}"
+SSH_CONNECT_TIMEOUT="${JETMON_ROLLOUT_SSH_CONNECT_TIMEOUT:-5}"
+WAIT_TIMEOUT="${JETMON_ROLLOUT_WAIT_TIMEOUT:-600}"
+JETMON2_BINARY="${JETMON_ROLLOUT_JETMON2_BINARY:-$REPO_ROOT/bin/jetmon2}"
+JETMON2_SERVICE="${JETMON_ROLLOUT_JETMON2_SERVICE:-$REPO_ROOT/systemd/jetmon2.service}"
+JETMON2_LOGROTATE="${JETMON_ROLLOUT_JETMON2_LOGROTATE:-$REPO_ROOT/systemd/jetmon2-logrotate}"
+LAB_BUCKET_MIN="${JETMON_ROLLOUT_BUCKET_MIN:-0}"
+LAB_BUCKET_MAX="${JETMON_ROLLOUT_BUCKET_MAX:-99}"
+LAB_BUCKET_TOTAL="${JETMON_ROLLOUT_BUCKET_TOTAL:-1000}"
+
+usage() {
+	cat <<'USAGE'
+usage: scripts/rollout-vm-lab.sh <command> [args]
+
+Commands:
+  doctor                         Verify host KVM/libvirt/image/key prerequisites.
+  fetch-image                    Download the configured Ubuntu cloud image.
+  create <role> [name]           Create one VM. Roles: db, v1, v2, generic.
+  create-topology                Create db, v1, and v2 lab VMs.
+  seed-db                        Seed v1-compatible site data into the DB VM.
+  install-v1-sim                 Install/start the v1 simulator service.
+  install-v2                     Stage jetmon2, config, and systemd unit on v2.
+  migrate-v2                     Run jetmon2 migrations from the v2 VM.
+  prepare-topology               Seed DB, install v1/v2, migrate, and smoke preflight.
+  smoke-preflight                Run rollout host-preflight from the v2 VM.
+  smoke-guided-dry-run           Print the guided fresh-server rollout plan on v2.
+  smoke-guided-execute-rollback  Execute guided cutover, then guided rollback.
+  smoke-failure-gates            Verify preflight refuses unsafe DB/systemd state.
+  wait-ssh <vm>                  Wait until a VM has an IP and accepts SSH.
+  ssh <vm> [command...]          SSH into a VM or run a command.
+  snapshot <vm> <snapshot>       Create an offline libvirt snapshot.
+  snapshot-all <snapshot>        Snapshot db, v1, and v2 VMs.
+  revert <vm> <snapshot>         Revert a VM to a snapshot.
+  revert-all <snapshot>          Revert db, v1, and v2 VMs.
+  destroy <vm>                   Destroy and undefine one VM plus its lab volumes.
+  destroy-topology               Destroy db, v1, and v2 lab VMs.
+  list                           List lab VMs, network leases, and pool volumes.
+
+Environment:
+  JETMON_ROLLOUT_LAB_DIR         Default: ~/rollout-lab
+  JETMON_ROLLOUT_POOL            Default: jetmon-rollout
+  JETMON_ROLLOUT_NETWORK         Default: default
+  JETMON_ROLLOUT_PREFIX          Default: jetmon-rollout
+  JETMON_ROLLOUT_IMAGE_URL       Default: Ubuntu 24.04 noble cloud image
+  JETMON_ROLLOUT_SSH_KEY         Default: ~/.ssh/jetmon-rollout-lab_ed25519
+  JETMON_ROLLOUT_BUCKET_MIN      Default: 0
+  JETMON_ROLLOUT_BUCKET_MAX      Default: 99
+  JETMON_ROLLOUT_BUCKET_TOTAL    Default: 1000
+USAGE
+}
+
+log() {
+	printf 'INFO %s\n' "$*"
+}
+
+pass() {
+	printf 'PASS %s\n' "$*"
+}
+
+warn() {
+	printf 'WARN %s\n' "$*" >&2
+}
+
+fail() {
+	printf 'FAIL %s\n' "$*" >&2
+	exit 1
+}
+
+need_cmd() {
+	command -v "$1" >/dev/null 2>&1 || fail "missing command: $1"
+}
+
+virsh_cmd() {
+	virsh -c "$LIBVIRT_URI" "$@"
+}
+
+vm_name() {
+	case "$1" in
+	"$PREFIX"-*) printf '%s\n' "$1" ;;
+	*) printf '%s-%s\n' "$PREFIX" "$1" ;;
+	esac
+}
+
+role_from_vm() {
+	local vm="$1"
+	vm="${vm#"$PREFIX"-}"
+	printf '%s\n' "$vm"
+}
+
+image_path() {
+	if [[ -n "${JETMON_ROLLOUT_IMAGE_PATH:-}" ]]; then
+		printf '%s\n' "$JETMON_ROLLOUT_IMAGE_PATH"
+		return 0
+	fi
+	printf '%s/%s\n' "$(pool_path)" "$IMAGE_NAME"
+}
+
+disk_path() {
+	printf '%s/%s.qcow2\n' "$(pool_path)" "$1"
+}
+
+seed_path() {
+	printf '%s/%s-seed.iso\n' "$(pool_path)" "$1"
+}
+
+user_data_path() {
+	printf '%s/cloud-init/%s-user-data.yaml\n' "$LAB_DIR" "$1"
+}
+
+meta_data_path() {
+	printf '%s/cloud-init/%s-meta-data.yaml\n' "$LAB_DIR" "$1"
+}
+
+pool_path() {
+	local target
+	target="$(virsh_cmd pool-dumpxml "$POOL" | sed -n 's:.*<path>\(.*\)</path>.*:\1:p' | head -n 1)"
+	[[ -n "$target" ]] || fail "could not determine path for pool $POOL"
+	printf '%s\n' "$target"
+}
+
+ensure_lab_dirs() {
+	mkdir -p "$LAB_DIR/images" "$LAB_DIR/cloud-init" "$LAB_DIR/logs" "$LAB_DIR/work"
+}
+
+doctor() {
+	local image
+	for cmd in virsh qemu-img virt-install cloud-localds ssh scp curl mysql sed awk; do
+		need_cmd "$cmd"
+	done
+	[[ -e /dev/kvm ]] || fail "/dev/kvm does not exist"
+	[[ -r /dev/kvm && -w /dev/kvm ]] || fail "/dev/kvm is not accessible to $(id -un)"
+	pass "kvm_accessible=/dev/kvm"
+	virsh_cmd list --all >/dev/null
+	pass "libvirt_uri=$LIBVIRT_URI"
+	virsh_cmd net-info "$NETWORK" >/dev/null
+	pass "network=$NETWORK"
+	virsh_cmd pool-info "$POOL" >/dev/null
+	pass "pool=$POOL path=$(pool_path)"
+	[[ -w "$(pool_path)" ]] || fail "pool path is not writable by $(id -un): $(pool_path)"
+	pass "pool_writable=$(pool_path)"
+	[[ -f "$SSH_KEY" ]] || fail "missing SSH key $SSH_KEY"
+	[[ -f "$SSH_PUBKEY" ]] || fail "missing SSH public key $SSH_PUBKEY"
+	pass "ssh_key=$SSH_KEY"
+	image="$(image_path)"
+	if [[ -f "$image" ]]; then
+		pass "image=$image"
+	else
+		warn "image_missing=$image; run fetch-image"
+	fi
+}
+
+fetch_image() {
+	ensure_lab_dirs
+	local image tmp
+	image="$(image_path)"
+	tmp="$image.tmp"
+	mkdir -p "$(dirname "$image")"
+	if [[ -s "$image" ]]; then
+		pass "image_exists=$image"
+		return 0
+	fi
+	log "download_image=$IMAGE_URL"
+	curl -fL --retry 3 --retry-delay 2 -o "$tmp" "$IMAGE_URL"
+	mv "$tmp" "$image"
+	pass "image_downloaded=$image"
+}
+
+role_packages() {
+	case "$1" in
+	db)
+		printf 'mariadb-server\nmariadb-client\n'
+		;;
+	v1 | v2 | generic)
+		;;
+	*)
+		fail "unknown role $1"
+		;;
+	esac
+}
+
+write_cloud_init() {
+	local role="$1"
+	local vm="$2"
+	local public_key
+	public_key="$(<"$SSH_PUBKEY")"
+	{
+		printf '#cloud-config\n'
+		printf 'hostname: %s\n' "$vm"
+		printf 'manage_etc_hosts: true\n'
+		printf 'users:\n'
+		printf '  - default\n'
+		printf '  - name: %s\n' "$VM_USER"
+		printf '    gecos: Jetmon Rollout Lab\n'
+		printf '    groups: sudo\n'
+		printf '    shell: /bin/bash\n'
+		printf '    sudo: ALL=(ALL) NOPASSWD:ALL\n'
+		printf '    lock_passwd: true\n'
+		printf '    ssh_authorized_keys:\n'
+		printf '      - %s\n' "$public_key"
+		printf 'package_update: true\n'
+		printf 'packages:\n'
+		printf '  - qemu-guest-agent\n'
+		printf '  - curl\n'
+		printf '  - ca-certificates\n'
+		printf '  - git\n'
+		printf '  - jq\n'
+		printf '  - make\n'
+		printf '  - netcat-openbsd\n'
+		while IFS= read -r package; do
+			[[ -n "$package" ]] && printf '  - %s\n' "$package"
+		done < <(role_packages "$role")
+		printf 'write_files:\n'
+		printf '  - path: /etc/jetmon-rollout-lab-role\n'
+		printf '    permissions: "0644"\n'
+		printf '    content: |\n'
+		printf '      %s\n' "$role"
+		if [[ "$role" == "db" ]]; then
+			printf '  - path: /etc/mysql/mariadb.conf.d/99-jetmon-rollout-lab.cnf\n'
+			printf '    permissions: "0644"\n'
+			printf '    content: |\n'
+			printf '      [mysqld]\n'
+			printf '      bind-address=0.0.0.0\n'
+		fi
+		printf 'runcmd:\n'
+		printf '  - systemctl enable --now qemu-guest-agent\n'
+		if [[ "$role" == "db" ]]; then
+			printf '  - systemctl restart mariadb\n'
+			printf '  - mysql -uroot -e "CREATE DATABASE IF NOT EXISTS jetmon_db CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"\n'
+			printf '  - mysql -uroot -e "CREATE USER IF NOT EXISTS '\''jetmon'\''@'\''%%'\'' IDENTIFIED BY '\''jetmon'\'';"\n'
+			printf '  - mysql -uroot -e "GRANT ALL PRIVILEGES ON jetmon_db.* TO '\''jetmon'\''@'\''%%'\'';"\n'
+			printf '  - mysql -uroot -e "FLUSH PRIVILEGES;"\n'
+		fi
+		printf 'final_message: "jetmon rollout lab %s ready"\n' "$role"
+	} >"$(user_data_path "$vm")"
+	{
+		printf 'instance-id: %s\n' "$vm"
+		printf 'local-hostname: %s\n' "$vm"
+	} >"$(meta_data_path "$vm")"
+	cloud-localds "$(seed_path "$vm")" "$(user_data_path "$vm")" "$(meta_data_path "$vm")"
+}
+
+create_vm() {
+	local role="$1"
+	local requested="${2:-$role}"
+	local vm disk seed image memory vcpus disk_gib
+	vm="$(vm_name "$requested")"
+	disk="$(disk_path "$vm")"
+	seed="$(seed_path "$vm")"
+	image="$(image_path)"
+	memory="${JETMON_ROLLOUT_CREATE_MEMORY_MIB:-$DEFAULT_MEMORY_MIB}"
+	vcpus="${JETMON_ROLLOUT_CREATE_VCPUS:-$DEFAULT_VCPUS}"
+	disk_gib="${JETMON_ROLLOUT_CREATE_DISK_GIB:-$DEFAULT_DISK_GIB}"
+	[[ "$role" == "db" ]] && memory="${JETMON_ROLLOUT_DB_MEMORY_MIB:-4096}"
+	[[ "$role" == "db" ]] && disk_gib="${JETMON_ROLLOUT_DB_DISK_GIB:-30}"
+	[[ -f "$image" ]] || fail "missing image $image; run fetch-image"
+	if virsh_cmd dominfo "$vm" >/dev/null 2>&1; then
+		fail "domain already exists: $vm"
+	fi
+	[[ ! -e "$disk" ]] || fail "disk already exists: $disk"
+	write_cloud_init "$role" "$vm"
+	qemu-img create -f qcow2 -F qcow2 -b "$image" "$disk" "${disk_gib}G" >/dev/null
+	virt-install \
+		--connect "$LIBVIRT_URI" \
+		--name "$vm" \
+		--memory "$memory" \
+		--vcpus "$vcpus" \
+		--cpu host \
+		--os-variant ubuntu24.04 \
+		--import \
+		--disk "path=$disk,format=qcow2,bus=virtio" \
+		--disk "path=$seed,device=cdrom" \
+		--network "network=$NETWORK,model=virtio" \
+		--channel unix,target.type=virtio,target.name=org.qemu.guest_agent.0 \
+		--graphics none \
+		--console pty,target_type=serial \
+		--noautoconsole
+	pass "vm_created=$vm role=$role disk=$disk seed=$seed"
+}
+
+create_topology() {
+	create_vm db db
+	create_vm v1 v1
+	create_vm v2 v2
+}
+
+vm_ip() {
+	local vm="$1"
+	local ip
+	ip="$(virsh_cmd net-dhcp-leases "$NETWORK" 2>/dev/null | awk -v vm="$vm" '$0 ~ vm && /ipv4/ {sub("/.*", "", $5); print $5; exit}')"
+	if [[ -z "$ip" ]]; then
+		ip="$(virsh_cmd domifaddr "$vm" --source lease 2>/dev/null | awk '/ipv4/ {sub("/.*", "", $4); print $4; exit}')"
+	fi
+	if [[ -z "$ip" ]]; then
+		ip="$(virsh_cmd domifaddr "$vm" --source agent 2>/dev/null | awk '/ipv4/ {sub("/.*", "", $4); print $4; exit}')"
+	fi
+	printf '%s\n' "$ip"
+}
+
+wait_ssh() {
+	local vm="$1"
+	local deadline ip
+	deadline=$((SECONDS + WAIT_TIMEOUT))
+	while (( SECONDS < deadline )); do
+		ip="$(vm_ip "$vm")"
+		if [[ -n "$ip" ]]; then
+			if ssh -i "$SSH_KEY" -o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o ConnectTimeout="$SSH_CONNECT_TIMEOUT" "$VM_USER@$ip" true >/dev/null 2>&1; then
+				pass "ssh_ready vm=$vm ip=$ip"
+				return 0
+			fi
+		fi
+		sleep 5
+	done
+	fail "timed out waiting for SSH: $vm"
+}
+
+ssh_vm() {
+	local vm="$1"
+	shift || true
+	local ip
+	ip="$(vm_ip "$vm")"
+	[[ -n "$ip" ]] || fail "no IP found for $vm"
+	ssh -i "$SSH_KEY" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR "$VM_USER@$ip" "$@"
+}
+
+vm_ip_required() {
+	local vm="$1"
+	local ip
+	ip="$(vm_ip "$vm")"
+	[[ -n "$ip" ]] || fail "no IP found for $vm"
+	printf '%s\n' "$ip"
+}
+
+scp_to_vm() {
+	local src="$1"
+	local vm="$2"
+	local dest="$3"
+	local ip
+	ip="$(vm_ip_required "$vm")"
+	scp -i "$SSH_KEY" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR "$src" "$VM_USER@$ip:$dest"
+}
+
+mysql_lab() {
+	local db_ip="$1"
+	shift
+	mysql --connect-timeout=5 -h "$db_ip" -u jetmon -pjetmon "$@"
+}
+
+wait_mysql() {
+	local db_ip="$1"
+	local deadline
+	deadline=$((SECONDS + WAIT_TIMEOUT))
+	while (( SECONDS < deadline )); do
+		if mysql_lab "$db_ip" jetmon_db -e 'SELECT 1' >/dev/null 2>&1; then
+			pass "mysql_ready host=$db_ip database=jetmon_db"
+			return 0
+		fi
+		sleep 5
+	done
+	fail "timed out waiting for MySQL: $db_ip"
+}
+
+write_seed_sql() {
+	ensure_lab_dirs
+	cat >"$LAB_DIR/work/seed-db.sql" <<'SQL'
+CREATE DATABASE IF NOT EXISTS jetmon_db CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+CREATE USER IF NOT EXISTS 'jetmon'@'%' IDENTIFIED BY 'jetmon';
+GRANT ALL PRIVILEGES ON jetmon_db.* TO 'jetmon'@'%';
+FLUSH PRIVILEGES;
+
+USE jetmon_db;
+
+CREATE TABLE IF NOT EXISTS jetpack_monitor_sites (
+	jetpack_monitor_site_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+	blog_id BIGINT UNSIGNED NOT NULL,
+	bucket_no SMALLINT UNSIGNED NOT NULL DEFAULT 0,
+	monitor_url VARCHAR(300) NOT NULL DEFAULT '',
+	monitor_active TINYINT UNSIGNED NOT NULL DEFAULT 0,
+	site_status TINYINT NOT NULL DEFAULT 1,
+	last_status_change DATETIME NULL,
+	check_interval SMALLINT UNSIGNED NOT NULL DEFAULT 5,
+	INDEX idx_bucket_active (bucket_no, monitor_active),
+	INDEX blog_id_monitor_url (blog_id, monitor_url)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+DELETE FROM jetpack_monitor_sites WHERE blog_id BETWEEN 910001 AND 910010;
+
+INSERT INTO jetpack_monitor_sites
+	(blog_id, bucket_no, monitor_url, monitor_active, site_status, last_status_change, check_interval)
+VALUES
+	(910001, 0,  'https://example.com/',             1, 1, UTC_TIMESTAMP(), 5),
+	(910002, 3,  'https://wordpress.com/',           1, 1, UTC_TIMESTAMP(), 5),
+	(910003, 7,  'https://developer.wordpress.com/', 1, 1, UTC_TIMESTAMP(), 5),
+	(910004, 15, 'https://jetpack.com/',             1, 1, UTC_TIMESTAMP(), 5),
+	(910005, 24, 'https://automattic.com/',          1, 1, UTC_TIMESTAMP(), 5),
+	(910006, 32, 'https://wp.com/',                  1, 1, UTC_TIMESTAMP(), 5),
+	(910007, 49, 'https://woocommerce.com/',         1, 1, UTC_TIMESTAMP(), 5),
+	(910008, 63, 'https://akismet.com/',             1, 1, UTC_TIMESTAMP(), 5),
+	(910009, 81, 'https://gravatar.com/',            1, 1, UTC_TIMESTAMP(), 5),
+	(910010, 99, 'https://wordpress.org/',           1, 1, UTC_TIMESTAMP(), 5);
+SQL
+}
+
+seed_db() {
+	local db_vm db_ip sql
+	db_vm="$(vm_name db)"
+	wait_ssh "$db_vm"
+	db_ip="$(vm_ip_required "$db_vm")"
+	wait_mysql "$db_ip"
+	write_seed_sql
+	sql="$LAB_DIR/work/seed-db.sql"
+	scp_to_vm "$sql" "$db_vm" /tmp/jetmon-rollout-seed-db.sql
+	ssh_vm "$db_vm" 'sudo mysql < /tmp/jetmon-rollout-seed-db.sql'
+	pass "db_seeded vm=$db_vm host=$db_ip rows=10"
+}
+
+write_v1_sim_files() {
+	ensure_lab_dirs
+	cat >"$LAB_DIR/work/jetmon-v1-sim.sh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_dir=/opt/jetmon-v1-sim/logs
+pid_file=/opt/jetmon-v1-sim/jetmon-v1-sim.pid
+mkdir -p "$log_dir"
+printf '%s\n' "$$" >"$pid_file"
+trap 'rm -f "$pid_file"; exit 0' INT TERM
+
+while true; do
+	printf '%s bucket_range=%s-%s db=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${BUCKET_NO_MIN:-}" "${BUCKET_NO_MAX:-}" "${DB_HOST:-}" >>"$log_dir/jetmon-v1-sim.log"
+	sleep 5
+done
+SH
+
+	cat >"$LAB_DIR/work/jetmon-v1-sim.service" <<'SERVICE'
+[Unit]
+Description=Jetmon v1 rollout lab simulator
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=jetmon
+Group=jetmon
+EnvironmentFile=/etc/jetmon-v1-sim.env
+ExecStart=/opt/jetmon-v1-sim/jetmon-v1-sim.sh
+Restart=on-failure
+RestartSec=2s
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+}
+
+install_v1_sim() {
+	local v1_vm db_vm db_ip env_file
+	v1_vm="$(vm_name v1)"
+	db_vm="$(vm_name db)"
+	wait_ssh "$v1_vm"
+	wait_ssh "$db_vm"
+	db_ip="$(vm_ip_required "$db_vm")"
+	write_v1_sim_files
+	env_file="$LAB_DIR/work/jetmon-v1-sim.env"
+	cat >"$env_file" <<ENV
+BUCKET_NO_MIN=$LAB_BUCKET_MIN
+BUCKET_NO_MAX=$LAB_BUCKET_MAX
+DB_HOST=$db_ip
+DB_NAME=jetmon_db
+ENV
+	ssh_vm "$v1_vm" 'mkdir -p /tmp/jetmon-v1-sim-upload'
+	scp_to_vm "$LAB_DIR/work/jetmon-v1-sim.sh" "$v1_vm" /tmp/jetmon-v1-sim-upload/jetmon-v1-sim.sh
+	scp_to_vm "$LAB_DIR/work/jetmon-v1-sim.service" "$v1_vm" /tmp/jetmon-v1-sim-upload/jetmon-v1-sim.service
+	scp_to_vm "$env_file" "$v1_vm" /tmp/jetmon-v1-sim-upload/jetmon-v1-sim.env
+	ssh_vm "$v1_vm" 'bash -s' <<'REMOTE'
+set -euo pipefail
+sudo install -d -o jetmon -g jetmon -m 0755 /opt/jetmon-v1-sim /opt/jetmon-v1-sim/logs
+sudo install -o jetmon -g jetmon -m 0755 /tmp/jetmon-v1-sim-upload/jetmon-v1-sim.sh /opt/jetmon-v1-sim/jetmon-v1-sim.sh
+sudo install -o root -g root -m 0644 /tmp/jetmon-v1-sim-upload/jetmon-v1-sim.service /etc/systemd/system/jetmon-v1-sim.service
+sudo install -o root -g root -m 0644 /tmp/jetmon-v1-sim-upload/jetmon-v1-sim.env /etc/jetmon-v1-sim.env
+sudo systemctl daemon-reload
+sudo systemctl enable --now jetmon-v1-sim
+systemctl is-active --quiet jetmon-v1-sim
+REMOTE
+	pass "v1_sim_installed vm=$v1_vm bucket_range=$LAB_BUCKET_MIN-$LAB_BUCKET_MAX"
+}
+
+write_v2_lab_files() {
+	local db_ip="$1"
+	local v1_ip="$2"
+	ensure_lab_dirs
+	cat >"$LAB_DIR/work/config.json" <<JSON
+{
+	"AUTH_TOKEN": "jetmon-rollout-lab",
+	"NUM_WORKERS": 2,
+	"NUM_TO_PROCESS": 2,
+	"DATASET_SIZE": 25,
+	"WORKER_MAX_MEM_MB": 256,
+	"LEGACY_STATUS_PROJECTION_ENABLE": true,
+	"BUCKET_TOTAL": $LAB_BUCKET_TOTAL,
+	"BUCKET_TARGET": 500,
+	"BUCKET_HEARTBEAT_GRACE_SEC": 600,
+	"PINNED_BUCKET_MIN": $LAB_BUCKET_MIN,
+	"PINNED_BUCKET_MAX": $LAB_BUCKET_MAX,
+	"BATCH_SIZE": 8,
+	"VERIFLIER_BATCH_SIZE": 10,
+	"SQL_UPDATE_BATCH": 1,
+	"DB_CONFIG_UPDATES_MIN": 10,
+	"PEER_OFFLINE_LIMIT": 1,
+	"NUM_OF_CHECKS": 3,
+	"TIME_BETWEEN_CHECKS_SEC": 30,
+	"ALERT_COOLDOWN_MINUTES": 30,
+	"STATS_UPDATE_INTERVAL_MS": 10000,
+	"TIME_BETWEEN_NOTICES_MIN": 59,
+	"MIN_TIME_BETWEEN_ROUNDS_SEC": 300,
+	"NET_COMMS_TIMEOUT": 10,
+	"LOG_FORMAT": "text",
+	"DASHBOARD_PORT": 0,
+	"API_PORT": 0,
+	"DEBUG_PORT": 0,
+	"EMAIL_TRANSPORT": "stub",
+	"EMAIL_FROM": "jetmon@noreply.invalid",
+	"VERIFIERS": []
+}
+JSON
+	cat >"$LAB_DIR/work/jetmon2.env" <<ENV
+DB_HOST=$db_ip
+DB_PORT=3306
+DB_USER=jetmon
+DB_PASSWORD=jetmon
+DB_NAME=jetmon_db
+ENV
+	{
+		printf 'host,bucket_min,bucket_max\n'
+		if (( LAB_BUCKET_MIN > 0 )); then
+			printf '%s-before,0,%d\n' "$PREFIX" "$((LAB_BUCKET_MIN - 1))"
+		fi
+		printf '%s,%d,%d\n' "$(vm_name v1)" "$LAB_BUCKET_MIN" "$LAB_BUCKET_MAX"
+		if (( LAB_BUCKET_MAX + 1 < LAB_BUCKET_TOTAL )); then
+			printf '%s-after,%d,%d\n' "$PREFIX" "$((LAB_BUCKET_MAX + 1))" "$((LAB_BUCKET_TOTAL - 1))"
+		fi
+	} >"$LAB_DIR/work/rollout-buckets.csv"
+	cat >"$LAB_DIR/work/v2-ssh-config" <<SSHCONFIG
+Host $(vm_name v1)
+  HostName $v1_ip
+  User $VM_USER
+  IdentityFile ~/.ssh/jetmon-rollout-lab_ed25519
+  BatchMode yes
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+  LogLevel ERROR
+SSHCONFIG
+}
+
+install_v2() {
+	local v2_vm v1_vm db_vm db_ip v1_ip
+	v2_vm="$(vm_name v2)"
+	v1_vm="$(vm_name v1)"
+	db_vm="$(vm_name db)"
+	[[ -x "$JETMON2_BINARY" ]] || fail "missing executable jetmon2 binary: $JETMON2_BINARY"
+	[[ -f "$JETMON2_SERVICE" ]] || fail "missing systemd unit: $JETMON2_SERVICE"
+	[[ -f "$JETMON2_LOGROTATE" ]] || fail "missing logrotate file: $JETMON2_LOGROTATE"
+	wait_ssh "$v2_vm"
+	wait_ssh "$v1_vm"
+	wait_ssh "$db_vm"
+	db_ip="$(vm_ip_required "$db_vm")"
+	v1_ip="$(vm_ip_required "$v1_vm")"
+	write_v2_lab_files "$db_ip" "$v1_ip"
+	ssh_vm "$v2_vm" 'mkdir -p /tmp/jetmon-v2-upload'
+	scp_to_vm "$JETMON2_BINARY" "$v2_vm" /tmp/jetmon-v2-upload/jetmon2
+	scp_to_vm "$JETMON2_SERVICE" "$v2_vm" /tmp/jetmon-v2-upload/jetmon2.service
+	scp_to_vm "$JETMON2_LOGROTATE" "$v2_vm" /tmp/jetmon-v2-upload/jetmon2-logrotate
+	scp_to_vm "$LAB_DIR/work/config.json" "$v2_vm" /tmp/jetmon-v2-upload/config.json
+	scp_to_vm "$LAB_DIR/work/jetmon2.env" "$v2_vm" /tmp/jetmon-v2-upload/jetmon2.env
+	scp_to_vm "$LAB_DIR/work/rollout-buckets.csv" "$v2_vm" /tmp/jetmon-v2-upload/rollout-buckets.csv
+	scp_to_vm "$LAB_DIR/work/v2-ssh-config" "$v2_vm" /tmp/jetmon-v2-upload/ssh-config
+	scp_to_vm "$SSH_KEY" "$v2_vm" /tmp/jetmon-v2-upload/jetmon-rollout-lab_ed25519
+	scp_to_vm "$SSH_PUBKEY" "$v2_vm" /tmp/jetmon-v2-upload/jetmon-rollout-lab_ed25519.pub
+	ssh_vm "$v2_vm" 'bash -s' <<'REMOTE'
+set -euo pipefail
+sudo install -d -o jetmon -g jetmon -m 0755 /opt/jetmon2 /opt/jetmon2/config /opt/jetmon2/logs /opt/jetmon2/logs/rollout /opt/jetmon2/stats
+sudo install -o root -g root -m 0755 /tmp/jetmon-v2-upload/jetmon2 /opt/jetmon2/jetmon2
+sudo install -o jetmon -g jetmon -m 0644 /tmp/jetmon-v2-upload/config.json /opt/jetmon2/config/config.json
+sudo install -o root -g jetmon -m 0640 /tmp/jetmon-v2-upload/jetmon2.env /opt/jetmon2/config/jetmon2.env
+sudo install -o jetmon -g jetmon -m 0644 /tmp/jetmon-v2-upload/rollout-buckets.csv /opt/jetmon2/rollout-buckets.csv
+sudo install -o root -g root -m 0644 /tmp/jetmon-v2-upload/jetmon2.service /etc/systemd/system/jetmon2.service
+sudo install -o root -g root -m 0644 /tmp/jetmon-v2-upload/jetmon2-logrotate /etc/logrotate.d/jetmon2
+sudo install -d -o jetmon -g jetmon -m 0700 /home/jetmon/.ssh
+sudo install -o jetmon -g jetmon -m 0600 /tmp/jetmon-v2-upload/jetmon-rollout-lab_ed25519 /home/jetmon/.ssh/jetmon-rollout-lab_ed25519
+sudo install -o jetmon -g jetmon -m 0644 /tmp/jetmon-v2-upload/jetmon-rollout-lab_ed25519.pub /home/jetmon/.ssh/jetmon-rollout-lab_ed25519.pub
+sudo install -o jetmon -g jetmon -m 0600 /tmp/jetmon-v2-upload/ssh-config /home/jetmon/.ssh/config
+sudo chown -R jetmon:jetmon /opt/jetmon2/logs /opt/jetmon2/stats
+sudo systemctl daemon-reload
+sudo systemctl disable --now jetmon2 >/dev/null 2>&1 || true
+sudo systemd-analyze verify /etc/systemd/system/jetmon2.service
+cd /opt/jetmon2
+set -a
+. /opt/jetmon2/config/jetmon2.env
+set +a
+sudo -u jetmon env \
+	JETMON_CONFIG=/opt/jetmon2/config/config.json \
+	DB_HOST="$DB_HOST" DB_PORT="$DB_PORT" DB_USER="$DB_USER" DB_PASSWORD="$DB_PASSWORD" DB_NAME="$DB_NAME" \
+	/opt/jetmon2/jetmon2 validate-config
+REMOTE
+	pass "v2_installed vm=$v2_vm db_host=$db_ip plan=/opt/jetmon2/rollout-buckets.csv"
+}
+
+migrate_v2() {
+	local v2_vm db_vm
+	v2_vm="$(vm_name v2)"
+	db_vm="$(vm_name db)"
+	wait_ssh "$v2_vm"
+	wait_ssh "$db_vm"
+	ssh_vm "$v2_vm" 'bash -s' <<'REMOTE'
+set -euo pipefail
+cd /opt/jetmon2
+set -a
+. /opt/jetmon2/config/jetmon2.env
+set +a
+sudo -u jetmon env \
+	JETMON_CONFIG=/opt/jetmon2/config/config.json \
+	DB_HOST="$DB_HOST" DB_PORT="$DB_PORT" DB_USER="$DB_USER" DB_PASSWORD="$DB_PASSWORD" DB_NAME="$DB_NAME" \
+	/opt/jetmon2/jetmon2 migrate
+REMOTE
+	mark_lab_activity
+	pass "v2_migrations_applied vm=$v2_vm"
+}
+
+mark_lab_activity() {
+	local db_vm db_ip
+	db_vm="$(vm_name db)"
+	db_ip="$(vm_ip_required "$db_vm")"
+	mysql_lab "$db_ip" jetmon_db -e "UPDATE jetpack_monitor_sites SET last_checked_at = UTC_TIMESTAMP() WHERE bucket_no BETWEEN $LAB_BUCKET_MIN AND $LAB_BUCKET_MAX"
+	pass "lab_activity_marked bucket_range=$LAB_BUCKET_MIN-$LAB_BUCKET_MAX"
+}
+
+smoke_preflight() {
+	local v2_vm
+	v2_vm="$(vm_name v2)"
+	wait_ssh "$v2_vm"
+	ssh_vm "$v2_vm" "bash -lc 'cd /opt/jetmon2 && set -a && . config/jetmon2.env && set +a && JETMON_CONFIG=config/config.json ./jetmon2 rollout host-preflight --file rollout-buckets.csv --host $(vm_name v1) --runtime-host $(vm_name v2) --bucket-min $LAB_BUCKET_MIN --bucket-max $LAB_BUCKET_MAX --bucket-total $LAB_BUCKET_TOTAL'"
+	pass "smoke_preflight_passed vm=$v2_vm"
+}
+
+smoke_guided_dry_run() {
+	local v2_vm
+	v2_vm="$(vm_name v2)"
+	wait_ssh "$v2_vm"
+	ssh_vm "$v2_vm" 'bash -s' <<REMOTE
+set -euo pipefail
+cd /opt/jetmon2
+set -a
+. config/jetmon2.env
+set +a
+JETMON_CONFIG=config/config.json ./jetmon2 rollout guided \\
+	--file rollout-buckets.csv \\
+	--host $(vm_name v1) \\
+	--runtime-host $(vm_name v2) \\
+	--bucket-min $LAB_BUCKET_MIN \\
+	--bucket-max $LAB_BUCKET_MAX \\
+	--bucket-total $LAB_BUCKET_TOTAL \\
+	--mode fresh-server \\
+	--v1-stop-command 'ssh $(vm_name v1) sudo systemctl stop jetmon-v1-sim' \\
+	--v1-start-command 'ssh $(vm_name v1) sudo systemctl start jetmon-v1-sim' \\
+	--log-dir logs/rollout \\
+	--skip-status \\
+	--dry-run
+REMOTE
+	pass "smoke_guided_dry_run_passed vm=$v2_vm"
+}
+
+reset_guided_lab_state() {
+	local v1_vm v2_vm
+	v1_vm="$(vm_name v1)"
+	v2_vm="$(vm_name v2)"
+	wait_ssh "$v1_vm"
+	wait_ssh "$v2_vm"
+	ssh_vm "$v2_vm" 'sudo systemctl stop jetmon2 >/dev/null 2>&1 || true; sudo rm -f /opt/jetmon2/logs/rollout/*.state.json'
+	ssh_vm "$v1_vm" 'sudo systemctl start jetmon-v1-sim; systemctl is-active --quiet jetmon-v1-sim'
+	pass "guided_lab_state_reset v1=$v1_vm v2=$v2_vm"
+}
+
+smoke_guided_execute_rollback() {
+	local v1_vm v2_vm
+	v1_vm="$(vm_name v1)"
+	v2_vm="$(vm_name v2)"
+	reset_guided_lab_state
+	mark_lab_activity
+	ssh_vm "$v2_vm" 'bash -s' <<REMOTE
+set -euo pipefail
+cd /opt/jetmon2
+set -a
+. config/jetmon2.env
+set +a
+printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \\
+	'y' \\
+	'y' \\
+	'y' \\
+	'STOP $v1_vm $LAB_BUCKET_MIN-$LAB_BUCKET_MAX' \\
+	'START V2 $v2_vm $LAB_BUCKET_MIN-$LAB_BUCKET_MAX' \\
+	'y' \\
+	'READY' | sudo env \\
+	JETMON_CONFIG=/opt/jetmon2/config/config.json \\
+	DB_HOST="\$DB_HOST" DB_PORT="\$DB_PORT" DB_USER="\$DB_USER" DB_PASSWORD="\$DB_PASSWORD" DB_NAME="\$DB_NAME" \\
+	/opt/jetmon2/jetmon2 rollout guided \\
+	--file rollout-buckets.csv \\
+	--host $v1_vm \\
+	--runtime-host $v2_vm \\
+	--bucket-min $LAB_BUCKET_MIN \\
+	--bucket-max $LAB_BUCKET_MAX \\
+	--bucket-total $LAB_BUCKET_TOTAL \\
+	--mode fresh-server \\
+	--v1-stop-command 'sudo -u jetmon ssh $v1_vm sudo systemctl stop jetmon-v1-sim' \\
+	--v1-start-command 'sudo -u jetmon ssh $v1_vm sudo systemctl start jetmon-v1-sim' \\
+	--log-dir logs/rollout \\
+	--execute-operator-commands \\
+	--skip-status
+REMOTE
+	ssh_vm "$v1_vm" '! systemctl is-active --quiet jetmon-v1-sim'
+	ssh_vm "$v2_vm" 'systemctl is-active --quiet jetmon2'
+	mark_lab_activity
+	ssh_vm "$v2_vm" 'bash -s' <<REMOTE
+set -euo pipefail
+cd /opt/jetmon2
+set -a
+. config/jetmon2.env
+set +a
+printf '%s\n%s\n%s\n%s\n' \\
+	'RESUME' \\
+	'STOP V2 $v2_vm $LAB_BUCKET_MIN-$LAB_BUCKET_MAX' \\
+	'y' \\
+	'START V1 $v1_vm $LAB_BUCKET_MIN-$LAB_BUCKET_MAX' | sudo env \\
+	JETMON_CONFIG=/opt/jetmon2/config/config.json \\
+	DB_HOST="\$DB_HOST" DB_PORT="\$DB_PORT" DB_USER="\$DB_USER" DB_PASSWORD="\$DB_PASSWORD" DB_NAME="\$DB_NAME" \\
+	/opt/jetmon2/jetmon2 rollout guided \\
+	--file rollout-buckets.csv \\
+	--host $v1_vm \\
+	--runtime-host $v2_vm \\
+	--bucket-min $LAB_BUCKET_MIN \\
+	--bucket-max $LAB_BUCKET_MAX \\
+	--bucket-total $LAB_BUCKET_TOTAL \\
+	--mode fresh-server \\
+	--v1-stop-command 'sudo -u jetmon ssh $v1_vm sudo systemctl stop jetmon-v1-sim' \\
+	--v1-start-command 'sudo -u jetmon ssh $v1_vm sudo systemctl start jetmon-v1-sim' \\
+	--log-dir logs/rollout \\
+	--execute-operator-commands \\
+	--skip-status \\
+	--rollback
+REMOTE
+	ssh_vm "$v2_vm" '! systemctl is-active --quiet jetmon2'
+	ssh_vm "$v1_vm" 'systemctl is-active --quiet jetmon-v1-sim'
+	pass "smoke_guided_execute_rollback_passed v1=$v1_vm v2=$v2_vm"
+}
+
+smoke_failure_gates() {
+	local v2_vm db_vm db_ip out
+	v2_vm="$(vm_name v2)"
+	db_vm="$(vm_name db)"
+	wait_ssh "$v2_vm"
+	wait_ssh "$db_vm"
+	ensure_lab_dirs
+	db_ip="$(vm_ip_required "$db_vm")"
+
+	out="$LAB_DIR/logs/overlap-preflight.out"
+	mysql_lab "$db_ip" jetmon_db -e "INSERT INTO jetmon_hosts (host_id, bucket_min, bucket_max, status) VALUES ('jetmon-rollout-overlap-test', $LAB_BUCKET_MIN, $LAB_BUCKET_MAX, 'active') ON DUPLICATE KEY UPDATE bucket_min = VALUES(bucket_min), bucket_max = VALUES(bucket_max), status = VALUES(status), last_heartbeat = UTC_TIMESTAMP()"
+	if ssh_vm "$v2_vm" "bash -lc 'cd /opt/jetmon2 && set -a && . config/jetmon2.env && set +a && JETMON_CONFIG=config/config.json ./jetmon2 rollout host-preflight --file rollout-buckets.csv --host $(vm_name v1) --runtime-host $(vm_name v2) --bucket-min $LAB_BUCKET_MIN --bucket-max $LAB_BUCKET_MAX --bucket-total $LAB_BUCKET_TOTAL'" >"$out" 2>&1; then
+		mysql_lab "$db_ip" jetmon_db -e "DELETE FROM jetmon_hosts WHERE host_id = 'jetmon-rollout-overlap-test'"
+		fail "overlap preflight unexpectedly passed"
+	fi
+	mysql_lab "$db_ip" jetmon_db -e "DELETE FROM jetmon_hosts WHERE host_id = 'jetmon-rollout-overlap-test'"
+	grep -q 'overlapping pinned range' "$out" || {
+		cat "$out"
+		fail "overlap preflight failed for an unexpected reason"
+	}
+	pass "failure_gate_overlap_refused output=$out"
+
+	out="$LAB_DIR/logs/bad-systemd-preflight.out"
+	ssh_vm "$v2_vm" "printf '%s\n' '[Unit]' 'Description=Broken Jetmon lab unit' '[Service]' 'ExecStart=/does/not/exist' | sudo tee /tmp/jetmon-bad.service >/dev/null"
+	if ssh_vm "$v2_vm" "bash -lc 'cd /opt/jetmon2 && set -a && . config/jetmon2.env && set +a && JETMON_CONFIG=config/config.json ./jetmon2 rollout host-preflight --file rollout-buckets.csv --host $(vm_name v1) --runtime-host $(vm_name v2) --bucket-min $LAB_BUCKET_MIN --bucket-max $LAB_BUCKET_MAX --bucket-total $LAB_BUCKET_TOTAL --systemd-unit /tmp/jetmon-bad.service'" >"$out" 2>&1; then
+		fail "bad systemd preflight unexpectedly passed"
+	fi
+	grep -qi 'systemd' "$out" || {
+		cat "$out"
+		fail "bad systemd preflight failed for an unexpected reason"
+	}
+	pass "failure_gate_bad_systemd_refused output=$out"
+}
+
+prepare_topology() {
+	seed_db
+	install_v1_sim
+	install_v2
+	migrate_v2
+	smoke_preflight
+	smoke_guided_dry_run
+	pass "topology_prepared prefix=$PREFIX bucket_range=$LAB_BUCKET_MIN-$LAB_BUCKET_MAX"
+}
+
+shutdown_vm() {
+	local vm="$1"
+	if ! virsh_cmd dominfo "$vm" >/dev/null 2>&1; then
+		return 0
+	fi
+	if [[ "$(virsh_cmd domstate "$vm")" == "running" ]]; then
+		virsh_cmd shutdown "$vm" >/dev/null || true
+		for _ in {1..36}; do
+			[[ "$(virsh_cmd domstate "$vm" 2>/dev/null || true)" != "running" ]] && return 0
+			sleep 5
+		done
+		virsh_cmd destroy "$vm" >/dev/null || true
+	fi
+}
+
+snapshot_vm() {
+	local vm="$1"
+	local snapshot="$2"
+	virsh_cmd dominfo "$vm" >/dev/null
+	shutdown_vm "$vm"
+	virsh_cmd snapshot-create-as "$vm" "$snapshot" "jetmon rollout lab snapshot $snapshot" --atomic >/dev/null
+	pass "snapshot_created vm=$vm snapshot=$snapshot"
+}
+
+snapshot_all() {
+	local snapshot="$1"
+	snapshot_vm "$(vm_name db)" "$snapshot"
+	snapshot_vm "$(vm_name v1)" "$snapshot"
+	snapshot_vm "$(vm_name v2)" "$snapshot"
+}
+
+revert_vm() {
+	local vm="$1"
+	local snapshot="$2"
+	virsh_cmd dominfo "$vm" >/dev/null
+	shutdown_vm "$vm"
+	virsh_cmd snapshot-revert "$vm" "$snapshot" >/dev/null
+	virsh_cmd start "$vm" >/dev/null
+	pass "snapshot_reverted vm=$vm snapshot=$snapshot"
+}
+
+revert_all() {
+	local snapshot="$1"
+	revert_vm "$(vm_name db)" "$snapshot"
+	revert_vm "$(vm_name v1)" "$snapshot"
+	revert_vm "$(vm_name v2)" "$snapshot"
+}
+
+destroy_vm() {
+	local vm="$1"
+	shutdown_vm "$vm"
+	if virsh_cmd dominfo "$vm" >/dev/null 2>&1; then
+		virsh_cmd undefine "$vm" --remove-all-storage --snapshots-metadata >/dev/null || virsh_cmd undefine "$vm" --snapshots-metadata >/dev/null
+	fi
+	rm -f "$(seed_path "$vm")" "$(user_data_path "$vm")" "$(meta_data_path "$vm")"
+	pass "vm_destroyed=$vm"
+}
+
+destroy_topology() {
+	destroy_vm "$(vm_name v2)"
+	destroy_vm "$(vm_name v1)"
+	destroy_vm "$(vm_name db)"
+}
+
+list_lab() {
+	printf '## domains\n'
+	virsh_cmd list --all | sed -n "1,2p; /$PREFIX-/p"
+	printf '\n## leases\n'
+	virsh_cmd net-dhcp-leases "$NETWORK" | sed -n "1,2p; /$PREFIX-/p"
+	printf '\n## volumes\n'
+	virsh_cmd vol-list "$POOL" | sed -n "1,2p; /$PREFIX-/p"
+}
+
+main() {
+	local cmd="${1:-}"
+	[[ -n "$cmd" ]] || {
+		usage
+		exit 2
+	}
+	shift || true
+	case "$cmd" in
+	doctor) doctor "$@" ;;
+	fetch-image) fetch_image "$@" ;;
+	create)
+		[[ $# -ge 1 ]] || fail "create requires role"
+		create_vm "$@"
+		;;
+	create-topology) create_topology "$@" ;;
+	seed-db) seed_db "$@" ;;
+	install-v1-sim) install_v1_sim "$@" ;;
+	install-v2) install_v2 "$@" ;;
+	migrate-v2) migrate_v2 "$@" ;;
+	prepare-topology) prepare_topology "$@" ;;
+	smoke-preflight) smoke_preflight "$@" ;;
+	smoke-guided-dry-run) smoke_guided_dry_run "$@" ;;
+	smoke-guided-execute-rollback) smoke_guided_execute_rollback "$@" ;;
+	smoke-failure-gates) smoke_failure_gates "$@" ;;
+	wait-ssh)
+		[[ $# -eq 1 ]] || fail "wait-ssh requires vm"
+		wait_ssh "$(vm_name "$1")"
+		;;
+	ssh)
+		[[ $# -ge 1 ]] || fail "ssh requires vm"
+		vm="$(vm_name "$1")"
+		shift
+		ssh_vm "$vm" "$@"
+		;;
+	snapshot)
+		[[ $# -eq 2 ]] || fail "snapshot requires vm and snapshot name"
+		snapshot_vm "$(vm_name "$1")" "$2"
+		;;
+	snapshot-all)
+		[[ $# -eq 1 ]] || fail "snapshot-all requires snapshot name"
+		snapshot_all "$1"
+		;;
+	revert)
+		[[ $# -eq 2 ]] || fail "revert requires vm and snapshot name"
+		revert_vm "$(vm_name "$1")" "$2"
+		;;
+	revert-all)
+		[[ $# -eq 1 ]] || fail "revert-all requires snapshot name"
+		revert_all "$1"
+		;;
+	destroy)
+		[[ $# -eq 1 ]] || fail "destroy requires vm"
+		destroy_vm "$(vm_name "$1")"
+		;;
+	destroy-topology) destroy_topology "$@" ;;
+	list) list_lab "$@" ;;
+	-h | --help | help) usage ;;
+	*) usage; fail "unknown command: $cmd" ;;
+	esac
+}
+
+main "$@"

--- a/scripts/rollout-vm-lab.sh
+++ b/scripts/rollout-vm-lab.sh
@@ -519,8 +519,8 @@ write_v2_lab_files() {
 	cat >"$LAB_DIR/work/config.json" <<JSON
 {
 	"AUTH_TOKEN": "jetmon-rollout-lab",
-	"NUM_WORKERS": 2,
-	"NUM_TO_PROCESS": 2,
+	"NUM_WORKERS": 10,
+	"NUM_TO_PROCESS": 10,
 	"DATASET_SIZE": 25,
 	"WORKER_MAX_MEM_MB": 256,
 	"LEGACY_STATUS_PROJECTION_ENABLE": true,
@@ -1314,6 +1314,7 @@ snapshot_run() {
 	trap cleanup_snapshot_run EXIT
 	revert_all "$snapshot"
 	wait_topology_ssh
+	install_v2
 	run_flow_by_name "$flow"
 	revert_all "$snapshot"
 	wait_topology_ssh


### PR DESCRIPTION
## Summary

This adds a KVM/libvirt rollout lab for rehearsing the Jetmon v1-to-v2 host migration on real Linux guests instead of only Docker or unit-level simulations.

The lab creates a three-VM topology:

- `jetmon-rollout-db`: MariaDB with v1-compatible seeded monitor rows and v2 migrations
- `jetmon-rollout-v1`: a v1 simulator service that owns the static bucket range
- `jetmon-rollout-v2`: a fresh v2 runtime host with staged `jetmon2`, config, systemd, logrotate, SSH access to v1, and rollout runbooks

## What this covers

- Adds `scripts/rollout-vm-lab.sh` with host doctor checks, image/bootstrap helpers, topology lifecycle, VM SSH helpers, DB seeding, v1/v2 service staging, offline snapshots, and snapshot revert support.
- Adds Make targets for syncing artifacts, staging v2, preparing the topology, and running focused smoke flows from the local workstation.
- Exercises the guided fresh-server rollout path with actual service transitions:
  - successful execute-mode cutover and guided rollback
  - interrupted rollout resume after v1 has stopped
  - failed post-start gate followed by guided rollback
  - bad SSH access to the old v1 host
  - v2 service start failure after v1 stops
  - unwritable rollout log directory refusal
  - bad DB connection refusal
  - real `jetmon2` activity writing `last_checked_at`
  - pre-stop dynamic overlap and bad systemd-unit refusals
- Adds snapshot-backed replay for every named VM lab flow from `pre-guided-flow`.
- Restages the current `jetmon2` artifact into the v2 guest after snapshot reverts so snapshot-backed smokes do not silently test an old binary.
- Hardens guided rollout service commands so v2 start/stop transitions verify the resulting systemd state:
  - start: `systemctl enable --now jetmon2 && systemctl is-active --quiet jetmon2`
  - stop: `systemctl stop jetmon2 && ! systemctl is-active --quiet jetmon2`

## Why this matters

The rollout process is intentionally cautious because this tool can move real monitoring ownership from v1 to v2. The VM lab catches failures that are hard to see in unit tests or containers, especially service-state ordering, stale artifact staging, broken SSH from the runtime host to the old v1 host, DB reachability, log-dir permissions, snapshot/revert behavior, and whether real monitor checks are writing activity after cutover.

## Testing

Passed locally:

- `bash -n scripts/rollout-vm-lab.sh`
- `git diff --check`
- `env GOCACHE=/tmp/jetmon-go-cache GOMODCACHE=/tmp/jetmon-gomod-cache /usr/local/go/bin/go test ./cmd/jetmon2`
- `make rollout-docs-verify`

Passed against `jetmon-deploy-test`:

- `make rollout-vm-lab-real-activity-smoke`
  - observed `PASS real_activity_seen checked=10 active=10 bucket_range=0-99`
- `make rollout-vm-lab-snapshot-all-smoke`
  - passed `execute-rollback`
  - passed `interrupted-resume`
  - passed `post-start-rollback`
  - passed `bad-ssh`
  - passed `v2-start-failure`
  - passed `runtime-guards`
  - passed `real-activity`
  - passed `failure-gates`
  - ended with `PASS snapshot_all_flows_passed snapshot=pre-guided-flow`

Final lab service state after testing:

- v1 simulator: `active`
- v2 `jetmon2`: `inactive`
- v2 `jetmon2`: `disabled`
