### PR TITLE
Improve host dashboard and add fleet health plumbing

### DIFF
--- a/cmd/jetmon-deliverer/main.go
+++ b/cmd/jetmon-deliverer/main.go
@@ -22,6 +22,8 @@ import (
 	"github.com/Automattic/jetmon/internal/metrics"
 )
 
+const processHealthWriteTimeout = 2 * time.Second
+
 // Injected at build time via -ldflags.
 var (
 	version   = "dev"
@@ -151,9 +153,11 @@ func run() {
 	workersEnabled := deliveryWorkersShouldStart(cfg, hostname)
 	publishProcessHealth := func(state string) {
 		snapshot := delivererProcessHealthSnapshot(hostname, processStartedAt, state, cfg, workersEnabled, delivererDependencyHealth(context.Background(), db.DB(), metrics.Global() != nil, time.Now().UTC()))
-		if err := fleethealth.Upsert(context.Background(), db.DB(), snapshot); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), processHealthWriteTimeout)
+		if err := fleethealth.Upsert(ctx, db.DB(), snapshot); err != nil {
 			log.Printf("process health: %v", err)
 		}
+		cancel()
 	}
 	if level, msg := deliveryOwnerStatus(cfg, hostname); msg != "" {
 		if level == "WARN" {
@@ -162,7 +166,7 @@ func run() {
 			log.Printf("config: %s", msg)
 		}
 	}
-	initialState := fleethealth.StateHealthy
+	initialState := fleethealth.StateRunning
 	if !workersEnabled {
 		initialState = fleethealth.StateIdle
 	}
@@ -185,9 +189,11 @@ func run() {
 		waitForShutdown()
 		close(stopHealth)
 		publishProcessHealth(fleethealth.StateStopping)
-		if err := fleethealth.MarkStopped(context.Background(), db.DB(), processID, time.Now().UTC()); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), processHealthWriteTimeout)
+		if err := fleethealth.MarkStopped(ctx, db.DB(), processID, time.Now().UTC()); err != nil {
 			log.Printf("process health: %v", err)
 		}
+		cancel()
 		log.Println("jetmon-deliverer: shutdown complete")
 		return
 	}
@@ -201,9 +207,11 @@ func run() {
 	close(stopHealth)
 	publishProcessHealth(fleethealth.StateStopping)
 	runtime.Stop()
-	if err := fleethealth.MarkStopped(context.Background(), db.DB(), processID, time.Now().UTC()); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), processHealthWriteTimeout)
+	if err := fleethealth.MarkStopped(ctx, db.DB(), processID, time.Now().UTC()); err != nil {
 		log.Printf("process health: %v", err)
 	}
+	cancel()
 	log.Println("jetmon-deliverer: shutdown complete")
 }
 
@@ -249,6 +257,13 @@ func validateDelivererConfigRequirements(cfg *config.Config, hostname string, op
 }
 
 func delivererProcessHealthSnapshot(hostname string, startedAt time.Time, state string, cfg *config.Config, workersEnabled bool, health []fleethealth.DependencyHealth) fleethealth.Snapshot {
+	healthStatus := fleethealth.RollupHealthStatus(health)
+	if workersEnabled && strings.TrimSpace(cfg.DeliveryOwnerHost) == "" && healthStatus == fleethealth.HealthGreen {
+		healthStatus = fleethealth.HealthAmber
+	}
+	if state == fleethealth.StateStopping || state == fleethealth.StateStopped {
+		healthStatus = fleethealth.HealthAmber
+	}
 	return fleethealth.Snapshot{
 		HostID:                 hostname,
 		ProcessType:            fleethealth.ProcessDeliverer,
@@ -257,11 +272,12 @@ func delivererProcessHealthSnapshot(hostname string, startedAt time.Time, state 
 		BuildDate:              buildDate,
 		GoVersion:              goVersion,
 		State:                  state,
+		HealthStatus:           healthStatus,
 		StartedAt:              startedAt,
 		UpdatedAt:              time.Now().UTC(),
 		DeliveryWorkersEnabled: workersEnabled,
 		DeliveryOwnerHost:      cfg.DeliveryOwnerHost,
-		MemRSSMB:               currentMemRSSMB(),
+		GoSysMemMB:             currentGoSysMemMB(),
 		DependencyHealth:       health,
 	}
 }
@@ -305,7 +321,7 @@ func delivererStatsDHealth(ready bool, checkedAt time.Time) fleethealth.Dependen
 	return entry
 }
 
-func currentMemRSSMB() int {
+func currentGoSysMemMB() int {
 	var ms runtime.MemStats
 	runtime.ReadMemStats(&ms)
 	return int(ms.Sys / 1024 / 1024)

--- a/cmd/jetmon-deliverer/main.go
+++ b/cmd/jetmon-deliverer/main.go
@@ -1,19 +1,24 @@
 package main
 
 import (
+	"context"
+	"database/sql"
 	"flag"
 	"fmt"
 	"io"
 	"log"
 	"os"
 	"os/signal"
+	"runtime"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/Automattic/jetmon/internal/audit"
 	"github.com/Automattic/jetmon/internal/config"
 	"github.com/Automattic/jetmon/internal/db"
 	"github.com/Automattic/jetmon/internal/deliverer"
+	"github.com/Automattic/jetmon/internal/fleethealth"
 	"github.com/Automattic/jetmon/internal/metrics"
 )
 
@@ -141,6 +146,15 @@ func run() {
 	}
 
 	hostname := db.Hostname()
+	processStartedAt := time.Now().UTC()
+	processID := fleethealth.ProcessID(hostname, fleethealth.ProcessDeliverer)
+	workersEnabled := deliveryWorkersShouldStart(cfg, hostname)
+	publishProcessHealth := func(state string) {
+		snapshot := delivererProcessHealthSnapshot(hostname, processStartedAt, state, cfg, workersEnabled, delivererDependencyHealth(context.Background(), db.DB(), metrics.Global() != nil, time.Now().UTC()))
+		if err := fleethealth.Upsert(context.Background(), db.DB(), snapshot); err != nil {
+			log.Printf("process health: %v", err)
+		}
+	}
 	if level, msg := deliveryOwnerStatus(cfg, hostname); msg != "" {
 		if level == "WARN" {
 			log.Printf("WARN: %s", msg)
@@ -148,8 +162,32 @@ func run() {
 			log.Printf("config: %s", msg)
 		}
 	}
-	if !deliveryWorkersShouldStart(cfg, hostname) {
+	initialState := fleethealth.StateHealthy
+	if !workersEnabled {
+		initialState = fleethealth.StateIdle
+	}
+	publishProcessHealth(initialState)
+	stopHealth := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(10 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				publishProcessHealth(initialState)
+			case <-stopHealth:
+				return
+			}
+		}
+	}()
+
+	if !workersEnabled {
 		waitForShutdown()
+		close(stopHealth)
+		publishProcessHealth(fleethealth.StateStopping)
+		if err := fleethealth.MarkStopped(context.Background(), db.DB(), processID, time.Now().UTC()); err != nil {
+			log.Printf("process health: %v", err)
+		}
 		log.Println("jetmon-deliverer: shutdown complete")
 		return
 	}
@@ -160,7 +198,12 @@ func run() {
 		Dispatchers: deliverer.BuildAlertDispatchers(cfg),
 	})
 	waitForShutdown()
+	close(stopHealth)
+	publishProcessHealth(fleethealth.StateStopping)
 	runtime.Stop()
+	if err := fleethealth.MarkStopped(context.Background(), db.DB(), processID, time.Now().UTC()); err != nil {
+		log.Printf("process health: %v", err)
+	}
 	log.Println("jetmon-deliverer: shutdown complete")
 }
 
@@ -203,6 +246,69 @@ func validateDelivererConfigRequirements(cfg *config.Config, hostname string, op
 		failures = append(failures, fmt.Sprintf("API_PORT=%d must be 0 for standalone deliverer config", cfg.APIPort))
 	}
 	return failures
