### PR TITLE
Add true RSS reporting to dashboards

### DIFF
--- a/cmd/jetmon-deliverer/main.go
+++ b/cmd/jetmon-deliverer/main.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"os"
 	"os/signal"
-	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -20,6 +19,7 @@ import (
 	"github.com/Automattic/jetmon/internal/deliverer"
 	"github.com/Automattic/jetmon/internal/fleethealth"
 	"github.com/Automattic/jetmon/internal/metrics"
+	"github.com/Automattic/jetmon/internal/processmetrics"
 )
 
 const processHealthWriteTimeout = 2 * time.Second
@@ -257,6 +257,7 @@ func validateDelivererConfigRequirements(cfg *config.Config, hostname string, op
 }
 
 func delivererProcessHealthSnapshot(hostname string, startedAt time.Time, state string, cfg *config.Config, workersEnabled bool, health []fleethealth.DependencyHealth) fleethealth.Snapshot {
+	mem := processmetrics.CurrentMemory()
 	healthStatus := fleethealth.RollupHealthStatus(health)
 	if workersEnabled && strings.TrimSpace(cfg.DeliveryOwnerHost) == "" && healthStatus == fleethealth.HealthGreen {
 		healthStatus = fleethealth.HealthAmber
@@ -277,7 +278,8 @@ func delivererProcessHealthSnapshot(hostname string, startedAt time.Time, state 
 		UpdatedAt:              time.Now().UTC(),
 		DeliveryWorkersEnabled: workersEnabled,
 		DeliveryOwnerHost:      cfg.DeliveryOwnerHost,
-		GoSysMemMB:             currentGoSysMemMB(),
+		GoSysMemMB:             mem.GoSysMemMB,
+		RSSMemMB:               mem.RSSMemMB,
 		DependencyHealth:       health,
 	}
 }
@@ -319,12 +321,6 @@ func delivererStatsDHealth(ready bool, checkedAt time.Time) fleethealth.Dependen
 	}
 	entry.Status = "green"
 	return entry
-}
-
-func currentGoSysMemMB() int {
-	var ms runtime.MemStats
-	runtime.ReadMemStats(&ms)
-	return int(ms.Sys / 1024 / 1024)
 }
 
 func waitForShutdown() {

--- a/cmd/jetmon2/main.go
+++ b/cmd/jetmon2/main.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -31,6 +30,7 @@ import (
 	"github.com/Automattic/jetmon/internal/fleethealth"
 	"github.com/Automattic/jetmon/internal/metrics"
 	"github.com/Automattic/jetmon/internal/orchestrator"
+	"github.com/Automattic/jetmon/internal/processmetrics"
 	"github.com/Automattic/jetmon/internal/veriflier"
 	"github.com/Automattic/jetmon/internal/wpcom"
 )
@@ -218,7 +218,7 @@ func runServe() {
 		}
 		bMin, bMax := orch.BucketRange()
 		sitesPerSec, roundDuration := orch.LastRoundStats()
-		goSysMemMB := currentGoSysMemMB()
+		mem := processmetrics.CurrentMemory()
 		deliveryConfigEligible := deliveryWorkersShouldStart(currentCfg, hostname)
 		st := dashboard.State{
 			WorkerCount:                   orch.WorkerCount(),
@@ -229,7 +229,8 @@ func runServe() {
 			RoundDurationMs:               roundDuration.Milliseconds(),
 			WPCOMCircuitOpen:              wp.IsCircuitOpen(),
 			WPCOMQueueDepth:               wp.QueueDepth(),
-			GoSysMemMB:                    goSysMemMB,
+			GoSysMemMB:                    mem.GoSysMemMB,
+			RSSMemMB:                      mem.RSSMemMB,
 			BucketMin:                     bMin,
 			BucketMax:                     bMax,
 			BucketOwnership:               bucketOwnershipLabel(currentCfg),
@@ -552,6 +553,7 @@ func monitorProcessHealthSnapshot(hostname string, startedAt time.Time, state st
 		WPCOMCircuitOpen:       st.WPCOMCircuitOpen,
 		WPCOMQueueDepth:        st.WPCOMQueueDepth,
 		GoSysMemMB:             st.GoSysMemMB,
+		RSSMemMB:               st.RSSMemMB,
 		DependencyHealth:       dashboardHealthToFleet(health),
 	}
 }
@@ -568,12 +570,6 @@ func dashboardHealthToFleet(entries []dashboard.HealthEntry) []fleethealth.Depen
 		})
 	}
 	return out
