### PR TITLE
Add rollout rehearsal verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ BUILD_FLAGS := -ldflags "-X main.version=$(shell git describe --tags --always --
                          -X main.buildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ) \
                          -X main.goVersion=$(shell $(GO) version | awk '{print $$3}')"
 
-.PHONY: all build build-deliverer build-veriflier generate test test-race lint rollout-docs-verify rollout-vm-lab-sync rollout-vm-lab-sync-artifacts rollout-vm-lab-stage-v2 rollout-vm-lab-doctor rollout-vm-lab-prepare rollout-vm-lab-smoke rollout-vm-lab-execute-smoke rollout-vm-lab-failure-smoke rollout-vm-lab-resume-smoke rollout-vm-lab-post-start-rollback-smoke rollout-vm-lab-bad-ssh-smoke rollout-vm-lab-v2-start-failure-smoke rollout-vm-lab-runtime-guard-smoke rollout-vm-lab-real-activity-smoke rollout-vm-lab-snapshot-execute-smoke rollout-vm-lab-snapshot-all-smoke api-cli-smoke api-cli-validate api-cli-token-create api-cli-token-list api-cli-token-revoke clean
+.PHONY: all build build-deliverer build-veriflier generate test test-race lint rollout-docs-verify rollout-rehearsal-verify rollout-vm-lab-sync rollout-vm-lab-sync-artifacts rollout-vm-lab-stage-v2 rollout-vm-lab-doctor rollout-vm-lab-prepare rollout-vm-lab-smoke rollout-vm-lab-execute-smoke rollout-vm-lab-failure-smoke rollout-vm-lab-resume-smoke rollout-vm-lab-post-start-rollback-smoke rollout-vm-lab-bad-ssh-smoke rollout-vm-lab-v2-start-failure-smoke rollout-vm-lab-runtime-guard-smoke rollout-vm-lab-real-activity-smoke rollout-vm-lab-snapshot-execute-smoke rollout-vm-lab-snapshot-all-smoke api-cli-smoke api-cli-validate api-cli-token-create api-cli-token-list api-cli-token-revoke clean
 
 all: build build-deliverer build-veriflier
 
@@ -60,6 +60,9 @@ lint:
 
 rollout-docs-verify: all test lint
 	scripts/rollout-docs-verify.sh
+
+rollout-rehearsal-verify: build
+	scripts/rollout-rehearsal-verify.sh
 
 rollout-vm-lab-sync:
 	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'mkdir -p ~/jetmon-rollout-tools/scripts ~/jetmon-rollout-tools/docs'

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -157,7 +157,7 @@ preflight, deliverer hardening, and API CLI fixture workflow branches:
 - [x] Do a full read-through of the migration runbook and quick reference after
   the new rehearsal verifier lands, then tighten any remaining wording that
   could cause operator copy/paste mistakes.
-- [ ] Run the VM lab snapshot flow after the docs/tooling pass if the
+- [x] Run the VM lab snapshot flow after the docs/tooling pass if the
   `jetmon-deploy-test` host is available, and capture any mismatch between the
   text runbook and real guided execution.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -145,6 +145,22 @@ preflight, deliverer hardening, and API CLI fixture workflow branches:
 - [x] Document and test the fleet dashboard's safe network exposure model
   before exposing it beyond trusted operator networks.
 
+### v2 Rollout Docs Rehearsal TODO
+
+- [x] Add a dedicated `make rollout-rehearsal-verify` target that exercises the
+  operator-facing same-server, fresh-server, and rollback dry-run flows without
+  requiring a database or VM lab.
+- [x] Keep the rehearsal verifier inside `make rollout-docs-verify` so rollout
+  docs, CLI output, and generated command plans cannot drift independently.
+- [x] Cover fresh-server SSH/run-origin warnings in automated rehearsal checks
+  so the runtime-host versus v1-host distinction stays explicit.
+- [x] Do a full read-through of the migration runbook and quick reference after
+  the new rehearsal verifier lands, then tighten any remaining wording that
+  could cause operator copy/paste mistakes.
+- [ ] Run the VM lab snapshot flow after the docs/tooling pass if the
+  `jetmon-deploy-test` host is available, and capture any mismatch between the
+  text runbook and real guided execution.
+
 Recently completed candidate branches:
 
 - **`feature/fleet-dashboard`** - adds `/fleet` and `/api/fleet` global