+}
+
+func delivererProcessHealthSnapshot(hostname string, startedAt time.Time, state string, cfg *config.Config, workersEnabled bool, health []fleethealth.DependencyHealth) fleethealth.Snapshot {
+	return fleethealth.Snapshot{
+		HostID:                 hostname,
+		ProcessType:            fleethealth.ProcessDeliverer,
+		PID:                    os.Getpid(),
+		Version:                version,
+		BuildDate:              buildDate,
+		GoVersion:              goVersion,
+		State:                  state,
+		StartedAt:              startedAt,
+		UpdatedAt:              time.Now().UTC(),
+		DeliveryWorkersEnabled: workersEnabled,
+		DeliveryOwnerHost:      cfg.DeliveryOwnerHost,
+		MemRSSMB:               currentMemRSSMB(),
+		DependencyHealth:       health,
+	}
+}
+
+func delivererDependencyHealth(ctx context.Context, sqlDB *sql.DB, statsdReady bool, checkedAt time.Time) []fleethealth.DependencyHealth {
+	return []fleethealth.DependencyHealth{
+		delivererMySQLHealth(ctx, sqlDB, checkedAt),
+		delivererStatsDHealth(statsdReady, checkedAt),
+	}
+}
+
+func delivererMySQLHealth(ctx context.Context, sqlDB *sql.DB, checkedAt time.Time) fleethealth.DependencyHealth {
+	entry := fleethealth.DependencyHealth{Name: "mysql", CheckedAt: checkedAt}
+	if sqlDB == nil {
+		entry.Status = "red"
+		entry.LastError = "database pool is not initialized"
+		return entry
+	}
+	pingCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	start := time.Now()
+	if err := sqlDB.PingContext(pingCtx); err != nil {
+		entry.Status = "red"
+		entry.LatencyMS = time.Since(start).Milliseconds()
+		entry.LastError = err.Error()
+		return entry
+	}
+	entry.Status = "green"
+	entry.LatencyMS = time.Since(start).Milliseconds()
+	return entry
+}
+
+func delivererStatsDHealth(ready bool, checkedAt time.Time) fleethealth.DependencyHealth {
+	entry := fleethealth.DependencyHealth{Name: "statsd", CheckedAt: checkedAt}
+	if !ready {
+		entry.Status = "amber"
+		entry.LastError = "statsd client is not initialized"
+		return entry
+	}
+	entry.Status = "green"
+	return entry
+}
+
+func currentMemRSSMB() int {
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	return int(ms.Sys / 1024 / 1024)
 }
 
 func waitForShutdown() {

--- a/cmd/jetmon-deliverer/main_test.go
+++ b/cmd/jetmon-deliverer/main_test.go
@@ -205,7 +205,7 @@ func TestEmailTransportLabelAndDelivery(t *testing.T) {
 func TestDelivererProcessHealthSnapshot(t *testing.T) {
 	started := time.Date(2026, 4, 30, 11, 0, 0, 0, time.UTC)
 	cfg := &config.Config{DeliveryOwnerHost: "deliverer-1"}
-	snapshot := delivererProcessHealthSnapshot("deliverer-1", started, fleethealth.StateHealthy, cfg, true, []fleethealth.DependencyHealth{{
+	snapshot := delivererProcessHealthSnapshot("deliverer-1", started, fleethealth.StateRunning, cfg, true, []fleethealth.DependencyHealth{{
 		Name:      "mysql",
 		Status:    "green",
 		CheckedAt: started,
@@ -222,6 +222,9 @@ func TestDelivererProcessHealthSnapshot(t *testing.T) {
 	}
 	if snapshot.DeliveryOwnerHost != "deliverer-1" {
 		t.Fatalf("DeliveryOwnerHost = %q, want deliverer-1", snapshot.DeliveryOwnerHost)
+	}
+	if snapshot.HealthStatus != fleethealth.HealthGreen {
+		t.Fatalf("HealthStatus = %q, want green", snapshot.HealthStatus)
 	}
 	if len(snapshot.DependencyHealth) != 1 {
 		t.Fatalf("DependencyHealth len = %d, want 1", len(snapshot.DependencyHealth))

--- a/cmd/jetmon-deliverer/main_test.go
+++ b/cmd/jetmon-deliverer/main_test.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Automattic/jetmon/internal/config"
+	"github.com/Automattic/jetmon/internal/fleethealth"
+	"github.com/DATA-DOG/go-sqlmock"
 )
 
 func TestDeliveryWorkersShouldStart(t *testing.T) {
@@ -195,6 +199,56 @@ func TestEmailTransportLabelAndDelivery(t *testing.T) {
 				t.Fatalf("emailTransportDelivers() = %v, want %v", got, tt.delivers)
 			}
 		})
+	}
+}
+
+func TestDelivererProcessHealthSnapshot(t *testing.T) {
+	started := time.Date(2026, 4, 30, 11, 0, 0, 0, time.UTC)
+	cfg := &config.Config{DeliveryOwnerHost: "deliverer-1"}
+	snapshot := delivererProcessHealthSnapshot("deliverer-1", started, fleethealth.StateHealthy, cfg, true, []fleethealth.DependencyHealth{{
+		Name:      "mysql",
+		Status:    "green",
+		CheckedAt: started,
+	}})
+
+	if snapshot.HostID != "deliverer-1" {
+		t.Fatalf("HostID = %q, want deliverer-1", snapshot.HostID)
+	}
+	if snapshot.ProcessType != fleethealth.ProcessDeliverer {
+		t.Fatalf("ProcessType = %q, want deliverer", snapshot.ProcessType)
+	}
+	if !snapshot.DeliveryWorkersEnabled {
+		t.Fatal("DeliveryWorkersEnabled = false, want true")
+	}
+	if snapshot.DeliveryOwnerHost != "deliverer-1" {
+		t.Fatalf("DeliveryOwnerHost = %q, want deliverer-1", snapshot.DeliveryOwnerHost)
+	}
+	if len(snapshot.DependencyHealth) != 1 {
+		t.Fatalf("DependencyHealth len = %d, want 1", len(snapshot.DependencyHealth))
+	}
+}
+
+func TestDelivererDependencyHealth(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqlDB.Close()
+	mock.ExpectPing()
+
+	checkedAt := time.Date(2026, 4, 30, 11, 1, 0, 0, time.UTC)
+	entries := delivererDependencyHealth(context.Background(), sqlDB, false, checkedAt)
+	if len(entries) != 2 {
+		t.Fatalf("entries len = %d, want 2", len(entries))
+	}
+	if entries[0].Name != "mysql" || entries[0].Status != "green" {
+		t.Fatalf("mysql entry = %+v, want green", entries[0])
+	}
+	if entries[1].Name != "statsd" || entries[1].Status != "amber" {
+		t.Fatalf("statsd entry = %+v, want amber", entries[1])
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sql expectations: %v", err)
 	}
 }
 

--- a/cmd/jetmon2/main.go
+++ b/cmd/jetmon2/main.go
@@ -11,7 +11,9 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -23,6 +25,7 @@ import (
 	"github.com/Automattic/jetmon/internal/dashboard"
 	"github.com/Automattic/jetmon/internal/db"
 	"github.com/Automattic/jetmon/internal/deliverer"
+	"github.com/Automattic/jetmon/internal/fleethealth"
 	"github.com/Automattic/jetmon/internal/metrics"
 	"github.com/Automattic/jetmon/internal/orchestrator"
 	"github.com/Automattic/jetmon/internal/veriflier"
@@ -103,7 +106,11 @@ func runServe() {
 		log.Printf("warning: statsd init failed: %v", err)
 	}
 
-	wp := wpcom.New(cfg.AuthToken, db.Hostname())
+	hostname := db.Hostname()
+	processStartedAt := time.Now().UTC()
+	processID := fleethealth.ProcessID(hostname, fleethealth.ProcessMonitor)
+
+	wp := wpcom.New(cfg.AuthToken, hostname)
 
 	orch := orchestrator.New(cfg, wp)
 	if err := orch.ClaimBuckets(); err != nil {
@@ -112,7 +119,7 @@ func runServe() {
 
 	var dash *dashboard.Server
 	if cfg.DashboardPort > 0 {
-		dash = dashboard.New(db.Hostname())
+		dash = dashboard.New(hostname)
 		go func() {
 			addr := fmt.Sprintf(":%d", cfg.DashboardPort)
 			if err := dash.Listen(addr); err != nil {
@@ -135,7 +142,7 @@ func runServe() {
 	// jetmon_api_keys; key management is CLI-only (`./jetmon2 keys`).
 	var apiSrv *api.Server
 	if cfg.APIPort > 0 {
-		apiSrv = api.New(fmt.Sprintf(":%d", cfg.APIPort), db.DB(), db.Hostname())
+		apiSrv = api.New(fmt.Sprintf(":%d", cfg.APIPort), db.DB(), hostname)
 		go func() {
 			if err := apiSrv.Listen(); err != nil && !api.IsServerClosed(err) {
 				log.Printf("api: %v", err)
@@ -143,14 +150,14 @@ func runServe() {
 		}()
 	}
 
-	if level, msg := deliveryOwnerStatus(cfg, db.Hostname()); msg != "" {
+	if level, msg := deliveryOwnerStatus(cfg, hostname); msg != "" {
 		if level == "WARN" {
 			log.Printf("WARN: %s", msg)
 		} else {
 			log.Printf("config: %s", msg)
 		}
 	}
-	deliveryWorkersEnabled := deliveryWorkersShouldStart(cfg, db.Hostname())
+	deliveryWorkersEnabled := deliveryWorkersShouldStart(cfg, hostname)
 
 	var alertDispatchers map[alerting.Transport]alerting.Dispatcher
 	if cfg.APIPort > 0 {
@@ -167,49 +174,72 @@ func runServe() {
 	if deliveryWorkersEnabled {
 		deliveryRuntime = deliverer.Start(deliverer.Config{
 			DB:          db.DB(),
-			InstanceID:  db.Hostname(),
+			InstanceID:  hostname,
 			Dispatchers: alertDispatchers,
 		})
 	}
 
-	// Push dashboard state every stats interval.
-	if dash != nil {
-		publishDashboardHealth(dash, wp)
-		go func() {
-			ticker := time.NewTicker(time.Duration(cfg.StatsUpdateIntervalMS) * time.Millisecond)
-			defer ticker.Stop()
-			for range ticker.C {
-				bMin, bMax := orch.BucketRange()
-				currentCfg := config.Get()
-				dash.Update(dashboard.State{
-					WorkerCount:                   orch.WorkerCount(),
-					ActiveChecks:                  orch.ActiveChecks(),
-					QueueDepth:                    orch.QueueDepth(),
-					RetryQueueSize:                orch.RetryQueueSize(),
-					SitesPerSec:                   0,
-					WPCOMCircuitOpen:              wp.IsCircuitOpen(),
-					WPCOMQueueDepth:               wp.QueueDepth(),
-					BucketMin:                     bMin,
-					BucketMax:                     bMax,
-					BucketOwnership:               bucketOwnershipLabel(currentCfg),
-					LegacyStatusProjectionEnabled: currentCfg.LegacyStatusProjectionEnable,
-					DeliveryWorkersEnabled:        deliveryWorkersEnabled,
-					DeliveryOwnerHost:             currentCfg.DeliveryOwnerHost,
-					RolloutPreflightCommand:       rolloutPreflightCommand(currentCfg),
-					RolloutActivityCommand:        rolloutActivityCommand(),
-					RolloutRollbackCommand:        rollbackCheckCommand(currentCfg),
-					ProjectionDriftCommand:        projectionDriftCommand(),
-				})
+	publishHostSnapshot := func(state string, refreshDependencies bool) {
+		currentCfg := config.Get()
+		if currentCfg == nil {
+			currentCfg = cfg
+		}
+		checkedAt := time.Now().UTC()
+		var health []dashboard.HealthEntry
+		if refreshDependencies {
+			health = dashboardHealthEntries(context.Background(), currentCfg, db.DB(), wp, metrics.Global() != nil, checkedAt)
+		}
+		bMin, bMax := orch.BucketRange()
+		memRSSMB := currentMemRSSMB()
+		st := dashboard.State{
+			WorkerCount:                   orch.WorkerCount(),
+			ActiveChecks:                  orch.ActiveChecks(),
+			QueueDepth:                    orch.QueueDepth(),
+			RetryQueueSize:                orch.RetryQueueSize(),
+			SitesPerSec:                   0,
+			WPCOMCircuitOpen:              wp.IsCircuitOpen(),
+			WPCOMQueueDepth:               wp.QueueDepth(),
+			MemRSSMB:                      memRSSMB,
+			BucketMin:                     bMin,
+			BucketMax:                     bMax,
+			BucketOwnership:               bucketOwnershipLabel(currentCfg),
+			LegacyStatusProjectionEnabled: currentCfg.LegacyStatusProjectionEnable,
+			DeliveryWorkersEnabled:        deliveryWorkersEnabled,
+			DeliveryOwnerHost:             currentCfg.DeliveryOwnerHost,
+			RolloutPreflightCommand:       rolloutPreflightCommand(currentCfg),
+			RolloutCutoverCommand:         cutoverCheckCommand(currentCfg),
+			RolloutActivityCommand:        rolloutActivityCommand(),
+			RolloutRollbackCommand:        rollbackCheckCommand(currentCfg),
+			RolloutStateReportCommand:     stateReportCommand(),
+			ProjectionDriftCommand:        projectionDriftCommand(),
+		}
+		if dash != nil {
+			if refreshDependencies {
+				dash.UpdateHealth(health)
 			}
-		}()
-		go func() {
-			ticker := time.NewTicker(time.Duration(cfg.StatsUpdateIntervalMS) * time.Millisecond)
-			defer ticker.Stop()
-			for range ticker.C {
-				publishDashboardHealth(dash, wp)
-			}
-		}()
+			dash.Update(st)
+		}
+		if err := fleethealth.Upsert(context.Background(), db.DB(), monitorProcessHealthSnapshot(hostname, processStartedAt, state, currentCfg, st, health)); err != nil {
+			log.Printf("process health: %v", err)
+		}
 	}
+
+	// Publish both host-dashboard state and the durable fleet-health heartbeat.
+	publishHostSnapshot(fleethealth.StateHealthy, true)
+	stopHostPublisher := make(chan struct{})
+	var stopHostPublisherOnce sync.Once
+	go func() {
+		ticker := time.NewTicker(time.Duration(cfg.StatsUpdateIntervalMS) * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				publishHostSnapshot(fleethealth.StateHealthy, true)
+			case <-stopHostPublisher:
+				return
+			}
+		}
+	}()
 
 	// Signal handling.
 	sigCh := make(chan os.Signal, 1)
@@ -227,6 +257,8 @@ func runServe() {
 				}
 			case syscall.SIGINT, syscall.SIGTERM:
 				log.Println("received shutdown signal, draining")
+				publishHostSnapshot(fleethealth.StateStopping, false)
+				stopHostPublisherOnce.Do(func() { close(stopHostPublisher) })
 				if apiSrv != nil {
 					ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 					if err := apiSrv.Shutdown(ctx); err != nil {
@@ -248,6 +280,10 @@ func runServe() {
 	}()
 
 	orch.Run()
+	stopHostPublisherOnce.Do(func() { close(stopHostPublisher) })
+	if err := fleethealth.MarkStopped(context.Background(), db.DB(), processID, time.Now().UTC()); err != nil {
+		log.Printf("process health: %v", err)
+	}
 	log.Println("jetmon2: shutdown complete")
 }
 
@@ -328,6 +364,7 @@ func rolloutAdviceLines(cfg *config.Config) []string {
 	if cmd := rollbackCheckCommand(cfg); cmd != "" {
 		lines = append(lines, "INFO rollout_rollback_check="+cmd)
 	}
+	lines = append(lines, "INFO rollout_state_report="+stateReportCommand())
 	lines = append(lines, "INFO rollout_drift_report="+projectionDriftCommand())
 	return lines
 }
@@ -369,14 +406,11 @@ func projectionDriftCommand() string {
 	return "./jetmon2 rollout projection-drift"
 }
 
-const dashboardHealthTimeout = 2 * time.Second
-
-func publishDashboardHealth(dash *dashboard.Server, wp *wpcom.Client) {
-	if dash == nil {
-		return
-	}
-	dash.UpdateHealth(dashboardHealthEntries(context.Background(), config.Get(), db.DB(), wp, metrics.Global() != nil, time.Now().UTC()))
+func stateReportCommand() string {
+	return "./jetmon2 rollout state-report --since=15m"
 }
+
+const dashboardHealthTimeout = 2 * time.Second
 
 func dashboardHealthEntries(ctx context.Context, cfg *config.Config, sqlDB *sql.DB, wp *wpcom.Client, statsdReady bool, checkedAt time.Time) []dashboard.HealthEntry {
 	entries := []dashboard.HealthEntry{
@@ -388,6 +422,57 @@ func dashboardHealthEntries(ctx context.Context, cfg *config.Config, sqlDB *sql.
 	}
 	entries = append(entries, veriflierHealthEntries(ctx, cfg, checkedAt)...)
 	return entries
+}
+
+func monitorProcessHealthSnapshot(hostname string, startedAt time.Time, state string, cfg *config.Config, st dashboard.State, health []dashboard.HealthEntry) fleethealth.Snapshot {
+	bucketMin, bucketMax := st.BucketMin, st.BucketMax
+	apiPort, dashboardPort := cfg.APIPort, cfg.DashboardPort
+	return fleethealth.Snapshot{
+		HostID:                 hostname,
+		ProcessType:            fleethealth.ProcessMonitor,
+		PID:                    os.Getpid(),
+		Version:                version,
+		BuildDate:              buildDate,
+		GoVersion:              goVersion,
+		State:                  state,
+		StartedAt:              startedAt,
+		UpdatedAt:              time.Now().UTC(),
+		BucketMin:              &bucketMin,
+		BucketMax:              &bucketMax,
+		BucketOwnership:        st.BucketOwnership,
+		APIPort:                &apiPort,
+		DashboardPort:          &dashboardPort,
+		DeliveryWorkersEnabled: st.DeliveryWorkersEnabled,
+		DeliveryOwnerHost:      st.DeliveryOwnerHost,
+		WorkerCount:            st.WorkerCount,
+		ActiveChecks:           st.ActiveChecks,
+		QueueDepth:             st.QueueDepth,
+		RetryQueueSize:         st.RetryQueueSize,
+		WPCOMCircuitOpen:       st.WPCOMCircuitOpen,
+		WPCOMQueueDepth:        st.WPCOMQueueDepth,
+		MemRSSMB:               st.MemRSSMB,
+		DependencyHealth:       dashboardHealthToFleet(health),
+	}
+}
+
+func dashboardHealthToFleet(entries []dashboard.HealthEntry) []fleethealth.DependencyHealth {
+	out := make([]fleethealth.DependencyHealth, 0, len(entries))
+	for _, entry := range entries {
+		out = append(out, fleethealth.DependencyHealth{
+			Name:      entry.Name,
+			Status:    entry.Status,
+			LatencyMS: entry.Latency,
+			LastError: entry.LastError,
+			CheckedAt: entry.CheckedAt,
+		})
+	}
+	return out
+}
+
+func currentMemRSSMB() int {
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	return int(ms.Sys / 1024 / 1024)
 }
 
 func mysqlHealthEntry(ctx context.Context, sqlDB *sql.DB, checkedAt time.Time) dashboard.HealthEntry {

--- a/cmd/jetmon2/main.go
+++ b/cmd/jetmon2/main.go
@@ -7,11 +7,13 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -31,6 +33,8 @@ import (
 	"github.com/Automattic/jetmon/internal/veriflier"
 	"github.com/Automattic/jetmon/internal/wpcom"
 )
+
+const processHealthWriteTimeout = 2 * time.Second
 
 // Injected at build time via -ldflags.
 var (
@@ -121,7 +125,7 @@ func runServe() {
 	if cfg.DashboardPort > 0 {
 		dash = dashboard.New(hostname)
 		go func() {
-			addr := fmt.Sprintf(":%d", cfg.DashboardPort)
+			addr := dashboardListenAddr(cfg)
 			if err := dash.Listen(addr); err != nil {
 				log.Printf("dashboard: %v", err)
 			}
@@ -179,6 +183,8 @@ func runServe() {
 		})
 	}
 
+	var healthMu sync.RWMutex
+	var lastHealth []dashboard.HealthEntry
 	publishHostSnapshot := func(state string, refreshDependencies bool) {
 		currentCfg := config.Get()
 		if currentCfg == nil {
@@ -188,23 +194,34 @@ func runServe() {
 		var health []dashboard.HealthEntry
 		if refreshDependencies {
 			health = dashboardHealthEntries(context.Background(), currentCfg, db.DB(), wp, metrics.Global() != nil, checkedAt)
+			healthMu.Lock()
+			lastHealth = append([]dashboard.HealthEntry(nil), health...)
+			healthMu.Unlock()
+		} else {
+			healthMu.RLock()
+			health = append([]dashboard.HealthEntry(nil), lastHealth...)
+			healthMu.RUnlock()
 		}
 		bMin, bMax := orch.BucketRange()
-		memRSSMB := currentMemRSSMB()
+		sitesPerSec, roundDuration := orch.LastRoundStats()
+		goSysMemMB := currentGoSysMemMB()
+		deliveryConfigEligible := deliveryWorkersShouldStart(currentCfg, hostname)
 		st := dashboard.State{
 			WorkerCount:                   orch.WorkerCount(),
 			ActiveChecks:                  orch.ActiveChecks(),
 			QueueDepth:                    orch.QueueDepth(),
 			RetryQueueSize:                orch.RetryQueueSize(),
-			SitesPerSec:                   0,
+			SitesPerSec:                   sitesPerSec,
+			RoundDurationMs:               roundDuration.Milliseconds(),
 			WPCOMCircuitOpen:              wp.IsCircuitOpen(),
 			WPCOMQueueDepth:               wp.QueueDepth(),
-			MemRSSMB:                      memRSSMB,
+			GoSysMemMB:                    goSysMemMB,
 			BucketMin:                     bMin,
 			BucketMax:                     bMax,
 			BucketOwnership:               bucketOwnershipLabel(currentCfg),
 			LegacyStatusProjectionEnabled: currentCfg.LegacyStatusProjectionEnable,
 			DeliveryWorkersEnabled:        deliveryWorkersEnabled,
+			DeliveryConfigEligible:        deliveryConfigEligible,
 			DeliveryOwnerHost:             currentCfg.DeliveryOwnerHost,
 			RolloutPreflightCommand:       rolloutPreflightCommand(currentCfg),
 			RolloutCutoverCommand:         cutoverCheckCommand(currentCfg),
@@ -213,28 +230,33 @@ func runServe() {
 			RolloutStateReportCommand:     stateReportCommand(),
 			ProjectionDriftCommand:        projectionDriftCommand(),
 		}
+		st.Hostname = hostname
+		st.UpdatedAt = checkedAt
 		if dash != nil {
 			if refreshDependencies {
 				dash.UpdateHealth(health)
 			}
 			dash.Update(st)
 		}
-		if err := fleethealth.Upsert(context.Background(), db.DB(), monitorProcessHealthSnapshot(hostname, processStartedAt, state, currentCfg, st, health)); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), processHealthWriteTimeout)
+		if err := fleethealth.Upsert(ctx, db.DB(), monitorProcessHealthSnapshot(hostname, processStartedAt, state, currentCfg, st, health)); err != nil {
 			log.Printf("process health: %v", err)
 		}
+		cancel()
 	}
 
 	// Publish both host-dashboard state and the durable fleet-health heartbeat.
-	publishHostSnapshot(fleethealth.StateHealthy, true)
+	publishHostSnapshot(fleethealth.StateRunning, false)
 	stopHostPublisher := make(chan struct{})
 	var stopHostPublisherOnce sync.Once
 	go func() {
 		ticker := time.NewTicker(time.Duration(cfg.StatsUpdateIntervalMS) * time.Millisecond)
 		defer ticker.Stop()
+		publishHostSnapshot(fleethealth.StateRunning, true)
 		for {
 			select {
 			case <-ticker.C:
-				publishHostSnapshot(fleethealth.StateHealthy, true)
+				publishHostSnapshot(fleethealth.StateRunning, true)
 			case <-stopHostPublisher:
 				return
 			}
@@ -281,9 +303,11 @@ func runServe() {
 
 	orch.Run()
 	stopHostPublisherOnce.Do(func() { close(stopHostPublisher) })
-	if err := fleethealth.MarkStopped(context.Background(), db.DB(), processID, time.Now().UTC()); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), processHealthWriteTimeout)
+	if err := fleethealth.MarkStopped(ctx, db.DB(), processID, time.Now().UTC()); err != nil {
 		log.Printf("process health: %v", err)
 	}
+	cancel()
 	log.Println("jetmon2: shutdown complete")
 }
 
@@ -410,6 +434,18 @@ func stateReportCommand() string {
 	return "./jetmon2 rollout state-report --since=15m"
 }
 
+func dashboardListenAddr(cfg *config.Config) string {
+	bindAddr := "127.0.0.1"
+	port := 0
+	if cfg != nil {
+		if strings.TrimSpace(cfg.DashboardBindAddr) != "" {
+			bindAddr = strings.TrimSpace(cfg.DashboardBindAddr)
+		}
+		port = cfg.DashboardPort
+	}
+	return net.JoinHostPort(bindAddr, strconv.Itoa(port))
+}
+
 const dashboardHealthTimeout = 2 * time.Second
 
 func dashboardHealthEntries(ctx context.Context, cfg *config.Config, sqlDB *sql.DB, wp *wpcom.Client, statsdReady bool, checkedAt time.Time) []dashboard.HealthEntry {
@@ -425,8 +461,15 @@ func dashboardHealthEntries(ctx context.Context, cfg *config.Config, sqlDB *sql.
 }
 
 func monitorProcessHealthSnapshot(hostname string, startedAt time.Time, state string, cfg *config.Config, st dashboard.State, health []dashboard.HealthEntry) fleethealth.Snapshot {
+	if st.UpdatedAt.IsZero() {
+		st.UpdatedAt = time.Now().UTC()
+	}
 	bucketMin, bucketMax := st.BucketMin, st.BucketMax
 	apiPort, dashboardPort := cfg.APIPort, cfg.DashboardPort
+	healthStatus := dashboard.SummarizeHost(st, health).Status
+	if state == fleethealth.StateStopping || state == fleethealth.StateStopped {
+		healthStatus = fleethealth.HealthAmber
+	}
 	return fleethealth.Snapshot{
 		HostID:                 hostname,
 		ProcessType:            fleethealth.ProcessMonitor,
@@ -435,6 +478,7 @@ func monitorProcessHealthSnapshot(hostname string, startedAt time.Time, state st
 		BuildDate:              buildDate,
 		GoVersion:              goVersion,
 		State:                  state,
+		HealthStatus:           healthStatus,
 		StartedAt:              startedAt,
 		UpdatedAt:              time.Now().UTC(),
 		BucketMin:              &bucketMin,
@@ -450,7 +494,7 @@ func monitorProcessHealthSnapshot(hostname string, startedAt time.Time, state st
 		RetryQueueSize:         st.RetryQueueSize,
 		WPCOMCircuitOpen:       st.WPCOMCircuitOpen,
 		WPCOMQueueDepth:        st.WPCOMQueueDepth,
-		MemRSSMB:               st.MemRSSMB,
+		GoSysMemMB:             st.GoSysMemMB,
 		DependencyHealth:       dashboardHealthToFleet(health),
 	}
 }
@@ -469,7 +513,7 @@ func dashboardHealthToFleet(entries []dashboard.HealthEntry) []fleethealth.Depen
 	return out
 }
 
-func currentMemRSSMB() int {
+func currentGoSysMemMB() int {
 	var ms runtime.MemStats
 	runtime.ReadMemStats(&ms)
 	return int(ms.Sys / 1024 / 1024)
@@ -655,7 +699,11 @@ func deliveryOwnerStatus(cfg *config.Config, hostname string) (string, string) {
 func cmdStatus() {
 	// Connect to the running instance's internal API.
 	port := envOrDefault("DASHBOARD_PORT", "8080")
-	resp, err := httpGet(fmt.Sprintf("http://localhost:%s/api/state", port))
+	host := envOrDefault("DASHBOARD_HOST", envOrDefault("DASHBOARD_BIND_ADDR", "localhost"))
+	if host == "0.0.0.0" || host == "::" {
+		host = "localhost"
+	}
+	resp, err := httpGet(fmt.Sprintf("http://%s/api/state", net.JoinHostPort(host, port)))
 	if err != nil {
 		log.Fatalf("status: %v", err)
 	}

--- a/cmd/jetmon2/main.go
+++ b/cmd/jetmon2/main.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -90,6 +91,11 @@ func runServe() {
 	log.Printf("config: email_transport=%s", emailTransportLabel(cfg))
 	if !emailTransportDelivers(cfg) {
 		log.Printf("WARN: email_transport=%s — alert-contact emails will be logged but not delivered", emailTransportLabel(cfg))
+	}
+	if cfg.DashboardPort > 0 {
+		if msg := dashboardBindWarning(cfg.DashboardBindAddr); msg != "" {
+			log.Printf("WARN: %s", msg)
+		}
 	}
 
 	config.LoadDB()
@@ -184,8 +190,15 @@ func runServe() {
 	}
 
 	var healthMu sync.RWMutex
+	var publishMu sync.Mutex
+	var shuttingDown atomic.Bool
 	var lastHealth []dashboard.HealthEntry
 	publishHostSnapshot := func(state string, refreshDependencies bool) {
+		publishMu.Lock()
+		defer publishMu.Unlock()
+		if shuttingDown.Load() && state == fleethealth.StateRunning {
+			return
+		}
 		currentCfg := config.Get()
 		if currentCfg == nil {
 			currentCfg = cfg
@@ -279,8 +292,9 @@ func runServe() {
 				}
 			case syscall.SIGINT, syscall.SIGTERM:
 				log.Println("received shutdown signal, draining")
-				publishHostSnapshot(fleethealth.StateStopping, false)
+				shuttingDown.Store(true)
 				stopHostPublisherOnce.Do(func() { close(stopHostPublisher) })
+				publishHostSnapshot(fleethealth.StateStopping, false)
 				if apiSrv != nil {
 					ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 					if err := apiSrv.Shutdown(ctx); err != nil {
@@ -302,7 +316,9 @@ func runServe() {
 	}()
 
 	orch.Run()
+	shuttingDown.Store(true)
 	stopHostPublisherOnce.Do(func() { close(stopHostPublisher) })
+	publishHostSnapshot(fleethealth.StateStopping, false)
 	ctx, cancel := context.WithTimeout(context.Background(), processHealthWriteTimeout)
 	if err := fleethealth.MarkStopped(ctx, db.DB(), processID, time.Now().UTC()); err != nil {
 		log.Printf("process health: %v", err)
@@ -346,6 +362,11 @@ func cmdValidateConfig() {
 	fmt.Printf("INFO email_transport=%s\n", emailTransportLabel(cfg))
 	if !emailTransportDelivers(cfg) {
 		fmt.Printf("WARN email_transport=%s — alert-contact emails will be logged but not delivered\n", emailTransportLabel(cfg))
+	}
+	if cfg.DashboardPort > 0 {
+		if msg := dashboardBindWarning(cfg.DashboardBindAddr); msg != "" {
+			fmt.Printf("WARN %s\n", msg)
+		}
 	}
 	if level, msg := deliveryOwnerStatus(cfg, db.Hostname()); msg != "" {
 		fmt.Printf("%s %s\n", level, msg)
@@ -444,6 +465,22 @@ func dashboardListenAddr(cfg *config.Config) string {
 		port = cfg.DashboardPort
 	}
 	return net.JoinHostPort(bindAddr, strconv.Itoa(port))
+}
+
+func dashboardBindWarning(bindAddr string) string {
+	bindAddr = strings.TrimSpace(bindAddr)
+	if bindAddr == "" {
+		bindAddr = "127.0.0.1"
+	}
+	host := strings.Trim(bindAddr, "[]")
+	host = strings.TrimSuffix(strings.ToLower(host), ".")
+	if host == "localhost" || strings.HasSuffix(host, ".localhost") {
+		return ""
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+		return ""
+	}
+	return fmt.Sprintf("DASHBOARD_BIND_ADDR=%q exposes the unauthenticated host dashboard; restrict access to trusted operator networks", bindAddr)
 }
 
 const dashboardHealthTimeout = 2 * time.Second

--- a/cmd/jetmon2/main_test.go
+++ b/cmd/jetmon2/main_test.go
@@ -14,7 +14,9 @@ import (
 
 	"github.com/Automattic/jetmon/internal/alerting"
 	"github.com/Automattic/jetmon/internal/config"
+	"github.com/Automattic/jetmon/internal/dashboard"
 	"github.com/Automattic/jetmon/internal/deliverer"
+	"github.com/Automattic/jetmon/internal/fleethealth"
 	"github.com/DATA-DOG/go-sqlmock"
 )
 
@@ -267,8 +269,8 @@ func TestBucketOwnershipLabel(t *testing.T) {
 
 func TestRolloutAdviceLines(t *testing.T) {
 	dynamic := rolloutAdviceLines(&config.Config{})
-	if len(dynamic) != 3 {
-		t.Fatalf("dynamic advice len = %d, want 3", len(dynamic))
+	if len(dynamic) != 4 {
+		t.Fatalf("dynamic advice len = %d, want 4", len(dynamic))
 	}
 	if !strings.Contains(dynamic[0], "rollout dynamic-check") {
 		t.Fatalf("dynamic preflight advice = %q", dynamic[0])
@@ -276,14 +278,17 @@ func TestRolloutAdviceLines(t *testing.T) {
 	if !strings.Contains(dynamic[1], "rollout activity-check") {
 		t.Fatalf("dynamic activity advice = %q", dynamic[1])
 	}
-	if !strings.Contains(dynamic[2], "rollout projection-drift") {
-		t.Fatalf("dynamic drift advice = %q", dynamic[2])
+	if !strings.Contains(dynamic[2], "rollout state-report") {
+		t.Fatalf("dynamic state report advice = %q", dynamic[2])
+	}
+	if !strings.Contains(dynamic[3], "rollout projection-drift") {
+		t.Fatalf("dynamic drift advice = %q", dynamic[3])
 	}
 
 	min, max := 12, 34
 	pinned := rolloutAdviceLines(&config.Config{PinnedBucketMin: &min, PinnedBucketMax: &max})
-	if len(pinned) != 6 {
-		t.Fatalf("pinned advice len = %d, want 6", len(pinned))
+	if len(pinned) != 7 {
+		t.Fatalf("pinned advice len = %d, want 7", len(pinned))
 	}
 	if !strings.Contains(pinned[0], "rollout static-plan-check") {
 		t.Fatalf("pinned static-plan advice = %q", pinned[0])
@@ -300,8 +305,11 @@ func TestRolloutAdviceLines(t *testing.T) {
 	if !strings.Contains(pinned[4], "rollout rollback-check") {
 		t.Fatalf("pinned rollback advice = %q", pinned[4])
 	}
-	if !strings.Contains(pinned[5], "rollout projection-drift") {
-		t.Fatalf("pinned drift advice = %q", pinned[5])
+	if !strings.Contains(pinned[5], "rollout state-report") {
+		t.Fatalf("pinned state report advice = %q", pinned[5])
+	}
+	if !strings.Contains(pinned[6], "rollout projection-drift") {
+		t.Fatalf("pinned drift advice = %q", pinned[6])
 	}
 }
 
@@ -335,6 +343,9 @@ func TestRolloutCommandHelpers(t *testing.T) {
 	}
 	if got := projectionDriftCommand(); got != "./jetmon2 rollout projection-drift" {
 		t.Fatalf("projectionDriftCommand() = %q", got)
+	}
+	if got := stateReportCommand(); got != "./jetmon2 rollout state-report --since=15m" {
+		t.Fatalf("stateReportCommand() = %q", got)
 	}
 }
 
@@ -391,6 +402,46 @@ func TestDashboardHealthEntriesReportsCoreDependencies(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("sql expectations: %v", err)
+	}
+}
+
+func TestMonitorProcessHealthSnapshot(t *testing.T) {
+	started := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	cfg := &config.Config{APIPort: 8090, DashboardPort: 8080, DeliveryOwnerHost: "host-a"}
+	st := dashboard.State{
+		WorkerCount:            12,
+		ActiveChecks:           3,
+		QueueDepth:             4,
+		RetryQueueSize:         5,
+		BucketMin:              0,
+		BucketMax:              99,
+		BucketOwnership:        "pinned range=0-99",
+		DeliveryWorkersEnabled: true,
+		DeliveryOwnerHost:      "host-a",
+		WPCOMQueueDepth:        2,
+		MemRSSMB:               88,
+	}
+	health := []dashboard.HealthEntry{{
+		Name:      "mysql",
+		Status:    "green",
+		CheckedAt: started,
+	}}
+
+	snapshot := monitorProcessHealthSnapshot("host-a", started, fleethealth.StateHealthy, cfg, st, health)
+	if snapshot.HostID != "host-a" {
+		t.Fatalf("HostID = %q, want host-a", snapshot.HostID)
+	}
+	if snapshot.ProcessType != fleethealth.ProcessMonitor {
+		t.Fatalf("ProcessType = %q, want monitor", snapshot.ProcessType)
+	}
+	if snapshot.BucketMin == nil || *snapshot.BucketMin != 0 {
+		t.Fatalf("BucketMin = %v, want 0", snapshot.BucketMin)
+	}
+	if snapshot.APIPort == nil || *snapshot.APIPort != 8090 {
+		t.Fatalf("APIPort = %v, want 8090", snapshot.APIPort)
+	}
+	if len(snapshot.DependencyHealth) != 1 || snapshot.DependencyHealth[0].Name != "mysql" {
+		t.Fatalf("DependencyHealth = %+v, want mysql entry", snapshot.DependencyHealth)
 	}
 }
 

--- a/cmd/jetmon2/main_test.go
+++ b/cmd/jetmon2/main_test.go
@@ -417,9 +417,10 @@ func TestMonitorProcessHealthSnapshot(t *testing.T) {
 		BucketMax:              99,
 		BucketOwnership:        "pinned range=0-99",
 		DeliveryWorkersEnabled: true,
+		DeliveryConfigEligible: true,
 		DeliveryOwnerHost:      "host-a",
 		WPCOMQueueDepth:        2,
-		MemRSSMB:               88,
+		GoSysMemMB:             88,
 	}
 	health := []dashboard.HealthEntry{{
 		Name:      "mysql",
@@ -427,7 +428,7 @@ func TestMonitorProcessHealthSnapshot(t *testing.T) {
 		CheckedAt: started,
 	}}
 
-	snapshot := monitorProcessHealthSnapshot("host-a", started, fleethealth.StateHealthy, cfg, st, health)
+	snapshot := monitorProcessHealthSnapshot("host-a", started, fleethealth.StateRunning, cfg, st, health)
 	if snapshot.HostID != "host-a" {
 		t.Fatalf("HostID = %q, want host-a", snapshot.HostID)
 	}
@@ -440,8 +441,23 @@ func TestMonitorProcessHealthSnapshot(t *testing.T) {
 	if snapshot.APIPort == nil || *snapshot.APIPort != 8090 {
 		t.Fatalf("APIPort = %v, want 8090", snapshot.APIPort)
 	}
+	if snapshot.HealthStatus != fleethealth.HealthGreen {
+		t.Fatalf("HealthStatus = %q, want green", snapshot.HealthStatus)
+	}
 	if len(snapshot.DependencyHealth) != 1 || snapshot.DependencyHealth[0].Name != "mysql" {
 		t.Fatalf("DependencyHealth = %+v, want mysql entry", snapshot.DependencyHealth)
+	}
+}
+
+func TestDashboardListenAddrDefaultsLocalhost(t *testing.T) {
+	cfg := &config.Config{DashboardPort: 8080}
+	if got := dashboardListenAddr(cfg); got != "127.0.0.1:8080" {
+		t.Fatalf("dashboardListenAddr() = %q, want 127.0.0.1:8080", got)
+	}
+
+	cfg.DashboardBindAddr = "0.0.0.0"
+	if got := dashboardListenAddr(cfg); got != "0.0.0.0:8080" {
+		t.Fatalf("dashboardListenAddr() = %q, want 0.0.0.0:8080", got)
 	}
 }
 

--- a/cmd/jetmon2/main_test.go
+++ b/cmd/jetmon2/main_test.go
@@ -461,6 +461,34 @@ func TestDashboardListenAddrDefaultsLocalhost(t *testing.T) {
 	}
 }
 
+func TestDashboardBindWarning(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+		want bool
+	}{
+		{name: "empty defaults local", addr: "", want: false},
+		{name: "ipv4 loopback", addr: "127.0.0.1", want: false},
+		{name: "ipv6 loopback", addr: "::1", want: false},
+		{name: "localhost", addr: "localhost", want: false},
+		{name: "wildcard", addr: "0.0.0.0", want: true},
+		{name: "private address", addr: "10.0.0.5", want: true},
+		{name: "hostname", addr: "dashboard.internal", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dashboardBindWarning(tt.addr)
+			if tt.want && got == "" {
+				t.Fatalf("dashboardBindWarning(%q) = empty, want warning", tt.addr)
+			}
+			if !tt.want && got != "" {
+				t.Fatalf("dashboardBindWarning(%q) = %q, want empty", tt.addr, got)
+			}
+		})
+	}
+}
+
 func TestCheckWritableDirReportsMissingDirectory(t *testing.T) {
 	err := checkWritableDir(filepath.Join(t.TempDir(), "missing"))
 	if err == nil {

--- a/config/config-sample.json
+++ b/config/config-sample.json
@@ -33,6 +33,7 @@
 
 	"LOG_FORMAT"     : "text",
 	"DASHBOARD_PORT" : 8080,
+	"DASHBOARD_BIND_ADDR" : "127.0.0.1",
 	"API_PORT"       : 0,
 	"DELIVERY_OWNER_HOST": "",
 	"DEBUG_PORT"     : 6060,

--- a/config/config.readme
+++ b/config/config.readme
@@ -76,6 +76,12 @@ Log output format. Set to "json" for structured logging (e.g. for log aggregator
 DASHBOARD_PORT
 Port for the operator dashboard. Set to 0 to disable. Default: 8080.
 
+DASHBOARD_BIND_ADDR
+Address for the operator dashboard listener. Defaults to 127.0.0.1 so the
+unauthenticated host dashboard is local-only unless an operator explicitly binds
+it to a trusted management interface. Use 0.0.0.0 only behind network controls
+that limit access to trusted operator hosts. Default: 127.0.0.1.
+
 API_PORT
 Port for the internal REST API. Set to 0 to disable. In the embedded v2 deployment, API_PORT also controls whether webhook and alert-contact delivery workers are eligible to run inside jetmon2. The standalone jetmon-deliverer binary does not start the API and does not require API_PORT. Default: 0.
 

--- a/config/config.readme
+++ b/config/config.readme
@@ -80,7 +80,8 @@ DASHBOARD_BIND_ADDR
 Address for the operator dashboard listener. Defaults to 127.0.0.1 so the
 unauthenticated host dashboard is local-only unless an operator explicitly binds
 it to a trusted management interface. Use 0.0.0.0 only behind network controls
-that limit access to trusted operator hosts. Default: 127.0.0.1.
+that limit access to trusted operator hosts. Startup and validate-config warn
+when this is set to a non-loopback address. Default: 127.0.0.1.
 
 API_PORT
 Port for the internal REST API. Set to 0 to disable. In the embedded v2 deployment, API_PORT also controls whether webhook and alert-contact delivery workers are eligible to run inside jetmon2. The standalone jetmon-deliverer binary does not start the API and does not require API_PORT. Default: 0.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -224,7 +224,7 @@ orchestrator.Run()
           │     │     └─ handleRecovery() or handleFailure()
           │     │
           │     ├─ emit StatsD metrics
-          │     └─ applyMemoryPressure()       // drain workers if RSS > limit
+          │     └─ applyMemoryPressure()       // drain workers if Go runtime memory > limit
           │
           └─ sleep to enforce MinTimeBetweenRoundsSec
 ```
@@ -415,6 +415,8 @@ Database Tables
     process_id            Stable key such as <host>:monitor or <host>:deliverer
     host_id/process_type  Fleet grouping dimensions
     state/updated_at      Lifecycle state and freshness marker
+    health_status         Green/amber/red process health rollup
+    go_sys_mem_mb         Go runtime system memory in MB
     dependency_health     JSON dependency health summary
 
   jetmon_events           Authoritative v2 incident current state

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -411,6 +411,12 @@ Database Tables
     last_heartbeat        Updated every round; expiry triggers rebalance
     status                active / draining
 
+  jetmon_process_health   Durable process heartbeat snapshots for dashboards
+    process_id            Stable key such as <host>:monitor or <host>:deliverer
+    host_id/process_type  Fleet grouping dimensions
+    state/updated_at      Lifecycle state and freshness marker
+    dependency_health     JSON dependency health summary
+
   jetmon_events           Authoritative v2 incident current state
     id                    Incident identifier
     blog_id               Site identifier

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -96,6 +96,9 @@ because it is intentionally **not** drop-in with the Jetmon 1 wire format
   red/amber/green summary behavior, clearer rollout-command visibility, and a
   durable `jetmon_process_health` heartbeat table that `jetmon2` and
   `jetmon-deliverer` publish to for future fleet dashboards.
+- Host dashboard exposure now defaults to localhost, host summaries include
+  named red/amber issues, process lifecycle is stored separately from health
+  rollup, and memory is labeled as Go runtime system memory rather than RSS.
 - `make all` now builds the currently implemented `jetmon2` and
   `veriflier2` binaries without requiring `protoc`; generated Veriflier
   gRPC stubs remain an explicit `make generate` step for the future

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -92,6 +92,10 @@ because it is intentionally **not** drop-in with the Jetmon 1 wire format
   roadmap.md.
 
 **Docs / tooling:**
+- Host dashboard now has a combined `/api/host` snapshot endpoint, stronger
+  red/amber/green summary behavior, clearer rollout-command visibility, and a
+  durable `jetmon_process_health` heartbeat table that `jetmon2` and
+  `jetmon-deliverer` publish to for future fleet dashboards.
 - `make all` now builds the currently implemented `jetmon2` and
   `veriflier2` binaries without requiring `protoc`; generated Veriflier
   gRPC stubs remain an explicit `make generate` step for the future

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -71,9 +71,12 @@ Each long-running process owns one stable `process_id` such as
 snapshot:
 
 - process identity: host, process type, PID, version, build date, Go version
-- lifecycle state: `healthy`, `idle`, `degraded`, `stopping`, or `stopped`
+- lifecycle state: `running`, `idle`, `stopping`, or `stopped`
+- health rollup: `green`, `amber`, or `red`, derived from local dependency
+  health and rollout-relevant warnings
 - monitor state: bucket range, ownership mode, worker counts, queue depths,
-  WPCOM circuit/queue state, delivery-owner state, API/dashboard ports, RSS
+  WPCOM circuit/queue state, delivery-owner state, API/dashboard ports, Go
+  runtime system memory
 - dependency health JSON: MySQL, Verifliers, WPCOM, StatsD, and local writable
   directories where applicable
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -61,6 +61,25 @@ The API can expose a derived `cli_batch` field for local API CLI test data when
 | `jetmon_alert_deliveries` | Outbound alert-contact attempts and retry state |
 | `jetmon_alert_dispatch_progress` | Alert worker high-water marks over transitions |
 | `jetmon_site_tenants` | Tenant-to-site mapping for gateway-scoped API access |
+| `jetmon_process_health` | Durable per-process heartbeat snapshots for host and fleet dashboards |
+
+## Process Health
+
+`jetmon_process_health` is the durable plumbing for fleet-level operator views.
+Each long-running process owns one stable `process_id` such as
+`<host>:monitor` or `<host>:deliverer` and periodically upserts a compact
+snapshot:
+
+- process identity: host, process type, PID, version, build date, Go version
+- lifecycle state: `healthy`, `idle`, `degraded`, `stopping`, or `stopped`
+- monitor state: bucket range, ownership mode, worker counts, queue depths,
+  WPCOM circuit/queue state, delivery-owner state, API/dashboard ports, RSS
+- dependency health JSON: MySQL, Verifliers, WPCOM, StatsD, and local writable
+  directories where applicable
+
+Fleet dashboards must treat stale `updated_at` values as unknown or unhealthy.
+The row says what the process last reported; it is not proof that the process is
+still alive after the heartbeat age exceeds the dashboard threshold.
 
 ## Event Source Of Truth
 

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -23,7 +23,7 @@ Key settings:
 | `MIN_TIME_BETWEEN_ROUNDS_SEC` | 300 | Minimum seconds between check rounds |
 | `NET_COMMS_TIMEOUT` | 10 | Default per-check HTTP timeout in seconds |
 | `PEER_OFFLINE_LIMIT` | 3 | Veriflier agreements required to confirm downtime |
-| `WORKER_MAX_MEM_MB` | 53 | RSS threshold that triggers worker-pool drain |
+| `WORKER_MAX_MEM_MB` | 53 | Go runtime memory threshold that triggers worker-pool drain |
 | `BUCKET_TOTAL` | 1000 | Total bucket range across all hosts |
 | `BUCKET_TARGET` | 500 | Maximum buckets this host should own |
 | `BUCKET_HEARTBEAT_GRACE_SEC` | 600 | Seconds before a silent host's buckets are reclaimed |
@@ -32,6 +32,7 @@ Key settings:
 | `LEGACY_STATUS_PROJECTION_ENABLE` | true | Keep v1 status fields projected during the [v1-to-v2 migration](v1-to-v2-migration.md) |
 | `LOG_FORMAT` | `text` | `text` or `json` |
 | `DASHBOARD_PORT` | 8080 | Internal operator dashboard port, 0 disables it |
+| `DASHBOARD_BIND_ADDR` | 127.0.0.1 | Dashboard listener address; keep localhost unless a trusted management network requires remote access |
 | `API_PORT` | 0 | Internal REST API port, 0 disables it |
 | `DELIVERY_OWNER_HOST` | empty | Optional host allowed to run embedded delivery workers |
 | `DEBUG_PORT` | 6060 | localhost-only pprof port, 0 disables it |
@@ -207,12 +208,18 @@ Status and reload commands:
 ./jetmon2 drain
 ```
 
-The host operator dashboard is available on `DASHBOARD_PORT` when enabled. It
-shows a red/amber/green host summary, worker count, active checks, queue depth,
-retry queue depth, throughput, round time, owned buckets, rollout guard state,
-RSS, WPCOM circuit-breaker state, dependency health for MySQL, Verifliers,
-WPCOM, StatsD, local log/stats writes, and the rollout commands an operator is
-most likely to need from that host.
+The host operator dashboard is available on `DASHBOARD_BIND_ADDR:DASHBOARD_PORT`
+when enabled. It defaults to `127.0.0.1`, because the host dashboard is
+unauthenticated and exposes internal dependency details, rollout commands, host
+names, ports, and bucket ownership. Bind it to a remote address only behind
+trusted operator-network controls.
+
+The dashboard shows a red/amber/green host summary with named issues, worker
+count, active checks, queue depth, retry queue depth, throughput, round time,
+owned buckets, rollout guard state, Go runtime system memory, WPCOM
+circuit-breaker state, dependency health for MySQL, Verifliers, WPCOM, StatsD,
+local log/stats writes, and the rollout commands an operator is most likely to
+need from that host.
 
 The dashboard exposes three local JSON endpoints:
 
@@ -242,6 +249,14 @@ Process health can be inspected directly:
 SELECT process_id, host_id, process_type, state, updated_at
 FROM jetmon_process_health
 ORDER BY process_type, host_id;
+```
+
+For health rollups and memory:
+
+```sql
+SELECT process_id, state, health_status, go_sys_mem_mb, updated_at
+FROM jetmon_process_health
+ORDER BY health_status DESC, updated_at;
 ```
 
 A host whose heartbeat is older than `BUCKET_HEARTBEAT_GRACE_SEC` will have its
@@ -291,9 +306,9 @@ go tool pprof heap.prof
 
 The debug listener binds to localhost only. Set `DEBUG_PORT` to 0 to disable it.
 
-If RSS exceeds `WORKER_MAX_MEM_MB`, the goroutine pool shrinks by 10 percent via
-graceful drain. Sustained memory pressure should be investigated with pprof
-before increasing the limit.
+If Go runtime memory exceeds `WORKER_MAX_MEM_MB`, the goroutine pool shrinks by
+10 percent via graceful drain. Sustained memory pressure should be investigated
+with pprof and operating-system RSS before increasing the limit.
 
 ## Veriflier Health
 

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -207,11 +207,26 @@ Status and reload commands:
 ./jetmon2 drain
 ```
 
-The operator dashboard is available on `DASHBOARD_PORT` when enabled. It shows
-worker count, active checks, queue depth, retry queue depth, throughput, round
-time, owned buckets, rollout guard state, RSS, WPCOM circuit-breaker state, and
-dependency health for MySQL, Verifliers, WPCOM, StatsD, and local log/stats
-writes.
+The host operator dashboard is available on `DASHBOARD_PORT` when enabled. It
+shows a red/amber/green host summary, worker count, active checks, queue depth,
+retry queue depth, throughput, round time, owned buckets, rollout guard state,
+RSS, WPCOM circuit-breaker state, dependency health for MySQL, Verifliers,
+WPCOM, StatsD, local log/stats writes, and the rollout commands an operator is
+most likely to need from that host.
+
+The dashboard exposes three local JSON endpoints:
+
+```text
+GET /api/state   # raw host state snapshot
+GET /api/health  # dependency health list
+GET /api/host    # combined host state, dependency health, and summary
+```
+
+Long-running `jetmon2` and `jetmon-deliverer` processes also publish compact
+heartbeat snapshots to `jetmon_process_health`. That table is the durable data
+source for the planned fleet dashboard. Treat stale `updated_at` values as
+unknown/unhealthy; the row is the last reported process state, not proof that a
+host is still alive.
 
 Bucket coverage can be inspected directly:
 
@@ -219,6 +234,14 @@ Bucket coverage can be inspected directly:
 SELECT host_id, bucket_min, bucket_max, last_heartbeat, status
 FROM jetmon_hosts
 ORDER BY bucket_min;
+```
+
+Process health can be inspected directly:
+
+```sql
+SELECT process_id, host_id, process_type, state, updated_at
+FROM jetmon_process_health
+ORDER BY process_type, host_id;
 ```
 
 A host whose heartbeat is older than `BUCKET_HEARTBEAT_GRACE_SEC` will have its

--- a/docs/project.md
+++ b/docs/project.md
@@ -229,6 +229,8 @@ A lightweight web UI served by the binary itself (no separate process) on a conf
 - WPCOM circuit-breaker state and queued notification depth
 - Live dependency health for MySQL, configured Verifliers, WPCOM, StatsD, and
   log/stats directory writes
+- Combined `/api/host` snapshot with local state, dependency health, and a
+  red/amber/green host summary for operator tooling
 
 Updates via server-sent events and lightweight JSON polling — no WebSocket library needed, no JavaScript framework. A plain HTML page with `<EventSource>` and `fetch` is sufficient and has no build toolchain dependency.
 
@@ -245,6 +247,12 @@ Future refinements can add primary/replica breakdowns, last successful
 orchestrator batch, WPCOM request error-rate windows, and disk free-space
 thresholds once production operating data shows which signals are worth paging
 on.
+
+Long-running `jetmon2` and `jetmon-deliverer` processes also publish compact
+heartbeat snapshots into `jetmon_process_health`. That table is the foundation
+for a fleet dashboard that can summarize monitor hosts, standalone deliverers,
+stale process heartbeats, delivery-owner state, and local dependency health
+without polling every host dashboard directly.
 
 **False Positive Tracker**
 Every time the system escalates a site to Veriflier confirmation and the Verifliers do NOT confirm it as down (i.e., the queue entry times out or all Verifliers report the site as up), the event is recorded in a `jetmon_false_positives` table with timestamp, site, HTTP code, error code, and RTT from the local check. A view in the operator dashboard surfaces sites with high false positive rates, helping operators tune per-site `NUM_OF_CHECKS` or `TIME_BETWEEN_CHECKS_SEC` settings.

--- a/docs/project.md
+++ b/docs/project.md
@@ -225,7 +225,7 @@ A lightweight web UI served by the binary itself (no separate process) on a conf
 - Owned bucket range
 - Bucket ownership mode, legacy projection mode, delivery-worker ownership, and
   rollout preflight / projection-drift commands
-- RSS memory usage
+- Go runtime system memory usage
 - WPCOM circuit-breaker state and queued notification depth
 - Live dependency health for MySQL, configured Verifliers, WPCOM, StatsD, and
   log/stats directory writes
@@ -251,7 +251,8 @@ on.
 Long-running `jetmon2` and `jetmon-deliverer` processes also publish compact
 heartbeat snapshots into `jetmon_process_health`. That table is the foundation
 for a fleet dashboard that can summarize monitor hosts, standalone deliverers,
-stale process heartbeats, delivery-owner state, and local dependency health
+stale process heartbeats, lifecycle state, red/amber/green health rollups,
+delivery-owner state, Go runtime system memory, and local dependency health
 without polling every host dashboard directly.
 
 **False Positive Tracker**
@@ -347,7 +348,7 @@ Benefits over the current static configuration:
 - **Veriflier unreachable**: A Veriflier that fails to respond is marked unhealthy and excluded from confirmation requests. Remaining healthy Verifliers continue; the `PEER_OFFLINE_LIMIT` threshold adjusts dynamically to the number of healthy Verifliers (with a floor to prevent false confirmations).
 - **WPCOM API failures**: Circuit breaker pattern. After N consecutive failures the circuit opens, pending notifications are queued in memory with timestamps, and the circuit is retried on a backoff schedule. Queue is bounded; oldest entries are dropped with an error log if it fills.
 - **Stuck check goroutine**: A watchdog goroutine tracks the last activity time of each check. A goroutine that exceeds `NET_COMMS_TIMEOUT * 2` without completing is cancelled via context cancellation, its result counted as a timeout, and a new goroutine is allocated to replace it.
-- **Memory pressure**: The binary exposes its RSS via the health endpoint. If RSS exceeds a configurable threshold, the pool size is reduced by 10% via graceful drain until pressure eases — the equivalent of the current worker recycling mechanism, but without process death.
+- **Memory pressure**: The binary exposes Go runtime system memory via the health endpoint. If that exceeds a configurable threshold, the pool size is reduced by 10% via graceful drain until pressure eases — the equivalent of the current worker recycling mechanism, but without process death. True operating-system RSS can still be checked with host tooling when investigating sustained memory pressure.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,9 +15,6 @@ migration and the operating data needed to make larger architecture decisions.
 These are scoped branches worth considering after the merged API CLI, rollout
 preflight, deliverer hardening, and API CLI fixture workflow branches:
 
-- **`feature/host-dashboard-fleet-plumbing`** - improve each host dashboard as
-  a clearer production rollout cockpit while publishing process health into
-  MySQL so a later fleet dashboard has a durable data source.
 - **`feature/fleet-dashboard`** - add a global dashboard for monitor hosts,
   standalone deliverers, Verifliers, bucket coverage, stale heartbeats,
   delivery backlog, projection drift, and fleet-level rollout blockers.
@@ -153,6 +150,9 @@ preflight, deliverer hardening, and API CLI fixture workflow branches:
 
 Recently completed candidate branches:
 
+- **`feature/host-dashboard-fleet-plumbing`** - improved each host dashboard as
+  a clearer production rollout cockpit while publishing monitor and deliverer
+  process health into MySQL for the later fleet dashboard.
 - **`feature/rollout-preflight-hardening`** - merged rollout safety commands
   for static bucket plans, pinned checks, activity checks, rollback checks,
   projection drift, and operator-visible rollout guidance.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -120,23 +120,24 @@ preflight, deliverer hardening, and API CLI fixture workflow branches:
   heartbeats and compact local health snapshots.
 - [x] Publish monitor-host health from `jetmon2`, including bucket ownership,
   worker queues, WPCOM circuit state, delivery-owner state, dependency health,
-  RSS, version, and process lifecycle state.
+  Go runtime system memory, version, and process lifecycle state.
 - [x] Publish standalone `jetmon-deliverer` health, including active/idle
-  owner state, DB/StatsD health, RSS, version, and process lifecycle state.
+  owner state, DB/StatsD health, Go runtime system memory, version, and process
+  lifecycle state.
 - [x] Add a combined host-dashboard snapshot endpoint so host state, dependency
   health, and red/amber/green summary rules are available from one local API.
 - [x] Polish the existing host dashboard so rollout blockers, delivery-owner
   warnings, dependency health, and operator commands are easier to scan.
-- [ ] Harden host dashboard exposure by binding to localhost by default, with
+- [x] Harden host dashboard exposure by binding to localhost by default, with
   an explicit operator-controlled bind address for trusted remote access.
-- [ ] Add a compact host-summary issue list so amber/red dashboard states name
+- [x] Add a compact host-summary issue list so amber/red dashboard states name
   the highest-priority blockers instead of only showing aggregate counts.
-- [ ] Split process lifecycle state from health rollup state in
+- [x] Split process lifecycle state from health rollup state in
   `jetmon_process_health` so a running process can still report degraded or red
   dependencies without overloading a single field.
-- [ ] Wire real per-host sites-per-second and last-round duration values into
+- [x] Wire real per-host sites-per-second and last-round duration values into
   the dashboard instead of showing placeholder zero values.
-- [ ] Label the dashboard memory value as Go runtime system memory so operators
+- [x] Label the dashboard memory value as Go runtime system memory so operators
   do not mistake `runtime.MemStats.Sys` for operating-system RSS.
 - [ ] Build the global fleet dashboard from `jetmon_process_health`,
   `jetmon_hosts`, delivery queues, projection drift, and Veriflier health.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -127,10 +127,26 @@ preflight, deliverer hardening, and API CLI fixture workflow branches:
   health, and red/amber/green summary rules are available from one local API.
 - [x] Polish the existing host dashboard so rollout blockers, delivery-owner
   warnings, dependency health, and operator commands are easier to scan.
+- [ ] Harden host dashboard exposure by binding to localhost by default, with
+  an explicit operator-controlled bind address for trusted remote access.
+- [ ] Add a compact host-summary issue list so amber/red dashboard states name
+  the highest-priority blockers instead of only showing aggregate counts.
+- [ ] Split process lifecycle state from health rollup state in
+  `jetmon_process_health` so a running process can still report degraded or red
+  dependencies without overloading a single field.
+- [ ] Wire real per-host sites-per-second and last-round duration values into
+  the dashboard instead of showing placeholder zero values.
+- [ ] Label the dashboard memory value as Go runtime system memory so operators
+  do not mistake `runtime.MemStats.Sys` for operating-system RSS.
 - [ ] Build the global fleet dashboard from `jetmon_process_health`,
   `jetmon_hosts`, delivery queues, projection drift, and Veriflier health.
 - [ ] Add stale-heartbeat thresholds and fleet-level suggested next actions for
   rollout handoffs.
+- [ ] Add explicit fleet delivery-ownership posture so operators can
+  distinguish intentional rollout-conservative `DELIVERY_OWNER_HOST` settings
+  from accidental all-host delivery eligibility.
+- [ ] Consider collecting true process RSS for fleet and host dashboards if
+  operators need OS-level memory accounting beyond Go runtime system memory.
 - [ ] Document and test the fleet dashboard's safe network exposure model
   before exposing it beyond trusted operator networks.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,9 +15,12 @@ migration and the operating data needed to make larger architecture decisions.
 These are scoped branches worth considering after the merged API CLI, rollout
 preflight, deliverer hardening, and API CLI fixture workflow branches:
 
-- **`feature/operator-dashboard-polish`** - turn the dashboard into a clearer
-  production rollout cockpit: stronger warning states, dependency health
-  details, rollout-command visibility, and event/API pointers for operators.
+- **`feature/host-dashboard-fleet-plumbing`** - improve each host dashboard as
+  a clearer production rollout cockpit while publishing process health into
+  MySQL so a later fleet dashboard has a durable data source.
+- **`feature/fleet-dashboard`** - add a global dashboard for monitor hosts,
+  standalone deliverers, Verifliers, bucket coverage, stale heartbeats,
+  delivery backlog, projection drift, and fleet-level rollout blockers.
 - **`feature/projection-drift-tooling`** - expand drift diagnostics beyond
   count/list output with range summaries, likely causes, rehearsal reports, and
   dry-run repair guidance if repair becomes safe enough to automate.
@@ -85,8 +88,8 @@ preflight, deliverer hardening, and API CLI fixture workflow branches:
 ### Rollout VM Lab TODO
 
 - [x] Prepare an in-house KVM/libvirt host with passwordless sudo, QEMU,
-  libvirt, cloud-init tooling, Ansible, Expect, Go, MariaDB client tools, and a
-  dedicated `jetmon-rollout` storage pool.
+  libvirt, cloud-init tooling, Go, MariaDB client tools, and a dedicated
+  `jetmon-rollout` storage pool.
 - [x] Add a repo-owned `scripts/rollout-vm-lab.sh` harness with host `doctor`,
   image fetch, VM create/destroy, topology create, SSH wait, and offline
   snapshot/revert primitives.
@@ -108,6 +111,28 @@ preflight, deliverer hardening, and API CLI fixture workflow branches:
   directory refusal, bad DB connection refusal, and real `last_checked_at`
   activity from the `jetmon2` service.
 - [x] Add snapshot-backed replay for every named VM lab smoke flow.
+
+### Dashboard and Fleet Health TODO
+
+- [x] Split dashboard work into two PRs: first improve host dashboards and add
+  fleet-dashboard plumbing, then build the global fleet dashboard on top.
+- [x] Add a durable `jetmon_process_health` table for long-running process
+  heartbeats and compact local health snapshots.
+- [x] Publish monitor-host health from `jetmon2`, including bucket ownership,
+  worker queues, WPCOM circuit state, delivery-owner state, dependency health,
+  RSS, version, and process lifecycle state.
+- [x] Publish standalone `jetmon-deliverer` health, including active/idle
+  owner state, DB/StatsD health, RSS, version, and process lifecycle state.
+- [x] Add a combined host-dashboard snapshot endpoint so host state, dependency
+  health, and red/amber/green summary rules are available from one local API.
+- [x] Polish the existing host dashboard so rollout blockers, delivery-owner
+  warnings, dependency health, and operator commands are easier to scan.
+- [ ] Build the global fleet dashboard from `jetmon_process_health`,
+  `jetmon_hosts`, delivery queues, projection drift, and Veriflier health.
+- [ ] Add stale-heartbeat thresholds and fleet-level suggested next actions for
+  rollout handoffs.
+- [ ] Document and test the fleet dashboard's safe network exposure model
+  before exposing it beyond trusted operator networks.
 
 Recently completed candidate branches:
 

--- a/docs/v1-to-v2-migration.md
+++ b/docs/v1-to-v2-migration.md
@@ -564,7 +564,7 @@ If `DASHBOARD_PORT` is enabled, confirm:
   and log/stats directory writes
 - WPCOM circuit breaker is closed
 - retry queue depth is not growing unexpectedly
-- RSS stays below the configured guardrail
+- Go runtime system memory stays below the configured guardrail
 - delivery workers are disabled unless explicitly approved
 
 Useful direct checks:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"sync"
 )
 
@@ -82,10 +83,11 @@ type Config struct {
 	NetCommsTimeout           int  `json:"NET_COMMS_TIMEOUT"`
 	UseVariableCheckIntervals bool `json:"USE_VARIABLE_CHECK_INTERVALS"`
 
-	LogFormat     string `json:"LOG_FORMAT"`
-	DashboardPort int    `json:"DASHBOARD_PORT"`
-	DebugPort     int    `json:"DEBUG_PORT"`
-	APIPort       int    `json:"API_PORT"` // 0 = API server disabled
+	LogFormat         string `json:"LOG_FORMAT"`
+	DashboardPort     int    `json:"DASHBOARD_PORT"`
+	DashboardBindAddr string `json:"DASHBOARD_BIND_ADDR"`
+	DebugPort         int    `json:"DEBUG_PORT"`
+	APIPort           int    `json:"API_PORT"` // 0 = API server disabled
 
 	// DeliveryOwnerHost constrains webhook and alert-contact delivery workers
 	// to a single named host while the v2 single-binary deployment still uses
@@ -213,6 +215,7 @@ func defaults() *Config {
 		NetCommsTimeout:              10,
 		LogFormat:                    "text",
 		DashboardPort:                8080,
+		DashboardBindAddr:            "127.0.0.1",
 		DebugPort:                    6060,
 		EmailTransport:               "stub",
 		EmailFrom:                    "jetmon@noreply.invalid",
@@ -280,6 +283,9 @@ func validate(cfg *Config) error {
 	}
 	if cfg.LogFormat != "text" && cfg.LogFormat != "json" {
 		return fmt.Errorf("LOG_FORMAT must be 'text' or 'json'")
+	}
+	if strings.TrimSpace(cfg.DashboardBindAddr) == "" {
+		cfg.DashboardBindAddr = "127.0.0.1"
 	}
 	switch cfg.EmailTransport {
 	case "", "stub":

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -147,6 +147,14 @@ func TestValidate(t *testing.T) {
 			mutate: func(c *Config) { c.LogFormat = "json" },
 		},
 		{
+			name:   "empty dashboard bind address falls back to localhost",
+			mutate: func(c *Config) { c.DashboardBindAddr = "" },
+		},
+		{
+			name:   "remote dashboard bind address is explicit and valid",
+			mutate: func(c *Config) { c.DashboardBindAddr = "0.0.0.0" },
+		},
+		{
 			name:   "stub email transport is valid",
 			mutate: func(c *Config) { c.EmailTransport = "stub" },
 		},
@@ -230,6 +238,23 @@ func TestPinnedBucketRange(t *testing.T) {
 	min, max, ok = cfg.PinnedBucketRange()
 	if !ok || min != 20 || max != 29 {
 		t.Fatalf("PinnedBucketRange legacy = %d-%d ok=%v, want 20-29 true", min, max, ok)
+	}
+}
+
+func TestValidateDefaultsDashboardBindAddr(t *testing.T) {
+	cfg := &Config{
+		AuthToken:       "token",
+		NumWorkers:      10,
+		BucketTotal:     100,
+		BucketTarget:    50,
+		NetCommsTimeout: 10,
+		LogFormat:       "text",
+	}
+	if err := validate(cfg); err != nil {
+		t.Fatalf("validate() error = %v", err)
+	}
+	if cfg.DashboardBindAddr != "127.0.0.1" {
+		t.Fatalf("DashboardBindAddr = %q, want 127.0.0.1", cfg.DashboardBindAddr)
 	}
 }
 

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -21,12 +21,13 @@ type State struct {
 	RoundDurationMs               int64     `json:"round_duration_ms"`
 	WPCOMCircuitOpen              bool      `json:"wpcom_circuit_open"`
 	WPCOMQueueDepth               int       `json:"wpcom_queue_depth"`
-	MemRSSMB                      int       `json:"mem_rss_mb"`
+	GoSysMemMB                    int       `json:"go_sys_mem_mb"`
 	BucketMin                     int       `json:"bucket_min"`
 	BucketMax                     int       `json:"bucket_max"`
 	BucketOwnership               string    `json:"bucket_ownership"`
 	LegacyStatusProjectionEnabled bool      `json:"legacy_status_projection_enabled"`
 	DeliveryWorkersEnabled        bool      `json:"delivery_workers_enabled"`
+	DeliveryConfigEligible        bool      `json:"delivery_config_eligible"`
 	DeliveryOwnerHost             string    `json:"delivery_owner_host"`
 	RolloutPreflightCommand       string    `json:"rollout_preflight_command"`
 	RolloutCutoverCommand         string    `json:"rollout_cutover_command"`
@@ -58,11 +59,12 @@ type HostSnapshot struct {
 // HostSummary gives callers an immediate status without reimplementing the
 // dashboard's red/amber/green rules.
 type HostSummary struct {
-	Status     string `json:"status"`
-	Message    string `json:"message"`
-	RedCount   int    `json:"red_count"`
-	AmberCount int    `json:"amber_count"`
-	GreenCount int    `json:"green_count"`
+	Status     string   `json:"status"`
+	Message    string   `json:"message"`
+	Issues     []string `json:"issues,omitempty"`
+	RedCount   int      `json:"red_count"`
+	AmberCount int      `json:"amber_count"`
+	GreenCount int      `json:"green_count"`
 }
 
 // Server is the operator dashboard HTTP server.
@@ -90,7 +92,7 @@ func (s *Server) Update(st State) {
 
 	var ms runtime.MemStats
 	runtime.ReadMemStats(&ms)
-	st.MemRSSMB = int(ms.Sys / 1024 / 1024)
+	st.GoSysMemMB = int(ms.Sys / 1024 / 1024)
 
 	s.mu.Lock()
 	s.state = st
@@ -116,7 +118,13 @@ func (s *Server) Listen(addr string) error {
 	mux.HandleFunc("/api/host", s.handleHost)
 
 	log.Printf("dashboard: listening on %s", addr)
-	return http.ListenAndServe(addr, mux)
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+	return srv.ListenAndServe()
 }
 
 // ListenDebug starts a localhost-only pprof/debug server on the given address.
@@ -227,30 +235,42 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 // operator attention, green means no local blocker is visible.
 func SummarizeHost(st State, health []HealthEntry) HostSummary {
 	summary := HostSummary{Status: "green", Message: "host checks are green"}
+	redIssues := []string{}
+	amberIssues := []string{}
 	if st.UpdatedAt.IsZero() {
 		summary.Status = "amber"
 		summary.Message = "waiting for host state"
+		amberIssues = append(amberIssues, "host state has not been published yet")
 	}
 	wpcomAlreadyRed := false
 	for _, entry := range health {
 		switch entry.Status {
 		case "red":
 			summary.RedCount++
+			redIssues = append(redIssues, issueText(entry))
 			if entry.Name == "wpcom" {
 				wpcomAlreadyRed = true
 			}
 		case "amber":
 			summary.AmberCount++
+			amberIssues = append(amberIssues, issueText(entry))
 		case "green":
 			summary.GreenCount++
 		}
 	}
 	if st.WPCOMCircuitOpen && !wpcomAlreadyRed {
 		summary.RedCount++
+		redIssues = append(redIssues, "wpcom red: circuit open")
 	}
 	if st.DeliveryWorkersEnabled && st.DeliveryOwnerHost == "" {
 		summary.AmberCount++
+		amberIssues = append(amberIssues, "delivery amber: runtime workers are enabled without DELIVERY_OWNER_HOST")
 	}
+	if st.DeliveryWorkersEnabled != st.DeliveryConfigEligible {
+		summary.AmberCount++
+		amberIssues = append(amberIssues, "delivery amber: runtime worker state differs from current config; restart to apply ownership changes")
+	}
+	summary.Issues = append(redIssues, amberIssues...)
 	switch {
 	case summary.RedCount > 0:
 		summary.Status = "red"
@@ -262,6 +282,14 @@ func SummarizeHost(st State, health []HealthEntry) HostSummary {
 		summary.Message = "host checks are green"
 	}
 	return summary
+}
+
+func issueText(entry HealthEntry) string {
+	detail := entry.LastError
+	if detail == "" {
+		detail = "no detail reported"
+	}
+	return fmt.Sprintf("%s %s: %s", entry.Name, entry.Status, detail)
 }
 
 const dashboardHTML = `<!DOCTYPE html>
@@ -315,6 +343,8 @@ const dashboardHTML = `<!DOCTYPE html>
   .summary.red { border-left-color: var(--red); }
   .summary-title { font-size: 1.25rem; margin-bottom: 6px; }
   .summary-detail { color: var(--muted); font-size: 0.9rem; }
+  .summary-issues { margin: 10px 0 0; padding-left: 18px; color: var(--text); font-size: 0.86rem; line-height: 1.45; }
+  .summary-issues:empty { display: none; }
   .summary-meta { display: grid; gap: 6px; justify-items: end; color: var(--muted); font-size: 0.8rem; }
   .status-pill {
     display: inline-flex;
@@ -366,6 +396,7 @@ const dashboardHTML = `<!DOCTYPE html>
     <div>
       <div class="summary-title" id="summary-title">Waiting for host state</div>
       <div class="summary-detail" id="summary-detail">No dashboard update has been received yet.</div>
+      <ul class="summary-issues" id="summary-issues"></ul>
     </div>
     <div class="summary-meta">
       <span id="host">host: unknown</span>
@@ -386,14 +417,15 @@ const dashboardHTML = `<!DOCTYPE html>
     <div class="card"><div class="label">Sites/Sec</div><div class="value" id="sps">-</div></div>
     <div class="card"><div class="label">Round Time</div><div class="value" id="round">-</div></div>
     <div class="card"><div class="label">Buckets</div><div class="value" id="buckets">-</div></div>
-    <div class="card"><div class="label">RSS</div><div class="value" id="rss">-</div></div>
+    <div class="card"><div class="label">Go Sys Memory</div><div class="value" id="go-sys">-</div></div>
   </div>
 
   <h2>Rollout State</h2>
   <div class="grid">
     <div class="card"><div class="label">Ownership</div><div class="value" id="ownership">-</div></div>
     <div class="card"><div class="label">Legacy Projection</div><div class="value" id="projection">-</div></div>
-    <div class="card"><div class="label">Delivery Workers</div><div class="value" id="delivery">-</div></div>
+    <div class="card"><div class="label">Delivery Runtime</div><div class="value" id="delivery">-</div></div>
+    <div class="card"><div class="label">Config Eligibility</div><div class="value" id="delivery-eligible">-</div></div>
     <div class="card"><div class="label">Delivery Owner</div><div class="value" id="delivery-owner">-</div></div>
     <div class="card"><div class="label">WPCOM Circuit</div><div class="value" id="wpcom">-</div></div>
     <div class="card"><div class="label">WPCOM Queue</div><div class="value" id="wpcomq">-</div></div>
@@ -431,10 +463,11 @@ function renderState(d) {
   setText('sps', d.sites_per_sec);
   setText('round', ((d.round_duration_ms || 0) / 1000).toFixed(1) + 's');
   setText('buckets', d.bucket_min + '-' + d.bucket_max);
-  setText('rss', d.mem_rss_mb + 'MB');
+  setText('go-sys', d.go_sys_mem_mb + 'MB');
   setText('ownership', d.bucket_ownership || '-');
   setText('projection', d.legacy_status_projection_enabled ? 'enabled' : 'disabled');
   setText('delivery', d.delivery_workers_enabled ? 'enabled' : 'disabled');
+  setText('delivery-eligible', d.delivery_config_eligible ? 'eligible' : 'not eligible');
   setText('delivery-owner', d.delivery_owner_host || 'unset');
   setText('state-report', d.rollout_state_report_command);
   setText('preflight', d.rollout_preflight_command);
@@ -460,26 +493,55 @@ function renderSummary(summary) {
   pill.textContent = status;
   setText('summary-title', summary.message || 'host status unavailable');
   setText('summary-detail', 'dependencies green=' + (summary.green_count || 0) + ' amber=' + (summary.amber_count || 0) + ' red=' + (summary.red_count || 0));
+  const issues = document.getElementById('summary-issues');
+  issues.textContent = '';
+  (summary.issues || []).slice(0, 5).forEach(function(issue) {
+    const item = document.createElement('li');
+    item.textContent = issue;
+    issues.appendChild(item);
+  });
 }
 
 function summarizeLocal() {
   let red = 0;
   let amber = currentState ? 0 : 1;
   let green = 0;
+  let redIssues = [];
+  let amberIssues = currentState ? [] : ['host state has not been published yet'];
   let wpcomAlreadyRed = false;
   currentHealth.forEach(function(entry) {
     if (entry.status === 'red') {
       red++;
+      redIssues.push(issueText(entry));
       if (entry.name === 'wpcom') wpcomAlreadyRed = true;
     }
-    else if (entry.status === 'amber') amber++;
+    else if (entry.status === 'amber') {
+      amber++;
+      amberIssues.push(issueText(entry));
+    }
     else if (entry.status === 'green') green++;
   });
-  if (currentState && currentState.wpcom_circuit_open && !wpcomAlreadyRed) red++;
-  if (currentState && currentState.delivery_workers_enabled && !currentState.delivery_owner_host) amber++;
-  if (red > 0) return { status: 'red', message: 'rollout-blocking dependency or circuit issue', red_count: red, amber_count: amber, green_count: green };
-  if (amber > 0) return { status: 'amber', message: 'operator attention needed before rollout', red_count: red, amber_count: amber, green_count: green };
-  return { status: 'green', message: 'host checks are green', red_count: red, amber_count: amber, green_count: green };
+  if (currentState && currentState.wpcom_circuit_open && !wpcomAlreadyRed) {
+    red++;
+    redIssues.push('wpcom red: circuit open');
+  }
+  if (currentState && currentState.delivery_workers_enabled && !currentState.delivery_owner_host) {
+    amber++;
+    amberIssues.push('delivery amber: runtime workers are enabled without DELIVERY_OWNER_HOST');
+  }
+  if (currentState && currentState.delivery_workers_enabled !== currentState.delivery_config_eligible) {
+    amber++;
+    amberIssues.push('delivery amber: runtime worker state differs from current config; restart to apply ownership changes');
+  }
+  const issues = redIssues.concat(amberIssues);
+  if (red > 0) return { status: 'red', message: 'rollout-blocking dependency or circuit issue', issues: issues, red_count: red, amber_count: amber, green_count: green };
+  if (amber > 0) return { status: 'amber', message: 'operator attention needed before rollout', issues: issues, red_count: red, amber_count: amber, green_count: green };
+  return { status: 'green', message: 'host checks are green', issues: [], red_count: red, amber_count: amber, green_count: green };
+}
+
+function issueText(entry) {
+  const detail = entry.last_error || 'no detail reported';
+  return entry.name + ' ' + entry.status + ': ' + detail;
 }
 
 const src = new EventSource('/events');

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -11,6 +11,8 @@ import (
 	"time"
 )
 
+const maxSSEClients = 32
+
 // State holds the real-time metrics snapshot served by the dashboard.
 type State struct {
 	WorkerCount                   int       `json:"worker_count"`
@@ -171,16 +173,21 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-
 	ch := make(chan string, 16)
 	id := fmt.Sprintf("%p", ch)
 
 	s.sseMu.Lock()
+	if len(s.sseClients) >= maxSSEClients {
+		s.sseMu.Unlock()
+		http.Error(w, "too many dashboard event clients", http.StatusServiceUnavailable)
+		return
+	}
 	s.sseClients[id] = ch
 	s.sseMu.Unlock()
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
 
 	defer func() {
 		s.sseMu.Lock()
@@ -241,6 +248,10 @@ func SummarizeHost(st State, health []HealthEntry) HostSummary {
 		summary.Status = "amber"
 		summary.Message = "waiting for host state"
 		amberIssues = append(amberIssues, "host state has not been published yet")
+	}
+	if len(health) == 0 {
+		summary.AmberCount++
+		amberIssues = append(amberIssues, "dependency health has not been published yet")
 	}
 	wpcomAlreadyRed := false
 	for _, entry := range health {
@@ -509,6 +520,10 @@ function summarizeLocal() {
   let redIssues = [];
   let amberIssues = currentState ? [] : ['host state has not been published yet'];
   let wpcomAlreadyRed = false;
+  if (currentHealth.length === 0) {
+    amber++;
+    amberIssues.push('dependency health has not been published yet');
+  }
   currentHealth.forEach(function(entry) {
     if (entry.status === 'red') {
       red++;

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -29,8 +29,10 @@ type State struct {
 	DeliveryWorkersEnabled        bool      `json:"delivery_workers_enabled"`
 	DeliveryOwnerHost             string    `json:"delivery_owner_host"`
 	RolloutPreflightCommand       string    `json:"rollout_preflight_command"`
+	RolloutCutoverCommand         string    `json:"rollout_cutover_command"`
 	RolloutActivityCommand        string    `json:"rollout_activity_command"`
 	RolloutRollbackCommand        string    `json:"rollout_rollback_command"`
+	RolloutStateReportCommand     string    `json:"rollout_state_report_command"`
 	ProjectionDriftCommand        string    `json:"projection_drift_command"`
 	Hostname                      string    `json:"hostname"`
 	UpdatedAt                     time.Time `json:"updated_at"`
@@ -43,6 +45,24 @@ type HealthEntry struct {
 	Latency   int64     `json:"latency_ms,omitempty"`
 	LastError string    `json:"last_error,omitempty"`
 	CheckedAt time.Time `json:"checked_at"`
+}
+
+// HostSnapshot is the combined per-host dashboard model. Fleet views can reuse
+// the same shape for a single process before aggregating many hosts.
+type HostSnapshot struct {
+	State   State         `json:"state"`
+	Health  []HealthEntry `json:"health"`
+	Summary HostSummary   `json:"summary"`
+}
+
+// HostSummary gives callers an immediate status without reimplementing the
+// dashboard's red/amber/green rules.
+type HostSummary struct {
+	Status     string `json:"status"`
+	Message    string `json:"message"`
+	RedCount   int    `json:"red_count"`
+	AmberCount int    `json:"amber_count"`
+	GreenCount int    `json:"green_count"`
 }
 
 // Server is the operator dashboard HTTP server.
@@ -93,6 +113,7 @@ func (s *Server) Listen(addr string) error {
 	mux.HandleFunc("/events", s.handleSSE)
 	mux.HandleFunc("/api/state", s.handleState)
 	mux.HandleFunc("/api/health", s.handleHealth)
+	mux.HandleFunc("/api/host", s.handleHost)
 
 	log.Printf("dashboard: listening on %s", addr)
 	return http.ListenAndServe(addr, mux)
@@ -116,10 +137,23 @@ func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	s.mu.RLock()
-	h := s.health
+	h := append([]HealthEntry(nil), s.health...)
 	s.mu.RUnlock()
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(h)
+}
+
+func (s *Server) handleHost(w http.ResponseWriter, r *http.Request) {
+	s.mu.RLock()
+	st := s.state
+	h := append([]HealthEntry(nil), s.health...)
+	s.mu.RUnlock()
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(HostSnapshot{
+		State:   st,
+		Health:  h,
+		Summary: SummarizeHost(st, h),
+	})
 }
 
 func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
@@ -188,120 +222,301 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, dashboardHTML)
 }
 
+// SummarizeHost reduces local state and dependency health into a dashboard
+// status. It deliberately stays simple: red blocks rollout, amber needs
+// operator attention, green means no local blocker is visible.
+func SummarizeHost(st State, health []HealthEntry) HostSummary {
+	summary := HostSummary{Status: "green", Message: "host checks are green"}
+	if st.UpdatedAt.IsZero() {
+		summary.Status = "amber"
+		summary.Message = "waiting for host state"
+	}
+	wpcomAlreadyRed := false
+	for _, entry := range health {
+		switch entry.Status {
+		case "red":
+			summary.RedCount++
+			if entry.Name == "wpcom" {
+				wpcomAlreadyRed = true
+			}
+		case "amber":
+			summary.AmberCount++
+		case "green":
+			summary.GreenCount++
+		}
+	}
+	if st.WPCOMCircuitOpen && !wpcomAlreadyRed {
+		summary.RedCount++
+	}
+	if st.DeliveryWorkersEnabled && st.DeliveryOwnerHost == "" {
+		summary.AmberCount++
+	}
+	switch {
+	case summary.RedCount > 0:
+		summary.Status = "red"
+		summary.Message = "rollout-blocking dependency or circuit issue"
+	case summary.AmberCount > 0:
+		summary.Status = "amber"
+		summary.Message = "operator attention needed before rollout"
+	case summary.Status == "green":
+		summary.Message = "host checks are green"
+	}
+	return summary
+}
+
 const dashboardHTML = `<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<title>Jetmon 2 — Operator Dashboard</title>
+<title>Jetmon 2 - Host Dashboard</title>
 <style>
-  body { font-family: monospace; background: #1a1a1a; color: #e0e0e0; margin: 2rem; }
-  h1 { color: #7ec8e3; }
-  h2 { color: #aaa; font-size: 1rem; margin-top: 2rem; }
-  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 1rem; }
-  .card { background: #2a2a2a; padding: 1rem; border-radius: 4px; }
-  .card .label { font-size: 0.75rem; color: #888; }
-  .card .value { font-size: 1.5rem; color: #7ec8e3; margin-top: 0.25rem; }
-  .card .value.command { font-size: 0.85rem; line-height: 1.35; overflow-wrap: anywhere; }
-  .health-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 0.5rem; margin-top: 1rem; }
-  .health-item { padding: 0.5rem 1rem; border-radius: 4px; font-size: 0.85rem; }
-  .green  { background: #1a3a1a; border-left: 4px solid #4caf50; }
-  .amber  { background: #3a2a00; border-left: 4px solid #ff9800; }
-  .red    { background: #3a1a1a; border-left: 4px solid #f44336; }
-  #updated { font-size: 0.75rem; color: #555; margin-top: 2rem; }
+  :root {
+    color-scheme: dark;
+    --bg: #101316;
+    --panel: #1b2024;
+    --panel-strong: #252b30;
+    --line: #353d43;
+    --text: #eef2f5;
+    --muted: #9aa7b0;
+    --green: #58c783;
+    --green-bg: #14301f;
+    --amber: #f0b85a;
+    --amber-bg: #342814;
+    --red: #f06b64;
+    --red-bg: #3b1d1b;
+    --accent: #77b7d9;
+  }
+  * { box-sizing: border-box; }
+  body {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    background: var(--bg);
+    color: var(--text);
+    margin: 0;
+    padding: 24px;
+  }
+  main { max-width: 1400px; margin: 0 auto; }
+  h1 { margin: 0; font-size: 1.65rem; color: var(--text); }
+  h2 { margin: 28px 0 12px; font-size: 0.85rem; color: var(--muted); letter-spacing: 0; text-transform: uppercase; }
+  .topline { display: flex; align-items: baseline; justify-content: space-between; gap: 16px; margin-bottom: 16px; }
+  .subtle { color: var(--muted); font-size: 0.85rem; }
+  .summary {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 16px;
+    align-items: center;
+    padding: 18px;
+    border: 1px solid var(--line);
+    border-left-width: 6px;
+    border-radius: 6px;
+    background: var(--panel);
+  }
+  .summary.green { border-left-color: var(--green); }
+  .summary.amber { border-left-color: var(--amber); }
+  .summary.red { border-left-color: var(--red); }
+  .summary-title { font-size: 1.25rem; margin-bottom: 6px; }
+  .summary-detail { color: var(--muted); font-size: 0.9rem; }
+  .summary-meta { display: grid; gap: 6px; justify-items: end; color: var(--muted); font-size: 0.8rem; }
+  .status-pill {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 72px;
+    padding: 5px 9px;
+    border-radius: 999px;
+    color: var(--text);
+    font-size: 0.78rem;
+    text-transform: uppercase;
+  }
+  .status-pill.green { background: var(--green-bg); color: var(--green); }
+  .status-pill.amber { background: var(--amber-bg); color: var(--amber); }
+  .status-pill.red { background: var(--red-bg); color: var(--red); }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(210px, 1fr)); gap: 12px; }
+  .card { background: var(--panel); padding: 14px; border: 1px solid var(--line); border-radius: 6px; min-height: 78px; }
+  .card .label { font-size: 0.72rem; color: var(--muted); text-transform: uppercase; }
+  .card .value { font-size: 1.35rem; color: var(--accent); margin-top: 8px; overflow-wrap: anywhere; }
+  .card .detail { color: var(--muted); font-size: 0.78rem; margin-top: 6px; overflow-wrap: anywhere; }
+  .command-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 10px; }
+  .command { background: var(--panel-strong); border: 1px solid var(--line); border-radius: 6px; padding: 12px; min-width: 0; }
+  .command .label { color: var(--muted); font-size: 0.72rem; text-transform: uppercase; margin-bottom: 8px; }
+  .command code { color: var(--accent); white-space: normal; overflow-wrap: anywhere; line-height: 1.35; }
+  .health-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(230px, 1fr)); gap: 10px; }
+  .health-item { padding: 11px 12px; border: 1px solid var(--line); border-left-width: 5px; border-radius: 6px; font-size: 0.83rem; overflow-wrap: anywhere; background: var(--panel); }
+  .health-item.green { border-left-color: var(--green); }
+  .health-item.amber { border-left-color: var(--amber); }
+  .health-item.red { border-left-color: var(--red); }
+  @media (max-width: 720px) {
+    body { padding: 14px; }
+    .topline, .summary { grid-template-columns: 1fr; }
+    .summary-meta { justify-items: start; }
+    .command-grid { grid-template-columns: 1fr; }
+  }
 </style>
 </head>
 <body>
-<h1>Jetmon 2</h1>
-<div id="host"></div>
+<main>
+  <div class="topline">
+    <div>
+      <h1>Jetmon 2</h1>
+      <div class="subtle">Host dashboard</div>
+    </div>
+    <span class="status-pill amber" id="summary-pill">waiting</span>
+  </div>
 
-<h2>CHECK POOL</h2>
-<div class="grid">
-  <div class="card"><div class="label">GOROUTINES</div><div class="value" id="workers">—</div></div>
-  <div class="card"><div class="label">ACTIVE CHECKS</div><div class="value" id="active">—</div></div>
-  <div class="card"><div class="label">QUEUE DEPTH</div><div class="value" id="queue">—</div></div>
-  <div class="card"><div class="label">RETRY QUEUE</div><div class="value" id="retry">—</div></div>
-</div>
+  <section class="summary amber" id="summary">
+    <div>
+      <div class="summary-title" id="summary-title">Waiting for host state</div>
+      <div class="summary-detail" id="summary-detail">No dashboard update has been received yet.</div>
+    </div>
+    <div class="summary-meta">
+      <span id="host">host: unknown</span>
+      <span id="updated">updated: never</span>
+    </div>
+  </section>
 
-<h2>THROUGHPUT</h2>
-<div class="grid">
-  <div class="card"><div class="label">SITES/SEC</div><div class="value" id="sps">—</div></div>
-  <div class="card"><div class="label">ROUND TIME</div><div class="value" id="round">—</div></div>
-  <div class="card"><div class="label">BUCKETS</div><div class="value" id="buckets">—</div></div>
-  <div class="card"><div class="label">RSS</div><div class="value" id="rss">—</div></div>
-</div>
+  <h2>Check Pool</h2>
+  <div class="grid">
+    <div class="card"><div class="label">Goroutines</div><div class="value" id="workers">-</div></div>
+    <div class="card"><div class="label">Active Checks</div><div class="value" id="active">-</div></div>
+    <div class="card"><div class="label">Queue Depth</div><div class="value" id="queue">-</div></div>
+    <div class="card"><div class="label">Retry Queue</div><div class="value" id="retry">-</div></div>
+  </div>
 
-<h2>ROLLOUT</h2>
-<div class="grid">
-  <div class="card"><div class="label">OWNERSHIP</div><div class="value" id="ownership">—</div></div>
-  <div class="card"><div class="label">LEGACY PROJECTION</div><div class="value" id="projection">—</div></div>
-  <div class="card"><div class="label">DELIVERY WORKERS</div><div class="value" id="delivery">—</div></div>
-  <div class="card"><div class="label">DELIVERY OWNER</div><div class="value" id="delivery-owner">—</div></div>
-  <div class="card"><div class="label">PREFLIGHT</div><div class="value command" id="preflight">—</div></div>
-  <div class="card"><div class="label">ACTIVITY</div><div class="value command" id="activity">—</div></div>
-  <div class="card"><div class="label">ROLLBACK</div><div class="value command" id="rollback">—</div></div>
-  <div class="card"><div class="label">DRIFT REPORT</div><div class="value command" id="drift">—</div></div>
-</div>
+  <h2>Throughput</h2>
+  <div class="grid">
+    <div class="card"><div class="label">Sites/Sec</div><div class="value" id="sps">-</div></div>
+    <div class="card"><div class="label">Round Time</div><div class="value" id="round">-</div></div>
+    <div class="card"><div class="label">Buckets</div><div class="value" id="buckets">-</div></div>
+    <div class="card"><div class="label">RSS</div><div class="value" id="rss">-</div></div>
+  </div>
 
-<h2>EXTERNAL DEPENDENCIES</h2>
-<div class="grid">
-  <div class="card"><div class="label">WPCOM CIRCUIT</div><div class="value" id="wpcom">—</div></div>
-  <div class="card"><div class="label">WPCOM QUEUE</div><div class="value" id="wpcomq">—</div></div>
-</div>
-<div class="health-grid" id="health"></div>
+  <h2>Rollout State</h2>
+  <div class="grid">
+    <div class="card"><div class="label">Ownership</div><div class="value" id="ownership">-</div></div>
+    <div class="card"><div class="label">Legacy Projection</div><div class="value" id="projection">-</div></div>
+    <div class="card"><div class="label">Delivery Workers</div><div class="value" id="delivery">-</div></div>
+    <div class="card"><div class="label">Delivery Owner</div><div class="value" id="delivery-owner">-</div></div>
+    <div class="card"><div class="label">WPCOM Circuit</div><div class="value" id="wpcom">-</div></div>
+    <div class="card"><div class="label">WPCOM Queue</div><div class="value" id="wpcomq">-</div></div>
+  </div>
 
-<div id="updated"></div>
+  <h2>Operator Commands</h2>
+  <div class="command-grid">
+    <div class="command"><div class="label">State Report</div><code id="state-report">-</code></div>
+    <div class="command"><div class="label">Preflight</div><code id="preflight">-</code></div>
+    <div class="command"><div class="label">Cutover</div><code id="cutover">-</code></div>
+    <div class="command"><div class="label">Activity</div><code id="activity">-</code></div>
+    <div class="command"><div class="label">Rollback</div><code id="rollback">-</code></div>
+    <div class="command"><div class="label">Drift Report</div><code id="drift">-</code></div>
+  </div>
+
+  <h2>External Dependencies</h2>
+  <div class="health-grid" id="health"></div>
+</main>
 
 <script>
+let currentState = null;
+let currentHealth = [];
+
+function setText(id, value) {
+  document.getElementById(id).textContent = value === undefined || value === null || value === '' ? '-' : value;
+}
+
+function renderState(d) {
+  currentState = d;
+  setText('host', 'host: ' + (d.hostname || 'unknown'));
+  setText('workers', d.worker_count);
+  setText('active', d.active_checks);
+  setText('queue', d.queue_depth);
+  setText('retry', d.retry_queue_size);
+  setText('sps', d.sites_per_sec);
+  setText('round', ((d.round_duration_ms || 0) / 1000).toFixed(1) + 's');
+  setText('buckets', d.bucket_min + '-' + d.bucket_max);
+  setText('rss', d.mem_rss_mb + 'MB');
+  setText('ownership', d.bucket_ownership || '-');
+  setText('projection', d.legacy_status_projection_enabled ? 'enabled' : 'disabled');
+  setText('delivery', d.delivery_workers_enabled ? 'enabled' : 'disabled');
+  setText('delivery-owner', d.delivery_owner_host || 'unset');
+  setText('state-report', d.rollout_state_report_command);
+  setText('preflight', d.rollout_preflight_command);
+  setText('cutover', d.rollout_cutover_command);
+  setText('activity', d.rollout_activity_command);
+  setText('rollback', d.rollout_rollback_command);
+  setText('drift', d.projection_drift_command);
+  setText('wpcom', d.wpcom_circuit_open ? 'OPEN' : 'closed');
+  setText('wpcomq', d.wpcom_queue_depth);
+  setText('updated', 'updated: ' + (d.updated_at ? new Date(d.updated_at).toLocaleTimeString() : 'never'));
+  renderSummary();
+}
+
+function renderSummary(summary) {
+  if (!summary) {
+    summary = summarizeLocal();
+  }
+  const status = summary.status || 'amber';
+  const box = document.getElementById('summary');
+  box.className = 'summary ' + status;
+  const pill = document.getElementById('summary-pill');
+  pill.className = 'status-pill ' + status;
+  pill.textContent = status;
+  setText('summary-title', summary.message || 'host status unavailable');
+  setText('summary-detail', 'dependencies green=' + (summary.green_count || 0) + ' amber=' + (summary.amber_count || 0) + ' red=' + (summary.red_count || 0));
+}
+
+function summarizeLocal() {
+  let red = 0;
+  let amber = currentState ? 0 : 1;
+  let green = 0;
+  let wpcomAlreadyRed = false;
+  currentHealth.forEach(function(entry) {
+    if (entry.status === 'red') {
+      red++;
+      if (entry.name === 'wpcom') wpcomAlreadyRed = true;
+    }
+    else if (entry.status === 'amber') amber++;
+    else if (entry.status === 'green') green++;
+  });
+  if (currentState && currentState.wpcom_circuit_open && !wpcomAlreadyRed) red++;
+  if (currentState && currentState.delivery_workers_enabled && !currentState.delivery_owner_host) amber++;
+  if (red > 0) return { status: 'red', message: 'rollout-blocking dependency or circuit issue', red_count: red, amber_count: amber, green_count: green };
+  if (amber > 0) return { status: 'amber', message: 'operator attention needed before rollout', red_count: red, amber_count: amber, green_count: green };
+  return { status: 'green', message: 'host checks are green', red_count: red, amber_count: amber, green_count: green };
+}
+
 const src = new EventSource('/events');
 src.onmessage = function(e) {
-  const d = JSON.parse(e.data);
-  document.getElementById('host').textContent    = d.hostname;
-  document.getElementById('workers').textContent = d.worker_count;
-  document.getElementById('active').textContent  = d.active_checks;
-  document.getElementById('queue').textContent   = d.queue_depth;
-  document.getElementById('retry').textContent   = d.retry_queue_size;
-  document.getElementById('sps').textContent     = d.sites_per_sec;
-  document.getElementById('round').textContent   = (d.round_duration_ms / 1000).toFixed(1) + 's';
-  document.getElementById('buckets').textContent = d.bucket_min + '–' + d.bucket_max;
-  document.getElementById('rss').textContent     = d.mem_rss_mb + 'MB';
-  document.getElementById('ownership').textContent = d.bucket_ownership || '—';
-  document.getElementById('projection').textContent = d.legacy_status_projection_enabled ? 'enabled' : 'disabled';
-  document.getElementById('delivery').textContent = d.delivery_workers_enabled ? 'enabled' : 'disabled';
-  document.getElementById('delivery-owner').textContent = d.delivery_owner_host || 'unset';
-  document.getElementById('preflight').textContent = d.rollout_preflight_command || '—';
-  document.getElementById('activity').textContent = d.rollout_activity_command || '—';
-  document.getElementById('rollback').textContent = d.rollout_rollback_command || '—';
-  document.getElementById('drift').textContent = d.projection_drift_command || '—';
-  document.getElementById('wpcom').textContent   = d.wpcom_circuit_open ? 'OPEN' : 'closed';
-  document.getElementById('wpcomq').textContent  = d.wpcom_queue_depth;
-  document.getElementById('updated').textContent = 'Updated: ' + new Date(d.updated_at).toLocaleTimeString();
+  renderState(JSON.parse(e.data));
 };
 
-async function refreshHealth() {
+async function refreshHost() {
   try {
-    const res = await fetch('/api/health', { cache: 'no-store' });
-    const entries = await res.json();
+    const res = await fetch('/api/host', { cache: 'no-store' });
+    const snapshot = await res.json();
+    if (snapshot.state) renderState(snapshot.state);
+    const entries = snapshot.health || [];
+    currentHealth = entries;
     const box = document.getElementById('health');
     box.textContent = '';
     entries.forEach(function(entry) {
       const item = document.createElement('div');
       item.className = 'health-item ' + (entry.status || 'amber');
       const latency = entry.latency_ms ? ' ' + entry.latency_ms + 'ms' : '';
-      const detail = entry.last_error ? ' — ' + entry.last_error : '';
+      const detail = entry.last_error ? ' - ' + entry.last_error : '';
       item.textContent = entry.name + ': ' + entry.status + latency + detail;
       box.appendChild(item);
     });
+    renderSummary(snapshot.summary);
   } catch (err) {
     const box = document.getElementById('health');
     box.textContent = '';
     const item = document.createElement('div');
     item.className = 'health-item red';
-    item.textContent = 'dashboard health: red — ' + err;
+    item.textContent = 'dashboard health: red - ' + err;
     box.appendChild(item);
+    renderSummary({ status: 'red', message: 'dashboard health endpoint failed', red_count: 1, amber_count: 0, green_count: 0 });
   }
 }
-refreshHealth();
-setInterval(refreshHealth, 10000);
+refreshHost();
+setInterval(refreshHost, 10000);
 </script>
 </body>
 </html>`

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestHandleState(t *testing.T) {
@@ -20,8 +21,10 @@ func TestHandleState(t *testing.T) {
 		DeliveryWorkersEnabled:        true,
 		DeliveryOwnerHost:             "api-1",
 		RolloutPreflightCommand:       "./jetmon2 rollout pinned-check",
+		RolloutCutoverCommand:         "./jetmon2 rollout cutover-check --since=15m",
 		RolloutActivityCommand:        "./jetmon2 rollout activity-check --since=15m",
 		RolloutRollbackCommand:        "./jetmon2 rollout rollback-check",
+		RolloutStateReportCommand:     "./jetmon2 rollout state-report --since=15m",
 		ProjectionDriftCommand:        "./jetmon2 rollout projection-drift",
 	})
 
@@ -57,11 +60,17 @@ func TestHandleState(t *testing.T) {
 	if st.RolloutPreflightCommand != "./jetmon2 rollout pinned-check" {
 		t.Fatalf("RolloutPreflightCommand = %q", st.RolloutPreflightCommand)
 	}
+	if st.RolloutCutoverCommand != "./jetmon2 rollout cutover-check --since=15m" {
+		t.Fatalf("RolloutCutoverCommand = %q", st.RolloutCutoverCommand)
+	}
 	if st.RolloutActivityCommand != "./jetmon2 rollout activity-check --since=15m" {
 		t.Fatalf("RolloutActivityCommand = %q", st.RolloutActivityCommand)
 	}
 	if st.RolloutRollbackCommand != "./jetmon2 rollout rollback-check" {
 		t.Fatalf("RolloutRollbackCommand = %q", st.RolloutRollbackCommand)
+	}
+	if st.RolloutStateReportCommand != "./jetmon2 rollout state-report --since=15m" {
+		t.Fatalf("RolloutStateReportCommand = %q", st.RolloutStateReportCommand)
 	}
 	if st.ProjectionDriftCommand != "./jetmon2 rollout projection-drift" {
 		t.Fatalf("ProjectionDriftCommand = %q", st.ProjectionDriftCommand)
@@ -94,6 +103,43 @@ func TestHandleHealth(t *testing.T) {
 	}
 }
 
+func TestHandleHostSnapshot(t *testing.T) {
+	srv := New("test-host")
+	srv.Update(State{
+		WorkerCount:            5,
+		WPCOMCircuitOpen:       true,
+		DeliveryWorkersEnabled: true,
+	})
+	srv.UpdateHealth([]HealthEntry{
+		{Name: "mysql", Status: "green"},
+		{Name: "statsd", Status: "amber"},
+	})
+
+	r := httptest.NewRequest(http.MethodGet, "/api/host", nil)
+	w := httptest.NewRecorder()
+	srv.handleHost(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var snapshot HostSnapshot
+	if err := json.NewDecoder(w.Body).Decode(&snapshot); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if snapshot.State.Hostname != "test-host" {
+		t.Fatalf("Hostname = %q, want test-host", snapshot.State.Hostname)
+	}
+	if len(snapshot.Health) != 2 {
+		t.Fatalf("health len = %d, want 2", len(snapshot.Health))
+	}
+	if snapshot.Summary.Status != "red" {
+		t.Fatalf("summary status = %q, want red", snapshot.Summary.Status)
+	}
+	if snapshot.Summary.RedCount == 0 {
+		t.Fatalf("summary red count = %d, want non-zero", snapshot.Summary.RedCount)
+	}
+}
+
 func TestHandleIndex(t *testing.T) {
 	srv := New("test-host")
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -112,6 +158,12 @@ func TestHandleIndex(t *testing.T) {
 	if !strings.Contains(w.Body.String(), "id=\"preflight\"") {
 		t.Fatal("body does not contain rollout preflight card")
 	}
+	if !strings.Contains(w.Body.String(), "id=\"cutover\"") {
+		t.Fatal("body does not contain rollout cutover command")
+	}
+	if !strings.Contains(w.Body.String(), "id=\"state-report\"") {
+		t.Fatal("body does not contain rollout state report command")
+	}
 	if !strings.Contains(w.Body.String(), "id=\"activity\"") {
 		t.Fatal("body does not contain rollout activity card")
 	}
@@ -123,6 +175,28 @@ func TestHandleIndex(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "id=\"health\"") {
 		t.Fatal("body does not contain dependency health grid")
+	}
+	if !strings.Contains(w.Body.String(), "/api/host") {
+		t.Fatal("body does not fetch combined host snapshot")
+	}
+}
+
+func TestSummarizeHost(t *testing.T) {
+	st := State{UpdatedAt: time.Now(), DeliveryWorkersEnabled: true}
+	summary := SummarizeHost(st, []HealthEntry{{Name: "mysql", Status: "green"}})
+	if summary.Status != "amber" {
+		t.Fatalf("summary status = %q, want amber for unset delivery owner", summary.Status)
+	}
+
+	st.DeliveryOwnerHost = "host-a"
+	summary = SummarizeHost(st, []HealthEntry{{Name: "mysql", Status: "red"}})
+	if summary.Status != "red" {
+		t.Fatalf("summary status = %q, want red for dependency failure", summary.Status)
+	}
+
+	summary = SummarizeHost(st, []HealthEntry{{Name: "mysql", Status: "green"}})
+	if summary.Status != "green" {
+		t.Fatalf("summary status = %q, want green", summary.Status)
 	}
 }
 

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -195,6 +196,14 @@ func TestHandleIndex(t *testing.T) {
 }
 
 func TestSummarizeHost(t *testing.T) {
+	waiting := SummarizeHost(State{UpdatedAt: time.Now()}, nil)
+	if waiting.Status != "amber" {
+		t.Fatalf("waiting summary status = %q, want amber", waiting.Status)
+	}
+	if waiting.AmberCount == 0 || len(waiting.Issues) == 0 || !strings.Contains(waiting.Issues[0], "dependency health") {
+		t.Fatalf("waiting summary = %+v, want dependency health issue", waiting)
+	}
+
 	st := State{UpdatedAt: time.Now(), DeliveryWorkersEnabled: true, DeliveryConfigEligible: true}
 	summary := SummarizeHost(st, []HealthEntry{{Name: "mysql", Status: "green"}})
 	if summary.Status != "amber" {
@@ -322,6 +331,21 @@ func TestHandleSSESendsInitialStateAndCleanup(t *testing.T) {
 
 	// Disconnect the client — handleSSE should return via r.Context().Done().
 	cancel()
+}
+
+func TestHandleSSERejectsExcessClients(t *testing.T) {
+	srv := New("test-host")
+	for i := 0; i < maxSSEClients; i++ {
+		srv.sseClients[fmt.Sprintf("client-%d", i)] = make(chan string, 1)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/events", nil)
+	w := httptest.NewRecorder()
+	srv.handleSSE(w, r)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", w.Code)
+	}
 }
 
 func TestBroadcastDropsOnSlowClient(t *testing.T) {

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -19,6 +19,7 @@ func TestHandleState(t *testing.T) {
 		BucketOwnership:               "pinned range=0-99",
 		LegacyStatusProjectionEnabled: true,
 		DeliveryWorkersEnabled:        true,
+		DeliveryConfigEligible:        true,
 		DeliveryOwnerHost:             "api-1",
 		RolloutPreflightCommand:       "./jetmon2 rollout pinned-check",
 		RolloutCutoverCommand:         "./jetmon2 rollout cutover-check --since=15m",
@@ -53,6 +54,9 @@ func TestHandleState(t *testing.T) {
 	}
 	if !st.DeliveryWorkersEnabled {
 		t.Fatal("DeliveryWorkersEnabled = false, want true")
+	}
+	if !st.DeliveryConfigEligible {
+		t.Fatal("DeliveryConfigEligible = false, want true")
 	}
 	if st.DeliveryOwnerHost != "api-1" {
 		t.Fatalf("DeliveryOwnerHost = %q, want api-1", st.DeliveryOwnerHost)
@@ -138,6 +142,9 @@ func TestHandleHostSnapshot(t *testing.T) {
 	if snapshot.Summary.RedCount == 0 {
 		t.Fatalf("summary red count = %d, want non-zero", snapshot.Summary.RedCount)
 	}
+	if len(snapshot.Summary.Issues) == 0 || !strings.Contains(snapshot.Summary.Issues[0], "wpcom") {
+		t.Fatalf("summary issues = %#v, want wpcom issue first", snapshot.Summary.Issues)
+	}
 }
 
 func TestHandleIndex(t *testing.T) {
@@ -173,6 +180,12 @@ func TestHandleIndex(t *testing.T) {
 	if !strings.Contains(w.Body.String(), "id=\"delivery-owner\"") {
 		t.Fatal("body does not contain delivery owner card")
 	}
+	if !strings.Contains(w.Body.String(), "id=\"delivery-eligible\"") {
+		t.Fatal("body does not contain delivery config eligibility card")
+	}
+	if !strings.Contains(w.Body.String(), "id=\"go-sys\"") {
+		t.Fatal("body does not contain Go system memory card")
+	}
 	if !strings.Contains(w.Body.String(), "id=\"health\"") {
 		t.Fatal("body does not contain dependency health grid")
 	}
@@ -182,21 +195,36 @@ func TestHandleIndex(t *testing.T) {
 }
 
 func TestSummarizeHost(t *testing.T) {
-	st := State{UpdatedAt: time.Now(), DeliveryWorkersEnabled: true}
+	st := State{UpdatedAt: time.Now(), DeliveryWorkersEnabled: true, DeliveryConfigEligible: true}
 	summary := SummarizeHost(st, []HealthEntry{{Name: "mysql", Status: "green"}})
 	if summary.Status != "amber" {
 		t.Fatalf("summary status = %q, want amber for unset delivery owner", summary.Status)
 	}
+	if len(summary.Issues) == 0 || !strings.Contains(summary.Issues[0], "DELIVERY_OWNER_HOST") {
+		t.Fatalf("summary issues = %#v, want delivery owner issue", summary.Issues)
+	}
 
 	st.DeliveryOwnerHost = "host-a"
-	summary = SummarizeHost(st, []HealthEntry{{Name: "mysql", Status: "red"}})
+	summary = SummarizeHost(st, []HealthEntry{{Name: "statsd", Status: "amber", LastError: "not initialized"}, {Name: "mysql", Status: "red", LastError: "access denied"}})
 	if summary.Status != "red" {
 		t.Fatalf("summary status = %q, want red for dependency failure", summary.Status)
+	}
+	if len(summary.Issues) < 2 || !strings.HasPrefix(summary.Issues[0], "mysql red") || !strings.HasPrefix(summary.Issues[1], "statsd amber") {
+		t.Fatalf("summary issues = %#v, want red issues before amber issues", summary.Issues)
 	}
 
 	summary = SummarizeHost(st, []HealthEntry{{Name: "mysql", Status: "green"}})
 	if summary.Status != "green" {
 		t.Fatalf("summary status = %q, want green", summary.Status)
+	}
+	if len(summary.Issues) != 0 {
+		t.Fatalf("summary issues = %#v, want none", summary.Issues)
+	}
+
+	st.DeliveryConfigEligible = false
+	summary = SummarizeHost(st, []HealthEntry{{Name: "mysql", Status: "green"}})
+	if summary.Status != "amber" || len(summary.Issues) == 0 {
+		t.Fatalf("summary = %+v, want amber config mismatch issue", summary)
 	}
 }
 

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -383,6 +383,43 @@ var migrations = []migration{
 		ADD INDEX idx_status_delivered_at (status, delivered_at),
 		ADD INDEX idx_status_last_attempt_at (status, last_attempt_at),
 		ADD INDEX idx_status_created_at (status, created_at)`},
+
+	// Migration 24 creates the durable process heartbeat table used as the
+	// foundation for fleet-wide operator dashboards. Each long-running Jetmon
+	// process owns one process_id and periodically upserts a compact snapshot of
+	// its local state. Fleet views should treat stale updated_at values as
+	// unknown/unhealthy rather than assuming the last state is still current.
+	{24, `CREATE TABLE IF NOT EXISTS jetmon_process_health (
+		process_id               VARCHAR(255) NOT NULL PRIMARY KEY,
+		host_id                  VARCHAR(255) NOT NULL,
+		process_type             VARCHAR(64) NOT NULL,
+		pid                      INT UNSIGNED NOT NULL DEFAULT 0,
+		version                  VARCHAR(64) NOT NULL DEFAULT '',
+		build_date               VARCHAR(64) NOT NULL DEFAULT '',
+		go_version               VARCHAR(64) NOT NULL DEFAULT '',
+		state                    VARCHAR(32) NOT NULL DEFAULT 'starting',
+		started_at               TIMESTAMP NULL,
+		updated_at               TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+		bucket_min               SMALLINT UNSIGNED NULL,
+		bucket_max               SMALLINT UNSIGNED NULL,
+		bucket_ownership         VARCHAR(128) NOT NULL DEFAULT '',
+		api_port                 INT UNSIGNED NULL,
+		dashboard_port           INT UNSIGNED NULL,
+		delivery_workers_enabled TINYINT UNSIGNED NOT NULL DEFAULT 0,
+		delivery_owner_host      VARCHAR(255) NOT NULL DEFAULT '',
+		worker_count             INT UNSIGNED NOT NULL DEFAULT 0,
+		active_checks            INT UNSIGNED NOT NULL DEFAULT 0,
+		queue_depth              INT UNSIGNED NOT NULL DEFAULT 0,
+		retry_queue_size         INT UNSIGNED NOT NULL DEFAULT 0,
+		wpcom_circuit_open       TINYINT UNSIGNED NOT NULL DEFAULT 0,
+		wpcom_queue_depth        INT UNSIGNED NOT NULL DEFAULT 0,
+		mem_rss_mb               INT UNSIGNED NOT NULL DEFAULT 0,
+		dependency_health        JSON NULL,
+		created_at               TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		INDEX idx_process_type_updated (process_type, updated_at),
+		INDEX idx_host_updated (host_id, updated_at),
+		INDEX idx_state_updated (state, updated_at)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
 }
 
 // Migrate applies all pending migrations idempotently.

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -420,6 +420,14 @@ var migrations = []migration{
 		INDEX idx_host_updated (host_id, updated_at),
 		INDEX idx_state_updated (state, updated_at)
 	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
+
+	// Migration 25 splits process lifecycle from health rollup and renames
+	// the memory column to the metric it actually stores. The value comes from
+	// runtime.MemStats.Sys, not operating-system RSS.
+	{25, `ALTER TABLE jetmon_process_health
+		ADD COLUMN health_status VARCHAR(16) NOT NULL DEFAULT 'green' AFTER state,
+		CHANGE COLUMN mem_rss_mb go_sys_mem_mb INT UNSIGNED NOT NULL DEFAULT 0,
+		ADD INDEX idx_health_status_updated (health_status, updated_at)`},
 }
 
 // Migrate applies all pending migrations idempotently.

--- a/internal/fleethealth/health.go
+++ b/internal/fleethealth/health.go
@@ -170,9 +170,15 @@ func normalizeSnapshot(snapshot Snapshot) (Snapshot, error) {
 	if snapshot.State == "" {
 		snapshot.State = StateRunning
 	}
+	if !validState(snapshot.State) {
+		return Snapshot{}, fmt.Errorf("invalid process state %q", snapshot.State)
+	}
 	snapshot.HealthStatus = strings.TrimSpace(snapshot.HealthStatus)
 	if snapshot.HealthStatus == "" {
 		snapshot.HealthStatus = RollupHealthStatus(snapshot.DependencyHealth)
+	}
+	if !validHealthStatus(snapshot.HealthStatus) {
+		return Snapshot{}, fmt.Errorf("invalid health status %q", snapshot.HealthStatus)
 	}
 	if snapshot.StartedAt.IsZero() {
 		snapshot.StartedAt = time.Now().UTC()
@@ -183,6 +189,24 @@ func normalizeSnapshot(snapshot Snapshot) (Snapshot, error) {
 	snapshot.StartedAt = snapshot.StartedAt.UTC()
 	snapshot.UpdatedAt = snapshot.UpdatedAt.UTC()
 	return snapshot, nil
+}
+
+func validState(state string) bool {
+	switch state {
+	case StateRunning, StateStopping, StateStopped, StateIdle:
+		return true
+	default:
+		return false
+	}
+}
+
+func validHealthStatus(status string) bool {
+	switch status {
+	case HealthGreen, HealthAmber, HealthRed:
+		return true
+	default:
+		return false
+	}
 }
 
 // RollupHealthStatus reduces dependency snapshots into a green/amber/red health

--- a/internal/fleethealth/health.go
+++ b/internal/fleethealth/health.go
@@ -1,0 +1,244 @@
+// Package fleethealth publishes durable process health snapshots for fleet views.
+package fleethealth
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	ProcessMonitor   = "monitor"
+	ProcessDeliverer = "deliverer"
+
+	StateHealthy  = "healthy"
+	StateIdle     = "idle"
+	StateDegraded = "degraded"
+	StateStopping = "stopping"
+	StateStopped  = "stopped"
+)
+
+// DependencyHealth is a compact dependency status snapshot suitable for JSON
+// storage and fleet dashboard summaries.
+type DependencyHealth struct {
+	Name      string    `json:"name"`
+	Status    string    `json:"status"`
+	LatencyMS int64     `json:"latency_ms,omitempty"`
+	LastError string    `json:"last_error,omitempty"`
+	CheckedAt time.Time `json:"checked_at"`
+}
+
+// Snapshot is the local process state written to jetmon_process_health.
+type Snapshot struct {
+	ProcessID              string
+	HostID                 string
+	ProcessType            string
+	PID                    int
+	Version                string
+	BuildDate              string
+	GoVersion              string
+	State                  string
+	StartedAt              time.Time
+	UpdatedAt              time.Time
+	BucketMin              *int
+	BucketMax              *int
+	BucketOwnership        string
+	APIPort                *int
+	DashboardPort          *int
+	DeliveryWorkersEnabled bool
+	DeliveryOwnerHost      string
+	WorkerCount            int
+	ActiveChecks           int
+	QueueDepth             int
+	RetryQueueSize         int
+	WPCOMCircuitOpen       bool
+	WPCOMQueueDepth        int
+	MemRSSMB               int
+	DependencyHealth       []DependencyHealth
+}
+
+// ProcessID returns the stable row key for one process type on one host.
+func ProcessID(hostID, processType string) string {
+	hostID = strings.TrimSpace(hostID)
+	processType = strings.TrimSpace(processType)
+	if hostID == "" || processType == "" {
+		return ""
+	}
+	return hostID + ":" + processType
+}
+
+// Upsert writes the current snapshot for a long-running process.
+func Upsert(ctx context.Context, db *sql.DB, snapshot Snapshot) error {
+	if db == nil {
+		return errors.New("database pool is not initialized")
+	}
+	normalized, err := normalizeSnapshot(snapshot)
+	if err != nil {
+		return err
+	}
+	deps, err := json.Marshal(normalized.DependencyHealth)
+	if err != nil {
+		return fmt.Errorf("marshal dependency health: %w", err)
+	}
+
+	_, err = db.ExecContext(ctx, upsertSnapshotSQL,
+		normalized.ProcessID,
+		normalized.HostID,
+		normalized.ProcessType,
+		normalized.PID,
+		normalized.Version,
+		normalized.BuildDate,
+		normalized.GoVersion,
+		normalized.State,
+		normalized.StartedAt,
+		normalized.UpdatedAt,
+		nullableInt(normalized.BucketMin),
+		nullableInt(normalized.BucketMax),
+		normalized.BucketOwnership,
+		nullableInt(normalized.APIPort),
+		nullableInt(normalized.DashboardPort),
+		boolInt(normalized.DeliveryWorkersEnabled),
+		normalized.DeliveryOwnerHost,
+		normalized.WorkerCount,
+		normalized.ActiveChecks,
+		normalized.QueueDepth,
+		normalized.RetryQueueSize,
+		boolInt(normalized.WPCOMCircuitOpen),
+		normalized.WPCOMQueueDepth,
+		normalized.MemRSSMB,
+		string(deps),
+	)
+	if err != nil {
+		return fmt.Errorf("upsert process health: %w", err)
+	}
+	return nil
+}
+
+// MarkStopped records a terminal stopped state during graceful shutdown.
+func MarkStopped(ctx context.Context, db *sql.DB, processID string, when time.Time) error {
+	if db == nil {
+		return errors.New("database pool is not initialized")
+	}
+	processID = strings.TrimSpace(processID)
+	if processID == "" {
+		return errors.New("process id is required")
+	}
+	if when.IsZero() {
+		when = time.Now().UTC()
+	}
+	_, err := db.ExecContext(ctx,
+		`UPDATE jetmon_process_health
+		   SET state = ?, updated_at = ?
+		 WHERE process_id = ?`,
+		StateStopped,
+		when.UTC(),
+		processID,
+	)
+	if err != nil {
+		return fmt.Errorf("mark process stopped: %w", err)
+	}
+	return nil
+}
+
+func normalizeSnapshot(snapshot Snapshot) (Snapshot, error) {
+	snapshot.HostID = strings.TrimSpace(snapshot.HostID)
+	snapshot.ProcessType = strings.TrimSpace(snapshot.ProcessType)
+	if snapshot.HostID == "" {
+		return Snapshot{}, errors.New("host id is required")
+	}
+	if snapshot.ProcessType == "" {
+		return Snapshot{}, errors.New("process type is required")
+	}
+	snapshot.ProcessID = strings.TrimSpace(snapshot.ProcessID)
+	if snapshot.ProcessID == "" {
+		snapshot.ProcessID = ProcessID(snapshot.HostID, snapshot.ProcessType)
+	}
+	if snapshot.ProcessID == "" {
+		return Snapshot{}, errors.New("process id is required")
+	}
+	snapshot.State = strings.TrimSpace(snapshot.State)
+	if snapshot.State == "" {
+		snapshot.State = StateHealthy
+	}
+	if snapshot.StartedAt.IsZero() {
+		snapshot.StartedAt = time.Now().UTC()
+	}
+	if snapshot.UpdatedAt.IsZero() {
+		snapshot.UpdatedAt = time.Now().UTC()
+	}
+	snapshot.StartedAt = snapshot.StartedAt.UTC()
+	snapshot.UpdatedAt = snapshot.UpdatedAt.UTC()
+	return snapshot, nil
+}
+
+func nullableInt(value *int) any {
+	if value == nil {
+		return nil
+	}
+	return *value
+}
+
+func boolInt(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}
+
+const upsertSnapshotSQL = `
+INSERT INTO jetmon_process_health (
+	process_id,
+	host_id,
+	process_type,
+	pid,
+	version,
+	build_date,
+	go_version,
+	state,
+	started_at,
+	updated_at,
+	bucket_min,
+	bucket_max,
+	bucket_ownership,
+	api_port,
+	dashboard_port,
+	delivery_workers_enabled,
+	delivery_owner_host,
+	worker_count,
+	active_checks,
+	queue_depth,
+	retry_queue_size,
+	wpcom_circuit_open,
+	wpcom_queue_depth,
+	mem_rss_mb,
+	dependency_health
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON DUPLICATE KEY UPDATE
+	host_id = VALUES(host_id),
+	process_type = VALUES(process_type),
+	pid = VALUES(pid),
+	version = VALUES(version),
+	build_date = VALUES(build_date),
+	go_version = VALUES(go_version),
+	state = VALUES(state),
+	started_at = VALUES(started_at),
+	updated_at = VALUES(updated_at),
+	bucket_min = VALUES(bucket_min),
+	bucket_max = VALUES(bucket_max),
+	bucket_ownership = VALUES(bucket_ownership),
+	api_port = VALUES(api_port),
+	dashboard_port = VALUES(dashboard_port),
+	delivery_workers_enabled = VALUES(delivery_workers_enabled),
+	delivery_owner_host = VALUES(delivery_owner_host),
+	worker_count = VALUES(worker_count),
+	active_checks = VALUES(active_checks),
+	queue_depth = VALUES(queue_depth),
+	retry_queue_size = VALUES(retry_queue_size),
+	wpcom_circuit_open = VALUES(wpcom_circuit_open),
+	wpcom_queue_depth = VALUES(wpcom_queue_depth),
+	mem_rss_mb = VALUES(mem_rss_mb),
+	dependency_health = VALUES(dependency_health)`

--- a/internal/fleethealth/health.go
+++ b/internal/fleethealth/health.go
@@ -15,11 +15,14 @@ const (
 	ProcessMonitor   = "monitor"
 	ProcessDeliverer = "deliverer"
 
-	StateHealthy  = "healthy"
-	StateIdle     = "idle"
-	StateDegraded = "degraded"
+	StateRunning  = "running"
 	StateStopping = "stopping"
 	StateStopped  = "stopped"
+	StateIdle     = "idle"
+
+	HealthGreen = "green"
+	HealthAmber = "amber"
+	HealthRed   = "red"
 )
 
 // DependencyHealth is a compact dependency status snapshot suitable for JSON
@@ -42,6 +45,7 @@ type Snapshot struct {
 	BuildDate              string
 	GoVersion              string
 	State                  string
+	HealthStatus           string
 	StartedAt              time.Time
 	UpdatedAt              time.Time
 	BucketMin              *int
@@ -57,7 +61,7 @@ type Snapshot struct {
 	RetryQueueSize         int
 	WPCOMCircuitOpen       bool
 	WPCOMQueueDepth        int
-	MemRSSMB               int
+	GoSysMemMB             int
 	DependencyHealth       []DependencyHealth
 }
 
@@ -94,6 +98,7 @@ func Upsert(ctx context.Context, db *sql.DB, snapshot Snapshot) error {
 		normalized.BuildDate,
 		normalized.GoVersion,
 		normalized.State,
+		normalized.HealthStatus,
 		normalized.StartedAt,
 		normalized.UpdatedAt,
 		nullableInt(normalized.BucketMin),
@@ -109,7 +114,7 @@ func Upsert(ctx context.Context, db *sql.DB, snapshot Snapshot) error {
 		normalized.RetryQueueSize,
 		boolInt(normalized.WPCOMCircuitOpen),
 		normalized.WPCOMQueueDepth,
-		normalized.MemRSSMB,
+		normalized.GoSysMemMB,
 		string(deps),
 	)
 	if err != nil {
@@ -132,9 +137,10 @@ func MarkStopped(ctx context.Context, db *sql.DB, processID string, when time.Ti
 	}
 	_, err := db.ExecContext(ctx,
 		`UPDATE jetmon_process_health
-		   SET state = ?, updated_at = ?
+		   SET state = ?, health_status = ?, updated_at = ?
 		 WHERE process_id = ?`,
 		StateStopped,
+		HealthAmber,
 		when.UTC(),
 		processID,
 	)
@@ -162,7 +168,11 @@ func normalizeSnapshot(snapshot Snapshot) (Snapshot, error) {
 	}
 	snapshot.State = strings.TrimSpace(snapshot.State)
 	if snapshot.State == "" {
-		snapshot.State = StateHealthy
+		snapshot.State = StateRunning
+	}
+	snapshot.HealthStatus = strings.TrimSpace(snapshot.HealthStatus)
+	if snapshot.HealthStatus == "" {
+		snapshot.HealthStatus = RollupHealthStatus(snapshot.DependencyHealth)
 	}
 	if snapshot.StartedAt.IsZero() {
 		snapshot.StartedAt = time.Now().UTC()
@@ -173,6 +183,27 @@ func normalizeSnapshot(snapshot Snapshot) (Snapshot, error) {
 	snapshot.StartedAt = snapshot.StartedAt.UTC()
 	snapshot.UpdatedAt = snapshot.UpdatedAt.UTC()
 	return snapshot, nil
+}
+
+// RollupHealthStatus reduces dependency snapshots into a green/amber/red health
+// status. Unknown dependency status is treated as amber because it needs
+// operator attention but is not itself proof of failure.
+func RollupHealthStatus(entries []DependencyHealth) string {
+	status := HealthGreen
+	for _, entry := range entries {
+		switch entry.Status {
+		case HealthRed:
+			return HealthRed
+		case HealthAmber:
+			status = HealthAmber
+		case HealthGreen:
+		default:
+			if status == HealthGreen {
+				status = HealthAmber
+			}
+		}
+	}
+	return status
 }
 
 func nullableInt(value *int) any {
@@ -199,6 +230,7 @@ INSERT INTO jetmon_process_health (
 	build_date,
 	go_version,
 	state,
+	health_status,
 	started_at,
 	updated_at,
 	bucket_min,
@@ -214,9 +246,9 @@ INSERT INTO jetmon_process_health (
 	retry_queue_size,
 	wpcom_circuit_open,
 	wpcom_queue_depth,
-	mem_rss_mb,
+	go_sys_mem_mb,
 	dependency_health
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON DUPLICATE KEY UPDATE
 	host_id = VALUES(host_id),
 	process_type = VALUES(process_type),
@@ -225,6 +257,7 @@ ON DUPLICATE KEY UPDATE
 	build_date = VALUES(build_date),
 	go_version = VALUES(go_version),
 	state = VALUES(state),
+	health_status = VALUES(health_status),
 	started_at = VALUES(started_at),
 	updated_at = VALUES(updated_at),
 	bucket_min = VALUES(bucket_min),
@@ -240,5 +273,5 @@ ON DUPLICATE KEY UPDATE
 	retry_queue_size = VALUES(retry_queue_size),
 	wpcom_circuit_open = VALUES(wpcom_circuit_open),
 	wpcom_queue_depth = VALUES(wpcom_queue_depth),
-	mem_rss_mb = VALUES(mem_rss_mb),
+	go_sys_mem_mb = VALUES(go_sys_mem_mb),
 	dependency_health = VALUES(dependency_health)`

--- a/internal/fleethealth/health_test.go
+++ b/internal/fleethealth/health_test.go
@@ -112,6 +112,34 @@ func TestUpsertValidatesRequiredFields(t *testing.T) {
 	}
 }
 
+func TestUpsertValidatesStateAndHealthStatus(t *testing.T) {
+	sqlDB, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqlDB.Close()
+
+	err = Upsert(context.Background(), sqlDB, Snapshot{
+		HostID:       "host-a",
+		ProcessType:  ProcessMonitor,
+		State:        "starting",
+		HealthStatus: HealthGreen,
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid process state") {
+		t.Fatalf("Upsert() error = %v, want invalid process state validation", err)
+	}
+
+	err = Upsert(context.Background(), sqlDB, Snapshot{
+		HostID:       "host-a",
+		ProcessType:  ProcessMonitor,
+		State:        StateRunning,
+		HealthStatus: "blue",
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid health status") {
+		t.Fatalf("Upsert() error = %v, want invalid health status validation", err)
+	}
+}
+
 func TestMarkStopped(t *testing.T) {
 	sqlDB, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/fleethealth/health_test.go
+++ b/internal/fleethealth/health_test.go
@@ -39,7 +39,8 @@ func TestUpsertSnapshot(t *testing.T) {
 			"abc123",
 			"2026-04-30T10:00:00Z",
 			"go1.26.2",
-			StateHealthy,
+			StateRunning,
+			HealthGreen,
 			started,
 			updated,
 			bucketMin,
@@ -67,7 +68,8 @@ func TestUpsertSnapshot(t *testing.T) {
 		Version:                "abc123",
 		BuildDate:              "2026-04-30T10:00:00Z",
 		GoVersion:              "go1.26.2",
-		State:                  StateHealthy,
+		State:                  StateRunning,
+		HealthStatus:           HealthGreen,
 		StartedAt:              started,
 		UpdatedAt:              updated,
 		BucketMin:              &bucketMin,
@@ -82,7 +84,7 @@ func TestUpsertSnapshot(t *testing.T) {
 		QueueDepth:             4,
 		RetryQueueSize:         5,
 		WPCOMQueueDepth:        2,
-		MemRSSMB:               88,
+		GoSysMemMB:             88,
 		DependencyHealth: []DependencyHealth{{
 			Name:      "mysql",
 			Status:    "green",
@@ -119,7 +121,7 @@ func TestMarkStopped(t *testing.T) {
 
 	when := time.Date(2026, 4, 30, 10, 2, 0, 0, time.UTC)
 	mock.ExpectExec("UPDATE jetmon_process_health").
-		WithArgs(StateStopped, when, "host-a:deliverer").
+		WithArgs(StateStopped, HealthAmber, when, "host-a:deliverer").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	if err := MarkStopped(context.Background(), sqlDB, "host-a:deliverer", when); err != nil {
@@ -127,5 +129,26 @@ func TestMarkStopped(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("sql expectations: %v", err)
+	}
+}
+
+func TestRollupHealthStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []DependencyHealth
+		want string
+	}{
+		{name: "empty is green", want: HealthGreen},
+		{name: "green entries are green", in: []DependencyHealth{{Status: HealthGreen}}, want: HealthGreen},
+		{name: "amber wins over green", in: []DependencyHealth{{Status: HealthGreen}, {Status: HealthAmber}}, want: HealthAmber},
+		{name: "red wins", in: []DependencyHealth{{Status: HealthAmber}, {Status: HealthRed}}, want: HealthRed},
+		{name: "unknown status is amber", in: []DependencyHealth{{Status: "unknown"}}, want: HealthAmber},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RollupHealthStatus(tt.in); got != tt.want {
+				t.Fatalf("RollupHealthStatus() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/fleethealth/health_test.go
+++ b/internal/fleethealth/health_test.go
@@ -1,0 +1,131 @@
+package fleethealth
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestProcessID(t *testing.T) {
+	if got := ProcessID(" host-a ", " monitor "); got != "host-a:monitor" {
+		t.Fatalf("ProcessID() = %q, want host-a:monitor", got)
+	}
+	if got := ProcessID("", "monitor"); got != "" {
+		t.Fatalf("ProcessID(empty host) = %q, want empty", got)
+	}
+}
+
+func TestUpsertSnapshot(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqlDB.Close()
+
+	started := time.Date(2026, 4, 30, 10, 0, 0, 0, time.UTC)
+	updated := started.Add(time.Minute)
+	bucketMin, bucketMax := 0, 99
+	apiPort, dashboardPort := 8090, 8080
+
+	mock.ExpectExec("INSERT INTO jetmon_process_health").
+		WithArgs(
+			"host-a:monitor",
+			"host-a",
+			ProcessMonitor,
+			123,
+			"abc123",
+			"2026-04-30T10:00:00Z",
+			"go1.26.2",
+			StateHealthy,
+			started,
+			updated,
+			bucketMin,
+			bucketMax,
+			"pinned range=0-99",
+			apiPort,
+			dashboardPort,
+			1,
+			"host-a",
+			12,
+			3,
+			4,
+			5,
+			0,
+			2,
+			88,
+			`[{"name":"mysql","status":"green","checked_at":"2026-04-30T10:01:00Z"}]`,
+		).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err = Upsert(context.Background(), sqlDB, Snapshot{
+		HostID:                 "host-a",
+		ProcessType:            ProcessMonitor,
+		PID:                    123,
+		Version:                "abc123",
+		BuildDate:              "2026-04-30T10:00:00Z",
+		GoVersion:              "go1.26.2",
+		State:                  StateHealthy,
+		StartedAt:              started,
+		UpdatedAt:              updated,
+		BucketMin:              &bucketMin,
+		BucketMax:              &bucketMax,
+		BucketOwnership:        "pinned range=0-99",
+		APIPort:                &apiPort,
+		DashboardPort:          &dashboardPort,
+		DeliveryWorkersEnabled: true,
+		DeliveryOwnerHost:      "host-a",
+		WorkerCount:            12,
+		ActiveChecks:           3,
+		QueueDepth:             4,
+		RetryQueueSize:         5,
+		WPCOMQueueDepth:        2,
+		MemRSSMB:               88,
+		DependencyHealth: []DependencyHealth{{
+			Name:      "mysql",
+			Status:    "green",
+			CheckedAt: updated,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sql expectations: %v", err)
+	}
+}
+
+func TestUpsertValidatesRequiredFields(t *testing.T) {
+	sqlDB, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqlDB.Close()
+
+	err = Upsert(context.Background(), sqlDB, Snapshot{ProcessType: ProcessMonitor})
+	if err == nil || !strings.Contains(err.Error(), "host id is required") {
+		t.Fatalf("Upsert() error = %v, want host id validation", err)
+	}
+}
+
+func TestMarkStopped(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqlDB.Close()
+
+	when := time.Date(2026, 4, 30, 10, 2, 0, 0, time.UTC)
+	mock.ExpectExec("UPDATE jetmon_process_health").
+		WithArgs(StateStopped, when, "host-a:deliverer").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := MarkStopped(context.Background(), sqlDB, "host-a:deliverer", when); err != nil {
+		t.Fatalf("MarkStopped() error = %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sql expectations: %v", err)
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -61,7 +61,9 @@ func (c *Client) send(msg string) {
 	_, _ = fmt.Fprintln(c.conn, msg)
 }
 
-// EmitMemStats optionally sends process RSS as a gauge.
+// EmitMemStats emits legacy memory gauges. process.rss_mb is retained for
+// StatsD compatibility, but the value is Go runtime Sys memory rather than OS
+// resident set size.
 func (c *Client) EmitMemStats() {
 	var ms runtime.MemStats
 	runtime.ReadMemStats(&ms)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -95,6 +95,9 @@ type Orchestrator struct {
 
 	totalChecked int
 	roundStart   time.Time
+	statsMu      sync.RWMutex
+	lastRoundSPS int
+	lastRoundDur time.Duration
 
 	ctx    stdctx.Context
 	cancel stdctx.CancelFunc
@@ -293,6 +296,15 @@ process:
 
 	// Emit metrics and update stats files.
 	roundDuration := time.Since(o.roundStart)
+	sps := 0
+	if roundDuration.Seconds() > 0 {
+		sps = int(float64(len(results)) / roundDuration.Seconds())
+	}
+	o.statsMu.Lock()
+	o.lastRoundSPS = sps
+	o.lastRoundDur = roundDuration
+	o.statsMu.Unlock()
+
 	m := metricsClientFunc()
 	if m != nil {
 		m.Timing("round.complete.time", roundDuration)
@@ -300,11 +312,6 @@ process:
 		m.Gauge("worker.queue.queue_size", o.pool.QueueDepth())
 		m.Gauge("retry.queue.size", o.retries.size())
 		m.Increment("round.sites.count", len(results))
-
-		sps := 0
-		if roundDuration.Seconds() > 0 {
-			sps = int(float64(len(results)) / roundDuration.Seconds())
-		}
 		m.Gauge("round.sps.count", sps)
 
 		if cfg.StatsdSendMemUsage {
@@ -879,6 +886,13 @@ func (o *Orchestrator) ActiveChecks() int {
 // QueueDepth returns the work queue depth.
 func (o *Orchestrator) QueueDepth() int {
 	return o.pool.QueueDepth()
+}
+
+// LastRoundStats returns the latest completed round's throughput and duration.
+func (o *Orchestrator) LastRoundStats() (int, time.Duration) {
+	o.statsMu.RLock()
+	defer o.statsMu.RUnlock()
+	return o.lastRoundSPS, o.lastRoundDur
 }
 
 func (o *Orchestrator) auditLog(e audit.Entry) {


### PR DESCRIPTION
## Summary

This is PR 1 of the dashboard work split. It improves the existing per-host operator dashboard and adds the durable process-health plumbing needed for a later fleet dashboard PR.

This PR does **not** build the global fleet dashboard yet. It gives each monitor/deliverer process a durable heartbeat row and makes the host dashboard more useful during rollout, so the next PR can aggregate those rows across monitor hosts, deliverers, and supporting processes.

## What changed

### Host dashboard

- Adds a host-level red/amber/green summary that puts rollout blockers and operator warnings at the top of the page.
- Adds `GET /api/host`, which returns `state`, `health`, and `summary` in one local JSON response for tooling.
- Splits rollout state from operator commands so the dashboard is easier to scan during cutover.
- Shows real monitor throughput and last-round duration from the orchestrator instead of placeholder values.
- Shows Go runtime system memory as `go_sys_mem_mb`, avoiding confusion with OS RSS.
- Treats missing dependency health as amber so the dashboard does not briefly report green before the first dependency probe completes.
- Caps SSE clients and keeps HTTP server timeouts in place so the unauthenticated local dashboard is harder to abuse accidentally.

### Fleet-health plumbing

- Adds migrations 24 and 25 for `jetmon_process_health`, including separate `state` and `health_status` fields.
- Adds `internal/fleethealth` for durable process snapshots keyed by `<host>:<process_type>`.
- Publishes monitor snapshots from `jetmon2`: lifecycle state, health status, bucket ownership, worker/queue state, WPCOM circuit state, delivery-owner state, dependency health, version/build data, API/dashboard ports, and Go runtime memory.
- Publishes standalone deliverer snapshots from `jetmon-deliverer`: active/idle ownership state, health status, MySQL/StatsD health, version/build data, and lifecycle state.
- Validates process `state` and `health_status` before writing process-health rows.
- Bounds process-health DB writes and serializes shutdown publishing so a late `running` heartbeat cannot overwrite `stopping` or `stopped` state.

### Rollout and security guardrails

- Adds `DASHBOARD_BIND_ADDR`, defaulting the dashboard listener to `127.0.0.1` instead of all interfaces.
- Emits startup and `validate-config` warnings when the dashboard is bound to a non-loopback address, because the dashboard is intentionally unauthenticated and exposes internal rollout context.
- Shows delivery runtime state separately from current config eligibility, so operators can see when a restart is needed for delivery-owner config changes to take effect.
- Updates the roadmap and operational/data-model docs to describe the host-dashboard PR, the future fleet-dashboard PR, and the `jetmon_process_health` data source.

## Dashboard example

These are representative text snapshots of the rendered dashboard using example host data, so the before/after shape is visible in the PR without running the branch.

### Before

The old page was a compact raw metric grid. It exposed useful fields, but the operator had to infer whether the host was safe to roll forward.

```text
Jetmon 2
jetmon-v2-a

CHECK POOL
GOROUTINES     24
ACTIVE CHECKS  3
QUEUE DEPTH    12
RETRY QUEUE    1

THROUGHPUT
SITES/SEC   0
ROUND TIME  8.5s
BUCKETS     0-99
RSS         91MB

ROLLOUT
OWNERSHIP           pinned range=0-99
LEGACY PROJECTION   enabled
DELIVERY WORKERS    enabled
DELIVERY OWNER      unset
PREFLIGHT           ./jetmon2 rollout host-preflight --file=<ranges.csv> ...
ACTIVITY            ./jetmon2 rollout activity-check --since=15m
ROLLBACK            ./jetmon2 rollout rollback-check
DRIFT REPORT        ./jetmon2 rollout projection-drift

EXTERNAL DEPENDENCIES
mysql: green 2ms
wpcom: green
statsd: amber - statsd client is not initialized
disk:logs: green
disk:stats: green
veriflier:iad: green 8ms
```

### After

The new page opens with a host-level status summary, keeps rollout state separate from commands, and makes delivery-owner/config warnings visible before cutover.

```text
Jetmon 2
Host dashboard                                           [AMBER]

operator attention needed before rollout
dependencies green=5 amber=1 red=0
- delivery amber: runtime workers are enabled without DELIVERY_OWNER_HOST

host: jetmon-v2-a                         updated: 10:42:15 AM

CHECK POOL
Goroutines       24
Active Checks    3
Queue Depth      12
Retry Queue      1

THROUGHPUT
Sites/Sec        173
Round Time       8.5s
Buckets          0-99
Go Sys Memory    91MB

ROLLOUT STATE
Ownership          pinned range=0-99
Legacy Projection  enabled
Delivery Runtime   enabled
Config Eligibility eligible
Delivery Owner     unset
WPCOM Circuit      closed
WPCOM Queue        0

OPERATOR COMMANDS
State Report  ./jetmon2 rollout state-report --since=15m
Preflight     ./jetmon2 rollout host-preflight --file=<ranges.csv> --host=<v1-hostname> --runtime-host=<v2-hostname> --bucket-min=0 --bucket-max=99 --bucket-total=1000
Cutover       ./jetmon2 rollout cutover-check --since=15m
Activity      ./jetmon2 rollout activity-check --since=15m
Rollback      ./jetmon2 rollout rollback-check
Drift Report  ./jetmon2 rollout projection-drift

EXTERNAL DEPENDENCIES
mysql: green 2ms
wpcom: green
statsd: amber - statsd client is not initialized
disk:logs: green
disk:stats: green
veriflier:iad: green 8ms
```

The same summary is available to local tooling through:

```bash
curl http://127.0.0.1:${DASHBOARD_PORT}/api/host
```

## Why

Rollout needs a dashboard that answers the sysadmin question first: "is this host safe to advance?" Raw metrics are still useful, but they are slower to interpret during a cutover window. This PR keeps the dashboard local and low-risk while adding the MySQL-backed process heartbeat model that the fleet dashboard can aggregate in the next PR.

The separate `health_status` field is intentional: a process can be `running` while degraded or red. That distinction matters for fleet views, stale heartbeat detection, rollout blockers, and eventual alerting around the monitoring system itself.

## Validation

- `go test ./...`
- `go vet ./...`
- `make rollout-docs-verify`