-}
-
-func currentGoSysMemMB() int {
-	var ms runtime.MemStats
-	runtime.ReadMemStats(&ms)
-	return int(ms.Sys / 1024 / 1024)
 }
 
 func mysqlHealthEntry(ctx context.Context, sqlDB *sql.DB, checkedAt time.Time) dashboard.HealthEntry {

--- a/cmd/jetmon2/main_test.go
+++ b/cmd/jetmon2/main_test.go
@@ -421,6 +421,7 @@ func TestMonitorProcessHealthSnapshot(t *testing.T) {
 		DeliveryOwnerHost:      "host-a",
 		WPCOMQueueDepth:        2,
 		GoSysMemMB:             88,
+		RSSMemMB:               99,
 	}
 	health := []dashboard.HealthEntry{{
 		Name:      "mysql",
@@ -443,6 +444,9 @@ func TestMonitorProcessHealthSnapshot(t *testing.T) {
 	}
 	if snapshot.HealthStatus != fleethealth.HealthGreen {
 		t.Fatalf("HealthStatus = %q, want green", snapshot.HealthStatus)
+	}
+	if snapshot.GoSysMemMB != 88 || snapshot.RSSMemMB != 99 {
+		t.Fatalf("memory fields = go=%d rss=%d, want go=88 rss=99", snapshot.GoSysMemMB, snapshot.RSSMemMB)
 	}
 	if len(snapshot.DependencyHealth) != 1 || snapshot.DependencyHealth[0].Name != "mysql" {
 		t.Fatalf("DependencyHealth = %+v, want mysql entry", snapshot.DependencyHealth)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -417,6 +417,7 @@ Database Tables
     state/updated_at      Lifecycle state and freshness marker
     health_status         Green/amber/red process health rollup
     go_sys_mem_mb         Go runtime system memory in MB
+    rss_mem_mb            Operating-system resident set size in MB
     dependency_health     JSON dependency health summary
 
   jetmon_events           Authoritative v2 incident current state

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -98,11 +98,14 @@ because it is intentionally **not** drop-in with the Jetmon 1 wire format
   `jetmon-deliverer` publish to for fleet dashboards.
 - Host dashboard exposure now defaults to localhost, host summaries include
   named red/amber issues, process lifecycle is stored separately from health
-  rollup, and memory is labeled as Go runtime system memory rather than RSS.
+  rollup, and the runtime memory value is clearly labeled as Go Sys memory.
 - Fleet dashboard now has `/fleet` and `/api/fleet` views backed by
   `jetmon_process_health`, `jetmon_hosts`, delivery queues, projection drift,
   and dependency rollups so operators can see stale heartbeats, bucket coverage,
   delivery-owner posture, and suggested next actions in one place.
+- Host and fleet dashboards now publish true process RSS beside Go runtime
+  system memory, and `process.rss_mb` again reports operating-system resident
+  memory when procfs is available.
 - `make all` now builds the currently implemented `jetmon2` and
   `veriflier2` binaries without requiring `protoc`; generated Veriflier
   gRPC stubs remain an explicit `make generate` step for the future

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -75,8 +75,8 @@ snapshot:
 - health rollup: `green`, `amber`, or `red`, derived from local dependency
   health and rollout-relevant warnings
 - monitor state: bucket range, ownership mode, worker counts, queue depths,
-  WPCOM circuit/queue state, delivery-owner state, API/dashboard ports, Go
-  runtime system memory
+  WPCOM circuit/queue state, delivery-owner state, API/dashboard ports, RSS
+  memory, and Go runtime system memory
 - dependency health JSON: MySQL, Verifliers, WPCOM, StatsD, and local writable
   directories where applicable
 

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -216,7 +216,7 @@ address only behind trusted operator-network controls.
 
 The host dashboard shows a red/amber/green host summary with named issues, worker
 count, active checks, queue depth, retry queue depth, throughput, round time,
-owned buckets, rollout guard state, Go runtime system memory, WPCOM
+owned buckets, rollout guard state, RSS memory, Go runtime system memory, WPCOM
 circuit-breaker state, dependency health for MySQL, Verifliers, WPCOM, StatsD,
 local log/stats writes, and the rollout commands an operator is most likely to
 need from that host.
@@ -337,7 +337,7 @@ ORDER BY process_type, host_id;
 For health rollups and memory:
 
 ```sql
-SELECT process_id, state, health_status, go_sys_mem_mb, updated_at
+SELECT process_id, state, health_status, rss_mem_mb, go_sys_mem_mb, updated_at
 FROM jetmon_process_health
 ORDER BY health_status DESC, updated_at;
 ```
@@ -376,7 +376,7 @@ Important metric groups include:
   recovery, or false alarm
 - Detection outcome counters by local failure class
 - Legacy projection drift
-- Memory usage
+- RSS and Go Sys memory usage
 
 StatsD is the primary metrics transport. Expose Graphite/StatsD data through the
 existing metrics pipeline when external systems need it.
@@ -402,8 +402,9 @@ go tool pprof heap.prof
 The debug listener binds to localhost only. Set `DEBUG_PORT` to 0 to disable it.
 
 If Go runtime memory exceeds `WORKER_MAX_MEM_MB`, the goroutine pool shrinks by
-10 percent via graceful drain. Sustained memory pressure should be investigated
-with pprof and operating-system RSS before increasing the limit.
+10 percent via graceful drain. Use the host/fleet dashboard RSS value to compare
+Jetmon's resident memory with operating-system tools, and use the Go Sys value
+with pprof when investigating sustained runtime memory pressure.
 
 ## Veriflier Health
 

--- a/docs/project.md
+++ b/docs/project.md
@@ -225,7 +225,7 @@ A lightweight web UI served by the binary itself (no separate process) on a conf
 - Owned bucket range
 - Bucket ownership mode, legacy projection mode, delivery-worker ownership, and
   rollout preflight / projection-drift commands
-- Go runtime system memory usage
+- RSS memory and Go runtime system memory usage
 - WPCOM circuit-breaker state and queued notification depth
 - Live dependency health for MySQL, configured Verifliers, WPCOM, StatsD, and
   log/stats directory writes
@@ -253,8 +253,8 @@ heartbeat snapshots into `jetmon_process_health`. The `/fleet` dashboard uses
 those snapshots alongside `jetmon_hosts`, outbound delivery queues, projection
 drift, and dependency rollups to summarize monitor hosts, standalone
 deliverers, stale process heartbeats, lifecycle state, red/amber/green health
-rollups, delivery-owner posture, Go runtime system memory, and local dependency
-health without polling every host dashboard directly.
+rollups, delivery-owner posture, RSS memory, Go runtime system memory, and
+local dependency health without polling every host dashboard directly.
 
 **False Positive Tracker**
 Every time the system escalates a site to Veriflier confirmation and the Verifliers do NOT confirm it as down (i.e., the queue entry times out or all Verifliers report the site as up), the event is recorded in a `jetmon_false_positives` table with timestamp, site, HTTP code, error code, and RTT from the local check. A view in the operator dashboard surfaces sites with high false positive rates, helping operators tune per-site `NUM_OF_CHECKS` or `TIME_BETWEEN_CHECKS_SEC` settings.
@@ -349,7 +349,7 @@ Benefits over the current static configuration:
 - **Veriflier unreachable**: A Veriflier that fails to respond is marked unhealthy and excluded from confirmation requests. Remaining healthy Verifliers continue; the `PEER_OFFLINE_LIMIT` threshold adjusts dynamically to the number of healthy Verifliers (with a floor to prevent false confirmations).
 - **WPCOM API failures**: Circuit breaker pattern. After N consecutive failures the circuit opens, pending notifications are queued in memory with timestamps, and the circuit is retried on a backoff schedule. Queue is bounded; oldest entries are dropped with an error log if it fills.
 - **Stuck check goroutine**: A watchdog goroutine tracks the last activity time of each check. A goroutine that exceeds `NET_COMMS_TIMEOUT * 2` without completing is cancelled via context cancellation, its result counted as a timeout, and a new goroutine is allocated to replace it.
-- **Memory pressure**: The binary exposes Go runtime system memory via the health endpoint. If that exceeds a configurable threshold, the pool size is reduced by 10% via graceful drain until pressure eases — the equivalent of the current worker recycling mechanism, but without process death. True operating-system RSS can still be checked with host tooling when investigating sustained memory pressure.
+- **Memory pressure**: The binary exposes both RSS memory and Go runtime system memory through the dashboard state endpoints. If Go runtime system memory exceeds a configurable threshold, the pool size is reduced by 10% via graceful drain until pressure eases — the equivalent of the current worker recycling mechanism, but without process death. Use RSS to compare Jetmon with host-level tools and Go Sys with pprof when investigating sustained memory pressure.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -119,10 +119,10 @@ preflight, deliverer hardening, and API CLI fixture workflow branches:
   heartbeats and compact local health snapshots.
 - [x] Publish monitor-host health from `jetmon2`, including bucket ownership,
   worker queues, WPCOM circuit state, delivery-owner state, dependency health,
-  Go runtime system memory, version, and process lifecycle state.
+  RSS memory, Go runtime system memory, version, and process lifecycle state.
 - [x] Publish standalone `jetmon-deliverer` health, including active/idle
-  owner state, DB/StatsD health, Go runtime system memory, version, and process
-  lifecycle state.
+  owner state, DB/StatsD health, RSS memory, Go runtime system memory, version,
+  and process lifecycle state.
 - [x] Add a combined host-dashboard snapshot endpoint so host state, dependency
   health, and red/amber/green summary rules are available from one local API.
 - [x] Polish the existing host dashboard so rollout blockers, delivery-owner
@@ -145,8 +145,8 @@ preflight, deliverer hardening, and API CLI fixture workflow branches:
 - [x] Add explicit fleet delivery-ownership posture so operators can
   distinguish intentional rollout-conservative `DELIVERY_OWNER_HOST` settings
   from accidental all-host delivery eligibility.
-- [ ] Consider collecting true process RSS for fleet and host dashboards if
-  operators need OS-level memory accounting beyond Go runtime system memory.
+- [x] Collect true process RSS for fleet and host dashboards while retaining Go
+  runtime system memory as a separate allocator/guardrail signal.
 - [x] Document and test the fleet dashboard's safe network exposure model
   before exposing it beyond trusted operator networks.
 

--- a/docs/v1-to-v2-migration.md
+++ b/docs/v1-to-v2-migration.md
@@ -576,7 +576,8 @@ If `DASHBOARD_PORT` is enabled, confirm:
   Verifliers, WPCOM, StatsD, and log/stats directory writes
 - the host dashboard shows the WPCOM circuit breaker closed
 - retry queue depth is not growing unexpectedly
-- Go runtime system memory stays below the configured guardrail
+- Go runtime system memory stays below the configured guardrail and RSS stays
+  within host-level expectations
 - delivery workers are disabled unless explicitly approved
 - the fleet dashboard at `/fleet` shows the replaced host as fresh, and pinned
   bucket mode as an expected amber rollout state

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -6,9 +6,10 @@ import (
 	"log"
 	"net/http"
 	_ "net/http/pprof"
-	"runtime"
 	"sync"
 	"time"
+
+	"github.com/Automattic/jetmon/internal/processmetrics"
 )
 
 const maxSSEClients = 32
@@ -24,6 +25,7 @@ type State struct {
 	WPCOMCircuitOpen              bool      `json:"wpcom_circuit_open"`
 	WPCOMQueueDepth               int       `json:"wpcom_queue_depth"`
 	GoSysMemMB                    int       `json:"go_sys_mem_mb"`
+	RSSMemMB                      int       `json:"rss_mem_mb"`
 	BucketMin                     int       `json:"bucket_min"`
 	BucketMax                     int       `json:"bucket_max"`
 	BucketOwnership               string    `json:"bucket_ownership"`
@@ -93,9 +95,9 @@ func (s *Server) Update(st State) {
 	st.Hostname = s.hostname
 	st.UpdatedAt = time.Now()
 
-	var ms runtime.MemStats
-	runtime.ReadMemStats(&ms)
-	st.GoSysMemMB = int(ms.Sys / 1024 / 1024)
+	mem := processmetrics.CurrentMemory()
+	st.GoSysMemMB = mem.GoSysMemMB
+	st.RSSMemMB = mem.RSSMemMB
 
 	s.mu.Lock()
 	s.state = st
@@ -492,6 +494,7 @@ const dashboardHTML = `<!DOCTYPE html>
     <div class="card"><div class="label">Sites/Sec</div><div class="value" id="sps">-</div></div>
     <div class="card"><div class="label">Round Time</div><div class="value" id="round">-</div></div>
     <div class="card"><div class="label">Buckets</div><div class="value" id="buckets">-</div></div>
+    <div class="card"><div class="label">RSS Memory</div><div class="value" id="rss-mem">-</div></div>
     <div class="card"><div class="label">Go Sys Memory</div><div class="value" id="go-sys">-</div></div>
   </div>
 
@@ -538,7 +541,8 @@ function renderState(d) {
   setText('sps', d.sites_per_sec);
   setText('round', ((d.round_duration_ms || 0) / 1000).toFixed(1) + 's');
   setText('buckets', d.bucket_min + '-' + d.bucket_max);
-  setText('go-sys', d.go_sys_mem_mb + 'MB');
+  setText('rss-mem', formatMem(d.rss_mem_mb));
+  setText('go-sys', formatMem(d.go_sys_mem_mb));
   setText('ownership', d.bucket_ownership || '-');
   setText('projection', d.legacy_status_projection_enabled ? 'enabled' : 'disabled');
   setText('delivery', d.delivery_workers_enabled ? 'enabled' : 'disabled');
@@ -554,6 +558,10 @@ function renderState(d) {
   setText('wpcomq', d.wpcom_queue_depth);
   setText('updated', 'updated: ' + (d.updated_at ? new Date(d.updated_at).toLocaleTimeString() : 'never'));
   renderSummary();
+}
+
+function formatMem(value) {
+  return value > 0 ? value + 'MB' : 'n/a';
 }
 
 function renderSummary(summary) {

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Automattic/jetmon/internal/processmetrics"
 )
 
 type fakeFleetSource struct {
@@ -47,8 +49,15 @@ func TestHandleState(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", w.Code)
 	}
+	body := w.Body.String()
+	if !strings.Contains(body, `"rss_mem_mb"`) {
+		t.Fatalf("state body missing rss_mem_mb: %s", body)
+	}
+	if !strings.Contains(body, `"go_sys_mem_mb"`) {
+		t.Fatalf("state body missing go_sys_mem_mb: %s", body)
+	}
 	var st State
-	if err := json.NewDecoder(w.Body).Decode(&st); err != nil {
+	if err := json.NewDecoder(strings.NewReader(body)).Decode(&st); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 	if st.WorkerCount != 5 {
@@ -56,6 +65,12 @@ func TestHandleState(t *testing.T) {
 	}
 	if st.Hostname != "test-host" {
 		t.Fatalf("Hostname = %q, want test-host", st.Hostname)
+	}
+	if st.GoSysMemMB <= 0 {
+		t.Fatalf("GoSysMemMB = %d, want positive runtime memory", st.GoSysMemMB)
+	}
+	if processmetrics.CurrentMemory().RSSMemMB > 0 && st.RSSMemMB <= 0 {
+		t.Fatalf("RSSMemMB = %d, want positive RSS when procfs is available", st.RSSMemMB)
 	}
 	if st.BucketOwnership != "pinned range=0-99" {
 		t.Fatalf("BucketOwnership = %q, want pinned range=0-99", st.BucketOwnership)

--- a/internal/dashboard/fleet.go
+++ b/internal/dashboard/fleet.go
@@ -190,6 +190,7 @@ type FleetProcess struct {
 	WPCOMCircuitOpen       bool                           `json:"wpcom_circuit_open"`
 	WPCOMQueueDepth        int                            `json:"wpcom_queue_depth"`
 	GoSysMemMB             int                            `json:"go_sys_mem_mb"`
+	RSSMemMB               int                            `json:"rss_mem_mb"`
 	DependencyHealth       []fleethealth.DependencyHealth `json:"dependency_health,omitempty"`
 }
 
@@ -307,6 +308,7 @@ func summarizeFleetProcesses(rows []fleethealth.Snapshot, now time.Time, heartbe
 			WPCOMCircuitOpen:       row.WPCOMCircuitOpen,
 			WPCOMQueueDepth:        row.WPCOMQueueDepth,
 			GoSysMemMB:             row.GoSysMemMB,
+			RSSMemMB:               row.RSSMemMB,
 			DependencyHealth:       append([]fleethealth.DependencyHealth(nil), row.DependencyHealth...),
 		})
 	}

--- a/internal/dashboard/fleet_html.go
+++ b/internal/dashboard/fleet_html.go
@@ -281,7 +281,7 @@ function render(snapshot) {
       ageLabel(process.last_heartbeat_age_sec),
       rangeLabel(process),
       'active=' + (process.active_checks || 0) + ' queue=' + (process.queue_depth || 0) + ' retry=' + (process.retry_queue_size || 0),
-      (process.go_sys_mem_mb || 0) + 'MB'
+      'rss=' + formatMem(process.rss_mem_mb) + ' go=' + formatMem(process.go_sys_mem_mb)
     ]));
   });
   if (processes.length === 0) {
@@ -296,6 +296,10 @@ function render(snapshot) {
   if ((snapshot.dependencies || []).length === 0) {
     depBody.appendChild(row(['No dependency snapshots found', '', '', '', '', '', '']));
   }
+}
+
+function formatMem(value) {
+  return value > 0 ? value + 'MB' : 'n/a';
 }
 
 async function refresh() {

--- a/internal/dashboard/fleet_test.go
+++ b/internal/dashboard/fleet_test.go
@@ -251,7 +251,7 @@ func TestSummarizeFleetProcessesOrdersUnhealthyFirst(t *testing.T) {
 	processes := summarizeFleetProcesses([]fleethealth.Snapshot{
 		{ProcessID: "host-c:monitor", HostID: "host-c", ProcessType: fleethealth.ProcessMonitor, HealthStatus: fleethealth.HealthGreen, UpdatedAt: now},
 		{ProcessID: "host-d:deliverer", HostID: "host-d", ProcessType: fleethealth.ProcessDeliverer, HealthStatus: fleethealth.HealthGreen, UpdatedAt: now},
-		{ProcessID: "host-b:monitor", HostID: "host-b", ProcessType: fleethealth.ProcessMonitor, HealthStatus: fleethealth.HealthAmber, UpdatedAt: now},
+		{ProcessID: "host-b:monitor", HostID: "host-b", ProcessType: fleethealth.ProcessMonitor, HealthStatus: fleethealth.HealthAmber, UpdatedAt: now, GoSysMemMB: 88, RSSMemMB: 99},
 		{ProcessID: "host-a:monitor", HostID: "host-a", ProcessType: fleethealth.ProcessMonitor, HealthStatus: fleethealth.HealthGreen, UpdatedAt: now.Add(-time.Hour)},
 	}, now, 10*time.Minute)
 	if got := processes[0].ProcessID; got != "host-a:monitor" {
@@ -262,6 +262,9 @@ func TestSummarizeFleetProcessesOrdersUnhealthyFirst(t *testing.T) {
 	}
 	if got := processes[2].ProcessID; got != "host-c:monitor" {
 		t.Fatalf("third process = %q, want healthy monitors before deliverers", got)
+	}
+	if processes[1].GoSysMemMB != 88 || processes[1].RSSMemMB != 99 {
+		t.Fatalf("memory fields = go=%d rss=%d, want go=88 rss=99", processes[1].GoSysMemMB, processes[1].RSSMemMB)
 	}
 }
 

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -428,6 +428,12 @@ var migrations = []migration{
 		ADD COLUMN health_status VARCHAR(16) NOT NULL DEFAULT 'green' AFTER state,
 		CHANGE COLUMN mem_rss_mb go_sys_mem_mb INT UNSIGNED NOT NULL DEFAULT 0,
 		ADD INDEX idx_health_status_updated (health_status, updated_at)`},
+
+	// Migration 26 adds true operating-system RSS beside Go runtime system
+	// memory so dashboards can show both the host-observed resident set and the
+	// runtime allocator footprint.
+	{26, `ALTER TABLE jetmon_process_health
+		ADD COLUMN rss_mem_mb INT UNSIGNED NOT NULL DEFAULT 0 AFTER go_sys_mem_mb`},
 }
 
 // Migrate applies all pending migrations idempotently.

--- a/internal/fleethealth/health.go
+++ b/internal/fleethealth/health.go
@@ -62,6 +62,7 @@ type Snapshot struct {
 	WPCOMCircuitOpen       bool
 	WPCOMQueueDepth        int
 	GoSysMemMB             int
+	RSSMemMB               int
 	DependencyHealth       []DependencyHealth
 }
 
@@ -115,6 +116,7 @@ func Upsert(ctx context.Context, db *sql.DB, snapshot Snapshot) error {
 		boolInt(normalized.WPCOMCircuitOpen),
 		normalized.WPCOMQueueDepth,
 		normalized.GoSysMemMB,
+		normalized.RSSMemMB,
 		string(deps),
 	)
 	if err != nil {
@@ -181,6 +183,7 @@ func ListSnapshots(ctx context.Context, db *sql.DB) ([]Snapshot, error) {
 		       wpcom_circuit_open,
 		       wpcom_queue_depth,
 		       go_sys_mem_mb,
+		       rss_mem_mb,
 		       dependency_health
 		  FROM jetmon_process_health
 		 ORDER BY process_type, host_id, process_id`)
@@ -222,6 +225,7 @@ func ListSnapshots(ctx context.Context, db *sql.DB) ([]Snapshot, error) {
 			&wpcomCircuitOpen,
 			&snapshot.WPCOMQueueDepth,
 			&snapshot.GoSysMemMB,
+			&snapshot.RSSMemMB,
 			&dependencyHealth,
 		); err != nil {
 			return nil, fmt.Errorf("scan process health: %w", err)
@@ -378,8 +382,9 @@ INSERT INTO jetmon_process_health (
 	wpcom_circuit_open,
 	wpcom_queue_depth,
 	go_sys_mem_mb,
+	rss_mem_mb,
 	dependency_health
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON DUPLICATE KEY UPDATE
 	host_id = VALUES(host_id),
 	process_type = VALUES(process_type),
@@ -405,4 +410,5 @@ ON DUPLICATE KEY UPDATE
 	wpcom_circuit_open = VALUES(wpcom_circuit_open),
 	wpcom_queue_depth = VALUES(wpcom_queue_depth),
 	go_sys_mem_mb = VALUES(go_sys_mem_mb),
+	rss_mem_mb = VALUES(rss_mem_mb),
 	dependency_health = VALUES(dependency_health)`

--- a/internal/fleethealth/health_test.go
+++ b/internal/fleethealth/health_test.go
@@ -57,6 +57,7 @@ func TestUpsertSnapshot(t *testing.T) {
 			0,
 			2,
 			88,
+			99,
 			`[{"name":"mysql","status":"green","checked_at":"2026-04-30T10:01:00Z"}]`,
 		).
 		WillReturnResult(sqlmock.NewResult(0, 1))
@@ -85,6 +86,7 @@ func TestUpsertSnapshot(t *testing.T) {
 		RetryQueueSize:         5,
 		WPCOMQueueDepth:        2,
 		GoSysMemMB:             88,
+		RSSMemMB:               99,
 		DependencyHealth: []DependencyHealth{{
 			Name:      "mysql",
 			Status:    "green",
@@ -195,6 +197,7 @@ func TestListSnapshots(t *testing.T) {
 		"wpcom_circuit_open",
 		"wpcom_queue_depth",
 		"go_sys_mem_mb",
+		"rss_mem_mb",
 		"dependency_health",
 	}).AddRow(
 		"host-a:monitor",
@@ -222,6 +225,7 @@ func TestListSnapshots(t *testing.T) {
 		1,
 		2,
 		88,
+		99,
 		`[{"name":"mysql","status":"green","checked_at":"2026-04-30T10:01:00Z"}]`,
 	)
 	mock.ExpectQuery("SELECT process_id").WillReturnRows(rows)
@@ -239,6 +243,9 @@ func TestListSnapshots(t *testing.T) {
 	}
 	if got.BucketMin == nil || *got.BucketMin != 0 || got.APIPort == nil || *got.APIPort != 8090 {
 		t.Fatalf("nullable ints not decoded: BucketMin=%v APIPort=%v", got.BucketMin, got.APIPort)
+	}
+	if got.GoSysMemMB != 88 || got.RSSMemMB != 99 {
+		t.Fatalf("memory fields = go=%d rss=%d, want go=88 rss=99", got.GoSysMemMB, got.RSSMemMB)
 	}
 	if !got.DeliveryWorkersEnabled || !got.WPCOMCircuitOpen {
 		t.Fatalf("bools not decoded: delivery=%v wpcom=%v", got.DeliveryWorkersEnabled, got.WPCOMCircuitOpen)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Automattic/jetmon/internal/processmetrics"
 )
 
 // Client sends StatsD metrics via UDP and writes stats files.
@@ -61,14 +62,19 @@ func (c *Client) send(msg string) {
 	_, _ = fmt.Fprintln(c.conn, msg)
 }
 
-// EmitMemStats emits legacy memory gauges. process.rss_mb is retained for
-// StatsD compatibility, but the value is Go runtime Sys memory rather than OS
-// resident set size.
+// EmitMemStats emits legacy memory gauges. process.rss_mb uses operating-system
+// resident set size when available and falls back to Go runtime Sys memory when
+// procfs is unavailable; process.go_sys_mem_mb keeps the runtime value visible.
 func (c *Client) EmitMemStats() {
-	var ms runtime.MemStats
-	runtime.ReadMemStats(&ms)
-	c.Gauge("process.rss_mb", int(ms.Sys/1024/1024))
-	c.Gauge("process.heap_alloc_mb", int(ms.HeapAlloc/1024/1024))
+	mem := processmetrics.CurrentMemory()
+	rssMB := mem.RSSMemMB
+	goSysMB := mem.GoSysMemMB
+	if rssMB <= 0 {
+		rssMB = goSysMB
+	}
+	c.Gauge("process.rss_mb", rssMB)
+	c.Gauge("process.go_sys_mem_mb", goSysMB)
+	c.Gauge("process.heap_alloc_mb", mem.HeapAllocMemMB)
 }
 
 // WriteStatsFiles writes sitespersec, sitesqueue, and totals to the stats/

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -51,12 +51,12 @@ func TestClientSendsStatsDMessages(t *testing.T) {
 		conn:   clientConn,
 	}
 
-	lines := make(chan string, 5)
+	lines := make(chan string, 6)
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		r := bufio.NewReader(serverConn)
-		for i := 0; i < 5; i++ {
+		for i := 0; i < 6; i++ {
 			line, err := r.ReadString('\n')
 			if err != nil {
 				return
@@ -70,8 +70,8 @@ func TestClientSendsStatsDMessages(t *testing.T) {
 	c.Timing("request.rtt", 1500*time.Millisecond)
 	c.EmitMemStats()
 
-	got := make([]string, 0, 5)
-	for len(got) < 5 {
+	got := make([]string, 0, 6)
+	for len(got) < 6 {
 		select {
 		case line := <-lines:
 			got = append(got, line)
@@ -84,16 +84,27 @@ func TestClientSendsStatsDMessages(t *testing.T) {
 
 	wantPrefix := "com.jetpack.jetmon.host_name."
 	expected := map[string]bool{
-		wantPrefix + "checks.total:2|c":    false,
-		wantPrefix + "queue.depth:7|g":     false,
-		wantPrefix + "request.rtt:1500|ms": false,
+		wantPrefix + "checks.total:2|c":       false,
+		wantPrefix + "queue.depth:7|g":        false,
+		wantPrefix + "request.rtt:1500|ms":    false,
+		wantPrefix + "process.rss_mb:":        false,
+		wantPrefix + "process.go_sys_mem_mb:": false,
+		wantPrefix + "process.heap_alloc_mb:": false,
 	}
 	for _, line := range got {
 		if _, ok := expected[line]; ok {
 			expected[line] = true
 			continue
 		}
-		if !strings.HasPrefix(line, wantPrefix+"process.") {
+		matchedDynamic := false
+		for prefix := range expected {
+			if strings.HasSuffix(prefix, ":") && strings.HasPrefix(line, prefix) {
+				expected[prefix] = true
+				matchedDynamic = true
+				break
+			}
+		}
+		if !matchedDynamic {
 			t.Fatalf("unexpected metric line %q in %v", line, got)
 		}
 	}

--- a/internal/processmetrics/memory.go
+++ b/internal/processmetrics/memory.go
@@ -1,0 +1,66 @@
+package processmetrics
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+const bytesPerMB = 1024 * 1024
+
+// MemorySnapshot is a compact local process memory sample.
+type MemorySnapshot struct {
+	RSSMemMB       int
+	GoSysMemMB     int
+	HeapAllocMemMB int
+}
+
+// CurrentMemory returns a single memory sample suitable for dashboards and
+// metrics. RSS is best-effort because it depends on Linux procfs availability.
+func CurrentMemory() MemorySnapshot {
+	mem := currentRuntimeMemory()
+	mem.RSSMemMB = rssMemMB()
+	return mem
+}
+
+func currentRuntimeMemory() MemorySnapshot {
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	return MemorySnapshot{
+		GoSysMemMB:     int(ms.Sys / bytesPerMB),
+		HeapAllocMemMB: int(ms.HeapAlloc / bytesPerMB),
+	}
+}
+
+// rssMemMB returns this process' resident set size in MiB when the operating
+// system exposes it. A zero return means RSS could not be collected.
+func rssMemMB() int {
+	rssMB, err := rssMemMBFromStatm("/proc/self/statm", os.Getpagesize())
+	if err != nil {
+		return 0
+	}
+	return rssMB
+}
+
+// rssMemMBFromStatm parses a Linux procfs statm file and converts resident
+// pages to MiB.
+func rssMemMBFromStatm(path string, pageSize int) (int, error) {
+	if pageSize <= 0 {
+		return 0, fmt.Errorf("invalid page size %d", pageSize)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	fields := strings.Fields(string(raw))
+	if len(fields) < 2 {
+		return 0, fmt.Errorf("statm %s has %d fields, want at least 2", path, len(fields))
+	}
+	residentPages, err := strconv.ParseUint(fields[1], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse resident pages: %w", err)
+	}
+	return int((residentPages * uint64(pageSize)) / bytesPerMB), nil
+}

--- a/internal/processmetrics/memory_test.go
+++ b/internal/processmetrics/memory_test.go
@@ -1,0 +1,44 @@
+package processmetrics
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRSSMemMBFromStatm(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "statm")
+	if err := os.WriteFile(path, []byte("1000 512 0 0 0 0 0\n"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := rssMemMBFromStatm(path, 4096)
+	if err != nil {
+		t.Fatalf("rssMemMBFromStatm() error = %v", err)
+	}
+	if got != 2 {
+		t.Fatalf("rssMemMBFromStatm() = %d, want 2", got)
+	}
+}
+
+func TestRSSMemMBFromStatmRejectsMalformedInput(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "statm")
+	if err := os.WriteFile(path, []byte("1000 nope\n"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err := rssMemMBFromStatm(path, 4096); err == nil {
+		t.Fatal("rssMemMBFromStatm() error = nil, want parse error")
+	}
+}
+
+func TestCurrentMemory(t *testing.T) {
+	snapshot := CurrentMemory()
+	if snapshot.GoSysMemMB <= 0 {
+		t.Fatalf("GoSysMemMB = %d, want positive runtime memory", snapshot.GoSysMemMB)
+	}
+	if snapshot.HeapAllocMemMB < 0 {
+		t.Fatalf("HeapAllocMemMB = %d, want non-negative heap allocation", snapshot.HeapAllocMemMB)
+	}
+	if snapshot.RSSMemMB < 0 {
+		t.Fatalf("RSSMemMB = %d, want non-negative RSS", snapshot.RSSMemMB)
+	}
+}


### PR DESCRIPTION
## Summary

This closes out the dashboard memory reporting work by adding true process RSS alongside the existing Go runtime memory signal.

The host and fleet dashboards now expose both values so operators can compare Jetmon with host-level tools like `ps`, `top`, and systemd while still keeping Go Sys memory visible for runtime guardrails and pprof investigations.

## What changed

- Added a shared `internal/processmetrics` helper for local process memory sampling.
- Added `rss_mem_mb` to `jetmon_process_health` via migration 26.
- Published RSS and Go Sys memory from both `jetmon2` and `jetmon-deliverer` process-health snapshots.
- Updated `/api/state`, `/api/host`, `/api/fleet`, the host dashboard, and the fleet dashboard to expose RSS beside Go Sys memory.
- Updated StatsD memory gauges so `process.rss_mb` reports resident memory when procfs is available, with additive `process.go_sys_mem_mb` for the runtime allocator view.
- Updated operations, migration, architecture, data-model, project, changelog, and roadmap docs.

## Example dashboard values

Host dashboard throughput section now shows memory as two separate cards:

```text
RSS Memory      37MB
Go Sys Memory   24MB
```

Fleet process rows now show both values in the memory column:

```text
host-a:monitor     green   running   2s   0-499   active=12 queue=4 retry=0   rss=37MB go=24MB
host-b:deliverer   green   running   3s   -       active=0 queue=0 retry=0    rss=19MB go=14MB
```

The JSON payload exposes both fields for machine parsing:

```json
{
  "go_sys_mem_mb": 24,
  "rss_mem_mb": 37
}
```

## Review notes

I reviewed the branch from sysadmin, security, and code-quality perspectives after the initial implementation.

- Sysadmin: RSS is now the first memory value shown, with Go Sys retained as the runtime and guardrail signal.
- Security: RSS collection reads only `/proc/self/statm`; there is no user-controlled path in production code and no additional remote surface beyond the existing internal dashboards and APIs.
- Engineering: memory sampling now flows through one focused `CurrentMemory()` helper, and tests assert the exact JSON and StatsD fields operators and automation will consume.

## Testing

- `go test ./...`
- `go vet ./...`
- `make all`
- Targeted dry-run style tests for procfs parsing, current memory sampling, `/api/state` JSON, fleet rollup preservation, and StatsD metric names.