--- a/docs/rollout-quick-reference.md
+++ b/docs/rollout-quick-reference.md
@@ -72,7 +72,7 @@ to v1" and keep the transcript with the incident record.
 
 ## Before The First Host
 
-0. Verify that the documented operator flow still matches the CLI output:
+1. Verify that the documented operator flow still matches the CLI output:
 
    ```bash
    make rollout-rehearsal-verify
@@ -83,7 +83,7 @@ to v1" and keep the transcript with the incident record.
    target also runs it after build, test, lint, command-help, JSON, and staged
    systemd checks.
 
-1. Confirm the approved static bucket plan exists as a reusable CSV:
+2. Confirm the approved static bucket plan exists as a reusable CSV:
 
    ```bash
    ./jetmon2 rollout static-plan-check \
@@ -94,7 +94,7 @@ to v1" and keep the transcript with the incident record.
      --bucket-total=<total>
    ```
 
-2. Generate the exact host command sequence:
+3. Generate the exact host command sequence:
 
    ```bash
    ./jetmon2 rollout rehearsal-plan \
@@ -112,7 +112,7 @@ to v1" and keep the transcript with the incident record.
    server taking over from an existing v1 server. Add `--systemd-unit=<path>`
    when the staged service unit is not `/etc/systemd/system/jetmon2.service`.
 
-3. Validate config, migrations, static plan match, pinned safety, and the
+4. Validate config, migrations, static plan match, pinned safety, and the
    staged systemd service:
 
    ```bash

--- a/docs/rollout-quick-reference.md
+++ b/docs/rollout-quick-reference.md
@@ -72,6 +72,17 @@ to v1" and keep the transcript with the incident record.
 
 ## Before The First Host
 
+0. Verify that the documented operator flow still matches the CLI output:
+
+   ```bash
+   make rollout-rehearsal-verify
+   ```
+
+   This is a no-database dry-run gate for the generated same-server,
+   fresh-server, and rollback flows. The broader `make rollout-docs-verify`
+   target also runs it after build, test, lint, command-help, JSON, and staged
+   systemd checks.
+
 1. Confirm the approved static bucket plan exists as a reusable CSV:
 
    ```bash
@@ -186,6 +197,10 @@ After every monitor host is stable on v2 pinned mode:
 ```bash
 ./jetmon2 rollout cutover-check --since=15m --require-all
 ```
+
+Run that pinned `cutover-check` from each v2 runtime host, or pass that host's
+explicit `--host`, `--bucket-min`, and `--bucket-max`. It is a per-range
+signoff, not the dynamic fleet-wide coverage check.
 
 Then remove `PINNED_BUCKET_MIN` / `PINNED_BUCKET_MAX` and legacy
 `BUCKET_NO_MIN` / `BUCKET_NO_MAX` aliases from every v2 monitor config,

--- a/docs/rollout-quick-reference.md
+++ b/docs/rollout-quick-reference.md
@@ -81,7 +81,8 @@ to v1" and keep the transcript with the incident record.
    This is a no-database dry-run gate for the generated same-server,
    fresh-server, and rollback flows. The broader `make rollout-docs-verify`
    target also runs it after build, test, lint, command-help, JSON, and staged
-   systemd checks.
+   systemd checks. It uses a disposable sample bucket plan and does not replace
+   the real `host-preflight` gate or VM lab rehearsal.
 
 2. Confirm the approved static bucket plan exists as a reusable CSV:
 

--- a/docs/v1-to-v2-migration.md
+++ b/docs/v1-to-v2-migration.md
@@ -225,8 +225,15 @@ make all
 make test
 make test-race
 make lint
+make rollout-rehearsal-verify
 make rollout-docs-verify
 ```
+
+`make rollout-rehearsal-verify` is a fast no-database check for the
+operator-facing same-server, fresh-server, and rollback dry-run flows. It
+verifies that generated plans, guided output, runtime-host warnings, typed
+confirmations, and rollback commands still match this runbook. The broader
+`make rollout-docs-verify` target also runs this rehearsal verifier.
 
 Stage these artifacts for each target host:
 

--- a/docs/v1-to-v2-migration.md
+++ b/docs/v1-to-v2-migration.md
@@ -221,19 +221,17 @@ the range was returned to v1. Keep the transcript with the rollout record.
 Build and verify the release:
 
 ```bash
