### PR TITLE
Add fleet-wide operator dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ one-page command checklist during rehearsals and rollout windows:
   the v2 API or event tables.
 - Use `SIGINT` or `./jetmon2 drain` for graceful shutdown.
 - Use `SIGHUP` or `./jetmon2 reload` for config reload without restart.
+- Use the host dashboard at `/` and the fleet dashboard at `/fleet` during
+  rollout windows. Keep `DASHBOARD_BIND_ADDR` on loopback unless the listener is
+  protected by trusted operator-network controls.
 
 After the fleet is fully on v2, dynamic bucket ownership lets surviving hosts
 absorb work during rolling updates.

--- a/cmd/jetmon2/main.go
+++ b/cmd/jetmon2/main.go
@@ -130,6 +130,10 @@ func runServe() {
 	var dash *dashboard.Server
 	if cfg.DashboardPort > 0 {
 		dash = dashboard.New(hostname)
+		dash.SetFleetSource(dashboard.NewFleetStore(db.DB(), dashboard.FleetStoreOptions{
+			BucketTotal:    cfg.BucketTotal,
+			HeartbeatGrace: time.Duration(cfg.BucketHeartbeatGraceSec) * time.Second,
+		}))
 		go func() {
 			addr := dashboardListenAddr(cfg)
 			if err := dash.Listen(addr); err != nil {

--- a/cmd/jetmon2/main.go
+++ b/cmd/jetmon2/main.go
@@ -130,10 +130,7 @@ func runServe() {
 	var dash *dashboard.Server
 	if cfg.DashboardPort > 0 {
 		dash = dashboard.New(hostname)
-		dash.SetFleetSource(dashboard.NewFleetStore(db.DB(), dashboard.FleetStoreOptions{
-			BucketTotal:    cfg.BucketTotal,
-			HeartbeatGrace: time.Duration(cfg.BucketHeartbeatGraceSec) * time.Second,
-		}))
+		dash.SetFleetSource(newFleetDashboardStore(cfg))
 		go func() {
 			addr := dashboardListenAddr(cfg)
 			if err := dash.Listen(addr); err != nil {
@@ -292,6 +289,9 @@ func runServe() {
 				if err := config.Reload(); err != nil {
 					log.Printf("config reload failed: %v", err)
 				} else {
+					if dash != nil {
+						dash.SetFleetSource(newFleetDashboardStore(config.Get()))
+					}
 					log.Println("config reloaded")
 				}
 			case syscall.SIGINT, syscall.SIGTERM:
@@ -484,7 +484,23 @@ func dashboardBindWarning(bindAddr string) string {
 	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
 		return ""
 	}
-	return fmt.Sprintf("DASHBOARD_BIND_ADDR=%q exposes the unauthenticated host dashboard; restrict access to trusted operator networks", bindAddr)
+	return fmt.Sprintf("DASHBOARD_BIND_ADDR=%q exposes unauthenticated operator dashboards; restrict access to trusted operator networks", bindAddr)
+}
+
+func newFleetDashboardStore(cfg *config.Config) *dashboard.FleetStore {
+	if cfg == nil {
+		cfg = config.Get()
+	}
+	bucketTotal := 0
+	heartbeatGrace := 0
+	if cfg != nil {
+		bucketTotal = cfg.BucketTotal
+		heartbeatGrace = cfg.BucketHeartbeatGraceSec
+	}
+	return dashboard.NewFleetStore(db.DB(), dashboard.FleetStoreOptions{
+		BucketTotal:    bucketTotal,
+		HeartbeatGrace: time.Duration(heartbeatGrace) * time.Second,
+	})
 }
 
 const dashboardHealthTimeout = 2 * time.Second

--- a/config/config.readme
+++ b/config/config.readme
@@ -78,10 +78,11 @@ Port for the operator dashboard. Set to 0 to disable. Default: 8080.
 
 DASHBOARD_BIND_ADDR
 Address for the operator dashboard listener. Defaults to 127.0.0.1 so the
-unauthenticated host dashboard is local-only unless an operator explicitly binds
-it to a trusted management interface. Use 0.0.0.0 only behind network controls
-that limit access to trusted operator hosts. Startup and validate-config warn
-when this is set to a non-loopback address. Default: 127.0.0.1.
+unauthenticated host and fleet dashboards are local-only unless an operator
+explicitly binds them to a trusted management interface. Use 0.0.0.0 only
+behind network controls that limit access to trusted operator hosts. Startup
+and validate-config warn when this is set to a non-loopback address. Default:
+127.0.0.1.
 
 API_PORT
 Port for the internal REST API. Set to 0 to disable. In the embedded v2 deployment, API_PORT also controls whether webhook and alert-contact delivery workers are eligible to run inside jetmon2. The standalone jetmon-deliverer binary does not start the API and does not require API_PORT. Default: 0.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -95,7 +95,7 @@ because it is intentionally **not** drop-in with the Jetmon 1 wire format
 - Host dashboard now has a combined `/api/host` snapshot endpoint, stronger
   red/amber/green summary behavior, clearer rollout-command visibility, and a
   durable `jetmon_process_health` heartbeat table that `jetmon2` and
-  `jetmon-deliverer` publish to for future fleet dashboards.
+  `jetmon-deliverer` publish to for fleet dashboards.
 - Host dashboard exposure now defaults to localhost, host summaries include
   named red/amber issues, process lifecycle is stored separately from health
   rollup, and memory is labeled as Go runtime system memory rather than RSS.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -99,6 +99,10 @@ because it is intentionally **not** drop-in with the Jetmon 1 wire format
 - Host dashboard exposure now defaults to localhost, host summaries include
   named red/amber issues, process lifecycle is stored separately from health
   rollup, and memory is labeled as Go runtime system memory rather than RSS.
+- Fleet dashboard now has `/fleet` and `/api/fleet` views backed by
+  `jetmon_process_health`, `jetmon_hosts`, delivery queues, projection drift,
+  and dependency rollups so operators can see stale heartbeats, bucket coverage,
+  delivery-owner posture, and suggested next actions in one place.
 - `make all` now builds the currently implemented `jetmon2` and
   `veriflier2` binaries without requiring `protoc`; generated Veriflier
   gRPC stubs remain an explicit `make generate` step for the future

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -65,7 +65,7 @@ The API can expose a derived `cli_batch` field for local API CLI test data when
 
 ## Process Health
 
-`jetmon_process_health` is the durable plumbing for fleet-level operator views.
+`jetmon_process_health` is the durable source for fleet-level operator views.
 Each long-running process owns one stable `process_id` such as
 `<host>:monitor` or `<host>:deliverer` and periodically upserts a compact
 snapshot:
@@ -83,6 +83,11 @@ snapshot:
 Fleet dashboards must treat stale `updated_at` values as unknown or unhealthy.
 The row says what the process last reported; it is not proof that the process is
 still alive after the heartbeat age exceeds the dashboard threshold.
+
+The fleet dashboard combines this table with `jetmon_hosts`, outbound delivery
+queues, and projection-drift counts. Dependency health stored in the process
+snapshot is also used to roll up shared dependencies such as Verifliers, MySQL,
+WPCOM, and StatsD across hosts.
 
 ## Event Source Of Truth
 

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -252,9 +252,15 @@ public interface:
 ssh -L 8080:127.0.0.1:8080 <jetmon-host>
 ```
 
-The fleet dashboard is read-only and unauthenticated. It accepts only `GET` and
-`HEAD` requests, and `/api/fleet` returns the same rollup as JSON for local
-operator scripts:
+The fleet dashboard is read-only and unauthenticated. It does not discover or
+scrape other hosts over HTTP; every `jetmon2` monitor dashboard reads the same
+shared MySQL state and can serve the fleet view if `DASHBOARD_PORT` is enabled.
+Standalone `jetmon-deliverer` processes do not serve a dashboard, but they do
+publish their own rows to `jetmon_process_health`.
+
+The dashboard accepts only `GET` and `HEAD` requests for static and JSON views,
+and `/api/fleet` returns the same complete snapshot the HTML page renders for
+local operator scripts:
 
 ```bash
 curl -sS http://127.0.0.1:8080/api/fleet

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -214,26 +214,36 @@ unauthenticated and exposes internal dependency details, rollout commands, host
 names, ports, and bucket ownership. Bind it to a remote address only behind
 trusted operator-network controls.
 
-The dashboard shows a red/amber/green host summary with named issues, worker
+The host dashboard shows a red/amber/green host summary with named issues, worker
 count, active checks, queue depth, retry queue depth, throughput, round time,
 owned buckets, rollout guard state, Go runtime system memory, WPCOM
 circuit-breaker state, dependency health for MySQL, Verifliers, WPCOM, StatsD,
 local log/stats writes, and the rollout commands an operator is most likely to
 need from that host.
 
-The dashboard exposes three local JSON endpoints:
+The fleet dashboard is available at `/fleet` on the same listener. It summarizes
+all rows in `jetmon_process_health` alongside `jetmon_hosts` dynamic bucket
+coverage, delivery backlog, delivery-owner posture, dependency rollups,
+Veriflier dependency health reported by monitor hosts, and global legacy
+projection drift. It uses stale heartbeat thresholds when deciding whether a
+process or dynamic bucket owner is healthy.
+
+The dashboard exposes these local JSON endpoints:
 
 ```text
 GET /api/state   # raw host state snapshot
 GET /api/health  # dependency health list
 GET /api/host    # combined host state, dependency health, and summary
+GET /api/fleet   # combined fleet rollup, process health, buckets, delivery, drift
 ```
 
 Long-running `jetmon2` and `jetmon-deliverer` processes also publish compact
 heartbeat snapshots to `jetmon_process_health`. That table is the durable data
-source for the planned fleet dashboard. Treat stale `updated_at` values as
+source for the fleet dashboard. Treat stale `updated_at` values as
 unknown/unhealthy; the row is the last reported process state, not proof that a
-host is still alive.
+host is still alive. The dashboard listener remains unauthenticated for both
+host and fleet views, so keep `DASHBOARD_BIND_ADDR` on loopback unless network
+access is restricted to trusted operator hosts.
 
 Bucket coverage can be inspected directly:
 

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -232,6 +232,59 @@ deciding whether a process or dynamic bucket owner is healthy.
 Fleet snapshots are cached briefly by the dashboard process so multiple open
 operator tabs do not run the full fleet query set on every refresh.
 
+### Fleet Dashboard Operation
+
+Enable the dashboards with:
+
+```json
+{
+  "DASHBOARD_PORT": 8080,
+  "DASHBOARD_BIND_ADDR": "127.0.0.1"
+}
+```
+
+Open the host dashboard at `http://127.0.0.1:8080/` and the fleet dashboard at
+`http://127.0.0.1:8080/fleet`. If an operator needs remote access, prefer an SSH
+tunnel or a trusted management network instead of binding the dashboard to a
+public interface:
+
+```bash
+ssh -L 8080:127.0.0.1:8080 <jetmon-host>
+```
+
+The fleet dashboard is read-only and unauthenticated. It accepts only `GET` and
+`HEAD` requests, and `/api/fleet` returns the same rollup as JSON for local
+operator scripts:
+
+```bash
+curl -sS http://127.0.0.1:8080/api/fleet
+```
+
+Read the top summary first:
+
+- **Red**: do not advance rollout. Typical causes are stale process heartbeats,
+  broken dynamic bucket coverage, projection drift, failed/abandoned delivery
+  rows, or red process dependency health.
+- **Amber**: operator attention needed before the next change. Typical causes
+  are pinned or mixed bucket ownership during rollout, due delivery rows,
+  delivery workers without a clear owner, no process snapshots yet, or amber
+  dependency health.
+- **Green**: no fleet-level blocker is visible. Continue normal monitoring or
+  the next approved rollout step.
+
+During the v1-to-v2 rollout, pinned monitor hosts should make bucket coverage
+show `mode=pinned` and amber. After the final dynamic-ownership cutover,
+`mode=dynamic` should be green with fresh `jetmon_hosts` coverage and no gaps or
+overlaps. A `mode=mixed` result means some monitor hosts still report pinned
+ownership while others report dynamic ownership; treat that as a rollout state
+to resolve intentionally.
+
+For delivery ownership, green means the visible fresh delivery-capable process
+set has a consistent owner posture. Amber means the fleet either has queued
+delivery rows with no fresh worker, multiple owner values, enabled workers
+without `DELIVERY_OWNER_HOST`, or a mix of explicit and unset ownership. Fix the
+delivery-owner plan before moving outbound delivery responsibility.
+
 The dashboard exposes these local JSON endpoints:
 
 ```text
@@ -271,6 +324,18 @@ For health rollups and memory:
 SELECT process_id, state, health_status, go_sys_mem_mb, updated_at
 FROM jetmon_process_health
 ORDER BY health_status DESC, updated_at;
+```
+
+Delivery queues can be inspected directly:
+
+```sql
+SELECT status, COUNT(*), MIN(COALESCE(next_attempt_at, created_at))
+FROM jetmon_webhook_deliveries
+GROUP BY status;
+
+SELECT status, COUNT(*), MIN(COALESCE(next_attempt_at, created_at))
+FROM jetmon_alert_deliveries
+GROUP BY status;
 ```
 
 A host whose heartbeat is older than `BUCKET_HEARTBEAT_GRACE_SEC` will have its

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -208,11 +208,11 @@ Status and reload commands:
 ./jetmon2 drain
 ```
 
-The host operator dashboard is available on `DASHBOARD_BIND_ADDR:DASHBOARD_PORT`
-when enabled. It defaults to `127.0.0.1`, because the host dashboard is
-unauthenticated and exposes internal dependency details, rollout commands, host
-names, ports, and bucket ownership. Bind it to a remote address only behind
-trusted operator-network controls.
+The operator dashboard is available on `DASHBOARD_BIND_ADDR:DASHBOARD_PORT`
+when enabled. It defaults to `127.0.0.1`, because the host and fleet dashboards
+are unauthenticated and expose internal dependency details, rollout commands,
+host names, ports, bucket ownership, and delivery posture. Bind it to a remote
+address only behind trusted operator-network controls.
 
 The host dashboard shows a red/amber/green host summary with named issues, worker
 count, active checks, queue depth, retry queue depth, throughput, round time,
@@ -225,8 +225,12 @@ The fleet dashboard is available at `/fleet` on the same listener. It summarizes
 all rows in `jetmon_process_health` alongside `jetmon_hosts` dynamic bucket
 coverage, delivery backlog, delivery-owner posture, dependency rollups,
 Veriflier dependency health reported by monitor hosts, and global legacy
-projection drift. It uses stale heartbeat thresholds when deciding whether a
-process or dynamic bucket owner is healthy.
+projection drift. It also shows per-table delivery queue counts and per-host
+bucket-owner rows for diagnosis. It uses stale heartbeat thresholds when
+deciding whether a process or dynamic bucket owner is healthy.
+
+Fleet snapshots are cached briefly by the dashboard process so multiple open
+operator tabs do not run the full fleet query set on every refresh.
 
 The dashboard exposes these local JSON endpoints:
 

--- a/docs/project.md
+++ b/docs/project.md
@@ -249,11 +249,12 @@ thresholds once production operating data shows which signals are worth paging
 on.
 
 Long-running `jetmon2` and `jetmon-deliverer` processes also publish compact
-heartbeat snapshots into `jetmon_process_health`. That table is the foundation
-for a fleet dashboard that can summarize monitor hosts, standalone deliverers,
-stale process heartbeats, lifecycle state, red/amber/green health rollups,
-delivery-owner state, Go runtime system memory, and local dependency health
-without polling every host dashboard directly.
+heartbeat snapshots into `jetmon_process_health`. The `/fleet` dashboard uses
+those snapshots alongside `jetmon_hosts`, outbound delivery queues, projection
+drift, and dependency rollups to summarize monitor hosts, standalone
+deliverers, stale process heartbeats, lifecycle state, red/amber/green health
+rollups, delivery-owner posture, Go runtime system memory, and local dependency
+health without polling every host dashboard directly.
 
 **False Positive Tracker**
 Every time the system escalates a site to Veriflier confirmation and the Verifliers do NOT confirm it as down (i.e., the queue entry times out or all Verifliers report the site as up), the event is recorded in a `jetmon_false_positives` table with timestamp, site, HTTP code, error code, and RTT from the local check. A view in the operator dashboard surfaces sites with high false positive rates, helping operators tune per-site `NUM_OF_CHECKS` or `TIME_BETWEEN_CHECKS_SEC` settings.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,9 +15,6 @@ migration and the operating data needed to make larger architecture decisions.
 These are scoped branches worth considering after the merged API CLI, rollout
 preflight, deliverer hardening, and API CLI fixture workflow branches:
 
-- **`feature/fleet-dashboard`** - add a global dashboard for monitor hosts,
-  standalone deliverers, Verifliers, bucket coverage, stale heartbeats,
-  delivery backlog, projection drift, and fleet-level rollout blockers.
 - **`feature/projection-drift-tooling`** - expand drift diagnostics beyond
   count/list output with range summaries, likely causes, rehearsal reports, and
   dry-run repair guidance if repair becomes safe enough to automate.
@@ -150,6 +147,10 @@ preflight, deliverer hardening, and API CLI fixture workflow branches:
 
 Recently completed candidate branches:
 
+- **`feature/fleet-dashboard`** - adds `/fleet` and `/api/fleet` global
+  dashboard views for monitor hosts, standalone deliverers, bucket coverage,
+  stale heartbeats, delivery backlog, delivery-owner posture, projection drift,
+  dependency rollups, and fleet-level rollout blockers.
 - **`feature/host-dashboard-fleet-plumbing`** - improved each host dashboard as
   a clearer production rollout cockpit while publishing monitor and deliverer
   process health into MySQL for the later fleet dashboard.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -136,11 +136,11 @@ preflight, deliverer hardening, and API CLI fixture workflow branches:
   the dashboard instead of showing placeholder zero values.
 - [x] Label the dashboard memory value as Go runtime system memory so operators
   do not mistake `runtime.MemStats.Sys` for operating-system RSS.
-- [ ] Build the global fleet dashboard from `jetmon_process_health`,
+- [x] Build the global fleet dashboard from `jetmon_process_health`,
   `jetmon_hosts`, delivery queues, projection drift, and Veriflier health.
-- [ ] Add stale-heartbeat thresholds and fleet-level suggested next actions for
+- [x] Add stale-heartbeat thresholds and fleet-level suggested next actions for
   rollout handoffs.
-- [ ] Add explicit fleet delivery-ownership posture so operators can
+- [x] Add explicit fleet delivery-ownership posture so operators can
   distinguish intentional rollout-conservative `DELIVERY_OWNER_HOST` settings
   from accidental all-host delivery eligibility.
 - [ ] Consider collecting true process RSS for fleet and host dashboards if

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -145,7 +145,7 @@ preflight, deliverer hardening, and API CLI fixture workflow branches:
   from accidental all-host delivery eligibility.
 - [ ] Consider collecting true process RSS for fleet and host dashboards if
   operators need OS-level memory accounting beyond Go runtime system memory.
-- [ ] Document and test the fleet dashboard's safe network exposure model
+- [x] Document and test the fleet dashboard's safe network exposure model
   before exposing it beyond trusted operator networks.
 
 Recently completed candidate branches:

--- a/docs/rollout-quick-reference.md
+++ b/docs/rollout-quick-reference.md
@@ -161,8 +161,9 @@ to v1" and keep the transcript with the incident record.
      --require-all
    ```
 
-6. Watch logs, dashboard health, WPCOM notification parity, event rows, and
-   projection drift before moving to the next host.
+6. Watch logs, the host dashboard, `/fleet`, WPCOM notification parity, event
+   rows, and projection drift before moving to the next host. In pinned rollout,
+   `/fleet` should show pinned bucket mode as amber rather than dynamic green.
 
 ## Rollback Gate
 

--- a/docs/v1-to-v2-migration.md
+++ b/docs/v1-to-v2-migration.md
@@ -559,13 +559,15 @@ For every replaced range, verify:
 
 If `DASHBOARD_PORT` is enabled, confirm:
 
-- bucket ownership mode is pinned
-- dependency health is green for MySQL, configured Verifliers, WPCOM, StatsD,
-  and log/stats directory writes
-- WPCOM circuit breaker is closed
+- the host dashboard at `/` shows bucket ownership mode as pinned
+- the host dashboard dependency health is green for MySQL, configured
+  Verifliers, WPCOM, StatsD, and log/stats directory writes
+- the host dashboard shows the WPCOM circuit breaker closed
 - retry queue depth is not growing unexpectedly
 - Go runtime system memory stays below the configured guardrail
 - delivery workers are disabled unless explicitly approved
+- the fleet dashboard at `/fleet` shows the replaced host as fresh, and pinned
+  bucket mode as an expected amber rollout state
 
 Useful direct checks:
 
@@ -673,7 +675,9 @@ After every monitor host is on v2 and stable in pinned mode:
    ```
 
 8. Confirm `jetmon_hosts` coverage is active, fresh, gap-free, and
-   overlap-free.
+   overlap-free. If `DASHBOARD_PORT` is enabled, `/fleet` should show
+   `mode=dynamic`, green bucket coverage, no stale processes, no projection
+   drift, and no failed or abandoned delivery rows.
 9. Continue with normal v2 rolling updates: stop one host, deploy, start it,
    verify `./jetmon2 status`, then move to the next host.
 

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -71,12 +71,13 @@ type HostSummary struct {
 
 // Server is the operator dashboard HTTP server.
 type Server struct {
-	mu         sync.RWMutex
-	state      State
-	health     []HealthEntry
-	sseClients map[string]chan string
-	sseMu      sync.Mutex
-	hostname   string
+	mu          sync.RWMutex
+	state       State
+	health      []HealthEntry
+	sseClients  map[string]chan string
+	sseMu       sync.Mutex
+	hostname    string
+	fleetSource FleetSource
 }
 
 // New creates a new dashboard Server.
@@ -118,6 +119,8 @@ func (s *Server) Listen(addr string) error {
 	mux.HandleFunc("/api/state", s.handleState)
 	mux.HandleFunc("/api/health", s.handleHealth)
 	mux.HandleFunc("/api/host", s.handleHost)
+	mux.HandleFunc("/fleet", s.handleFleetIndex)
+	mux.HandleFunc("/api/fleet", s.handleFleet)
 
 	log.Printf("dashboard: listening on %s", addr)
 	srv := &http.Server{

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -249,6 +249,11 @@ func (s *Server) broadcast(st State) {
 }
 
 func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		setDashboardNoStoreHeaders(w)
+		http.NotFound(w, r)
+		return
+	}
 	if rejectNonGet(w, r) {
 		return
 	}
@@ -271,7 +276,10 @@ func setDashboardReadHeaders(w http.ResponseWriter, contentType string) {
 
 func setDashboardNoStoreHeaders(w http.ResponseWriter) {
 	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Security-Policy", "default-src 'self'; base-uri 'none'; connect-src 'self'; form-action 'none'; frame-ancestors 'none'; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'")
+	w.Header().Set("Referrer-Policy", "no-referrer")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("X-Frame-Options", "DENY")
 }
 
 func rejectNonGet(w http.ResponseWriter, r *http.Request) bool {

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -240,6 +240,15 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, dashboardHTML)
 }
 
+func rejectNonGet(w http.ResponseWriter, r *http.Request) bool {
+	if r.Method == http.MethodGet || r.Method == http.MethodHead {
+		return false
+	}
+	w.Header().Set("Allow", "GET, HEAD")
+	http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	return true
+}
+
 // SummarizeHost reduces local state and dependency health into a dashboard
 // status. It deliberately stays simple: red blocks rollout, amber needs
 // operator attention, green means no local blocker is visible.
@@ -339,6 +348,7 @@ const dashboardHTML = `<!DOCTYPE html>
   main { max-width: 1400px; margin: 0 auto; }
   h1 { margin: 0; font-size: 1.65rem; color: var(--text); }
   h2 { margin: 28px 0 12px; font-size: 0.85rem; color: var(--muted); letter-spacing: 0; text-transform: uppercase; }
+  a { color: var(--accent); }
   .topline { display: flex; align-items: baseline; justify-content: space-between; gap: 16px; margin-bottom: 16px; }
   .subtle { color: var(--muted); font-size: 0.85rem; }
   .summary {
@@ -401,7 +411,7 @@ const dashboardHTML = `<!DOCTYPE html>
   <div class="topline">
     <div>
       <h1>Jetmon 2</h1>
-      <div class="subtle">Host dashboard</div>
+      <div class="subtle">Host dashboard · <a href="/fleet">fleet dashboard</a></div>
     </div>
     <span class="status-pill amber" id="summary-pill">waiting</span>
   </div>

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -141,27 +141,36 @@ func ListenDebug(addr string) error {
 }
 
 func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
+	if rejectNonGet(w, r) {
+		return
+	}
 	s.mu.RLock()
 	st := s.state
 	s.mu.RUnlock()
-	w.Header().Set("Content-Type", "application/json")
+	setDashboardJSONHeaders(w)
 	_ = json.NewEncoder(w).Encode(st)
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	if rejectNonGet(w, r) {
+		return
+	}
 	s.mu.RLock()
 	h := append([]HealthEntry(nil), s.health...)
 	s.mu.RUnlock()
-	w.Header().Set("Content-Type", "application/json")
+	setDashboardJSONHeaders(w)
 	_ = json.NewEncoder(w).Encode(h)
 }
 
 func (s *Server) handleHost(w http.ResponseWriter, r *http.Request) {
+	if rejectNonGet(w, r) {
+		return
+	}
 	s.mu.RLock()
 	st := s.state
 	h := append([]HealthEntry(nil), s.health...)
 	s.mu.RUnlock()
-	w.Header().Set("Content-Type", "application/json")
+	setDashboardJSONHeaders(w)
 	_ = json.NewEncoder(w).Encode(HostSnapshot{
 		State:   st,
 		Health:  h,
@@ -170,6 +179,9 @@ func (s *Server) handleHost(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
+	if rejectNonGetOnly(w, r) {
+		return
+	}
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		http.Error(w, "streaming not supported", http.StatusInternalServerError)
@@ -189,8 +201,9 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	s.sseMu.Unlock()
 
 	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Cache-Control", "no-cache, no-store")
 	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 
 	defer func() {
 		s.sseMu.Lock()
@@ -236,8 +249,29 @@ func (s *Server) broadcast(st State) {
 }
 
 func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if rejectNonGet(w, r) {
+		return
+	}
+	setDashboardHTMLHeaders(w)
 	fmt.Fprint(w, dashboardHTML)
+}
+
+func setDashboardHTMLHeaders(w http.ResponseWriter) {
+	setDashboardReadHeaders(w, "text/html; charset=utf-8")
+}
+
+func setDashboardJSONHeaders(w http.ResponseWriter) {
+	setDashboardReadHeaders(w, "application/json")
+}
+
+func setDashboardReadHeaders(w http.ResponseWriter, contentType string) {
+	w.Header().Set("Content-Type", contentType)
+	setDashboardNoStoreHeaders(w)
+}
+
+func setDashboardNoStoreHeaders(w http.ResponseWriter) {
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 }
 
 func rejectNonGet(w http.ResponseWriter, r *http.Request) bool {
@@ -245,6 +279,15 @@ func rejectNonGet(w http.ResponseWriter, r *http.Request) bool {
 		return false
 	}
 	w.Header().Set("Allow", "GET, HEAD")
+	http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	return true
+}
+
+func rejectNonGetOnly(w http.ResponseWriter, r *http.Request) bool {
+	if r.Method == http.MethodGet {
+		return false
+	}
+	w.Header().Set("Allow", "GET")
 	http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	return true
 }

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -158,6 +158,65 @@ func TestHandleHostSnapshot(t *testing.T) {
 	}
 }
 
+func TestDashboardReadHandlersSetNoStoreHeaders(t *testing.T) {
+	srv := New("test-host")
+	srv.SetFleetSource(fakeFleetSource{snapshot: FleetSnapshot{Summary: FleetSummary{Status: "green"}}})
+	handlers := map[string]http.HandlerFunc{
+		"/":           srv.handleIndex,
+		"/api/state":  srv.handleState,
+		"/api/health": srv.handleHealth,
+		"/api/host":   srv.handleHost,
+		"/fleet":      srv.handleFleetIndex,
+		"/api/fleet":  srv.handleFleet,
+	}
+	for path, handler := range handlers {
+		t.Run(path, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, path, nil)
+			w := httptest.NewRecorder()
+			handler(w, r)
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", w.Code)
+			}
+			if got := w.Header().Get("Cache-Control"); got != "no-store" {
+				t.Fatalf("Cache-Control = %q, want no-store", got)
+			}
+			if got := w.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+				t.Fatalf("X-Content-Type-Options = %q, want nosniff", got)
+			}
+		})
+	}
+}
+
+func TestDashboardReadHandlersRejectWriteMethods(t *testing.T) {
+	srv := New("test-host")
+	srv.SetFleetSource(fakeFleetSource{snapshot: FleetSnapshot{Summary: FleetSummary{Status: "green"}}})
+	handlers := map[string]struct {
+		handler http.HandlerFunc
+		allow   string
+	}{
+		"/":           {handler: srv.handleIndex, allow: "GET, HEAD"},
+		"/api/state":  {handler: srv.handleState, allow: "GET, HEAD"},
+		"/api/health": {handler: srv.handleHealth, allow: "GET, HEAD"},
+		"/api/host":   {handler: srv.handleHost, allow: "GET, HEAD"},
+		"/fleet":      {handler: srv.handleFleetIndex, allow: "GET, HEAD"},
+		"/api/fleet":  {handler: srv.handleFleet, allow: "GET, HEAD"},
+		"/events":     {handler: srv.handleSSE, allow: "GET"},
+	}
+	for path, tc := range handlers {
+		t.Run(path, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodPost, path, nil)
+			w := httptest.NewRecorder()
+			tc.handler(w, r)
+			if w.Code != http.StatusMethodNotAllowed {
+				t.Fatalf("status = %d, want 405", w.Code)
+			}
+			if got := w.Header().Get("Allow"); got != tc.allow {
+				t.Fatalf("Allow = %q, want %q", got, tc.allow)
+			}
+		})
+	}
+}
+
 func TestHandleIndex(t *testing.T) {
 	srv := New("test-host")
 	r := httptest.NewRequest(http.MethodGet, "/", nil)

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -183,6 +183,15 @@ func TestDashboardReadHandlersSetNoStoreHeaders(t *testing.T) {
 			if got := w.Header().Get("X-Content-Type-Options"); got != "nosniff" {
 				t.Fatalf("X-Content-Type-Options = %q, want nosniff", got)
 			}
+			if got := w.Header().Get("X-Frame-Options"); got != "DENY" {
+				t.Fatalf("X-Frame-Options = %q, want DENY", got)
+			}
+			if got := w.Header().Get("Referrer-Policy"); got != "no-referrer" {
+				t.Fatalf("Referrer-Policy = %q, want no-referrer", got)
+			}
+			if got := w.Header().Get("Content-Security-Policy"); !strings.Contains(got, "frame-ancestors 'none'") {
+				t.Fatalf("Content-Security-Policy = %q, want frame-ancestors guard", got)
+			}
 		})
 	}
 }
@@ -214,6 +223,23 @@ func TestDashboardReadHandlersRejectWriteMethods(t *testing.T) {
 				t.Fatalf("Allow = %q, want %q", got, tc.allow)
 			}
 		})
+	}
+}
+
+func TestHandleIndexRejectsUnknownPaths(t *testing.T) {
+	srv := New("test-host")
+	r := httptest.NewRequest(http.MethodGet, "/api/unknown", nil)
+	w := httptest.NewRecorder()
+	srv.handleIndex(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+	if strings.Contains(w.Body.String(), "Jetmon") {
+		t.Fatal("unknown path returned dashboard HTML")
+	}
+	if got := w.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", got)
 	}
 }
 

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,15 @@ import (
 	"testing"
 	"time"
 )
+
+type fakeFleetSource struct {
+	snapshot FleetSnapshot
+	err      error
+}
+
+func (f fakeFleetSource) Snapshot(context.Context) (FleetSnapshot, error) {
+	return f.snapshot, f.err
+}
 
 func TestHandleState(t *testing.T) {
 	srv := New("test-host")
@@ -192,6 +202,69 @@ func TestHandleIndex(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "/api/host") {
 		t.Fatal("body does not fetch combined host snapshot")
+	}
+}
+
+func TestHandleFleetIndex(t *testing.T) {
+	srv := New("test-host")
+	r := httptest.NewRequest(http.MethodGet, "/fleet", nil)
+	w := httptest.NewRecorder()
+	srv.handleFleetIndex(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "/api/fleet") {
+		t.Fatal("body does not fetch fleet snapshot")
+	}
+	if !strings.Contains(w.Body.String(), "Fleet dashboard") {
+		t.Fatal("body does not contain fleet dashboard label")
+	}
+}
+
+func TestHandleFleetSnapshot(t *testing.T) {
+	srv := New("test-host")
+	srv.SetFleetSource(fakeFleetSource{
+		snapshot: FleetSnapshot{
+			GeneratedAt: time.Date(2026, 4, 30, 10, 0, 0, 0, time.UTC),
+			Summary:     FleetSummary{Status: "green", Message: "fleet checks are green"},
+			Processes:   []FleetProcess{{ProcessID: "host-a:monitor", HostID: "host-a", ProcessType: "monitor"}},
+		},
+	})
+
+	r := httptest.NewRequest(http.MethodGet, "/api/fleet", nil)
+	w := httptest.NewRecorder()
+	srv.handleFleet(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var snapshot FleetSnapshot
+	if err := json.NewDecoder(w.Body).Decode(&snapshot); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if snapshot.Summary.Status != "green" {
+		t.Fatalf("Summary.Status = %q, want green", snapshot.Summary.Status)
+	}
+	if len(snapshot.Processes) != 1 || snapshot.Processes[0].ProcessID != "host-a:monitor" {
+		t.Fatalf("Processes = %+v, want host-a monitor", snapshot.Processes)
+	}
+}
+
+func TestHandleFleetErrors(t *testing.T) {
+	srv := New("test-host")
+	r := httptest.NewRequest(http.MethodGet, "/api/fleet", nil)
+	w := httptest.NewRecorder()
+	srv.handleFleet(w, r)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status without source = %d, want 503", w.Code)
+	}
+
+	srv.SetFleetSource(fakeFleetSource{err: errors.New("db down")})
+	w = httptest.NewRecorder()
+	srv.handleFleet(w, r)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status with source error = %d, want 500", w.Code)
 	}
 }
 

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -203,6 +203,9 @@ func TestHandleIndex(t *testing.T) {
 	if !strings.Contains(w.Body.String(), "/api/host") {
 		t.Fatal("body does not fetch combined host snapshot")
 	}
+	if !strings.Contains(w.Body.String(), "/fleet") {
+		t.Fatal("body does not link to fleet dashboard")
+	}
 }
 
 func TestHandleFleetIndex(t *testing.T) {
@@ -251,6 +254,22 @@ func TestHandleFleetSnapshot(t *testing.T) {
 	}
 }
 
+func TestHandleFleetRejectsNonGet(t *testing.T) {
+	srv := New("test-host")
+	srv.SetFleetSource(fakeFleetSource{snapshot: FleetSnapshot{Summary: FleetSummary{Status: "green"}}})
+
+	r := httptest.NewRequest(http.MethodPost, "/api/fleet", nil)
+	w := httptest.NewRecorder()
+	srv.handleFleet(w, r)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", w.Code)
+	}
+	if got := w.Header().Get("Allow"); got != "GET, HEAD" {
+		t.Fatalf("Allow = %q, want GET, HEAD", got)
+	}
+}
+
 func TestHandleFleetErrors(t *testing.T) {
 	srv := New("test-host")
 	r := httptest.NewRequest(http.MethodGet, "/api/fleet", nil)
@@ -265,6 +284,9 @@ func TestHandleFleetErrors(t *testing.T) {
 	srv.handleFleet(w, r)
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("status with source error = %d, want 500", w.Code)
+	}
+	if strings.Contains(w.Body.String(), "db down") {
+		t.Fatalf("error body = %q, leaked backend error", w.Body.String())
 	}
 }
 

--- a/internal/dashboard/fleet.go
+++ b/internal/dashboard/fleet.go
@@ -315,8 +315,9 @@ func summarizeFleetProcesses(rows []fleethealth.Snapshot, now time.Time, heartbe
 		if left != right {
 			return left > right
 		}
-		if out[i].ProcessType != out[j].ProcessType {
-			return out[i].ProcessType < out[j].ProcessType
+		leftType, rightType := fleetProcessTypeRank(out[i].ProcessType), fleetProcessTypeRank(out[j].ProcessType)
+		if leftType != rightType {
+			return leftType < rightType
 		}
 		if out[i].HostID != out[j].HostID {
 			return out[i].HostID < out[j].HostID
@@ -337,6 +338,17 @@ func fleetProcessRank(process FleetProcess) int {
 		return 3
 	default:
 		return 1
+	}
+}
+
+func fleetProcessTypeRank(processType string) int {
+	switch processType {
+	case fleethealth.ProcessMonitor:
+		return 1
+	case fleethealth.ProcessDeliverer:
+		return 2
+	default:
+		return 99
 	}
 }
 
@@ -438,6 +450,9 @@ func fleetBucketOwnershipMode(processes []FleetProcess) string {
 		if process.ProcessType != fleethealth.ProcessMonitor {
 			continue
 		}
+		if !processActiveForFleetOwnership(process) {
+			continue
+		}
 		ownership := strings.ToLower(strings.TrimSpace(process.BucketOwnership))
 		switch {
 		case strings.Contains(ownership, "pinned"):
@@ -455,6 +470,18 @@ func fleetBucketOwnershipMode(processes []FleetProcess) string {
 		return "dynamic"
 	default:
 		return "unknown"
+	}
+}
+
+func processActiveForFleetOwnership(process FleetProcess) bool {
+	if process.Stale {
+		return false
+	}
+	switch process.State {
+	case fleethealth.StateStopped, fleethealth.StateStopping:
+		return false
+	default:
+		return true
 	}
 }
 

--- a/internal/dashboard/fleet.go
+++ b/internal/dashboard/fleet.go
@@ -6,9 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Automattic/jetmon/internal/fleethealth"
@@ -29,6 +31,7 @@ type FleetStoreOptions struct {
 	BucketTotal    int
 	HeartbeatGrace time.Duration
 	RecentWindow   time.Duration
+	CacheTTL       time.Duration
 	Now            func() time.Time
 }
 
@@ -39,7 +42,11 @@ type FleetStore struct {
 	bucketTotal    int
 	heartbeatGrace time.Duration
 	recentWindow   time.Duration
+	cacheTTL       time.Duration
 	now            func() time.Time
+	cacheMu        sync.Mutex
+	cacheSnapshot  FleetSnapshot
+	cacheUntil     time.Time
 }
 
 // NewFleetStore creates a MySQL-backed fleet dashboard source.
@@ -50,6 +57,9 @@ func NewFleetStore(db *sql.DB, opts FleetStoreOptions) *FleetStore {
 	if opts.RecentWindow <= 0 {
 		opts.RecentWindow = defaultFleetRecentWindow
 	}
+	if opts.CacheTTL == 0 {
+		opts.CacheTTL = 5 * time.Second
+	}
 	if opts.Now == nil {
 		opts.Now = time.Now
 	}
@@ -58,6 +68,7 @@ func NewFleetStore(db *sql.DB, opts FleetStoreOptions) *FleetStore {
 		bucketTotal:    opts.BucketTotal,
 		heartbeatGrace: opts.HeartbeatGrace,
 		recentWindow:   opts.RecentWindow,
+		cacheTTL:       opts.CacheTTL,
 		now:            opts.Now,
 	}
 }
@@ -68,6 +79,9 @@ func (s *FleetStore) Snapshot(ctx context.Context) (FleetSnapshot, error) {
 		return FleetSnapshot{}, errors.New("fleet dashboard database source is not configured")
 	}
 	now := s.now().UTC()
+	if cached, ok := s.cachedSnapshot(now); ok {
+		return cached, nil
+	}
 	processRows, err := fleethealth.ListSnapshots(ctx, s.db)
 	if err != nil {
 		return FleetSnapshot{}, err
@@ -75,10 +89,10 @@ func (s *FleetStore) Snapshot(ctx context.Context) (FleetSnapshot, error) {
 	processes := summarizeFleetProcesses(processRows, now, s.heartbeatGrace)
 
 	hosts, hostErr := queryFleetBucketHosts(ctx, s.db)
-	bucketCoverage := summarizeFleetBucketCoverage(hosts, s.bucketTotal, s.heartbeatGrace, now, hostErr)
+	bucketCoverage := summarizeFleetBucketCoverage(hosts, s.bucketTotal, s.heartbeatGrace, now, hostErr, processes)
 
 	delivery := queryFleetDelivery(ctx, s.db, now, s.recentWindow)
-	delivery.Posture = summarizeFleetDeliveryPosture(processes)
+	delivery.Posture = summarizeFleetDeliveryPosture(processes, delivery.Pending)
 
 	projectionDrift := queryFleetProjectionDrift(ctx, s.db, s.bucketTotal)
 	dependencies := summarizeFleetDependencies(processes)
@@ -93,7 +107,30 @@ func (s *FleetStore) Snapshot(ctx context.Context) (FleetSnapshot, error) {
 		Dependencies:    dependencies,
 	}
 	snapshot.Summary = summarizeFleet(snapshot)
+	s.storeCachedSnapshot(snapshot)
 	return snapshot, nil
+}
+
+func (s *FleetStore) cachedSnapshot(now time.Time) (FleetSnapshot, bool) {
+	if s.cacheTTL < 0 {
+		return FleetSnapshot{}, false
+	}
+	s.cacheMu.Lock()
+	defer s.cacheMu.Unlock()
+	if s.cacheUntil.IsZero() || !now.Before(s.cacheUntil) {
+		return FleetSnapshot{}, false
+	}
+	return cloneFleetSnapshot(s.cacheSnapshot), true
+}
+
+func (s *FleetStore) storeCachedSnapshot(snapshot FleetSnapshot) {
+	if s.cacheTTL < 0 {
+		return
+	}
+	s.cacheMu.Lock()
+	defer s.cacheMu.Unlock()
+	s.cacheSnapshot = cloneFleetSnapshot(snapshot)
+	s.cacheUntil = snapshot.GeneratedAt.Add(s.cacheTTL)
 }
 
 // FleetSnapshot is the JSON model for the global dashboard.
@@ -159,6 +196,7 @@ type FleetProcess struct {
 // FleetBucketCoverage summarizes jetmon_hosts dynamic bucket ownership.
 type FleetBucketCoverage struct {
 	Status      string            `json:"status"`
+	Mode        string            `json:"mode"`
 	BucketTotal int               `json:"bucket_total"`
 	HostCount   int               `json:"host_count"`
 	Error       string            `json:"error,omitempty"`
@@ -272,7 +310,34 @@ func summarizeFleetProcesses(rows []fleethealth.Snapshot, now time.Time, heartbe
 			DependencyHealth:       append([]fleethealth.DependencyHealth(nil), row.DependencyHealth...),
 		})
 	}
+	sort.Slice(out, func(i, j int) bool {
+		left, right := fleetProcessRank(out[i]), fleetProcessRank(out[j])
+		if left != right {
+			return left > right
+		}
+		if out[i].ProcessType != out[j].ProcessType {
+			return out[i].ProcessType < out[j].ProcessType
+		}
+		if out[i].HostID != out[j].HostID {
+			return out[i].HostID < out[j].HostID
+		}
+		return out[i].ProcessID < out[j].ProcessID
+	})
 	return out
+}
+
+func fleetProcessRank(process FleetProcess) int {
+	if process.Stale {
+		return 5
+	}
+	switch process.HealthStatus {
+	case fleethealth.HealthRed:
+		return 4
+	case fleethealth.HealthAmber:
+		return 3
+	default:
+		return 1
+	}
 }
 
 func queryFleetBucketHosts(ctx context.Context, db *sql.DB) ([]FleetBucketHost, error) {
@@ -300,26 +365,28 @@ func queryFleetBucketHosts(ctx context.Context, db *sql.DB) ([]FleetBucketHost, 
 	return hosts, nil
 }
 
-func summarizeFleetBucketCoverage(hosts []FleetBucketHost, bucketTotal int, heartbeatGrace time.Duration, now time.Time, queryErr error) FleetBucketCoverage {
+func summarizeFleetBucketCoverage(hosts []FleetBucketHost, bucketTotal int, heartbeatGrace time.Duration, now time.Time, queryErr error, processes []FleetProcess) FleetBucketCoverage {
+	mode := fleetBucketOwnershipMode(processes)
+	if mode == "unknown" && len(hosts) > 0 {
+		mode = "dynamic"
+	}
 	coverage := FleetBucketCoverage{
 		Status:      "green",
+		Mode:        mode,
 		BucketTotal: bucketTotal,
 		HostCount:   len(hosts),
 		Hosts:       append([]FleetBucketHost(nil), hosts...),
 	}
 	if queryErr != nil {
 		coverage.Status = "red"
+		coverage.Mode = "unknown"
 		coverage.Error = queryErr.Error()
 		return coverage
 	}
 	if bucketTotal <= 0 {
 		coverage.Status = "amber"
+		coverage.Mode = "unknown"
 		coverage.Error = "BUCKET_TOTAL is not configured"
-		return coverage
-	}
-	if len(hosts) == 0 {
-		coverage.Status = "amber"
-		coverage.Error = "jetmon_hosts has no dynamic ownership rows"
 		return coverage
 	}
 	for i := range coverage.Hosts {
@@ -329,6 +396,21 @@ func summarizeFleetBucketCoverage(hosts []FleetBucketHost, bucketTotal int, hear
 		}
 		coverage.Hosts[i].LastHeartbeatAgeSec = int64(age.Round(time.Second) / time.Second)
 		coverage.Hosts[i].Stale = age > heartbeatGrace
+	}
+	if mode == "pinned" {
+		coverage.Status = "amber"
+		coverage.Error = "monitor process snapshots report pinned bucket ranges; dynamic jetmon_hosts coverage is not active"
+		return coverage
+	}
+	if mode == "mixed" {
+		coverage.Status = "amber"
+		coverage.Error = "monitor process snapshots report mixed pinned and dynamic bucket ownership"
+		return coverage
+	}
+	if len(hosts) == 0 {
+		coverage.Status = "amber"
+		coverage.Error = "jetmon_hosts has no dynamic ownership rows"
+		return coverage
 	}
 	if err := validateFleetBucketCoverage(coverage.Hosts, bucketTotal); err != nil {
 		coverage.Status = "red"
@@ -348,6 +430,32 @@ func summarizeFleetBucketCoverage(hosts []FleetBucketHost, bucketTotal int, hear
 		}
 	}
 	return coverage
+}
+
+func fleetBucketOwnershipMode(processes []FleetProcess) string {
+	hasPinned, hasDynamic := false, false
+	for _, process := range processes {
+		if process.ProcessType != fleethealth.ProcessMonitor {
+			continue
+		}
+		ownership := strings.ToLower(strings.TrimSpace(process.BucketOwnership))
+		switch {
+		case strings.Contains(ownership, "pinned"):
+			hasPinned = true
+		case strings.Contains(ownership, "dynamic"):
+			hasDynamic = true
+		}
+	}
+	switch {
+	case hasPinned && hasDynamic:
+		return "mixed"
+	case hasPinned:
+		return "pinned"
+	case hasDynamic:
+		return "dynamic"
+	default:
+		return "unknown"
+	}
 }
 
 func validateFleetBucketCoverage(hosts []FleetBucketHost, bucketTotal int) error {
@@ -497,19 +605,25 @@ func queryFleetRecentTerminalDeliveryCount(ctx context.Context, db *sql.DB, tabl
 	return withAttempt + createdFallback, nil
 }
 
-func summarizeFleetDeliveryPosture(processes []FleetProcess) FleetDeliveryPosture {
+func summarizeFleetDeliveryPosture(processes []FleetProcess, queuedDeliveries int64) FleetDeliveryPosture {
 	enabledHosts := map[string]struct{}{}
 	ownerHosts := map[string]struct{}{}
 	enabledCount := 0
+	enabledWithoutOwner := 0
 	for _, process := range processes {
-		if owner := strings.TrimSpace(process.DeliveryOwnerHost); owner != "" {
-			ownerHosts[owner] = struct{}{}
+		if !processActiveForDeliveryPosture(process) {
+			continue
 		}
 		if !process.DeliveryWorkersEnabled {
 			continue
 		}
 		enabledCount++
 		enabledHosts[process.HostID] = struct{}{}
+		if owner := strings.TrimSpace(process.DeliveryOwnerHost); owner != "" {
+			ownerHosts[owner] = struct{}{}
+		} else {
+			enabledWithoutOwner++
+		}
 	}
 	posture := FleetDeliveryPosture{
 		Status:              "green",
@@ -518,12 +632,17 @@ func summarizeFleetDeliveryPosture(processes []FleetProcess) FleetDeliveryPostur
 		OwnerHosts:          sortedStringKeys(ownerHosts),
 	}
 	switch {
+	case enabledCount == 0 && queuedDeliveries > 0:
+		posture.Status = "amber"
+		posture.Message = "delivery rows are queued but no fresh process snapshot reports delivery workers enabled"
 	case enabledCount == 0:
+		posture.Message = "no fresh process snapshot reports delivery workers enabled; delivery queues are empty"
+	case enabledWithoutOwner > 0 && len(posture.OwnerHosts) > 0:
 		posture.Status = "amber"
-		posture.Message = "no process snapshot reports delivery workers enabled"
-	case len(posture.OwnerHosts) == 0 && enabledCount > 1:
+		posture.Message = "delivery-capable processes mix explicit DELIVERY_OWNER_HOST and unset ownership"
+	case enabledWithoutOwner > 0:
 		posture.Status = "amber"
-		posture.Message = "multiple delivery-capable processes are enabled without DELIVERY_OWNER_HOST"
+		posture.Message = "delivery workers are enabled without DELIVERY_OWNER_HOST"
 	case len(posture.OwnerHosts) > 1:
 		posture.Status = "amber"
 		posture.Message = "multiple DELIVERY_OWNER_HOST values are visible across process snapshots"
@@ -533,6 +652,18 @@ func summarizeFleetDeliveryPosture(processes []FleetProcess) FleetDeliveryPostur
 		posture.Message = "delivery workers are enabled without an explicit owner"
 	}
 	return posture
+}
+
+func processActiveForDeliveryPosture(process FleetProcess) bool {
+	if process.Stale {
+		return false
+	}
+	switch process.State {
+	case fleethealth.StateStopped, fleethealth.StateStopping:
+		return false
+	default:
+		return true
+	}
 }
 
 func queryFleetProjectionDrift(ctx context.Context, db *sql.DB, bucketTotal int) FleetProjectionDrift {
@@ -635,7 +766,9 @@ func summarizeFleet(snapshot FleetSnapshot) FleetSummary {
 		}
 		if process.Stale {
 			summary.StaleProcesses++
+			summary.RedProcesses++
 			redIssues = append(redIssues, fmt.Sprintf("%s heartbeat stale age=%ds", process.ProcessID, process.LastHeartbeatAgeSec))
+			continue
 		}
 		switch process.HealthStatus {
 		case fleethealth.HealthRed:
@@ -661,9 +794,6 @@ func summarizeFleet(snapshot FleetSnapshot) FleetSummary {
 	}
 	if summary.MonitorProcesses == 0 {
 		amberIssues = append(amberIssues, "no monitor process snapshots found")
-	}
-	if summary.DelivererProcesses == 0 {
-		amberIssues = append(amberIssues, "no standalone deliverer process snapshots found")
 	}
 	appendStatusIssue := func(prefix, status, detail string) {
 		if status == "red" {
@@ -730,13 +860,30 @@ func suggestFleetNextAction(snapshot FleetSnapshot, summary FleetSummary) string
 		return "Confirm whether the fleet is still in pinned rollout before expecting dynamic bucket coverage."
 	case summary.MonitorProcesses == 0:
 		return "Confirm monitor processes are publishing jetmon_process_health snapshots."
-	case summary.DelivererProcesses == 0:
-		return "Confirm whether standalone delivery is deployed yet; embedded delivery may still be active."
 	case summary.AmberProcesses > 0:
 		return "Open amber host dashboards and clear dependency warnings before the next rollout step."
 	default:
 		return "Fleet checks look healthy; continue normal monitoring and rollout validation."
 	}
+}
+
+func cloneFleetSnapshot(in FleetSnapshot) FleetSnapshot {
+	out := in
+	out.Summary.Issues = append([]string(nil), in.Summary.Issues...)
+	out.Processes = append([]FleetProcess(nil), in.Processes...)
+	for i := range out.Processes {
+		out.Processes[i].DependencyHealth = append([]fleethealth.DependencyHealth(nil), in.Processes[i].DependencyHealth...)
+	}
+	out.ProcessCounts = make(map[string]int, len(in.ProcessCounts))
+	for key, value := range in.ProcessCounts {
+		out.ProcessCounts[key] = value
+	}
+	out.BucketCoverage.Hosts = append([]FleetBucketHost(nil), in.BucketCoverage.Hosts...)
+	out.Delivery.Tables = append([]FleetDeliveryTable(nil), in.Delivery.Tables...)
+	out.Delivery.Posture.EnabledHosts = append([]string(nil), in.Delivery.Posture.EnabledHosts...)
+	out.Delivery.Posture.OwnerHosts = append([]string(nil), in.Delivery.Posture.OwnerHosts...)
+	out.Dependencies = append([]FleetDependencySummary(nil), in.Dependencies...)
+	return out
 }
 
 func countFleetProcesses(processes []FleetProcess) map[string]int {
@@ -792,6 +939,9 @@ func (s *Server) SetFleetSource(source FleetSource) {
 }
 
 func (s *Server) handleFleet(w http.ResponseWriter, r *http.Request) {
+	if rejectNonGet(w, r) {
+		return
+	}
 	s.mu.RLock()
 	source := s.fleetSource
 	s.mu.RUnlock()
@@ -803,7 +953,8 @@ func (s *Server) handleFleet(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	snapshot, err := source.Snapshot(ctx)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		log.Printf("fleet dashboard: %v", err)
+		http.Error(w, "fleet dashboard query failed", http.StatusInternalServerError)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -811,6 +962,9 @@ func (s *Server) handleFleet(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleFleetIndex(w http.ResponseWriter, r *http.Request) {
+	if rejectNonGet(w, r) {
+		return
+	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	fmt.Fprint(w, fleetDashboardHTML)
 }

--- a/internal/dashboard/fleet.go
+++ b/internal/dashboard/fleet.go
@@ -474,15 +474,7 @@ func fleetBucketOwnershipMode(processes []FleetProcess) string {
 }
 
 func processActiveForFleetOwnership(process FleetProcess) bool {
-	if process.Stale {
-		return false
-	}
-	switch process.State {
-	case fleethealth.StateStopped, fleethealth.StateStopping:
-		return false
-	default:
-		return true
-	}
+	return processActiveForFleetRollup(process)
 }
 
 func validateFleetBucketCoverage(hosts []FleetBucketHost, bucketTotal int) error {
@@ -558,78 +550,92 @@ func queryFleetDeliveryTable(ctx context.Context, db *sql.DB, kind, table string
 		return FleetDeliveryTable{}, fmt.Errorf("unsupported delivery table %q", table)
 	}
 	summary := FleetDeliveryTable{Kind: kind}
-	pendingQuery := fmt.Sprintf(`
-		SELECT COUNT(*),
-		       COALESCE(TIMESTAMPDIFF(SECOND, MIN(created_at), ?), 0)
-		  FROM %s
-		 WHERE status = 'pending'`, table)
-	if err := db.QueryRowContext(ctx, pendingQuery, now).Scan(&summary.Pending, &summary.OldestPendingAgeSec); err != nil {
-		return FleetDeliveryTable{}, fmt.Errorf("%s pending delivery summary: %w", kind, err)
-	}
-	dueQuery := fmt.Sprintf(`
-		SELECT COUNT(*),
-		       COALESCE(TIMESTAMPDIFF(SECOND, MIN(COALESCE(next_attempt_at, created_at)), ?), 0)
+
+	query := fmt.Sprintf(`
+		SELECT 'pending' AS metric,
+		       COUNT(*) AS count,
+		       COALESCE(TIMESTAMPDIFF(SECOND, MIN(created_at), ?), 0) AS age_sec
 		  FROM %s
 		 WHERE status = 'pending'
-		   AND (next_attempt_at IS NULL OR next_attempt_at <= ?)`, table)
-	if err := db.QueryRowContext(ctx, dueQuery, now, now).Scan(&summary.DueNow, &summary.OldestDueAgeSec); err != nil {
-		return FleetDeliveryTable{}, fmt.Errorf("%s due delivery summary: %w", kind, err)
-	}
-	futureQuery := fmt.Sprintf(`
-		SELECT COUNT(*)
+		UNION ALL
+		SELECT 'due' AS metric,
+		       COUNT(*) AS count,
+		       COALESCE(TIMESTAMPDIFF(SECOND, MIN(COALESCE(next_attempt_at, created_at)), ?), 0) AS age_sec
 		  FROM %s
 		 WHERE status = 'pending'
-		   AND next_attempt_at > ?`, table)
-	if err := db.QueryRowContext(ctx, futureQuery, now).Scan(&summary.FutureRetry); err != nil {
-		return FleetDeliveryTable{}, fmt.Errorf("%s future delivery summary: %w", kind, err)
-	}
-	deliveredQuery := fmt.Sprintf(`
-		SELECT COUNT(*)
+		   AND (next_attempt_at IS NULL OR next_attempt_at <= ?)
+		UNION ALL
+		SELECT 'future' AS metric,
+		       COUNT(*) AS count,
+		       0 AS age_sec
+		  FROM %s
+		 WHERE status = 'pending'
+		   AND next_attempt_at > ?
+		UNION ALL
+		SELECT 'delivered' AS metric,
+		       COUNT(*) AS count,
+		       0 AS age_sec
 		  FROM %s
 		 WHERE status = 'delivered'
-		   AND delivered_at >= ?`, table)
-	if err := db.QueryRowContext(ctx, deliveredQuery, cutoff).Scan(&summary.DeliveredSince); err != nil {
-		return FleetDeliveryTable{}, fmt.Errorf("%s delivered summary: %w", kind, err)
-	}
-	abandoned, err := queryFleetRecentTerminalDeliveryCount(ctx, db, table, "abandoned", cutoff)
+		   AND delivered_at >= ?
+		UNION ALL
+		SELECT 'abandoned' AS metric,
+		       COUNT(*) AS count,
+		       0 AS age_sec
+		  FROM %s
+		 WHERE status = 'abandoned'
+		   AND (last_attempt_at >= ? OR (last_attempt_at IS NULL AND created_at >= ?))
+		UNION ALL
+		SELECT 'failed' AS metric,
+		       COUNT(*) AS count,
+		       0 AS age_sec
+		  FROM %s
+		 WHERE status = 'failed'
+		   AND (last_attempt_at >= ? OR (last_attempt_at IS NULL AND created_at >= ?))`,
+		table, table, table, table, table, table,
+	)
+	rows, err := db.QueryContext(ctx, query,
+		now,
+		now, now,
+		now,
+		cutoff,
+		cutoff, cutoff,
+		cutoff, cutoff,
+	)
 	if err != nil {
-		return FleetDeliveryTable{}, fmt.Errorf("%s abandoned summary: %w", kind, err)
+		return FleetDeliveryTable{}, fmt.Errorf("%s delivery summary: %w", kind, err)
 	}
-	failed, err := queryFleetRecentTerminalDeliveryCount(ctx, db, table, "failed", cutoff)
-	if err != nil {
-		return FleetDeliveryTable{}, fmt.Errorf("%s failed summary: %w", kind, err)
-	}
-	summary.AbandonedSince = abandoned
-	summary.FailedSince = failed
-	return summary, nil
-}
+	defer rows.Close()
 
-func queryFleetRecentTerminalDeliveryCount(ctx context.Context, db *sql.DB, table, status string, cutoff time.Time) (int64, error) {
-	switch status {
-	case "abandoned", "failed":
-	default:
-		return 0, fmt.Errorf("unsupported terminal status %q", status)
+	for rows.Next() {
+		var metric string
+		var count, ageSec int64
+		if err := rows.Scan(&metric, &count, &ageSec); err != nil {
+			return FleetDeliveryTable{}, fmt.Errorf("%s delivery summary scan: %w", kind, err)
+		}
+		switch metric {
+		case "pending":
+			summary.Pending = count
+			summary.OldestPendingAgeSec = ageSec
+		case "due":
+			summary.DueNow = count
+			summary.OldestDueAgeSec = ageSec
+		case "future":
+			summary.FutureRetry = count
+		case "delivered":
+			summary.DeliveredSince = count
+		case "abandoned":
+			summary.AbandonedSince = count
+		case "failed":
+			summary.FailedSince = count
+		default:
+			return FleetDeliveryTable{}, fmt.Errorf("%s delivery summary returned unknown metric %q", kind, metric)
+		}
 	}
-	withAttemptQuery := fmt.Sprintf(`
-		SELECT COUNT(*)
-		  FROM %s
-		 WHERE status = ?
-		   AND last_attempt_at >= ?`, table)
-	var withAttempt int64
-	if err := db.QueryRowContext(ctx, withAttemptQuery, status, cutoff).Scan(&withAttempt); err != nil {
-		return 0, err
+	if err := rows.Err(); err != nil {
+		return FleetDeliveryTable{}, fmt.Errorf("%s delivery summary iterate: %w", kind, err)
 	}
-	createdFallbackQuery := fmt.Sprintf(`
-		SELECT COUNT(*)
-		  FROM %s
-		 WHERE status = ?
-		   AND last_attempt_at IS NULL
-		   AND created_at >= ?`, table)
-	var createdFallback int64
-	if err := db.QueryRowContext(ctx, createdFallbackQuery, status, cutoff).Scan(&createdFallback); err != nil {
-		return 0, err
-	}
-	return withAttempt + createdFallback, nil
+	return summary, nil
 }
 
 func summarizeFleetDeliveryPosture(processes []FleetProcess, queuedDeliveries int64) FleetDeliveryPosture {
@@ -682,6 +688,10 @@ func summarizeFleetDeliveryPosture(processes []FleetProcess, queuedDeliveries in
 }
 
 func processActiveForDeliveryPosture(process FleetProcess) bool {
+	return processActiveForFleetRollup(process)
+}
+
+func processActiveForFleetRollup(process FleetProcess) bool {
 	if process.Stale {
 		return false
 	}

--- a/internal/dashboard/fleet.go
+++ b/internal/dashboard/fleet.go
@@ -942,6 +942,7 @@ func (s *Server) handleFleet(w http.ResponseWriter, r *http.Request) {
 	if rejectNonGet(w, r) {
 		return
 	}
+	setDashboardNoStoreHeaders(w)
 	s.mu.RLock()
 	source := s.fleetSource
 	s.mu.RUnlock()
@@ -957,7 +958,7 @@ func (s *Server) handleFleet(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "fleet dashboard query failed", http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
+	setDashboardJSONHeaders(w)
 	_ = json.NewEncoder(w).Encode(snapshot)
 }
 
@@ -965,6 +966,6 @@ func (s *Server) handleFleetIndex(w http.ResponseWriter, r *http.Request) {
 	if rejectNonGet(w, r) {
 		return
 	}
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	setDashboardHTMLHeaders(w)
 	fmt.Fprint(w, fleetDashboardHTML)
 }

--- a/internal/dashboard/fleet.go
+++ b/internal/dashboard/fleet.go
@@ -1,0 +1,816 @@
+package dashboard
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Automattic/jetmon/internal/fleethealth"
+)
+
+const (
+	defaultFleetRequestTimeout = 3 * time.Second
+	defaultFleetRecentWindow   = 15 * time.Minute
+)
+
+// FleetSource supplies the global dashboard snapshot.
+type FleetSource interface {
+	Snapshot(context.Context) (FleetSnapshot, error)
+}
+
+// FleetStoreOptions controls fleet dashboard summary thresholds.
+type FleetStoreOptions struct {
+	BucketTotal    int
+	HeartbeatGrace time.Duration
+	RecentWindow   time.Duration
+	Now            func() time.Time
+}
+
+// FleetStore builds fleet dashboard snapshots from MySQL-backed process health
+// and rollout state.
+type FleetStore struct {
+	db             *sql.DB
+	bucketTotal    int
+	heartbeatGrace time.Duration
+	recentWindow   time.Duration
+	now            func() time.Time
+}
+
+// NewFleetStore creates a MySQL-backed fleet dashboard source.
+func NewFleetStore(db *sql.DB, opts FleetStoreOptions) *FleetStore {
+	if opts.HeartbeatGrace <= 0 {
+		opts.HeartbeatGrace = 10 * time.Minute
+	}
+	if opts.RecentWindow <= 0 {
+		opts.RecentWindow = defaultFleetRecentWindow
+	}
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	return &FleetStore{
+		db:             db,
+		bucketTotal:    opts.BucketTotal,
+		heartbeatGrace: opts.HeartbeatGrace,
+		recentWindow:   opts.RecentWindow,
+		now:            opts.Now,
+	}
+}
+
+// Snapshot returns the current fleet-wide operator view.
+func (s *FleetStore) Snapshot(ctx context.Context) (FleetSnapshot, error) {
+	if s == nil || s.db == nil {
+		return FleetSnapshot{}, errors.New("fleet dashboard database source is not configured")
+	}
+	now := s.now().UTC()
+	processRows, err := fleethealth.ListSnapshots(ctx, s.db)
+	if err != nil {
+		return FleetSnapshot{}, err
+	}
+	processes := summarizeFleetProcesses(processRows, now, s.heartbeatGrace)
+
+	hosts, hostErr := queryFleetBucketHosts(ctx, s.db)
+	bucketCoverage := summarizeFleetBucketCoverage(hosts, s.bucketTotal, s.heartbeatGrace, now, hostErr)
+
+	delivery := queryFleetDelivery(ctx, s.db, now, s.recentWindow)
+	delivery.Posture = summarizeFleetDeliveryPosture(processes)
+
+	projectionDrift := queryFleetProjectionDrift(ctx, s.db, s.bucketTotal)
+	dependencies := summarizeFleetDependencies(processes)
+
+	snapshot := FleetSnapshot{
+		GeneratedAt:     now,
+		Processes:       processes,
+		ProcessCounts:   countFleetProcesses(processes),
+		BucketCoverage:  bucketCoverage,
+		Delivery:        delivery,
+		ProjectionDrift: projectionDrift,
+		Dependencies:    dependencies,
+	}
+	snapshot.Summary = summarizeFleet(snapshot)
+	return snapshot, nil
+}
+
+// FleetSnapshot is the JSON model for the global dashboard.
+type FleetSnapshot struct {
+	GeneratedAt     time.Time                `json:"generated_at"`
+	Summary         FleetSummary             `json:"summary"`
+	Processes       []FleetProcess           `json:"processes"`
+	ProcessCounts   map[string]int           `json:"process_counts"`
+	BucketCoverage  FleetBucketCoverage      `json:"bucket_coverage"`
+	Delivery        FleetDeliverySummary     `json:"delivery"`
+	ProjectionDrift FleetProjectionDrift     `json:"projection_drift"`
+	Dependencies    []FleetDependencySummary `json:"dependencies,omitempty"`
+}
+
+// FleetSummary is the top-level red/amber/green rollup for the fleet.
+type FleetSummary struct {
+	Status               string   `json:"status"`
+	Message              string   `json:"message"`
+	SuggestedNextAction  string   `json:"suggested_next_action,omitempty"`
+	Issues               []string `json:"issues,omitempty"`
+	RedProcesses         int      `json:"red_processes"`
+	AmberProcesses       int      `json:"amber_processes"`
+	GreenProcesses       int      `json:"green_processes"`
+	StaleProcesses       int      `json:"stale_processes"`
+	MonitorProcesses     int      `json:"monitor_processes"`
+	DelivererProcesses   int      `json:"deliverer_processes"`
+	DependencyRedCount   int      `json:"dependency_red_count"`
+	DependencyAmberCount int      `json:"dependency_amber_count"`
+}
+
+// FleetProcess is one process-health row with dashboard-derived freshness.
+type FleetProcess struct {
+	ProcessID              string                         `json:"process_id"`
+	HostID                 string                         `json:"host_id"`
+	ProcessType            string                         `json:"process_type"`
+	PID                    int                            `json:"pid"`
+	Version                string                         `json:"version"`
+	BuildDate              string                         `json:"build_date"`
+	GoVersion              string                         `json:"go_version"`
+	State                  string                         `json:"state"`
+	HealthStatus           string                         `json:"health_status"`
+	StartedAt              time.Time                      `json:"started_at,omitempty"`
+	UpdatedAt              time.Time                      `json:"updated_at"`
+	LastHeartbeatAgeSec    int64                          `json:"last_heartbeat_age_sec"`
+	Stale                  bool                           `json:"stale"`
+	BucketMin              *int                           `json:"bucket_min,omitempty"`
+	BucketMax              *int                           `json:"bucket_max,omitempty"`
+	BucketOwnership        string                         `json:"bucket_ownership"`
+	APIPort                *int                           `json:"api_port,omitempty"`
+	DashboardPort          *int                           `json:"dashboard_port,omitempty"`
+	DeliveryWorkersEnabled bool                           `json:"delivery_workers_enabled"`
+	DeliveryOwnerHost      string                         `json:"delivery_owner_host"`
+	WorkerCount            int                            `json:"worker_count"`
+	ActiveChecks           int                            `json:"active_checks"`
+	QueueDepth             int                            `json:"queue_depth"`
+	RetryQueueSize         int                            `json:"retry_queue_size"`
+	WPCOMCircuitOpen       bool                           `json:"wpcom_circuit_open"`
+	WPCOMQueueDepth        int                            `json:"wpcom_queue_depth"`
+	GoSysMemMB             int                            `json:"go_sys_mem_mb"`
+	DependencyHealth       []fleethealth.DependencyHealth `json:"dependency_health,omitempty"`
+}
+
+// FleetBucketCoverage summarizes jetmon_hosts dynamic bucket ownership.
+type FleetBucketCoverage struct {
+	Status      string            `json:"status"`
+	BucketTotal int               `json:"bucket_total"`
+	HostCount   int               `json:"host_count"`
+	Error       string            `json:"error,omitempty"`
+	Hosts       []FleetBucketHost `json:"hosts,omitempty"`
+}
+
+// FleetBucketHost is one jetmon_hosts row with freshness metadata.
+type FleetBucketHost struct {
+	HostID              string    `json:"host_id"`
+	BucketMin           int       `json:"bucket_min"`
+	BucketMax           int       `json:"bucket_max"`
+	Status              string    `json:"status"`
+	LastHeartbeat       time.Time `json:"last_heartbeat"`
+	LastHeartbeatAgeSec int64     `json:"last_heartbeat_age_sec"`
+	Stale               bool      `json:"stale"`
+}
+
+// FleetDeliverySummary describes global outbound delivery queues.
+type FleetDeliverySummary struct {
+	Status              string               `json:"status"`
+	Error               string               `json:"error,omitempty"`
+	Since               time.Time            `json:"since"`
+	Pending             int64                `json:"pending"`
+	DueNow              int64                `json:"due_now"`
+	FutureRetry         int64                `json:"future_retry"`
+	DeliveredSince      int64                `json:"delivered_since"`
+	AbandonedSince      int64                `json:"abandoned_since"`
+	FailedSince         int64                `json:"failed_since"`
+	OldestPendingAgeSec int64                `json:"oldest_pending_age_sec"`
+	OldestDueAgeSec     int64                `json:"oldest_due_age_sec"`
+	Tables              []FleetDeliveryTable `json:"tables,omitempty"`
+	Posture             FleetDeliveryPosture `json:"posture"`
+}
+
+// FleetDeliveryTable is a per-table outbound delivery queue summary.
+type FleetDeliveryTable struct {
+	Kind                string `json:"kind"`
+	Pending             int64  `json:"pending"`
+	DueNow              int64  `json:"due_now"`
+	FutureRetry         int64  `json:"future_retry"`
+	DeliveredSince      int64  `json:"delivered_since"`
+	AbandonedSince      int64  `json:"abandoned_since"`
+	FailedSince         int64  `json:"failed_since"`
+	OldestPendingAgeSec int64  `json:"oldest_pending_age_sec"`
+	OldestDueAgeSec     int64  `json:"oldest_due_age_sec"`
+}
+
+// FleetDeliveryPosture describes which process snapshots report delivery
+// workers as enabled.
+type FleetDeliveryPosture struct {
+	Status              string   `json:"status"`
+	EnabledProcessCount int      `json:"enabled_process_count"`
+	EnabledHosts        []string `json:"enabled_hosts,omitempty"`
+	OwnerHosts          []string `json:"owner_hosts,omitempty"`
+	Message             string   `json:"message"`
+}
+
+// FleetProjectionDrift summarizes legacy projection drift globally.
+type FleetProjectionDrift struct {
+	Status string `json:"status"`
+	Count  int    `json:"count"`
+	Error  string `json:"error,omitempty"`
+}
+
+// FleetDependencySummary aggregates dependency health by dependency name.
+type FleetDependencySummary struct {
+	Name       string `json:"name"`
+	Status     string `json:"status"`
+	RedCount   int    `json:"red_count"`
+	AmberCount int    `json:"amber_count"`
+	GreenCount int    `json:"green_count"`
+	StaleCount int    `json:"stale_count"`
+	LastError  string `json:"last_error,omitempty"`
+}
+
+func summarizeFleetProcesses(rows []fleethealth.Snapshot, now time.Time, heartbeatGrace time.Duration) []FleetProcess {
+	out := make([]FleetProcess, 0, len(rows))
+	for _, row := range rows {
+		age := now.Sub(row.UpdatedAt)
+		if age < 0 {
+			age = 0
+		}
+		out = append(out, FleetProcess{
+			ProcessID:              row.ProcessID,
+			HostID:                 row.HostID,
+			ProcessType:            row.ProcessType,
+			PID:                    row.PID,
+			Version:                row.Version,
+			BuildDate:              row.BuildDate,
+			GoVersion:              row.GoVersion,
+			State:                  row.State,
+			HealthStatus:           row.HealthStatus,
+			StartedAt:              row.StartedAt,
+			UpdatedAt:              row.UpdatedAt,
+			LastHeartbeatAgeSec:    int64(age.Round(time.Second) / time.Second),
+			Stale:                  age > heartbeatGrace,
+			BucketMin:              row.BucketMin,
+			BucketMax:              row.BucketMax,
+			BucketOwnership:        row.BucketOwnership,
+			APIPort:                row.APIPort,
+			DashboardPort:          row.DashboardPort,
+			DeliveryWorkersEnabled: row.DeliveryWorkersEnabled,
+			DeliveryOwnerHost:      row.DeliveryOwnerHost,
+			WorkerCount:            row.WorkerCount,
+			ActiveChecks:           row.ActiveChecks,
+			QueueDepth:             row.QueueDepth,
+			RetryQueueSize:         row.RetryQueueSize,
+			WPCOMCircuitOpen:       row.WPCOMCircuitOpen,
+			WPCOMQueueDepth:        row.WPCOMQueueDepth,
+			GoSysMemMB:             row.GoSysMemMB,
+			DependencyHealth:       append([]fleethealth.DependencyHealth(nil), row.DependencyHealth...),
+		})
+	}
+	return out
+}
+
+func queryFleetBucketHosts(ctx context.Context, db *sql.DB) ([]FleetBucketHost, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT host_id, bucket_min, bucket_max, last_heartbeat, status
+		  FROM jetmon_hosts
+		 ORDER BY bucket_min, host_id`)
+	if err != nil {
+		return nil, fmt.Errorf("query jetmon_hosts: %w", err)
+	}
+	defer rows.Close()
+
+	var hosts []FleetBucketHost
+	for rows.Next() {
+		var host FleetBucketHost
+		if err := rows.Scan(&host.HostID, &host.BucketMin, &host.BucketMax, &host.LastHeartbeat, &host.Status); err != nil {
+			return nil, fmt.Errorf("scan jetmon_hosts: %w", err)
+		}
+		host.LastHeartbeat = host.LastHeartbeat.UTC()
+		hosts = append(hosts, host)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate jetmon_hosts: %w", err)
+	}
+	return hosts, nil
+}
+
+func summarizeFleetBucketCoverage(hosts []FleetBucketHost, bucketTotal int, heartbeatGrace time.Duration, now time.Time, queryErr error) FleetBucketCoverage {
+	coverage := FleetBucketCoverage{
+		Status:      "green",
+		BucketTotal: bucketTotal,
+		HostCount:   len(hosts),
+		Hosts:       append([]FleetBucketHost(nil), hosts...),
+	}
+	if queryErr != nil {
+		coverage.Status = "red"
+		coverage.Error = queryErr.Error()
+		return coverage
+	}
+	if bucketTotal <= 0 {
+		coverage.Status = "amber"
+		coverage.Error = "BUCKET_TOTAL is not configured"
+		return coverage
+	}
+	if len(hosts) == 0 {
+		coverage.Status = "amber"
+		coverage.Error = "jetmon_hosts has no dynamic ownership rows"
+		return coverage
+	}
+	for i := range coverage.Hosts {
+		age := now.Sub(coverage.Hosts[i].LastHeartbeat)
+		if age < 0 {
+			age = 0
+		}
+		coverage.Hosts[i].LastHeartbeatAgeSec = int64(age.Round(time.Second) / time.Second)
+		coverage.Hosts[i].Stale = age > heartbeatGrace
+	}
+	if err := validateFleetBucketCoverage(coverage.Hosts, bucketTotal); err != nil {
+		coverage.Status = "red"
+		coverage.Error = err.Error()
+		return coverage
+	}
+	for _, host := range coverage.Hosts {
+		if host.Status != "active" {
+			coverage.Status = "red"
+			coverage.Error = fmt.Sprintf("host %q has status=%q", host.HostID, host.Status)
+			return coverage
+		}
+		if host.Stale {
+			coverage.Status = "red"
+			coverage.Error = fmt.Sprintf("host %q heartbeat is stale", host.HostID)
+			return coverage
+		}
+	}
+	return coverage
+}
+
+func validateFleetBucketCoverage(hosts []FleetBucketHost, bucketTotal int) error {
+	sortedHosts := append([]FleetBucketHost(nil), hosts...)
+	sort.Slice(sortedHosts, func(i, j int) bool {
+		if sortedHosts[i].BucketMin == sortedHosts[j].BucketMin {
+			return sortedHosts[i].HostID < sortedHosts[j].HostID
+		}
+		return sortedHosts[i].BucketMin < sortedHosts[j].BucketMin
+	})
+
+	expectedMin := 0
+	for _, host := range sortedHosts {
+		if host.BucketMin < 0 || host.BucketMax < host.BucketMin || host.BucketMax >= bucketTotal {
+			return fmt.Errorf("host %q has invalid bucket range %d-%d for BUCKET_TOTAL=%d", host.HostID, host.BucketMin, host.BucketMax, bucketTotal)
+		}
+		if host.BucketMin > expectedMin {
+			return fmt.Errorf("dynamic bucket coverage has gap %d-%d before host %q", expectedMin, host.BucketMin-1, host.HostID)
+		}
+		if host.BucketMin < expectedMin {
+			return fmt.Errorf("dynamic bucket coverage overlaps before host %q at bucket %d", host.HostID, host.BucketMin)
+		}
+		expectedMin = host.BucketMax + 1
+	}
+	if expectedMin < bucketTotal {
+		return fmt.Errorf("dynamic bucket coverage has trailing gap %d-%d", expectedMin, bucketTotal-1)
+	}
+	return nil
+}
+
+func queryFleetDelivery(ctx context.Context, db *sql.DB, now time.Time, recentWindow time.Duration) FleetDeliverySummary {
+	cutoff := now.Add(-recentWindow).UTC()
+	summary := FleetDeliverySummary{Status: "green", Since: cutoff}
+	tables := []struct {
+		kind string
+		name string
+	}{
+		{kind: "webhook", name: "jetmon_webhook_deliveries"},
+		{kind: "alert", name: "jetmon_alert_deliveries"},
+	}
+	for _, table := range tables {
+		tableSummary, err := queryFleetDeliveryTable(ctx, db, table.kind, table.name, now, cutoff)
+		if err != nil {
+			summary.Status = "red"
+			summary.Error = err.Error()
+			return summary
+		}
+		summary.Tables = append(summary.Tables, tableSummary)
+		summary.Pending += tableSummary.Pending
+		summary.DueNow += tableSummary.DueNow
+		summary.FutureRetry += tableSummary.FutureRetry
+		summary.DeliveredSince += tableSummary.DeliveredSince
+		summary.AbandonedSince += tableSummary.AbandonedSince
+		summary.FailedSince += tableSummary.FailedSince
+		summary.OldestPendingAgeSec = maxInt64(summary.OldestPendingAgeSec, tableSummary.OldestPendingAgeSec)
+		summary.OldestDueAgeSec = maxInt64(summary.OldestDueAgeSec, tableSummary.OldestDueAgeSec)
+	}
+	switch {
+	case summary.AbandonedSince > 0 || summary.FailedSince > 0:
+		summary.Status = "red"
+	case summary.DueNow > 0:
+		summary.Status = "amber"
+	default:
+		summary.Status = "green"
+	}
+	return summary
+}
+
+func queryFleetDeliveryTable(ctx context.Context, db *sql.DB, kind, table string, now, cutoff time.Time) (FleetDeliveryTable, error) {
+	switch table {
+	case "jetmon_webhook_deliveries", "jetmon_alert_deliveries":
+	default:
+		return FleetDeliveryTable{}, fmt.Errorf("unsupported delivery table %q", table)
+	}
+	summary := FleetDeliveryTable{Kind: kind}
+	pendingQuery := fmt.Sprintf(`
+		SELECT COUNT(*),
+		       COALESCE(TIMESTAMPDIFF(SECOND, MIN(created_at), ?), 0)
+		  FROM %s
+		 WHERE status = 'pending'`, table)
+	if err := db.QueryRowContext(ctx, pendingQuery, now).Scan(&summary.Pending, &summary.OldestPendingAgeSec); err != nil {
+		return FleetDeliveryTable{}, fmt.Errorf("%s pending delivery summary: %w", kind, err)
+	}
+	dueQuery := fmt.Sprintf(`
+		SELECT COUNT(*),
+		       COALESCE(TIMESTAMPDIFF(SECOND, MIN(COALESCE(next_attempt_at, created_at)), ?), 0)
+		  FROM %s
+		 WHERE status = 'pending'
+		   AND (next_attempt_at IS NULL OR next_attempt_at <= ?)`, table)
+	if err := db.QueryRowContext(ctx, dueQuery, now, now).Scan(&summary.DueNow, &summary.OldestDueAgeSec); err != nil {
+		return FleetDeliveryTable{}, fmt.Errorf("%s due delivery summary: %w", kind, err)
+	}
+	futureQuery := fmt.Sprintf(`
+		SELECT COUNT(*)
+		  FROM %s
+		 WHERE status = 'pending'
+		   AND next_attempt_at > ?`, table)
+	if err := db.QueryRowContext(ctx, futureQuery, now).Scan(&summary.FutureRetry); err != nil {
+		return FleetDeliveryTable{}, fmt.Errorf("%s future delivery summary: %w", kind, err)
+	}
+	deliveredQuery := fmt.Sprintf(`
+		SELECT COUNT(*)
+		  FROM %s
+		 WHERE status = 'delivered'
+		   AND delivered_at >= ?`, table)
+	if err := db.QueryRowContext(ctx, deliveredQuery, cutoff).Scan(&summary.DeliveredSince); err != nil {
+		return FleetDeliveryTable{}, fmt.Errorf("%s delivered summary: %w", kind, err)
+	}
+	abandoned, err := queryFleetRecentTerminalDeliveryCount(ctx, db, table, "abandoned", cutoff)
+	if err != nil {
+		return FleetDeliveryTable{}, fmt.Errorf("%s abandoned summary: %w", kind, err)
+	}
+	failed, err := queryFleetRecentTerminalDeliveryCount(ctx, db, table, "failed", cutoff)
+	if err != nil {
+		return FleetDeliveryTable{}, fmt.Errorf("%s failed summary: %w", kind, err)
+	}
+	summary.AbandonedSince = abandoned
+	summary.FailedSince = failed
+	return summary, nil
+}
+
+func queryFleetRecentTerminalDeliveryCount(ctx context.Context, db *sql.DB, table, status string, cutoff time.Time) (int64, error) {
+	switch status {
+	case "abandoned", "failed":
+	default:
+		return 0, fmt.Errorf("unsupported terminal status %q", status)
+	}
+	withAttemptQuery := fmt.Sprintf(`
+		SELECT COUNT(*)
+		  FROM %s
+		 WHERE status = ?
+		   AND last_attempt_at >= ?`, table)
+	var withAttempt int64
+	if err := db.QueryRowContext(ctx, withAttemptQuery, status, cutoff).Scan(&withAttempt); err != nil {
+		return 0, err
+	}
+	createdFallbackQuery := fmt.Sprintf(`
+		SELECT COUNT(*)
+		  FROM %s
+		 WHERE status = ?
+		   AND last_attempt_at IS NULL
+		   AND created_at >= ?`, table)
+	var createdFallback int64
+	if err := db.QueryRowContext(ctx, createdFallbackQuery, status, cutoff).Scan(&createdFallback); err != nil {
+		return 0, err
+	}
+	return withAttempt + createdFallback, nil
+}
+
+func summarizeFleetDeliveryPosture(processes []FleetProcess) FleetDeliveryPosture {
+	enabledHosts := map[string]struct{}{}
+	ownerHosts := map[string]struct{}{}
+	enabledCount := 0
+	for _, process := range processes {
+		if owner := strings.TrimSpace(process.DeliveryOwnerHost); owner != "" {
+			ownerHosts[owner] = struct{}{}
+		}
+		if !process.DeliveryWorkersEnabled {
+			continue
+		}
+		enabledCount++
+		enabledHosts[process.HostID] = struct{}{}
+	}
+	posture := FleetDeliveryPosture{
+		Status:              "green",
+		EnabledProcessCount: enabledCount,
+		EnabledHosts:        sortedStringKeys(enabledHosts),
+		OwnerHosts:          sortedStringKeys(ownerHosts),
+	}
+	switch {
+	case enabledCount == 0:
+		posture.Status = "amber"
+		posture.Message = "no process snapshot reports delivery workers enabled"
+	case len(posture.OwnerHosts) == 0 && enabledCount > 1:
+		posture.Status = "amber"
+		posture.Message = "multiple delivery-capable processes are enabled without DELIVERY_OWNER_HOST"
+	case len(posture.OwnerHosts) > 1:
+		posture.Status = "amber"
+		posture.Message = "multiple DELIVERY_OWNER_HOST values are visible across process snapshots"
+	case len(posture.OwnerHosts) == 1:
+		posture.Message = fmt.Sprintf("delivery owner is constrained to %s", posture.OwnerHosts[0])
+	default:
+		posture.Message = "delivery workers are enabled without an explicit owner"
+	}
+	return posture
+}
+
+func queryFleetProjectionDrift(ctx context.Context, db *sql.DB, bucketTotal int) FleetProjectionDrift {
+	if bucketTotal <= 0 {
+		return FleetProjectionDrift{Status: "amber", Error: "BUCKET_TOTAL is not configured"}
+	}
+	var count int
+	err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		  FROM jetpack_monitor_sites s
+		  LEFT JOIN jetmon_events e
+		    ON e.blog_id = s.blog_id
+		   AND e.check_type = 'http'
+		   AND e.ended_at IS NULL
+		 WHERE s.monitor_active = 1
+		   AND s.bucket_no BETWEEN 0 AND ?
+		   AND s.site_status <> CASE
+		     WHEN e.state = 'Down' THEN 2
+		     WHEN e.state = 'Seems Down' THEN 0
+		     ELSE 1
+		   END`,
+		bucketTotal-1,
+	).Scan(&count)
+	if err != nil {
+		return FleetProjectionDrift{Status: "red", Error: fmt.Sprintf("count projection drift: %v", err)}
+	}
+	if count > 0 {
+		return FleetProjectionDrift{Status: "red", Count: count}
+	}
+	return FleetProjectionDrift{Status: "green"}
+}
+
+func summarizeFleetDependencies(processes []FleetProcess) []FleetDependencySummary {
+	byName := map[string]*FleetDependencySummary{}
+	for _, process := range processes {
+		for _, dep := range process.DependencyHealth {
+			name := strings.TrimSpace(dep.Name)
+			if name == "" {
+				name = "unknown"
+			}
+			summary := byName[name]
+			if summary == nil {
+				summary = &FleetDependencySummary{Name: name, Status: "green"}
+				byName[name] = summary
+			}
+			if process.Stale {
+				summary.StaleCount++
+			}
+			switch dep.Status {
+			case fleethealth.HealthRed:
+				summary.RedCount++
+				summary.Status = "red"
+				if dep.LastError != "" {
+					summary.LastError = dep.LastError
+				}
+			case fleethealth.HealthAmber:
+				summary.AmberCount++
+				if summary.Status != "red" {
+					summary.Status = "amber"
+				}
+				if dep.LastError != "" && summary.LastError == "" {
+					summary.LastError = dep.LastError
+				}
+			case fleethealth.HealthGreen:
+				summary.GreenCount++
+			default:
+				summary.AmberCount++
+				if summary.Status != "red" {
+					summary.Status = "amber"
+				}
+			}
+		}
+	}
+	out := make([]FleetDependencySummary, 0, len(byName))
+	for _, dep := range byName {
+		out = append(out, *dep)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Status == out[j].Status {
+			return out[i].Name < out[j].Name
+		}
+		return statusRank(out[i].Status) > statusRank(out[j].Status)
+	})
+	return out
+}
+
+func summarizeFleet(snapshot FleetSnapshot) FleetSummary {
+	summary := FleetSummary{Status: "green", Message: "fleet checks are green"}
+	var redIssues []string
+	var amberIssues []string
+	if len(snapshot.Processes) == 0 {
+		amberIssues = append(amberIssues, "no process-health snapshots found")
+	}
+	for _, process := range snapshot.Processes {
+		switch process.ProcessType {
+		case fleethealth.ProcessMonitor:
+			summary.MonitorProcesses++
+		case fleethealth.ProcessDeliverer:
+			summary.DelivererProcesses++
+		}
+		if process.Stale {
+			summary.StaleProcesses++
+			redIssues = append(redIssues, fmt.Sprintf("%s heartbeat stale age=%ds", process.ProcessID, process.LastHeartbeatAgeSec))
+		}
+		switch process.HealthStatus {
+		case fleethealth.HealthRed:
+			summary.RedProcesses++
+			redIssues = append(redIssues, fmt.Sprintf("%s health_status=red", process.ProcessID))
+		case fleethealth.HealthAmber:
+			summary.AmberProcesses++
+			amberIssues = append(amberIssues, fmt.Sprintf("%s health_status=amber", process.ProcessID))
+		case fleethealth.HealthGreen:
+			summary.GreenProcesses++
+		default:
+			summary.AmberProcesses++
+			amberIssues = append(amberIssues, fmt.Sprintf("%s health_status=%q", process.ProcessID, process.HealthStatus))
+		}
+	}
+	for _, dep := range snapshot.Dependencies {
+		if dep.Status == "red" {
+			summary.DependencyRedCount += dep.RedCount
+		}
+		if dep.Status == "amber" {
+			summary.DependencyAmberCount += dep.AmberCount
+		}
+	}
+	if summary.MonitorProcesses == 0 {
+		amberIssues = append(amberIssues, "no monitor process snapshots found")
+	}
+	if summary.DelivererProcesses == 0 {
+		amberIssues = append(amberIssues, "no standalone deliverer process snapshots found")
+	}
+	appendStatusIssue := func(prefix, status, detail string) {
+		if status == "red" {
+			redIssues = append(redIssues, prefix+": "+detail)
+		}
+		if status == "amber" {
+			amberIssues = append(amberIssues, prefix+": "+detail)
+		}
+	}
+	if snapshot.BucketCoverage.Status != "green" {
+		appendStatusIssue("bucket coverage", snapshot.BucketCoverage.Status, firstNonEmpty(snapshot.BucketCoverage.Error, snapshot.BucketCoverage.Status))
+	}
+	if snapshot.ProjectionDrift.Status != "green" {
+		detail := snapshot.ProjectionDrift.Error
+		if detail == "" {
+			detail = fmt.Sprintf("legacy projection drift=%d", snapshot.ProjectionDrift.Count)
+		}
+		appendStatusIssue("projection drift", snapshot.ProjectionDrift.Status, detail)
+	}
+	if snapshot.Delivery.Status != "green" {
+		detail := snapshot.Delivery.Error
+		if detail == "" {
+			detail = fmt.Sprintf("pending=%d due=%d failed_since=%d abandoned_since=%d", snapshot.Delivery.Pending, snapshot.Delivery.DueNow, snapshot.Delivery.FailedSince, snapshot.Delivery.AbandonedSince)
+		}
+		appendStatusIssue("delivery queues", snapshot.Delivery.Status, detail)
+	}
+	if snapshot.Delivery.Posture.Status != "green" {
+		appendStatusIssue("delivery posture", snapshot.Delivery.Posture.Status, snapshot.Delivery.Posture.Message)
+	}
+
+	summary.Issues = append(redIssues, amberIssues...)
+	switch {
+	case len(redIssues) > 0:
+		summary.Status = "red"
+		summary.Message = "fleet has rollout-blocking issues"
+	case len(amberIssues) > 0:
+		summary.Status = "amber"
+		summary.Message = "fleet needs operator attention"
+	default:
+		summary.Status = "green"
+		summary.Message = "fleet checks are green"
+	}
+	summary.SuggestedNextAction = suggestFleetNextAction(snapshot, summary)
+	return summary
+}
+
+func suggestFleetNextAction(snapshot FleetSnapshot, summary FleetSummary) string {
+	switch {
+	case summary.StaleProcesses > 0:
+		return "Investigate stale process heartbeats before advancing rollout or relying on fleet status."
+	case snapshot.BucketCoverage.Status == "red":
+		return "Fix jetmon_hosts bucket coverage before relying on dynamic ownership."
+	case snapshot.ProjectionDrift.Status == "red":
+		return "Run rollout projection-drift --limit=100 and fix legacy projection drift before continuing."
+	case snapshot.Delivery.Status == "red":
+		return "Investigate failed or abandoned delivery rows before moving delivery ownership."
+	case summary.RedProcesses > 0:
+		return "Open the affected host dashboard and resolve red process health before rollout."
+	case snapshot.Delivery.Status == "amber":
+		return "Watch delivery-check and confirm due deliveries drain before moving delivery ownership."
+	case snapshot.Delivery.Posture.Status == "amber":
+		return "Confirm DELIVERY_OWNER_HOST posture before enabling or moving delivery workers."
+	case snapshot.BucketCoverage.Status == "amber":
+		return "Confirm whether the fleet is still in pinned rollout before expecting dynamic bucket coverage."
+	case summary.MonitorProcesses == 0:
+		return "Confirm monitor processes are publishing jetmon_process_health snapshots."
+	case summary.DelivererProcesses == 0:
+		return "Confirm whether standalone delivery is deployed yet; embedded delivery may still be active."
+	case summary.AmberProcesses > 0:
+		return "Open amber host dashboards and clear dependency warnings before the next rollout step."
+	default:
+		return "Fleet checks look healthy; continue normal monitoring and rollout validation."
+	}
+}
+
+func countFleetProcesses(processes []FleetProcess) map[string]int {
+	out := map[string]int{}
+	for _, process := range processes {
+		out[process.ProcessType]++
+	}
+	return out
+}
+
+func sortedStringKeys(values map[string]struct{}) []string {
+	out := make([]string, 0, len(values))
+	for value := range values {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func maxInt64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func statusRank(status string) int {
+	switch status {
+	case "red":
+		return 3
+	case "amber":
+		return 2
+	case "green":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func (s *Server) SetFleetSource(source FleetSource) {
+	s.mu.Lock()
+	s.fleetSource = source
+	s.mu.Unlock()
+}
+
+func (s *Server) handleFleet(w http.ResponseWriter, r *http.Request) {
+	s.mu.RLock()
+	source := s.fleetSource
+	s.mu.RUnlock()
+	if source == nil {
+		http.Error(w, "fleet dashboard source is not configured", http.StatusServiceUnavailable)
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), defaultFleetRequestTimeout)
+	defer cancel()
+	snapshot, err := source.Snapshot(ctx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(snapshot)
+}
+
+func (s *Server) handleFleetIndex(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprint(w, fleetDashboardHTML)
+}

--- a/internal/dashboard/fleet_html.go
+++ b/internal/dashboard/fleet_html.go
@@ -1,0 +1,252 @@
+package dashboard
+
+const fleetDashboardHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Jetmon 2 - Fleet Dashboard</title>
+<style>
+  :root {
+    color-scheme: dark;
+    --bg: #101316;
+    --panel: #1b2024;
+    --panel-strong: #252b30;
+    --line: #353d43;
+    --text: #eef2f5;
+    --muted: #9aa7b0;
+    --green: #58c783;
+    --green-bg: #14301f;
+    --amber: #f0b85a;
+    --amber-bg: #342814;
+    --red: #f06b64;
+    --red-bg: #3b1d1b;
+    --accent: #77b7d9;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    padding: 24px;
+    background: var(--bg);
+    color: var(--text);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  }
+  main { max-width: 1500px; margin: 0 auto; }
+  h1 { margin: 0; font-size: 1.65rem; }
+  h2 { margin: 28px 0 12px; font-size: 0.85rem; color: var(--muted); letter-spacing: 0; text-transform: uppercase; }
+  a { color: var(--accent); }
+  .topline { display: flex; align-items: baseline; justify-content: space-between; gap: 16px; margin-bottom: 16px; }
+  .subtle { color: var(--muted); font-size: 0.85rem; }
+  .summary {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 16px;
+    align-items: center;
+    padding: 18px;
+    border: 1px solid var(--line);
+    border-left-width: 6px;
+    border-radius: 6px;
+    background: var(--panel);
+  }
+  .summary.green { border-left-color: var(--green); }
+  .summary.amber { border-left-color: var(--amber); }
+  .summary.red { border-left-color: var(--red); }
+  .summary-title { font-size: 1.25rem; margin-bottom: 6px; }
+  .summary-detail { color: var(--muted); font-size: 0.9rem; line-height: 1.45; }
+  .summary-issues { margin: 10px 0 0; padding-left: 18px; font-size: 0.86rem; line-height: 1.45; }
+  .summary-issues:empty { display: none; }
+  .summary-meta { display: grid; gap: 6px; justify-items: end; color: var(--muted); font-size: 0.8rem; }
+  .status-pill {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 72px;
+    padding: 5px 9px;
+    border-radius: 999px;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+  }
+  .status-pill.green { background: var(--green-bg); color: var(--green); }
+  .status-pill.amber { background: var(--amber-bg); color: var(--amber); }
+  .status-pill.red { background: var(--red-bg); color: var(--red); }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(210px, 1fr)); gap: 12px; }
+  .card { background: var(--panel); padding: 14px; border: 1px solid var(--line); border-radius: 6px; min-height: 78px; }
+  .card .label { font-size: 0.72rem; color: var(--muted); text-transform: uppercase; }
+  .card .value { font-size: 1.35rem; color: var(--accent); margin-top: 8px; overflow-wrap: anywhere; }
+  .card .detail { color: var(--muted); font-size: 0.78rem; margin-top: 6px; overflow-wrap: anywhere; }
+  table { width: 100%; border-collapse: collapse; background: var(--panel); border: 1px solid var(--line); border-radius: 6px; overflow: hidden; }
+  th, td { padding: 9px 10px; border-bottom: 1px solid var(--line); text-align: left; font-size: 0.82rem; vertical-align: top; }
+  th { color: var(--muted); text-transform: uppercase; font-size: 0.72rem; background: var(--panel-strong); }
+  tr:last-child td { border-bottom: 0; }
+  td { overflow-wrap: anywhere; }
+  .empty { color: var(--muted); padding: 14px; border: 1px solid var(--line); border-radius: 6px; background: var(--panel); }
+  @media (max-width: 760px) {
+    body { padding: 14px; }
+    .topline, .summary { grid-template-columns: 1fr; }
+    .summary-meta { justify-items: start; }
+    table { display: block; overflow-x: auto; }
+  }
+</style>
+</head>
+<body>
+<main>
+  <div class="topline">
+    <div>
+      <h1>Jetmon 2</h1>
+      <div class="subtle">Fleet dashboard · <a href="/">host dashboard</a></div>
+    </div>
+    <span class="status-pill amber" id="summary-pill">loading</span>
+  </div>
+
+  <section class="summary amber" id="summary">
+    <div>
+      <div class="summary-title" id="summary-title">Loading fleet state</div>
+      <div class="summary-detail" id="summary-detail">Waiting for process health, bucket ownership, and delivery queue summaries.</div>
+      <ul class="summary-issues" id="summary-issues"></ul>
+    </div>
+    <div class="summary-meta">
+      <span id="updated">updated: never</span>
+      <span id="counts">processes: -</span>
+    </div>
+  </section>
+
+  <h2>Fleet Rollup</h2>
+  <div class="grid">
+    <div class="card"><div class="label">Monitors</div><div class="value" id="monitors">-</div></div>
+    <div class="card"><div class="label">Deliverers</div><div class="value" id="deliverers">-</div></div>
+    <div class="card"><div class="label">Stale Processes</div><div class="value" id="stale">-</div></div>
+    <div class="card"><div class="label">Bucket Coverage</div><div class="value" id="bucket-status">-</div><div class="detail" id="bucket-detail"></div></div>
+    <div class="card"><div class="label">Delivery Due</div><div class="value" id="delivery-due">-</div><div class="detail" id="delivery-detail"></div></div>
+    <div class="card"><div class="label">Projection Drift</div><div class="value" id="drift">-</div></div>
+  </div>
+
+  <h2>Delivery Ownership</h2>
+  <div class="grid">
+    <div class="card"><div class="label">Posture</div><div class="value" id="delivery-posture">-</div><div class="detail" id="delivery-posture-detail"></div></div>
+    <div class="card"><div class="label">Enabled Hosts</div><div class="value" id="delivery-enabled">-</div></div>
+    <div class="card"><div class="label">Owner Hosts</div><div class="value" id="delivery-owners">-</div></div>
+  </div>
+
+  <h2>Processes</h2>
+  <table>
+    <thead>
+      <tr><th>Process</th><th>Health</th><th>State</th><th>Heartbeat</th><th>Buckets</th><th>Queues</th><th>Memory</th></tr>
+    </thead>
+    <tbody id="processes"></tbody>
+  </table>
+
+  <h2>Dependencies</h2>
+  <table>
+    <thead>
+      <tr><th>Name</th><th>Status</th><th>Green</th><th>Amber</th><th>Red</th><th>Stale</th><th>Last Error</th></tr>
+    </thead>
+    <tbody id="dependencies"></tbody>
+  </table>
+</main>
+
+<script>
+function setText(id, value) {
+  document.getElementById(id).textContent = value === undefined || value === null || value === '' ? '-' : value;
+}
+
+function statusClass(status) {
+  if (status === 'red' || status === 'amber' || status === 'green') return status;
+  return 'amber';
+}
+
+function renderSummary(summary, generatedAt, processTotal) {
+  const status = statusClass(summary.status);
+  const box = document.getElementById('summary');
+  box.className = 'summary ' + status;
+  const pill = document.getElementById('summary-pill');
+  pill.className = 'status-pill ' + status;
+  pill.textContent = status;
+  setText('summary-title', summary.message || 'fleet status unavailable');
+  let detail = 'green=' + (summary.green_processes || 0) + ' amber=' + (summary.amber_processes || 0) + ' red=' + (summary.red_processes || 0);
+  if (summary.suggested_next_action) detail += ' · next: ' + summary.suggested_next_action;
+  setText('summary-detail', detail);
+  setText('updated', 'updated: ' + (generatedAt ? new Date(generatedAt).toLocaleTimeString() : 'never'));
+  setText('counts', 'processes: ' + processTotal);
+  const issues = document.getElementById('summary-issues');
+  issues.textContent = '';
+  (summary.issues || []).slice(0, 8).forEach(function(issue) {
+    const item = document.createElement('li');
+    item.textContent = issue;
+    issues.appendChild(item);
+  });
+}
+
+function row(cells) {
+  const tr = document.createElement('tr');
+  cells.forEach(function(value) {
+    const td = document.createElement('td');
+    td.textContent = value === undefined || value === null || value === '' ? '-' : value;
+    tr.appendChild(td);
+  });
+  return tr;
+}
+
+function rangeLabel(item) {
+  if (item.bucket_min === undefined || item.bucket_max === undefined || item.bucket_min === null || item.bucket_max === null) return item.bucket_ownership || '-';
+  return item.bucket_min + '-' + item.bucket_max;
+}
+
+function render(snapshot) {
+  const summary = snapshot.summary || {};
+  const processes = snapshot.processes || [];
+  renderSummary(summary, snapshot.generated_at, processes.length);
+  setText('monitors', summary.monitor_processes || 0);
+  setText('deliverers', summary.deliverer_processes || 0);
+  setText('stale', summary.stale_processes || 0);
+  setText('bucket-status', (snapshot.bucket_coverage || {}).status || '-');
+  setText('bucket-detail', ((snapshot.bucket_coverage || {}).host_count || 0) + ' hosts · ' + ((snapshot.bucket_coverage || {}).error || ''));
+  setText('delivery-due', (snapshot.delivery || {}).due_now || 0);
+  setText('delivery-detail', 'pending=' + ((snapshot.delivery || {}).pending || 0) + ' failed=' + ((snapshot.delivery || {}).failed_since || 0) + ' abandoned=' + ((snapshot.delivery || {}).abandoned_since || 0));
+  setText('drift', (snapshot.projection_drift || {}).count || 0);
+  const posture = (snapshot.delivery || {}).posture || {};
+  setText('delivery-posture', posture.status || '-');
+  setText('delivery-posture-detail', posture.message || '');
+  setText('delivery-enabled', (posture.enabled_hosts || []).join(', '));
+  setText('delivery-owners', (posture.owner_hosts || []).join(', '));
+
+  const processBody = document.getElementById('processes');
+  processBody.textContent = '';
+  processes.forEach(function(process) {
+    processBody.appendChild(row([
+      process.process_id,
+      process.health_status + (process.stale ? ' stale' : ''),
+      process.state,
+      (process.last_heartbeat_age_sec || 0) + 's ago',
+      rangeLabel(process),
+      'active=' + (process.active_checks || 0) + ' queue=' + (process.queue_depth || 0) + ' retry=' + (process.retry_queue_size || 0),
+      (process.go_sys_mem_mb || 0) + 'MB'
+    ]));
+  });
+  if (processes.length === 0) {
+    processBody.appendChild(row(['No process-health snapshots found', '', '', '', '', '', '']));
+  }
+
+  const depBody = document.getElementById('dependencies');
+  depBody.textContent = '';
+  (snapshot.dependencies || []).forEach(function(dep) {
+    depBody.appendChild(row([dep.name, dep.status, dep.green_count, dep.amber_count, dep.red_count, dep.stale_count, dep.last_error]));
+  });
+  if ((snapshot.dependencies || []).length === 0) {
+    depBody.appendChild(row(['No dependency snapshots found', '', '', '', '', '', '']));
+  }
+}
+
+async function refresh() {
+  try {
+    const res = await fetch('/api/fleet', { cache: 'no-store' });
+    if (!res.ok) throw new Error(await res.text());
+    render(await res.json());
+  } catch (err) {
+    renderSummary({ status: 'red', message: 'fleet dashboard unavailable', issues: [String(err)] }, null, 0);
+  }
+}
+
+refresh();
+setInterval(refresh, 10000);
+</script>
+</body>
+</html>`

--- a/internal/dashboard/fleet_html.go
+++ b/internal/dashboard/fleet_html.go
@@ -189,6 +189,11 @@ function renderSummary(summary, generatedAt, processTotal) {
     item.textContent = issue;
     issues.appendChild(item);
   });
+  if ((summary.issues || []).length > 8) {
+    const item = document.createElement('li');
+    item.textContent = '+' + ((summary.issues || []).length - 8) + ' more issues in /api/fleet';
+    issues.appendChild(item);
+  }
 }
 
 function row(cells) {
@@ -210,6 +215,12 @@ function ageLabel(seconds) {
   return (seconds || 0) + 's ago';
 }
 
+function joinParts(parts) {
+  return parts.filter(function(part) {
+    return part !== undefined && part !== null && part !== '';
+  }).join(' · ');
+}
+
 function render(snapshot) {
   const summary = snapshot.summary || {};
   const processes = snapshot.processes || [];
@@ -218,7 +229,7 @@ function render(snapshot) {
   setText('deliverers', summary.deliverer_processes || 0);
   setText('stale', summary.stale_processes || 0);
   setText('bucket-status', (snapshot.bucket_coverage || {}).status || '-');
-  setText('bucket-detail', ((snapshot.bucket_coverage || {}).mode || '-') + ' · ' + ((snapshot.bucket_coverage || {}).host_count || 0) + ' hosts · ' + ((snapshot.bucket_coverage || {}).error || ''));
+  setText('bucket-detail', joinParts([((snapshot.bucket_coverage || {}).mode || '-'), ((snapshot.bucket_coverage || {}).host_count || 0) + ' hosts', (snapshot.bucket_coverage || {}).error]));
   setText('delivery-due', (snapshot.delivery || {}).due_now || 0);
   setText('delivery-detail', 'pending=' + ((snapshot.delivery || {}).pending || 0) + ' failed=' + ((snapshot.delivery || {}).failed_since || 0) + ' abandoned=' + ((snapshot.delivery || {}).abandoned_since || 0));
   setText('drift', (snapshot.projection_drift || {}).count || 0);
@@ -239,7 +250,7 @@ function render(snapshot) {
       table.delivered_since || 0,
       table.failed_since || 0,
       table.abandoned_since || 0,
-      ageLabel(table.oldest_due_age_sec)
+      table.due_now > 0 ? ageLabel(table.oldest_due_age_sec) : '-'
     ]));
   });
   if (((snapshot.delivery || {}).tables || []).length === 0) {

--- a/internal/dashboard/fleet_html.go
+++ b/internal/dashboard/fleet_html.go
@@ -126,6 +126,22 @@ const fleetDashboardHTML = `<!DOCTYPE html>
     <div class="card"><div class="label">Owner Hosts</div><div class="value" id="delivery-owners">-</div></div>
   </div>
 
+  <h2>Delivery Queues</h2>
+  <table>
+    <thead>
+      <tr><th>Kind</th><th>Pending</th><th>Due</th><th>Future Retry</th><th>Delivered</th><th>Failed</th><th>Abandoned</th><th>Oldest Due</th></tr>
+    </thead>
+    <tbody id="delivery-tables"></tbody>
+  </table>
+
+  <h2>Bucket Owners</h2>
+  <table>
+    <thead>
+      <tr><th>Host</th><th>Range</th><th>Status</th><th>Heartbeat</th></tr>
+    </thead>
+    <tbody id="bucket-hosts"></tbody>
+  </table>
+
   <h2>Processes</h2>
   <table>
     <thead>
@@ -190,6 +206,10 @@ function rangeLabel(item) {
   return item.bucket_min + '-' + item.bucket_max;
 }
 
+function ageLabel(seconds) {
+  return (seconds || 0) + 's ago';
+}
+
 function render(snapshot) {
   const summary = snapshot.summary || {};
   const processes = snapshot.processes || [];
@@ -198,7 +218,7 @@ function render(snapshot) {
   setText('deliverers', summary.deliverer_processes || 0);
   setText('stale', summary.stale_processes || 0);
   setText('bucket-status', (snapshot.bucket_coverage || {}).status || '-');
-  setText('bucket-detail', ((snapshot.bucket_coverage || {}).host_count || 0) + ' hosts · ' + ((snapshot.bucket_coverage || {}).error || ''));
+  setText('bucket-detail', ((snapshot.bucket_coverage || {}).mode || '-') + ' · ' + ((snapshot.bucket_coverage || {}).host_count || 0) + ' hosts · ' + ((snapshot.bucket_coverage || {}).error || ''));
   setText('delivery-due', (snapshot.delivery || {}).due_now || 0);
   setText('delivery-detail', 'pending=' + ((snapshot.delivery || {}).pending || 0) + ' failed=' + ((snapshot.delivery || {}).failed_since || 0) + ' abandoned=' + ((snapshot.delivery || {}).abandoned_since || 0));
   setText('drift', (snapshot.projection_drift || {}).count || 0);
@@ -208,6 +228,38 @@ function render(snapshot) {
   setText('delivery-enabled', (posture.enabled_hosts || []).join(', '));
   setText('delivery-owners', (posture.owner_hosts || []).join(', '));
 
+  const deliveryBody = document.getElementById('delivery-tables');
+  deliveryBody.textContent = '';
+  ((snapshot.delivery || {}).tables || []).forEach(function(table) {
+    deliveryBody.appendChild(row([
+      table.kind,
+      table.pending || 0,
+      table.due_now || 0,
+      table.future_retry || 0,
+      table.delivered_since || 0,
+      table.failed_since || 0,
+      table.abandoned_since || 0,
+      ageLabel(table.oldest_due_age_sec)
+    ]));
+  });
+  if (((snapshot.delivery || {}).tables || []).length === 0) {
+    deliveryBody.appendChild(row(['No delivery queue summaries found', '', '', '', '', '', '', '']));
+  }
+
+  const bucketBody = document.getElementById('bucket-hosts');
+  bucketBody.textContent = '';
+  ((snapshot.bucket_coverage || {}).hosts || []).forEach(function(host) {
+    bucketBody.appendChild(row([
+      host.host_id,
+      rangeLabel(host),
+      host.status + (host.stale ? ' stale' : ''),
+      ageLabel(host.last_heartbeat_age_sec)
+    ]));
+  });
+  if (((snapshot.bucket_coverage || {}).hosts || []).length === 0) {
+    bucketBody.appendChild(row(['No dynamic bucket-owner rows found', '', '', '']));
+  }
+
   const processBody = document.getElementById('processes');
   processBody.textContent = '';
   processes.forEach(function(process) {
@@ -215,7 +267,7 @@ function render(snapshot) {
       process.process_id,
       process.health_status + (process.stale ? ' stale' : ''),
       process.state,
-      (process.last_heartbeat_age_sec || 0) + 's ago',
+      ageLabel(process.last_heartbeat_age_sec),
       rangeLabel(process),
       'active=' + (process.active_checks || 0) + ' queue=' + (process.queue_depth || 0) + ' retry=' + (process.retry_queue_size || 0),
       (process.go_sys_mem_mb || 0) + 'MB'

--- a/internal/dashboard/fleet_test.go
+++ b/internal/dashboard/fleet_test.go
@@ -50,6 +50,9 @@ func TestSummarizeFleetFlagsStaleAndDrift(t *testing.T) {
 	if summary.StaleProcesses != 1 {
 		t.Fatalf("StaleProcesses = %d, want 1", summary.StaleProcesses)
 	}
+	if summary.RedProcesses != 1 {
+		t.Fatalf("RedProcesses = %d, want stale process counted as red", summary.RedProcesses)
+	}
 	if summary.MonitorProcesses != 1 || summary.DelivererProcesses != 1 {
 		t.Fatalf("process counts = monitor %d deliverer %d, want 1/1", summary.MonitorProcesses, summary.DelivererProcesses)
 	}
@@ -69,17 +72,46 @@ func TestSummarizeFleetBucketCoverage(t *testing.T) {
 	coverage := summarizeFleetBucketCoverage([]FleetBucketHost{
 		{HostID: "host-a", BucketMin: 0, BucketMax: 4, LastHeartbeat: now.Add(-time.Second), Status: "active"},
 		{HostID: "host-b", BucketMin: 5, BucketMax: 9, LastHeartbeat: now.Add(-2 * time.Second), Status: "active"},
-	}, 10, 30*time.Second, now, nil)
+	}, 10, 30*time.Second, now, nil, nil)
 	if coverage.Status != "green" {
 		t.Fatalf("coverage status = %q, want green (%s)", coverage.Status, coverage.Error)
+	}
+	if coverage.Mode != "dynamic" {
+		t.Fatalf("coverage mode = %q, want dynamic", coverage.Mode)
 	}
 
 	coverage = summarizeFleetBucketCoverage([]FleetBucketHost{
 		{HostID: "host-a", BucketMin: 0, BucketMax: 3, LastHeartbeat: now, Status: "active"},
 		{HostID: "host-b", BucketMin: 5, BucketMax: 9, LastHeartbeat: now, Status: "active"},
-	}, 10, 30*time.Second, now, nil)
+	}, 10, 30*time.Second, now, nil, nil)
 	if coverage.Status != "red" || !strings.Contains(coverage.Error, "gap") {
 		t.Fatalf("coverage = %+v, want gap error", coverage)
+	}
+
+	coverage = summarizeFleetBucketCoverage(nil, 10, 30*time.Second, now, nil, []FleetProcess{{
+		ProcessType:     fleethealth.ProcessMonitor,
+		BucketOwnership: "pinned range=0-4",
+	}})
+	if coverage.Status != "amber" || coverage.Mode != "pinned" {
+		t.Fatalf("coverage = %+v, want pinned amber", coverage)
+	}
+
+	coverage = summarizeFleetBucketCoverage([]FleetBucketHost{
+		{HostID: "host-a", BucketMin: 0, BucketMax: 9, LastHeartbeat: now.Add(-time.Hour), Status: "active"},
+	}, 10, 30*time.Second, now, nil, []FleetProcess{{
+		ProcessType:     fleethealth.ProcessMonitor,
+		BucketOwnership: "pinned range=0-9",
+	}})
+	if coverage.Status != "amber" || coverage.Mode != "pinned" || strings.Contains(coverage.Error, "stale") {
+		t.Fatalf("coverage = %+v, want pinned mode to ignore stale dynamic rows", coverage)
+	}
+
+	coverage = summarizeFleetBucketCoverage(nil, 10, 30*time.Second, now, nil, []FleetProcess{
+		{ProcessType: fleethealth.ProcessMonitor, BucketOwnership: "pinned range=0-4"},
+		{ProcessType: fleethealth.ProcessMonitor, BucketOwnership: "dynamic jetmon_hosts"},
+	})
+	if coverage.Status != "amber" || coverage.Mode != "mixed" {
+		t.Fatalf("coverage = %+v, want mixed amber", coverage)
 	}
 }
 
@@ -87,7 +119,7 @@ func TestSummarizeFleetDeliveryPosture(t *testing.T) {
 	posture := summarizeFleetDeliveryPosture([]FleetProcess{
 		{HostID: "host-a", DeliveryWorkersEnabled: true},
 		{HostID: "host-b", DeliveryWorkersEnabled: true},
-	})
+	}, 0)
 	if posture.Status != "amber" {
 		t.Fatalf("posture status = %q, want amber", posture.Status)
 	}
@@ -98,12 +130,40 @@ func TestSummarizeFleetDeliveryPosture(t *testing.T) {
 	posture = summarizeFleetDeliveryPosture([]FleetProcess{
 		{HostID: "host-a", DeliveryWorkersEnabled: true, DeliveryOwnerHost: "host-a"},
 		{HostID: "host-b", DeliveryOwnerHost: "host-a"},
-	})
+	}, 0)
 	if posture.Status != "green" {
 		t.Fatalf("posture status = %q, want green", posture.Status)
 	}
 	if len(posture.OwnerHosts) != 1 || posture.OwnerHosts[0] != "host-a" {
 		t.Fatalf("OwnerHosts = %#v, want host-a", posture.OwnerHosts)
+	}
+
+	posture = summarizeFleetDeliveryPosture([]FleetProcess{
+		{HostID: "host-a", DeliveryWorkersEnabled: true},
+	}, 0)
+	if posture.Status != "amber" || !strings.Contains(posture.Message, "without DELIVERY_OWNER_HOST") {
+		t.Fatalf("posture = %+v, want unset owner warning", posture)
+	}
+
+	posture = summarizeFleetDeliveryPosture([]FleetProcess{
+		{HostID: "host-a", DeliveryWorkersEnabled: true, DeliveryOwnerHost: "host-a"},
+		{HostID: "host-b", DeliveryWorkersEnabled: true},
+	}, 0)
+	if posture.Status != "amber" || !strings.Contains(posture.Message, "mix") {
+		t.Fatalf("posture = %+v, want mixed owner warning", posture)
+	}
+
+	posture = summarizeFleetDeliveryPosture([]FleetProcess{
+		{HostID: "host-a", State: fleethealth.StateStopped, DeliveryWorkersEnabled: true, DeliveryOwnerHost: "host-a"},
+		{HostID: "host-b", Stale: true, DeliveryWorkersEnabled: true, DeliveryOwnerHost: "host-b"},
+	}, 0)
+	if posture.Status != "green" || posture.EnabledProcessCount != 0 {
+		t.Fatalf("posture = %+v, want inactive processes ignored", posture)
+	}
+
+	posture = summarizeFleetDeliveryPosture(nil, 3)
+	if posture.Status != "amber" || !strings.Contains(posture.Message, "queued") {
+		t.Fatalf("posture = %+v, want queued delivery warning", posture)
 	}
 }
 
@@ -133,6 +193,79 @@ func TestSummarizeFleetDependencies(t *testing.T) {
 	}
 	if deps[1].Name != "mysql" || deps[1].Status != "amber" || deps[1].StaleCount != 1 {
 		t.Fatalf("deps[1] = %+v, want amber mysql with stale count", deps[1])
+	}
+}
+
+func TestSummarizeFleetProcessesOrdersUnhealthyFirst(t *testing.T) {
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	processes := summarizeFleetProcesses([]fleethealth.Snapshot{
+		{ProcessID: "host-c:monitor", HostID: "host-c", ProcessType: fleethealth.ProcessMonitor, HealthStatus: fleethealth.HealthGreen, UpdatedAt: now},
+		{ProcessID: "host-b:monitor", HostID: "host-b", ProcessType: fleethealth.ProcessMonitor, HealthStatus: fleethealth.HealthAmber, UpdatedAt: now},
+		{ProcessID: "host-a:monitor", HostID: "host-a", ProcessType: fleethealth.ProcessMonitor, HealthStatus: fleethealth.HealthGreen, UpdatedAt: now.Add(-time.Hour)},
+	}, now, 10*time.Minute)
+	if got := processes[0].ProcessID; got != "host-a:monitor" {
+		t.Fatalf("first process = %q, want stale host first", got)
+	}
+	if got := processes[1].ProcessID; got != "host-b:monitor" {
+		t.Fatalf("second process = %q, want amber host second", got)
+	}
+}
+
+func TestFleetStoreCachedSnapshotIsCloned(t *testing.T) {
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	store := NewFleetStore(nil, FleetStoreOptions{CacheTTL: time.Minute})
+	store.storeCachedSnapshot(FleetSnapshot{
+		GeneratedAt:   now,
+		Summary:       FleetSummary{Issues: []string{"first issue"}},
+		ProcessCounts: map[string]int{fleethealth.ProcessMonitor: 1},
+		Processes: []FleetProcess{{
+			ProcessID: "host-a:monitor",
+			DependencyHealth: []fleethealth.DependencyHealth{{
+				Name:   "mysql",
+				Status: fleethealth.HealthGreen,
+			}},
+		}},
+		BucketCoverage: FleetBucketCoverage{Hosts: []FleetBucketHost{{HostID: "host-a"}}},
+		Delivery: FleetDeliverySummary{
+			Tables:  []FleetDeliveryTable{{Kind: "webhook", Pending: 1}},
+			Posture: FleetDeliveryPosture{EnabledHosts: []string{"host-a"}, OwnerHosts: []string{"host-a"}},
+		},
+		Dependencies: []FleetDependencySummary{{Name: "mysql", Status: "green"}},
+	})
+
+	cached, ok := store.cachedSnapshot(now.Add(time.Second))
+	if !ok {
+		t.Fatal("cachedSnapshot() missed")
+	}
+	cached.Summary.Issues[0] = "mutated"
+	cached.ProcessCounts[fleethealth.ProcessMonitor] = 99
+	cached.Processes[0].DependencyHealth[0].Status = fleethealth.HealthRed
+	cached.BucketCoverage.Hosts[0].HostID = "mutated"
+	cached.Delivery.Tables[0].Pending = 99
+	cached.Delivery.Posture.EnabledHosts[0] = "mutated"
+	cached.Dependencies[0].Status = "red"
+
+	cachedAgain, ok := store.cachedSnapshot(now.Add(2 * time.Second))
+	if !ok {
+		t.Fatal("cachedSnapshot() second read missed")
+	}
+	if cachedAgain.Summary.Issues[0] != "first issue" {
+		t.Fatalf("Summary.Issues = %#v, cache was mutated", cachedAgain.Summary.Issues)
+	}
+	if cachedAgain.ProcessCounts[fleethealth.ProcessMonitor] != 1 {
+		t.Fatalf("ProcessCounts = %#v, cache was mutated", cachedAgain.ProcessCounts)
+	}
+	if cachedAgain.Processes[0].DependencyHealth[0].Status != fleethealth.HealthGreen {
+		t.Fatalf("DependencyHealth = %#v, cache was mutated", cachedAgain.Processes[0].DependencyHealth)
+	}
+	if cachedAgain.BucketCoverage.Hosts[0].HostID != "host-a" {
+		t.Fatalf("BucketCoverage.Hosts = %#v, cache was mutated", cachedAgain.BucketCoverage.Hosts)
+	}
+	if cachedAgain.Delivery.Tables[0].Pending != 1 || cachedAgain.Delivery.Posture.EnabledHosts[0] != "host-a" {
+		t.Fatalf("Delivery = %+v, cache was mutated", cachedAgain.Delivery)
+	}
+	if cachedAgain.Dependencies[0].Status != "green" {
+		t.Fatalf("Dependencies = %#v, cache was mutated", cachedAgain.Dependencies)
 	}
 }
 

--- a/internal/dashboard/fleet_test.go
+++ b/internal/dashboard/fleet_test.go
@@ -1,0 +1,146 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Automattic/jetmon/internal/fleethealth"
+)
+
+func TestSummarizeFleetFlagsStaleAndDrift(t *testing.T) {
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	processes := summarizeFleetProcesses([]fleethealth.Snapshot{
+		{
+			ProcessID:    "host-a:monitor",
+			HostID:       "host-a",
+			ProcessType:  fleethealth.ProcessMonitor,
+			State:        fleethealth.StateRunning,
+			HealthStatus: fleethealth.HealthGreen,
+			UpdatedAt:    now.Add(-20 * time.Minute),
+			DependencyHealth: []fleethealth.DependencyHealth{
+				{Name: "mysql", Status: fleethealth.HealthGreen},
+			},
+		},
+		{
+			ProcessID:    "host-b:deliverer",
+			HostID:       "host-b",
+			ProcessType:  fleethealth.ProcessDeliverer,
+			State:        fleethealth.StateRunning,
+			HealthStatus: fleethealth.HealthAmber,
+			UpdatedAt:    now.Add(-time.Minute),
+			DependencyHealth: []fleethealth.DependencyHealth{
+				{Name: "statsd", Status: fleethealth.HealthAmber, LastError: "not initialized"},
+			},
+		},
+	}, now, 10*time.Minute)
+
+	snapshot := FleetSnapshot{
+		Processes:       processes,
+		ProcessCounts:   countFleetProcesses(processes),
+		BucketCoverage:  FleetBucketCoverage{Status: "green"},
+		Delivery:        FleetDeliverySummary{Status: "green", Posture: FleetDeliveryPosture{Status: "green"}},
+		ProjectionDrift: FleetProjectionDrift{Status: "red", Count: 2},
+		Dependencies:    summarizeFleetDependencies(processes),
+	}
+	summary := summarizeFleet(snapshot)
+	if summary.Status != "red" {
+		t.Fatalf("summary status = %q, want red", summary.Status)
+	}
+	if summary.StaleProcesses != 1 {
+		t.Fatalf("StaleProcesses = %d, want 1", summary.StaleProcesses)
+	}
+	if summary.MonitorProcesses != 1 || summary.DelivererProcesses != 1 {
+		t.Fatalf("process counts = monitor %d deliverer %d, want 1/1", summary.MonitorProcesses, summary.DelivererProcesses)
+	}
+	if !containsIssue(summary.Issues, "heartbeat stale") {
+		t.Fatalf("issues = %#v, want stale heartbeat issue", summary.Issues)
+	}
+	if !containsIssue(summary.Issues, "legacy projection drift=2") {
+		t.Fatalf("issues = %#v, want projection drift issue", summary.Issues)
+	}
+	if !strings.Contains(summary.SuggestedNextAction, "stale process") {
+		t.Fatalf("SuggestedNextAction = %q, want stale process guidance", summary.SuggestedNextAction)
+	}
+}
+
+func TestSummarizeFleetBucketCoverage(t *testing.T) {
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	coverage := summarizeFleetBucketCoverage([]FleetBucketHost{
+		{HostID: "host-a", BucketMin: 0, BucketMax: 4, LastHeartbeat: now.Add(-time.Second), Status: "active"},
+		{HostID: "host-b", BucketMin: 5, BucketMax: 9, LastHeartbeat: now.Add(-2 * time.Second), Status: "active"},
+	}, 10, 30*time.Second, now, nil)
+	if coverage.Status != "green" {
+		t.Fatalf("coverage status = %q, want green (%s)", coverage.Status, coverage.Error)
+	}
+
+	coverage = summarizeFleetBucketCoverage([]FleetBucketHost{
+		{HostID: "host-a", BucketMin: 0, BucketMax: 3, LastHeartbeat: now, Status: "active"},
+		{HostID: "host-b", BucketMin: 5, BucketMax: 9, LastHeartbeat: now, Status: "active"},
+	}, 10, 30*time.Second, now, nil)
+	if coverage.Status != "red" || !strings.Contains(coverage.Error, "gap") {
+		t.Fatalf("coverage = %+v, want gap error", coverage)
+	}
+}
+
+func TestSummarizeFleetDeliveryPosture(t *testing.T) {
+	posture := summarizeFleetDeliveryPosture([]FleetProcess{
+		{HostID: "host-a", DeliveryWorkersEnabled: true},
+		{HostID: "host-b", DeliveryWorkersEnabled: true},
+	})
+	if posture.Status != "amber" {
+		t.Fatalf("posture status = %q, want amber", posture.Status)
+	}
+	if !strings.Contains(posture.Message, "without DELIVERY_OWNER_HOST") {
+		t.Fatalf("posture message = %q, want owner warning", posture.Message)
+	}
+
+	posture = summarizeFleetDeliveryPosture([]FleetProcess{
+		{HostID: "host-a", DeliveryWorkersEnabled: true, DeliveryOwnerHost: "host-a"},
+		{HostID: "host-b", DeliveryOwnerHost: "host-a"},
+	})
+	if posture.Status != "green" {
+		t.Fatalf("posture status = %q, want green", posture.Status)
+	}
+	if len(posture.OwnerHosts) != 1 || posture.OwnerHosts[0] != "host-a" {
+		t.Fatalf("OwnerHosts = %#v, want host-a", posture.OwnerHosts)
+	}
+}
+
+func TestSummarizeFleetDependencies(t *testing.T) {
+	processes := []FleetProcess{
+		{
+			ProcessID: "host-a:monitor",
+			DependencyHealth: []fleethealth.DependencyHealth{
+				{Name: "mysql", Status: fleethealth.HealthGreen},
+				{Name: "wpcom", Status: fleethealth.HealthRed, LastError: "500"},
+			},
+		},
+		{
+			ProcessID: "host-b:monitor",
+			Stale:     true,
+			DependencyHealth: []fleethealth.DependencyHealth{
+				{Name: "mysql", Status: fleethealth.HealthAmber, LastError: "slow"},
+			},
+		},
+	}
+	deps := summarizeFleetDependencies(processes)
+	if len(deps) != 2 {
+		t.Fatalf("deps len = %d, want 2", len(deps))
+	}
+	if deps[0].Name != "wpcom" || deps[0].Status != "red" {
+		t.Fatalf("deps[0] = %+v, want red wpcom first", deps[0])
+	}
+	if deps[1].Name != "mysql" || deps[1].Status != "amber" || deps[1].StaleCount != 1 {
+		t.Fatalf("deps[1] = %+v, want amber mysql with stale count", deps[1])
+	}
+}
+
+func containsIssue(issues []string, want string) bool {
+	for _, issue := range issues {
+		if strings.Contains(issue, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/dashboard/fleet_test.go
+++ b/internal/dashboard/fleet_test.go
@@ -1,11 +1,13 @@
 package dashboard
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/Automattic/jetmon/internal/fleethealth"
+	"github.com/DATA-DOG/go-sqlmock"
 )
 
 func TestSummarizeFleetFlagsStaleAndDrift(t *testing.T) {
@@ -174,6 +176,44 @@ func TestSummarizeFleetDeliveryPosture(t *testing.T) {
 	posture = summarizeFleetDeliveryPosture(nil, 3)
 	if posture.Status != "amber" || !strings.Contains(posture.Message, "queued") {
 		t.Fatalf("posture = %+v, want queued delivery warning", posture)
+	}
+}
+
+func TestQueryFleetDeliveryTableAggregatesInSingleQuery(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqlDB.Close()
+
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	cutoff := now.Add(-15 * time.Minute)
+	rows := sqlmock.NewRows([]string{"metric", "count", "age_sec"}).
+		AddRow("pending", int64(4), int64(900)).
+		AddRow("due", int64(2), int64(120)).
+		AddRow("future", int64(1), int64(0)).
+		AddRow("delivered", int64(7), int64(0)).
+		AddRow("abandoned", int64(1), int64(0)).
+		AddRow("failed", int64(3), int64(0))
+	mock.ExpectQuery(`(?s)SELECT 'pending'.*FROM jetmon_webhook_deliveries.*UNION ALL.*SELECT 'failed'.*FROM jetmon_webhook_deliveries`).
+		WithArgs(now, now, now, now, cutoff, cutoff, cutoff, cutoff, cutoff).
+		WillReturnRows(rows)
+
+	summary, err := queryFleetDeliveryTable(context.Background(), sqlDB, "webhook", "jetmon_webhook_deliveries", now, cutoff)
+	if err != nil {
+		t.Fatalf("queryFleetDeliveryTable: %v", err)
+	}
+	if summary.Pending != 4 || summary.OldestPendingAgeSec != 900 {
+		t.Fatalf("pending summary = %+v, want count 4 age 900", summary)
+	}
+	if summary.DueNow != 2 || summary.OldestDueAgeSec != 120 {
+		t.Fatalf("due summary = %+v, want count 2 age 120", summary)
+	}
+	if summary.FutureRetry != 1 || summary.DeliveredSince != 7 || summary.AbandonedSince != 1 || summary.FailedSince != 3 {
+		t.Fatalf("summary = %+v, want all aggregate counts populated", summary)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
 	}
 }
 

--- a/internal/dashboard/fleet_test.go
+++ b/internal/dashboard/fleet_test.go
@@ -113,6 +113,16 @@ func TestSummarizeFleetBucketCoverage(t *testing.T) {
 	if coverage.Status != "amber" || coverage.Mode != "mixed" {
 		t.Fatalf("coverage = %+v, want mixed amber", coverage)
 	}
+
+	coverage = summarizeFleetBucketCoverage([]FleetBucketHost{
+		{HostID: "host-a", BucketMin: 0, BucketMax: 9, LastHeartbeat: now, Status: "active"},
+	}, 10, 30*time.Second, now, nil, []FleetProcess{
+		{ProcessType: fleethealth.ProcessMonitor, BucketOwnership: "pinned range=0-4", Stale: true},
+		{ProcessType: fleethealth.ProcessMonitor, BucketOwnership: "dynamic jetmon_hosts"},
+	})
+	if coverage.Status != "green" || coverage.Mode != "dynamic" {
+		t.Fatalf("coverage = %+v, want stale pinned snapshots ignored for ownership mode", coverage)
+	}
 }
 
 func TestSummarizeFleetDeliveryPosture(t *testing.T) {
@@ -200,6 +210,7 @@ func TestSummarizeFleetProcessesOrdersUnhealthyFirst(t *testing.T) {
 	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
 	processes := summarizeFleetProcesses([]fleethealth.Snapshot{
 		{ProcessID: "host-c:monitor", HostID: "host-c", ProcessType: fleethealth.ProcessMonitor, HealthStatus: fleethealth.HealthGreen, UpdatedAt: now},
+		{ProcessID: "host-d:deliverer", HostID: "host-d", ProcessType: fleethealth.ProcessDeliverer, HealthStatus: fleethealth.HealthGreen, UpdatedAt: now},
 		{ProcessID: "host-b:monitor", HostID: "host-b", ProcessType: fleethealth.ProcessMonitor, HealthStatus: fleethealth.HealthAmber, UpdatedAt: now},
 		{ProcessID: "host-a:monitor", HostID: "host-a", ProcessType: fleethealth.ProcessMonitor, HealthStatus: fleethealth.HealthGreen, UpdatedAt: now.Add(-time.Hour)},
 	}, now, 10*time.Minute)
@@ -208,6 +219,9 @@ func TestSummarizeFleetProcessesOrdersUnhealthyFirst(t *testing.T) {
 	}
 	if got := processes[1].ProcessID; got != "host-b:monitor" {
 		t.Fatalf("second process = %q, want amber host second", got)
+	}
+	if got := processes[2].ProcessID; got != "host-c:monitor" {
+		t.Fatalf("third process = %q, want healthy monitors before deliverers", got)
 	}
 }
 

--- a/internal/fleethealth/health.go
+++ b/internal/fleethealth/health.go
@@ -150,6 +150,113 @@ func MarkStopped(ctx context.Context, db *sql.DB, processID string, when time.Ti
 	return nil
 }
 
+// ListSnapshots returns durable process-health rows ordered for operator views.
+func ListSnapshots(ctx context.Context, db *sql.DB) ([]Snapshot, error) {
+	if db == nil {
+		return nil, errors.New("database pool is not initialized")
+	}
+	rows, err := db.QueryContext(ctx, `
+		SELECT process_id,
+		       host_id,
+		       process_type,
+		       pid,
+		       version,
+		       build_date,
+		       go_version,
+		       state,
+		       health_status,
+		       started_at,
+		       updated_at,
+		       bucket_min,
+		       bucket_max,
+		       bucket_ownership,
+		       api_port,
+		       dashboard_port,
+		       delivery_workers_enabled,
+		       delivery_owner_host,
+		       worker_count,
+		       active_checks,
+		       queue_depth,
+		       retry_queue_size,
+		       wpcom_circuit_open,
+		       wpcom_queue_depth,
+		       go_sys_mem_mb,
+		       dependency_health
+		  FROM jetmon_process_health
+		 ORDER BY process_type, host_id, process_id`)
+	if err != nil {
+		return nil, fmt.Errorf("query process health: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Snapshot
+	for rows.Next() {
+		var snapshot Snapshot
+		var startedAt sql.NullTime
+		var bucketMin, bucketMax, apiPort, dashboardPort sql.NullInt64
+		var deliveryWorkersEnabled, wpcomCircuitOpen int
+		var dependencyHealth sql.NullString
+		if err := rows.Scan(
+			&snapshot.ProcessID,
+			&snapshot.HostID,
+			&snapshot.ProcessType,
+			&snapshot.PID,
+			&snapshot.Version,
+			&snapshot.BuildDate,
+			&snapshot.GoVersion,
+			&snapshot.State,
+			&snapshot.HealthStatus,
+			&startedAt,
+			&snapshot.UpdatedAt,
+			&bucketMin,
+			&bucketMax,
+			&snapshot.BucketOwnership,
+			&apiPort,
+			&dashboardPort,
+			&deliveryWorkersEnabled,
+			&snapshot.DeliveryOwnerHost,
+			&snapshot.WorkerCount,
+			&snapshot.ActiveChecks,
+			&snapshot.QueueDepth,
+			&snapshot.RetryQueueSize,
+			&wpcomCircuitOpen,
+			&snapshot.WPCOMQueueDepth,
+			&snapshot.GoSysMemMB,
+			&dependencyHealth,
+		); err != nil {
+			return nil, fmt.Errorf("scan process health: %w", err)
+		}
+		if startedAt.Valid {
+			snapshot.StartedAt = startedAt.Time.UTC()
+		}
+		snapshot.UpdatedAt = snapshot.UpdatedAt.UTC()
+		snapshot.BucketMin = nullableIntPtr(bucketMin)
+		snapshot.BucketMax = nullableIntPtr(bucketMax)
+		snapshot.APIPort = nullableIntPtr(apiPort)
+		snapshot.DashboardPort = nullableIntPtr(dashboardPort)
+		snapshot.DeliveryWorkersEnabled = deliveryWorkersEnabled != 0
+		snapshot.WPCOMCircuitOpen = wpcomCircuitOpen != 0
+		if dependencyHealth.Valid && strings.TrimSpace(dependencyHealth.String) != "" {
+			if err := json.Unmarshal([]byte(dependencyHealth.String), &snapshot.DependencyHealth); err != nil {
+				return nil, fmt.Errorf("decode dependency health for %s: %w", snapshot.ProcessID, err)
+			}
+		}
+		out = append(out, snapshot)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate process health: %w", err)
+	}
+	return out, nil
+}
+
+func nullableIntPtr(value sql.NullInt64) *int {
+	if !value.Valid {
+		return nil
+	}
+	v := int(value.Int64)
+	return &v
+}
+
 func normalizeSnapshot(snapshot Snapshot) (Snapshot, error) {
 	snapshot.HostID = strings.TrimSpace(snapshot.HostID)
 	snapshot.ProcessType = strings.TrimSpace(snapshot.ProcessType)

--- a/internal/fleethealth/health_test.go
+++ b/internal/fleethealth/health_test.go
@@ -160,6 +160,97 @@ func TestMarkStopped(t *testing.T) {
 	}
 }
 
+func TestListSnapshots(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqlDB.Close()
+
+	started := time.Date(2026, 4, 30, 10, 0, 0, 0, time.UTC)
+	updated := started.Add(time.Minute)
+	rows := sqlmock.NewRows([]string{
+		"process_id",
+		"host_id",
+		"process_type",
+		"pid",
+		"version",
+		"build_date",
+		"go_version",
+		"state",
+		"health_status",
+		"started_at",
+		"updated_at",
+		"bucket_min",
+		"bucket_max",
+		"bucket_ownership",
+		"api_port",
+		"dashboard_port",
+		"delivery_workers_enabled",
+		"delivery_owner_host",
+		"worker_count",
+		"active_checks",
+		"queue_depth",
+		"retry_queue_size",
+		"wpcom_circuit_open",
+		"wpcom_queue_depth",
+		"go_sys_mem_mb",
+		"dependency_health",
+	}).AddRow(
+		"host-a:monitor",
+		"host-a",
+		ProcessMonitor,
+		123,
+		"abc123",
+		"2026-04-30T10:00:00Z",
+		"go1.26.2",
+		StateRunning,
+		HealthAmber,
+		started,
+		updated,
+		0,
+		99,
+		"pinned range=0-99",
+		8090,
+		8080,
+		1,
+		"host-a",
+		12,
+		3,
+		4,
+		5,
+		1,
+		2,
+		88,
+		`[{"name":"mysql","status":"green","checked_at":"2026-04-30T10:01:00Z"}]`,
+	)
+	mock.ExpectQuery("SELECT process_id").WillReturnRows(rows)
+
+	snapshots, err := ListSnapshots(context.Background(), sqlDB)
+	if err != nil {
+		t.Fatalf("ListSnapshots() error = %v", err)
+	}
+	if len(snapshots) != 1 {
+		t.Fatalf("snapshots len = %d, want 1", len(snapshots))
+	}
+	got := snapshots[0]
+	if got.ProcessID != "host-a:monitor" || got.HealthStatus != HealthAmber {
+		t.Fatalf("snapshot = %+v, want host-a amber", got)
+	}
+	if got.BucketMin == nil || *got.BucketMin != 0 || got.APIPort == nil || *got.APIPort != 8090 {
+		t.Fatalf("nullable ints not decoded: BucketMin=%v APIPort=%v", got.BucketMin, got.APIPort)
+	}
+	if !got.DeliveryWorkersEnabled || !got.WPCOMCircuitOpen {
+		t.Fatalf("bools not decoded: delivery=%v wpcom=%v", got.DeliveryWorkersEnabled, got.WPCOMCircuitOpen)
+	}
+	if len(got.DependencyHealth) != 1 || got.DependencyHealth[0].Name != "mysql" {
+		t.Fatalf("DependencyHealth = %+v, want mysql", got.DependencyHealth)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sql expectations: %v", err)
+	}
+}
+
 func TestRollupHealthStatus(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Why

This adds the fleet-wide operator view that sits on top of the host dashboard plumbing merged in #90. The host dashboard is useful when an operator is already looking at one server, but rollout decisions need a single view of monitor hosts, standalone deliverers, bucket coverage, stale heartbeats, delivery backlog, projection drift, dependency health, and the next safest action.

## What changed

- Adds `/fleet` and `/api/fleet` to the existing operator dashboard listener.
- Builds fleet snapshots from `jetmon_process_health`, `jetmon_hosts`, webhook and alert delivery queues, projection drift, and dependency rollups.
- Adds fleet-level red/amber/green summary rules with suggested next actions.
- Treats stale process heartbeats as red rollout blockers and sorts unhealthy processes first.
- Distinguishes dynamic, pinned, mixed, and unknown bucket ownership modes so pinned rollout does not look like broken dynamic coverage.
- Adds explicit delivery-owner posture so operators can spot queued delivery work without a fresh worker, multiple owner values, or enabled delivery workers without `DELIVERY_OWNER_HOST`.
- Consolidates delivery queue aggregation so each uncached fleet snapshot uses one indexed summary query per delivery table instead of six separate round trips per table.
- Caches fleet snapshots briefly so multiple open dashboard tabs do not run the full query set on every refresh.
- Returns generic `/api/fleet` backend errors while logging the real error server-side.
- Sends no-store, nosniff, no-referrer, frame-denial, and CSP headers on dashboard HTML and JSON responses; rejects write methods on read-only dashboard routes; and returns 404 for unknown dashboard paths instead of falling back to the host dashboard.
- Links host and fleet dashboards together.
- Updates operations, rollout, migration, config, changelog, project, and roadmap docs to explain configuration and use.

## Example fleet dashboard output

An operator opening `http://127.0.0.1:8080/fleet` during a pinned rollout would see the most important action at the top:

```text
Jetmon 2
Fleet dashboard

[amber] fleet needs operator attention
green=3 amber=0 red=0
next: Confirm whether the fleet is still in pinned rollout before expecting dynamic bucket coverage.

Issues
- bucket coverage: monitor process snapshots report pinned bucket ranges; dynamic jetmon_hosts coverage is not active

Fleet Rollup
Monitors:          3
Deliverers:        1
Stale Processes:   0
Bucket Coverage:   amber
  pinned - 0 dynamic hosts - dynamic ownership is not active
Delivery Due:      0
Projection Drift:  0

Delivery Ownership
Posture:       green
Enabled Hosts: jetmon-deliverer-1
Owner Hosts:   jetmon-deliverer-1

Delivery Queues
Kind      Pending  Due  Future Retry  Delivered  Failed  Abandoned  Oldest Due
webhook   0        0    0             42         0       0          0s ago
alert     0        0    0             18         0       0          0s ago

Bucket Owners
Host      Range  Status  Heartbeat
No dynamic bucket-owner rows found

Processes
Process                    Health  State    Heartbeat  Buckets  Queues
jetmon-a:monitor           green   running  4s ago     0-333    active=128 queue=40 retry=2
jetmon-b:monitor           green   running  5s ago     334-666  active=120 queue=36 retry=1
jetmon-c:monitor           green   running  4s ago     667-999  active=121 queue=38 retry=0
jetmon-deliverer-1:deliverer green running  3s ago     -        active=0 queue=0 retry=0
```

`/api/fleet` returns the same complete snapshot that the HTML dashboard renders. It is not a reduced API surface; operator scripts get the summary, process rows, bucket-owner rows, delivery queue tables, delivery posture, projection drift, and dependency rollups. This representative JSON example keeps the arrays short while showing the full response shape:

```json
{
  "generated_at": "2026-04-30T14:00:00Z",
  "summary": {
    "status": "amber",
    "message": "fleet needs operator attention",
    "suggested_next_action": "Confirm whether the fleet is still in pinned rollout before expecting dynamic bucket coverage.",
    "issues": [
      "bucket coverage: monitor process snapshots report pinned bucket ranges; dynamic jetmon_hosts coverage is not active"
    ],
    "red_processes": 0,
    "amber_processes": 0,
    "green_processes": 4,
    "stale_processes": 0,
    "monitor_processes": 3,
    "deliverer_processes": 1,
    "dependency_red_count": 0,
    "dependency_amber_count": 0
  },
  "processes": [
    {
      "process_id": "jetmon-a:monitor",
      "host_id": "jetmon-a",
      "process_type": "monitor",
      "state": "running",
      "health_status": "green",
      "last_heartbeat_age_sec": 4,
      "stale": false,
      "bucket_min": 0,
      "bucket_max": 333,
      "bucket_ownership": "pinned range=0-333",
      "api_port": 8090,
      "dashboard_port": 8080,
      "delivery_workers_enabled": false,
      "delivery_owner_host": "jetmon-deliverer-1",
      "worker_count": 256,
      "active_checks": 128,
      "queue_depth": 40,
      "retry_queue_size": 2,
      "wpcom_circuit_open": false,
      "wpcom_queue_depth": 0,
      "go_sys_mem_mb": 96,
      "dependency_health": [
        {
          "name": "mysql",
          "status": "green",
          "latency_ms": 3,
          "checked_at": "2026-04-30T13:59:56Z"
        }
      ]
    }
  ],
  "process_counts": {
    "monitor": 3,
    "deliverer": 1
  },
  "bucket_coverage": {
    "status": "amber",
    "mode": "pinned",
    "bucket_total": 1000,
    "host_count": 0,
    "error": "monitor process snapshots report pinned bucket ranges; dynamic jetmon_hosts coverage is not active",
    "hosts": []
  },
  "delivery": {
    "status": "green",
    "pending": 0,
    "due_now": 0,
    "future_retry": 0,
    "delivered_since": 60,
    "abandoned_since": 0,
    "failed_since": 0,
    "oldest_pending_age_sec": 0,
    "oldest_due_age_sec": 0,
    "tables": [
      {
        "kind": "webhook",
        "pending": 0,
        "due_now": 0,
        "future_retry": 0,
        "delivered_since": 42,
        "abandoned_since": 0,
        "failed_since": 0,
        "oldest_pending_age_sec": 0,
        "oldest_due_age_sec": 0
      },
      {
        "kind": "alert",
        "pending": 0,
        "due_now": 0,
        "future_retry": 0,
        "delivered_since": 18,
        "abandoned_since": 0,
        "failed_since": 0,
        "oldest_pending_age_sec": 0,
        "oldest_due_age_sec": 0
      }
    ],
    "posture": {
      "status": "green",
      "enabled_process_count": 1,
      "enabled_hosts": [
        "jetmon-deliverer-1"
      ],
      "owner_hosts": [
        "jetmon-deliverer-1"
      ],
      "message": "delivery owner is constrained to jetmon-deliverer-1"
    }
  },
  "projection_drift": {
    "status": "green",
    "count": 0
  },
  "dependencies": [
    {
      "name": "mysql",
      "status": "green",
      "red_count": 0,
      "amber_count": 0,
      "green_count": 4,
      "stale_count": 0
    }
  ]
}
```

## Operational notes

- The host and fleet dashboards share `DASHBOARD_PORT` and `DASHBOARD_BIND_ADDR`.
- The fleet dashboard does not scrape other host dashboards; any `jetmon2` monitor dashboard connected to the same MySQL database can serve the fleet view from shared process-health, bucket, delivery, and event state.
- The listener remains unauthenticated, so it defaults to loopback and should only be exposed through SSH tunnels or trusted operator-network controls.
- During pinned rollout, amber `mode=pinned` is expected. After dynamic ownership cutover, operators should expect green `mode=dynamic`, fresh `jetmon_hosts` coverage, no stale processes, zero projection drift, and no failed or abandoned delivery rows.

## Validation

- `go test ./...`
- `go vet ./...`
- `make rollout-docs-verify`