-make all
-make test
 make test-race
-make lint
-make rollout-rehearsal-verify
 make rollout-docs-verify
 ```
 
-`make rollout-rehearsal-verify` is a fast no-database check for the
-operator-facing same-server, fresh-server, and rollback dry-run flows. It
-verifies that generated plans, guided output, runtime-host warnings, typed
-confirmations, and rollback commands still match this runbook. The broader
-`make rollout-docs-verify` target also runs this rehearsal verifier.
+`make rollout-docs-verify` builds all binaries, runs the standard test suite
+and `go vet`, checks rollout command help, verifies JSON output and staged
+systemd units, and runs the operator rehearsal verifier. `make test-race` is
+kept separate because it is slower. For a faster no-database check while
+editing the runbook, run `make rollout-rehearsal-verify`; it verifies that
+generated plans, guided output, runtime-host warnings, typed confirmations, and
+rollback commands still match this runbook.
 
 Stage these artifacts for each target host:
 

--- a/docs/v1-to-v2-migration.md
+++ b/docs/v1-to-v2-migration.md
@@ -231,7 +231,9 @@ systemd units, and runs the operator rehearsal verifier. `make test-race` is
 kept separate because it is slower. For a faster no-database check while
 editing the runbook, run `make rollout-rehearsal-verify`; it verifies that
 generated plans, guided output, runtime-host warnings, typed confirmations, and
-rollback commands still match this runbook.
+rollback commands still match this runbook. That target uses a disposable
+sample bucket plan and does not replace the real `host-preflight` gate or VM
+lab rehearsal.
 
 Stage these artifacts for each target host:
 

--- a/scripts/rollout-docs-verify.sh
+++ b/scripts/rollout-docs-verify.sh
@@ -128,6 +128,9 @@ printf '%s\n' "$json_output"
 grep -q '"ok": true' <<<"$json_output" || fail "static-plan-check JSON did not report ok=true"
 grep -q '"command": "rollout static-plan-check"' <<<"$json_output" || fail "static-plan-check JSON omitted command name"
 
+step "operator rehearsal flow verification"
+ROLLOUT_REHEARSAL_JETMON2="$jetmon_binary" scripts/rollout-rehearsal-verify.sh
+
 step "staged systemd verify"
 if ! command -v systemd-analyze >/dev/null 2>&1; then
 	printf 'WARN systemd-analyze not found; skipping service-unit verification\n'

--- a/scripts/rollout-rehearsal-verify.sh
+++ b/scripts/rollout-rehearsal-verify.sh
@@ -55,6 +55,10 @@ fi
 mkdir -p "$work_dir"
 mkdir -p "$(dirname "$plan_file")"
 printf 'INFO rehearsal_work_dir=%s\n' "$work_dir"
+printf 'INFO rehearsal_plan_file=%s\n' "$plan_file"
+if [[ (-e "$plan_file" || -L "$plan_file") && "${ROLLOUT_REHEARSAL_OVERWRITE_PLAN:-}" != "1" ]]; then
+	fail "rehearsal plan file already exists: $plan_file (set ROLLOUT_REHEARSAL_OVERWRITE_PLAN=1 to replace it)"
+fi
 printf '%s\n' \
 	'host,bucket_min,bucket_max' \
 	'jetmon-v1-a,0,4' \

--- a/scripts/rollout-rehearsal-verify.sh
+++ b/scripts/rollout-rehearsal-verify.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+jetmon_binary="${ROLLOUT_REHEARSAL_JETMON2:-./bin/jetmon2}"
+work_dir="${ROLLOUT_REHEARSAL_WORK_DIR:-/tmp/jetmon-rollout-rehearsal-$$}"
+plan_file="${ROLLOUT_REHEARSAL_PLAN_FILE:-$work_dir/ranges.csv}"
+
+step() {
+	printf '\n== %s ==\n' "$1"
+}
+
+fail() {
+	printf 'FAIL %s\n' "$1" >&2
+	exit 1
+}
+
+require_contains() {
+	local haystack="$1"
+	local needle="$2"
+	local message="$3"
+	if ! grep -Fq -- "$needle" <<<"$haystack"; then
+		fail "$message"
+	fi
+}
+
+require_absent() {
+	local haystack="$1"
+	local needle="$2"
+	local message="$3"
+	if grep -Fq -- "$needle" <<<"$haystack"; then
+		fail "$message"
+	fi
+}
+
+mkdir -p "$work_dir"
+printf '%s\n' \
+	'host,bucket_min,bucket_max' \
+	'jetmon-v1-a,0,4' \
+	'jetmon-v1-b,5,9' \
+	>"$plan_file"
+
+step "same-server rehearsal plan"
+same_plan="$("$jetmon_binary" rollout rehearsal-plan \
+	--file "$plan_file" \
+	--bucket-total 10 \
+	--host jetmon-v1-a \
+	--runtime-host jetmon-v1-a \
+	--bucket-min 0 \
+	--bucket-max 4 \
+	--mode same-server \
+	--v1-stop-command 'systemctl stop jetmon' \
+	--v1-start-command 'systemctl start jetmon')"
+printf '%s\n' "$same_plan"
+require_contains "$same_plan" 'INFO mode=same-server' "same-server plan omitted mode"
+require_contains "$same_plan" 'INFO plan_host="jetmon-v1-a" runtime_host="jetmon-v1-a" range=0-4' "same-server plan omitted host/range context"
+require_contains "$same_plan" 'same DB_* environment used by the jetmon2 service' "same-server plan omitted service environment reminder"
+require_contains "$same_plan" './jetmon2 rollout host-preflight' "same-server plan omitted host-preflight"
+require_contains "$same_plan" 'systemctl stop jetmon' "same-server plan omitted v1 stop command"
+require_contains "$same_plan" 'systemctl start jetmon' "same-server plan omitted v1 start command"
+require_contains "$same_plan" './jetmon2 rollout cutover-check --host jetmon-v1-a --bucket-min 0 --bucket-max 4 --since 15m --require-all' "same-server plan omitted full-round cutover gate"
+require_contains "$same_plan" './jetmon2 rollout dynamic-check' "same-server plan omitted fleet dynamic gate"
+require_absent "$same_plan" 'Fresh-server mode requires' "same-server plan printed fresh-server SSH warning"
+
+step "fresh-server rehearsal plan"
+fresh_plan="$("$jetmon_binary" rollout rehearsal-plan \
+	--file "$plan_file" \
+	--bucket-total 10 \
+	--host jetmon-v1-a \
+	--runtime-host jetmon-v2-a \
+	--bucket-min 0 \
+	--bucket-max 4 \
+	--mode fresh-server \
+	--v1-stop-command 'ssh jetmon-v1-a sudo systemctl stop jetmon' \
+	--v1-start-command 'ssh jetmon-v1-a sudo systemctl start jetmon')"
+printf '%s\n' "$fresh_plan"
+require_contains "$fresh_plan" 'INFO mode=fresh-server' "fresh-server plan omitted mode"
+require_contains "$fresh_plan" 'INFO plan_host="jetmon-v1-a" runtime_host="jetmon-v2-a" range=0-4' "fresh-server plan omitted old/new host context"
+require_contains "$fresh_plan" 'Fresh-server mode requires jetmon-v2-a to have SSH access to old v1 host jetmon-v1-a' "fresh-server plan omitted SSH access warning"
+require_contains "$fresh_plan" 'HOLD: keep v2 stopped on the fresh server until the old v1 monitor process is stopped.' "fresh-server plan omitted v2 hold point"
+require_contains "$fresh_plan" 'ssh jetmon-v1-a sudo systemctl stop jetmon' "fresh-server plan omitted remote v1 stop command"
+require_contains "$fresh_plan" './jetmon2 rollout cutover-check --host jetmon-v2-a --bucket-min 0 --bucket-max 4 --since 15m --require-all' "fresh-server plan omitted runtime-host cutover gate"
+require_contains "$fresh_plan" './jetmon2 rollout rollback-check --host jetmon-v2-a --bucket-min 0 --bucket-max 4' "fresh-server plan omitted runtime-host rollback gate"
+require_contains "$fresh_plan" 'ssh jetmon-v1-a sudo systemctl start jetmon' "fresh-server plan omitted remote v1 rollback command"
+
+step "same-server guided dry-run"
+same_guided="$("$jetmon_binary" rollout guided \
+	--dry-run \
+	--file "$plan_file" \
+	--bucket-total 10 \
+	--host jetmon-v1-a \
+	--runtime-host jetmon-v1-a \
+	--bucket-min 0 \
+	--bucket-max 4 \
+	--mode same-server \
+	--v1-stop-command 'systemctl stop jetmon' \
+	--v1-start-command 'systemctl start jetmon' \
+	--log-dir "$work_dir/guided-same")"
+printf '%s\n' "$same_guided"
+require_contains "$same_guided" 'PASS rollout_log_dir_writable=' "same-server guided dry-run omitted log-dir write check"
+require_contains "$same_guided" 'INFO guided_run_origin=runtime_host mode="same-server" v1_host="jetmon-v1-a" runtime_host="jetmon-v1-a"' "same-server guided dry-run omitted run origin"
+require_contains "$same_guided" 'INFO remote_v1_access_required=false reason=same_server' "same-server guided dry-run omitted same-server remote access note"
+require_contains "$same_guided" 'PLAN path=FORWARD step=stop-v1 typed_confirmation="STOP jetmon-v1-a 0-4"' "same-server guided dry-run omitted v1 stop confirmation"
+require_contains "$same_guided" 'PLAN path=FORWARD step=start-v2 typed_confirmation="START V2 jetmon-v1-a 0-4"' "same-server guided dry-run omitted v2 start confirmation"
+require_contains "$same_guided" 'PLAN path=ROLLBACK step=rollback-start-v1 typed_confirmation="START V1 jetmon-v1-a 0-4"' "same-server guided dry-run omitted v1 rollback confirmation"
+
+step "fresh-server guided dry-run"
+fresh_guided="$("$jetmon_binary" rollout guided \
+	--dry-run \
+	--file "$plan_file" \
+	--bucket-total 10 \
+	--host jetmon-v1-a \
+	--runtime-host jetmon-v2-a \
+	--bucket-min 0 \
+	--bucket-max 4 \
+	--mode fresh-server \
+	--v1-stop-command 'ssh jetmon-v1-a sudo systemctl stop jetmon' \
+	--v1-start-command 'ssh jetmon-v1-a sudo systemctl start jetmon' \
+	--log-dir "$work_dir/guided-fresh")"
+printf '%s\n' "$fresh_guided"
+require_contains "$fresh_guided" 'INFO guided_run_origin=runtime_host mode="fresh-server" v1_host="jetmon-v1-a" runtime_host="jetmon-v2-a"' "fresh-server guided dry-run omitted run origin"
+require_contains "$fresh_guided" 'WARN remote_v1_access_required=true runtime_host="jetmon-v2-a" v1_host="jetmon-v1-a"' "fresh-server guided dry-run omitted remote access warning"
+require_contains "$fresh_guided" 'PLAN path=FORWARD step=stop-v1 command="ssh jetmon-v1-a sudo systemctl stop jetmon"' "fresh-server guided dry-run omitted remote v1 stop command"
+require_contains "$fresh_guided" 'PLAN path=FORWARD step=start-v2 typed_confirmation="START V2 jetmon-v2-a 0-4"' "fresh-server guided dry-run omitted runtime-host v2 start confirmation"
+require_contains "$fresh_guided" 'PLAN path=ROLLBACK step=rollback-start-v1 command="ssh jetmon-v1-a sudo systemctl start jetmon"' "fresh-server guided dry-run omitted remote v1 rollback command"
+require_contains "$fresh_guided" 'PLAN path=ROLLBACK step=rollback-start-v1 typed_confirmation="START V1 jetmon-v1-a 0-4"' "fresh-server guided dry-run omitted old-host v1 restart confirmation"
+
+step "guided rollback dry-run"
+rollback_guided="$("$jetmon_binary" rollout guided \
+	--dry-run \
+	--rollback \
+	--file "$plan_file" \
+	--bucket-total 10 \
+	--host jetmon-v1-a \
+	--runtime-host jetmon-v2-a \
+	--bucket-min 0 \
+	--bucket-max 4 \
+	--mode fresh-server \
+	--v1-start-command 'ssh jetmon-v1-a sudo systemctl start jetmon' \
+	--log-dir "$work_dir/guided-rollback")"
+printf '%s\n' "$rollback_guided"
+require_contains "$rollback_guided" 'INFO selected_path=rollback' "rollback guided dry-run omitted rollback path marker"
+require_contains "$rollback_guided" 'PLAN path=ROLLBACK step=rollback-stop-v2 command="systemctl stop jetmon2 && ! systemctl is-active --quiet jetmon2"' "rollback guided dry-run omitted v2 stop command"
+require_contains "$rollback_guided" 'PLAN path=ROLLBACK step=rollback-check title="Run the rollback safety gate"' "rollback guided dry-run omitted rollback safety gate"
+require_contains "$rollback_guided" 'PLAN path=ROLLBACK step=rollback-start-v1 command="ssh jetmon-v1-a sudo systemctl start jetmon"' "rollback guided dry-run omitted v1 start command"
+require_absent "$rollback_guided" 'PLAN path=FORWARD' "rollback guided dry-run printed forward steps"
+
+printf '\nrollout rehearsal verification passed\n'

--- a/scripts/rollout-rehearsal-verify.sh
+++ b/scripts/rollout-rehearsal-verify.sh
@@ -5,8 +5,21 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
 jetmon_binary="${ROLLOUT_REHEARSAL_JETMON2:-./bin/jetmon2}"
-work_dir="${ROLLOUT_REHEARSAL_WORK_DIR:-/tmp/jetmon-rollout-rehearsal-$$}"
+cleanup_work_dir=0
+if [[ -n "${ROLLOUT_REHEARSAL_WORK_DIR:-}" ]]; then
+	work_dir="$ROLLOUT_REHEARSAL_WORK_DIR"
+else
+	work_dir="$(mktemp -d "${TMPDIR:-/tmp}/jetmon-rollout-rehearsal.XXXXXXXXXX")"
+	cleanup_work_dir=1
+fi
 plan_file="${ROLLOUT_REHEARSAL_PLAN_FILE:-$work_dir/ranges.csv}"
+
+cleanup() {
+	if [[ "$cleanup_work_dir" -eq 1 && -n "${work_dir:-}" ]]; then
+		rm -rf "$work_dir"
+	fi
+}
+trap cleanup EXIT
 
 step() {
 	printf '\n== %s ==\n' "$1"
@@ -35,7 +48,13 @@ require_absent() {
 	fi
 }
 
+if [[ ! -x "$jetmon_binary" ]]; then
+	fail "jetmon binary is not executable: $jetmon_binary"
+fi
+
 mkdir -p "$work_dir"
+mkdir -p "$(dirname "$plan_file")"
+printf 'INFO rehearsal_work_dir=%s\n' "$work_dir"
 printf '%s\n' \
 	'host,bucket_min,bucket_max' \
 	'jetmon-v1-a,0,4' \


### PR DESCRIPTION
## Why

This adds a focused rehearsal-verification pass for the v1-to-v2 rollout docs and CLI output. The rollout path is intentionally operator-heavy, so the generated plans, guided dry-run output, runtime-host warnings, typed confirmations, rollback commands, and docs need to stay aligned before a production cutover.

## What changed

- Adds `make rollout-rehearsal-verify`.
- Adds `scripts/rollout-rehearsal-verify.sh`, a no-database verifier for same-server generated rehearsal plans, fresh-server generated rehearsal plans, guided same-server dry-runs, guided fresh-server dry-runs, and guided rollback dry-runs.
- Wires the rehearsal verifier into `make rollout-docs-verify`.
- Documents the verifier in the migration runbook and rollout quick reference.
- Tracks and completes the branch checklist in `docs/roadmap.md`.
- Hardens the verifier by using `mktemp`, cleaning its default workspace, checking the configured binary, and refusing to overwrite custom plan files without `ROLLOUT_REHEARSAL_OVERWRITE_PLAN=1`.
- Clarifies that the rehearsal verifier uses a disposable sample plan and does not replace real `host-preflight` or VM lab rehearsal.

## Validation

- `make rollout-rehearsal-verify`
- `make rollout-docs-verify`
- `make rollout-vm-lab-doctor`
- `make rollout-vm-lab-snapshot-all-smoke`
- `bash -n scripts/rollout-rehearsal-verify.sh scripts/rollout-docs-verify.sh`
- `shellcheck scripts/rollout-rehearsal-verify.sh scripts/rollout-docs-verify.sh`
- Existing-plan refusal path for `ROLLOUT_REHEARSAL_PLAN_FILE`
- `make test-race`