### PR TITLE
Add production telemetry report command

### DIFF
--- a/cmd/jetmon2/main.go
+++ b/cmd/jetmon2/main.go
@@ -71,6 +71,8 @@ func main() {
 		cmdAPI(os.Args[2:])
 	case "site-tenants":
 		cmdSiteTenants(os.Args[2:])
+	case "telemetry":
+		cmdTelemetry(os.Args[2:])
 	case "rollout":
 		cmdRollout(os.Args[2:])
 	default:

--- a/cmd/jetmon2/telemetry_report.go
+++ b/cmd/jetmon2/telemetry_report.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"sort"
 	"strings"
 	"time"
 
@@ -20,11 +19,17 @@ import (
 	"github.com/Automattic/jetmon/internal/eventstore"
 )
 
+const (
+	defaultTelemetryQueryTimeout = 30 * time.Second
+	maxTelemetryQueryTimeout     = 5 * time.Minute
+)
+
 type telemetryReportOptions struct {
-	Since  string
-	Until  string
-	Output string
-	Limit  int
+	Since        string
+	Until        string
+	Output       string
+	Limit        int
+	QueryTimeout time.Duration
 }
 
 type telemetryWindow struct {
@@ -36,6 +41,8 @@ type telemetryReport struct {
 	Command              string                  `json:"command"`
 	GeneratedAt          time.Time               `json:"generated_at"`
 	Window               telemetryWindow         `json:"window"`
+	Status               string                  `json:"status"`
+	Highlights           []string                `json:"highlights,omitempty"`
 	Summary              telemetrySummary        `json:"summary"`
 	Timings              []telemetryTiming       `json:"timings"`
 	Verifier             telemetryVerifierReport `json:"verifier"`
@@ -122,9 +129,10 @@ func cmdTelemetry(args []string) {
 
 func cmdTelemetryReport(args []string) {
 	opts := telemetryReportOptions{
-		Since:  "24h",
-		Output: "text",
-		Limit:  10,
+		Since:        "24h",
+		Output:       "text",
+		Limit:        10,
+		QueryTimeout: defaultTelemetryQueryTimeout,
 	}
 	fs := newTelemetryReportFlagSet(&opts, os.Stderr)
 	if err := fs.Parse(args); err != nil {
@@ -135,7 +143,7 @@ func cmdTelemetryReport(args []string) {
 		os.Exit(2)
 	}
 	if fs.NArg() != 0 {
-		fmt.Fprintln(os.Stderr, "usage: jetmon2 telemetry report [--since=24h] [--until=<RFC3339>] [--output=text|json] [--limit=N]")
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 telemetry report [--since=24h] [--until=<RFC3339>] [--output=text|json] [--limit=N] [--query-timeout=30s]")
 		os.Exit(1)
 	}
 
@@ -146,6 +154,10 @@ func cmdTelemetryReport(args []string) {
 	}
 	opts.Output = outputFormat
 	if err := validateTelemetryLimit(opts.Limit); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL %v\n", err)
+		os.Exit(2)
+	}
+	if err := validateTelemetryQueryTimeout(opts.QueryTimeout); err != nil {
 		fmt.Fprintf(os.Stderr, "FAIL %v\n", err)
 		os.Exit(2)
 	}
@@ -176,6 +188,7 @@ func newTelemetryReportFlagSet(opts *telemetryReportOptions, out io.Writer) *fla
 	fs.StringVar(&opts.Until, "until", opts.Until, "report end as RFC3339 timestamp (default now)")
 	fs.StringVar(&opts.Output, "output", opts.Output, "output format: text or json")
 	fs.IntVar(&opts.Limit, "limit", opts.Limit, "maximum verifier hosts and false-alarm classes to show")
+	fs.DurationVar(&opts.QueryTimeout, "query-timeout", opts.QueryTimeout, "maximum time for the report query set")
 	fs.Usage = func() {
 		printAPIFlagUsage(fs.Output(), fs)
 	}
@@ -203,6 +216,16 @@ func validateTelemetryLimit(limit int) error {
 	return nil
 }
 
+func validateTelemetryQueryTimeout(timeout time.Duration) error {
+	if timeout < 0 {
+		return errors.New("--query-timeout must be >= 0")
+	}
+	if timeout > maxTelemetryQueryTimeout {
+		return fmt.Errorf("--query-timeout must be <= %s", maxTelemetryQueryTimeout)
+	}
+	return nil
+}
+
 func buildTelemetryReport(ctx context.Context, conn *sql.DB, now time.Time, opts telemetryReportOptions) (telemetryReport, error) {
 	if conn == nil {
 		return telemetryReport{}, errors.New("database pool is not initialized")
@@ -210,6 +233,17 @@ func buildTelemetryReport(ctx context.Context, conn *sql.DB, now time.Time, opts
 	if err := validateTelemetryLimit(opts.Limit); err != nil {
 		return telemetryReport{}, err
 	}
+	if err := validateTelemetryQueryTimeout(opts.QueryTimeout); err != nil {
+		return telemetryReport{}, err
+	}
+	queryTimeout := opts.QueryTimeout
+	if queryTimeout == 0 {
+		queryTimeout = defaultTelemetryQueryTimeout
+	}
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, queryTimeout)
+	defer cancel()
+
 	window, err := resolveTelemetryWindow(now, opts.Since, opts.Until)
 	if err != nil {
 		return telemetryReport{}, err
@@ -252,6 +286,8 @@ func buildTelemetryReport(ctx context.Context, conn *sql.DB, now time.Time, opts
 		WPCOM:             wpcom,
 		ExplanationGaps:   gaps,
 	}
+	report.Status = telemetryReportStatus(report.ExplanationGaps)
+	report.Highlights = telemetryReportHighlights(report)
 	report.SuggestedNextActions = suggestTelemetryNextActions(report)
 	return report, nil
 }
@@ -283,7 +319,7 @@ func queryTelemetryReasonCounts(ctx context.Context, conn *sql.DB, window teleme
 		SELECT reason, COUNT(*)
 		  FROM jetmon_event_transitions
 		 WHERE changed_at >= ?
-		   AND changed_at <= ?
+		   AND changed_at < ?
 		 GROUP BY reason`,
 		window.Since, window.Until,
 	)
@@ -332,7 +368,7 @@ func queryTelemetryTimings(ctx context.Context, conn *sql.DB, window telemetryWi
 			   AND opened.reason = ?
 			 WHERE outcome.reason = ?
 			   AND outcome.changed_at >= ?
-			   AND outcome.changed_at <= ?`,
+			   AND outcome.changed_at < ?`,
 			eventstore.ReasonOpened, item.reason, window.Since, window.Until,
 		).Scan(&timing.Count, &timing.AvgMS, &timing.MaxMS)
 		if err != nil {
@@ -354,7 +390,7 @@ func queryTelemetryVerifier(ctx context.Context, conn *sql.DB, window telemetryW
 		 WHERE event_type = ?
 		   AND detail = 'veriflier reply'
 		   AND created_at >= ?
-		   AND created_at <= ?`,
+		   AND created_at < ?`,
 		audit.EventVeriflierSent, window.Since, window.Until,
 	).Scan(&summary.Replies, &summary.ConfirmDown, &summary.Disagree, &summary.MissingOutcome)
 	if err != nil {
@@ -374,7 +410,7 @@ func queryTelemetryVerifier(ctx context.Context, conn *sql.DB, window telemetryW
 		 WHERE event_type = ?
 		   AND detail = 'veriflier reply'
 		   AND created_at >= ?
-		   AND created_at <= ?
+		   AND created_at < ?
 		 GROUP BY source
 		 ORDER BY COUNT(*) DESC, source
 		 LIMIT %d`, limit)
@@ -420,7 +456,7 @@ func queryTelemetryFalseAlarmClasses(ctx context.Context, conn *sql.DB, window t
 		   AND opened.reason = ?
 		 WHERE outcome.reason IN (?, ?)
 		   AND outcome.changed_at >= ?
-		   AND outcome.changed_at <= ?
+		   AND outcome.changed_at < ?
 		 GROUP BY outcome.reason, class
 		 ORDER BY count DESC, outcome, class
 		 LIMIT %d`,
@@ -469,7 +505,7 @@ func queryTelemetryWPCOM(ctx context.Context, conn *sql.DB, window telemetryWind
 		  FROM jetmon_audit_log
 		 WHERE event_type = ?
 		   AND created_at >= ?
-		   AND created_at <= ?`,
+		   AND created_at < ?`,
 		audit.EventWPCOMSent, window.Since, window.Until,
 	).Scan(&report.Attempts, &report.DownAttempts, &report.RecoveryAttempts)
 	if err != nil {
@@ -481,7 +517,7 @@ func queryTelemetryWPCOM(ctx context.Context, conn *sql.DB, window telemetryWind
 		  FROM jetmon_audit_log
 		 WHERE event_type = ?
 		   AND created_at >= ?
-		   AND created_at <= ?`,
+		   AND created_at < ?`,
 		audit.EventWPCOMRetry, window.Since, window.Until,
 	).Scan(&report.Retries)
 	if err != nil {
@@ -493,7 +529,7 @@ func queryTelemetryWPCOM(ctx context.Context, conn *sql.DB, window telemetryWind
 		  FROM jetmon_audit_log
 		 WHERE event_type IN (?, ?)
 		   AND created_at >= ?
-		   AND created_at <= ?`,
+		   AND created_at < ?`,
 		audit.EventMaintenanceActive, audit.EventAlertSuppressed, window.Since, window.Until,
 	).Scan(&report.Suppressed)
 	if err != nil {
@@ -525,7 +561,7 @@ func queryTelemetryExplanationGaps(ctx context.Context, conn *sql.DB, window tel
 				  FROM jetmon_event_transitions
 				 WHERE reason = ?
 				   AND changed_at >= ?
-				   AND changed_at <= ?
+				   AND changed_at < ?
 				   AND (metadata IS NULL
 				    OR (JSON_EXTRACT(metadata, '$.http_code') IS NULL AND JSON_EXTRACT(metadata, '$.error_code') IS NULL)
 				    OR JSON_EXTRACT(metadata, '$.rtt_ms') IS NULL)`,
@@ -540,7 +576,7 @@ func queryTelemetryExplanationGaps(ctx context.Context, conn *sql.DB, window tel
 				  FROM jetmon_event_transitions
 				 WHERE reason = ?
 				   AND changed_at >= ?
-				   AND changed_at <= ?
+				   AND changed_at < ?
 				   AND (metadata IS NULL OR JSON_EXTRACT(metadata, '$.verifier_results') IS NULL)`,
 			args: []any{eventstore.ReasonVerifierConfirmed, window.Since, window.Until},
 		},
@@ -553,7 +589,7 @@ func queryTelemetryExplanationGaps(ctx context.Context, conn *sql.DB, window tel
 				  FROM jetmon_event_transitions
 				 WHERE reason = ?
 				   AND changed_at >= ?
-				   AND changed_at <= ?
+				   AND changed_at < ?
 				   AND (metadata IS NULL
 				    OR JSON_EXTRACT(metadata, '$.verifier_healthy') IS NULL
 				    OR JSON_EXTRACT(metadata, '$.verifier_confirmed') IS NULL)`,
@@ -569,7 +605,7 @@ func queryTelemetryExplanationGaps(ctx context.Context, conn *sql.DB, window tel
 				 WHERE event_type = ?
 				   AND detail = 'veriflier reply'
 				   AND created_at >= ?
-				   AND created_at <= ?
+				   AND created_at < ?
 				   AND (metadata IS NULL OR JSON_EXTRACT(metadata, '$.success') IS NULL)`,
 			args: []any{audit.EventVeriflierSent, window.Since, window.Until},
 		},
@@ -626,6 +662,39 @@ func derivedTelemetryGaps(wpcom telemetryWPCOMReport, verifier telemetryVerifier
 	return gaps
 }
 
+func telemetryReportStatus(gaps []telemetryGap) string {
+	status := "pass"
+	for _, gap := range gaps {
+		if gap.Severity == "red" {
+			return "fail"
+		}
+		if gap.Count > 0 {
+			status = "warn"
+		}
+	}
+	return status
+}
+
+func telemetryReportHighlights(report telemetryReport) []string {
+	var highlights []string
+	if len(report.ExplanationGaps) > 0 {
+		highlights = append(highlights, fmt.Sprintf("%d explanation gap(s) need follow-up before using this report for customer-facing explanations.", len(report.ExplanationGaps)))
+	}
+	if report.WPCOM.AttemptDelta != 0 {
+		highlights = append(highlights, fmt.Sprintf("WPCOM attempt delta is %d after expected suppressions.", report.WPCOM.AttemptDelta))
+	}
+	if report.Verifier.Replies > 0 {
+		highlights = append(highlights, fmt.Sprintf("Verifier agreement is %.1f%% across %d replies.", report.Verifier.ConfirmPercent, report.Verifier.Replies))
+	}
+	if report.Summary.Opened == 0 {
+		highlights = append(highlights, "No events opened in this window; widen --since before drawing production conclusions.")
+	}
+	if len(highlights) == 0 {
+		highlights = append(highlights, "Telemetry looks internally consistent for this window.")
+	}
+	return uniqueStrings(highlights)
+}
+
 func suggestTelemetryNextActions(report telemetryReport) []string {
 	var actions []string
 	for _, gap := range report.ExplanationGaps {
@@ -656,13 +725,26 @@ func renderTelemetryReport(out io.Writer, report telemetryReport, output string)
 		enc.SetIndent("", "  ")
 		return enc.Encode(report)
 	}
-	renderTelemetryReportText(out, report)
-	return nil
+	if output == "text" {
+		renderTelemetryReportText(out, report)
+		return nil
+	}
+	return fmt.Errorf("unsupported telemetry output %q", output)
 }
 
 func renderTelemetryReportText(out io.Writer, report telemetryReport) {
 	fmt.Fprintf(out, "## Production Telemetry Report\n")
-	fmt.Fprintf(out, "INFO generated_at=%s window=%s..%s\n",
+	statusLevel := telemetryReportStatusLevel(report.Status)
+	fmt.Fprintf(out, "%s status=%s explanation_gaps=%d suggested_actions=%d\n",
+		statusLevel,
+		report.Status,
+		len(report.ExplanationGaps),
+		len(report.SuggestedNextActions),
+	)
+	for _, highlight := range report.Highlights {
+		fmt.Fprintf(out, "INFO highlight=%q\n", highlight)
+	}
+	fmt.Fprintf(out, "INFO generated_at=%s window=%s..%s window_end=exclusive\n",
 		report.GeneratedAt.Format(time.RFC3339),
 		report.Window.Since.Format(time.RFC3339),
 		report.Window.Until.Format(time.RFC3339),
@@ -738,6 +820,17 @@ func renderTelemetryReportText(out io.Writer, report telemetryReport) {
 	}
 }
 
+func telemetryReportStatusLevel(status string) string {
+	switch status {
+	case "fail":
+		return "FAIL"
+	case "warn":
+		return "WARN"
+	default:
+		return "PASS"
+	}
+}
+
 func uniqueStrings(values []string) []string {
 	seen := map[string]struct{}{}
 	var out []string
@@ -752,7 +845,6 @@ func uniqueStrings(values []string) []string {
 		seen[value] = struct{}{}
 		out = append(out, value)
 	}
-	sort.Strings(out)
 	return out
 }
 

--- a/cmd/jetmon2/telemetry_report.go
+++ b/cmd/jetmon2/telemetry_report.go
@@ -1,0 +1,764 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Automattic/jetmon/internal/audit"
+	"github.com/Automattic/jetmon/internal/checker"
+	"github.com/Automattic/jetmon/internal/config"
+	"github.com/Automattic/jetmon/internal/db"
+	"github.com/Automattic/jetmon/internal/eventstore"
+)
+
+type telemetryReportOptions struct {
+	Since  string
+	Until  string
+	Output string
+	Limit  int
+}
+
+type telemetryWindow struct {
+	Since time.Time `json:"since"`
+	Until time.Time `json:"until"`
+}
+
+type telemetryReport struct {
+	Command              string                  `json:"command"`
+	GeneratedAt          time.Time               `json:"generated_at"`
+	Window               telemetryWindow         `json:"window"`
+	Summary              telemetrySummary        `json:"summary"`
+	Timings              []telemetryTiming       `json:"timings"`
+	Verifier             telemetryVerifierReport `json:"verifier"`
+	FalseAlarmClasses    []telemetryClassCount   `json:"false_alarm_classes"`
+	WPCOM                telemetryWPCOMReport    `json:"wpcom"`
+	ExplanationGaps      []telemetryGap          `json:"explanation_gaps,omitempty"`
+	SuggestedNextActions []string                `json:"suggested_next_actions,omitempty"`
+}
+
+type telemetrySummary struct {
+	Opened             int64 `json:"opened"`
+	ConfirmedDown      int64 `json:"confirmed_down"`
+	VerifierCleared    int64 `json:"verifier_cleared"`
+	ProbeCleared       int64 `json:"probe_cleared"`
+	VerifierFalseAlarm int64 `json:"verifier_false_alarm"`
+	ManualOverride     int64 `json:"manual_override"`
+	AutoTimeout        int64 `json:"auto_timeout"`
+}
+
+type telemetryTiming struct {
+	Name  string `json:"name"`
+	Count int64  `json:"count"`
+	AvgMS int64  `json:"avg_ms"`
+	MaxMS int64  `json:"max_ms"`
+}
+
+type telemetryVerifierReport struct {
+	Replies        int64                   `json:"replies"`
+	ConfirmDown    int64                   `json:"confirm_down"`
+	Disagree       int64                   `json:"disagree"`
+	MissingOutcome int64                   `json:"missing_outcome"`
+	ConfirmPercent float64                 `json:"confirm_percent"`
+	Hosts          []telemetryVerifierHost `json:"hosts,omitempty"`
+}
+
+type telemetryVerifierHost struct {
+	Host           string  `json:"host"`
+	Replies        int64   `json:"replies"`
+	ConfirmDown    int64   `json:"confirm_down"`
+	Disagree       int64   `json:"disagree"`
+	MissingOutcome int64   `json:"missing_outcome"`
+	ConfirmPercent float64 `json:"confirm_percent"`
+}
+
+type telemetryClassCount struct {
+	Outcome string `json:"outcome"`
+	Class   string `json:"class"`
+	Count   int64  `json:"count"`
+}
+
+type telemetryWPCOMReport struct {
+	ExpectedDownTransitions     int64   `json:"expected_down_transitions"`
+	ExpectedRecoveryTransitions int64   `json:"expected_recovery_transitions"`
+	Attempts                    int64   `json:"attempts"`
+	DownAttempts                int64   `json:"down_attempts"`
+	RecoveryAttempts            int64   `json:"recovery_attempts"`
+	Retries                     int64   `json:"retries"`
+	Suppressed                  int64   `json:"suppressed"`
+	AttemptDelta                int64   `json:"attempt_delta"`
+	RetryRatePercent            float64 `json:"retry_rate_percent"`
+}
+
+type telemetryGap struct {
+	Name     string `json:"name"`
+	Severity string `json:"severity"`
+	Count    int64  `json:"count"`
+	Detail   string `json:"detail"`
+}
+
+func cmdTelemetry(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 telemetry <report> [args]")
+		os.Exit(1)
+	}
+
+	switch args[0] {
+	case "report":
+		cmdTelemetryReport(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown telemetry subcommand %q (want: report)\n", args[0])
+		os.Exit(1)
+	}
+}
+
+func cmdTelemetryReport(args []string) {
+	opts := telemetryReportOptions{
+		Since:  "24h",
+		Output: "text",
+		Limit:  10,
+	}
+	fs := newTelemetryReportFlagSet(&opts, os.Stderr)
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(0)
+		}
+		fmt.Fprintf(os.Stderr, "FAIL parse telemetry report flags: %v\n", err)
+		os.Exit(2)
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 telemetry report [--since=24h] [--until=<RFC3339>] [--output=text|json] [--limit=N]")
+		os.Exit(1)
+	}
+
+	outputFormat, err := normalizeTelemetryOutput(opts.Output)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL %v\n", err)
+		os.Exit(2)
+	}
+	opts.Output = outputFormat
+	if err := validateTelemetryLimit(opts.Limit); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL %v\n", err)
+		os.Exit(2)
+	}
+
+	config.LoadDB()
+	if err := db.ConnectWithRetry(3); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL db connect: %v\n", err)
+		os.Exit(1)
+	}
+
+	report, err := buildTelemetryReport(context.Background(), db.DB(), time.Now().UTC(), opts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL telemetry report: %v\n", err)
+		os.Exit(1)
+	}
+	if err := renderTelemetryReport(os.Stdout, report, opts.Output); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL render telemetry report: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func newTelemetryReportFlagSet(opts *telemetryReportOptions, out io.Writer) *flag.FlagSet {
+	fs := flag.NewFlagSet("telemetry report", flag.ContinueOnError)
+	if out != nil {
+		fs.SetOutput(out)
+	}
+	fs.StringVar(&opts.Since, "since", opts.Since, "report start as duration like 24h or RFC3339 timestamp")
+	fs.StringVar(&opts.Until, "until", opts.Until, "report end as RFC3339 timestamp (default now)")
+	fs.StringVar(&opts.Output, "output", opts.Output, "output format: text or json")
+	fs.IntVar(&opts.Limit, "limit", opts.Limit, "maximum verifier hosts and false-alarm classes to show")
+	fs.Usage = func() {
+		printAPIFlagUsage(fs.Output(), fs)
+	}
+	return fs
+}
+
+func normalizeTelemetryOutput(output string) (string, error) {
+	output = strings.ToLower(strings.TrimSpace(output))
+	if output == "" {
+		output = "text"
+	}
+	if output != "text" && output != "json" {
+		return "", errors.New("--output must be text or json")
+	}
+	return output, nil
+}
+
+func validateTelemetryLimit(limit int) error {
+	if limit <= 0 {
+		return errors.New("--limit must be > 0")
+	}
+	if limit > 100 {
+		return errors.New("--limit must be <= 100")
+	}
+	return nil
+}
+
+func buildTelemetryReport(ctx context.Context, conn *sql.DB, now time.Time, opts telemetryReportOptions) (telemetryReport, error) {
+	if conn == nil {
+		return telemetryReport{}, errors.New("database pool is not initialized")
+	}
+	if err := validateTelemetryLimit(opts.Limit); err != nil {
+		return telemetryReport{}, err
+	}
+	window, err := resolveTelemetryWindow(now, opts.Since, opts.Until)
+	if err != nil {
+		return telemetryReport{}, err
+	}
+
+	reasonCounts, err := queryTelemetryReasonCounts(ctx, conn, window)
+	if err != nil {
+		return telemetryReport{}, err
+	}
+	timings, err := queryTelemetryTimings(ctx, conn, window)
+	if err != nil {
+		return telemetryReport{}, err
+	}
+	verifier, err := queryTelemetryVerifier(ctx, conn, window, opts.Limit)
+	if err != nil {
+		return telemetryReport{}, err
+	}
+	falseAlarmClasses, err := queryTelemetryFalseAlarmClasses(ctx, conn, window, opts.Limit)
+	if err != nil {
+		return telemetryReport{}, err
+	}
+	wpcom, err := queryTelemetryWPCOM(ctx, conn, window, reasonCounts)
+	if err != nil {
+		return telemetryReport{}, err
+	}
+	gaps, err := queryTelemetryExplanationGaps(ctx, conn, window)
+	if err != nil {
+		return telemetryReport{}, err
+	}
+	gaps = append(gaps, derivedTelemetryGaps(wpcom, verifier)...)
+
+	report := telemetryReport{
+		Command:           "telemetry report",
+		GeneratedAt:       now.UTC(),
+		Window:            window,
+		Summary:           telemetrySummaryFromReasons(reasonCounts),
+		Timings:           timings,
+		Verifier:          verifier,
+		FalseAlarmClasses: falseAlarmClasses,
+		WPCOM:             wpcom,
+		ExplanationGaps:   gaps,
+	}
+	report.SuggestedNextActions = suggestTelemetryNextActions(report)
+	return report, nil
+}
+
+func resolveTelemetryWindow(now time.Time, since, until string) (telemetryWindow, error) {
+	now = now.UTC()
+	end := now
+	until = strings.TrimSpace(until)
+	if until != "" {
+		t, err := time.Parse(time.RFC3339, until)
+		if err != nil {
+			return telemetryWindow{}, fmt.Errorf("until %q must be an RFC3339 timestamp", until)
+		}
+		end = t.UTC()
+	}
+
+	start, err := resolveActivityCutoff(end, since)
+	if err != nil {
+		return telemetryWindow{}, err
+	}
+	if !start.Before(end) {
+		return telemetryWindow{}, errors.New("since must be before until")
+	}
+	return telemetryWindow{Since: start, Until: end}, nil
+}
+
+func queryTelemetryReasonCounts(ctx context.Context, conn *sql.DB, window telemetryWindow) (map[string]int64, error) {
+	rows, err := conn.QueryContext(ctx, `
+		SELECT reason, COUNT(*)
+		  FROM jetmon_event_transitions
+		 WHERE changed_at >= ?
+		   AND changed_at <= ?
+		 GROUP BY reason`,
+		window.Since, window.Until,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query transition reason counts: %w", err)
+	}
+	defer rows.Close()
+
+	counts := map[string]int64{}
+	for rows.Next() {
+		var reason string
+		var count int64
+		if err := rows.Scan(&reason, &count); err != nil {
+			return nil, fmt.Errorf("scan transition reason count: %w", err)
+		}
+		counts[reason] = count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate transition reason counts: %w", err)
+	}
+	return counts, nil
+}
+
+func queryTelemetryTimings(ctx context.Context, conn *sql.DB, window telemetryWindow) ([]telemetryTiming, error) {
+	reasons := []struct {
+		reason string
+		name   string
+	}{
+		{eventstore.ReasonVerifierConfirmed, "first_failure_to_down"},
+		{eventstore.ReasonFalseAlarm, "first_failure_to_false_alarm"},
+		{eventstore.ReasonProbeCleared, "first_failure_to_probe_cleared"},
+		{eventstore.ReasonVerifierCleared, "first_failure_to_recovery"},
+	}
+
+	out := make([]telemetryTiming, 0, len(reasons))
+	for _, item := range reasons {
+		var timing telemetryTiming
+		timing.Name = item.name
+		err := conn.QueryRowContext(ctx, `
+			SELECT COUNT(*),
+			       COALESCE(CAST(ROUND(AVG(TIMESTAMPDIFF(MICROSECOND, opened.changed_at, outcome.changed_at) / 1000)) AS SIGNED), 0),
+			       COALESCE(MAX(TIMESTAMPDIFF(MICROSECOND, opened.changed_at, outcome.changed_at) DIV 1000), 0)
+			  FROM jetmon_event_transitions outcome
+			  JOIN jetmon_event_transitions opened
+			    ON opened.event_id = outcome.event_id
+			   AND opened.reason = ?
+			 WHERE outcome.reason = ?
+			   AND outcome.changed_at >= ?
+			   AND outcome.changed_at <= ?`,
+			eventstore.ReasonOpened, item.reason, window.Since, window.Until,
+		).Scan(&timing.Count, &timing.AvgMS, &timing.MaxMS)
+		if err != nil {
+			return nil, fmt.Errorf("query timing %s: %w", item.name, err)
+		}
+		out = append(out, timing)
+	}
+	return out, nil
+}
+
+func queryTelemetryVerifier(ctx context.Context, conn *sql.DB, window telemetryWindow, limit int) (telemetryVerifierReport, error) {
+	summary := telemetryVerifierReport{}
+	err := conn.QueryRowContext(ctx, `
+		SELECT COUNT(*),
+		       COALESCE(SUM(CASE WHEN LOWER(JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.success'))) = 'false' THEN 1 ELSE 0 END), 0),
+		       COALESCE(SUM(CASE WHEN LOWER(JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.success'))) = 'true' THEN 1 ELSE 0 END), 0),
+		       COALESCE(SUM(CASE WHEN JSON_EXTRACT(metadata, '$.success') IS NULL THEN 1 ELSE 0 END), 0)
+		  FROM jetmon_audit_log
+		 WHERE event_type = ?
+		   AND detail = 'veriflier reply'
+		   AND created_at >= ?
+		   AND created_at <= ?`,
+		audit.EventVeriflierSent, window.Since, window.Until,
+	).Scan(&summary.Replies, &summary.ConfirmDown, &summary.Disagree, &summary.MissingOutcome)
+	if err != nil {
+		return telemetryVerifierReport{}, fmt.Errorf("query verifier summary: %w", err)
+	}
+	if summary.Replies > 0 {
+		summary.ConfirmPercent = float64(summary.ConfirmDown) * 100 / float64(summary.Replies)
+	}
+
+	query := fmt.Sprintf(`
+		SELECT source,
+		       COUNT(*),
+		       COALESCE(SUM(CASE WHEN LOWER(JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.success'))) = 'false' THEN 1 ELSE 0 END), 0),
+		       COALESCE(SUM(CASE WHEN LOWER(JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.success'))) = 'true' THEN 1 ELSE 0 END), 0),
+		       COALESCE(SUM(CASE WHEN JSON_EXTRACT(metadata, '$.success') IS NULL THEN 1 ELSE 0 END), 0)
+		  FROM jetmon_audit_log
+		 WHERE event_type = ?
+		   AND detail = 'veriflier reply'
+		   AND created_at >= ?
+		   AND created_at <= ?
+		 GROUP BY source
+		 ORDER BY COUNT(*) DESC, source
+		 LIMIT %d`, limit)
+	rows, err := conn.QueryContext(ctx, query, audit.EventVeriflierSent, window.Since, window.Until)
+	if err != nil {
+		return telemetryVerifierReport{}, fmt.Errorf("query verifier hosts: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var host telemetryVerifierHost
+		if err := rows.Scan(&host.Host, &host.Replies, &host.ConfirmDown, &host.Disagree, &host.MissingOutcome); err != nil {
+			return telemetryVerifierReport{}, fmt.Errorf("scan verifier host: %w", err)
+		}
+		if host.Replies > 0 {
+			host.ConfirmPercent = float64(host.ConfirmDown) * 100 / float64(host.Replies)
+		}
+		summary.Hosts = append(summary.Hosts, host)
+	}
+	if err := rows.Err(); err != nil {
+		return telemetryVerifierReport{}, fmt.Errorf("iterate verifier hosts: %w", err)
+	}
+	return summary, nil
+}
+
+func queryTelemetryFalseAlarmClasses(ctx context.Context, conn *sql.DB, window telemetryWindow, limit int) ([]telemetryClassCount, error) {
+	query := fmt.Sprintf(`
+		SELECT outcome.reason AS outcome,
+		       CASE
+		         WHEN CAST(JSON_UNQUOTE(JSON_EXTRACT(opened.metadata, '$.error_code')) AS SIGNED) IN (%d, %d) THEN 'https'
+		         WHEN CAST(JSON_UNQUOTE(JSON_EXTRACT(opened.metadata, '$.error_code')) AS SIGNED) = %d THEN 'intermittent'
+		         WHEN CAST(JSON_UNQUOTE(JSON_EXTRACT(opened.metadata, '$.error_code')) AS SIGNED) = %d THEN 'redirect'
+		         WHEN CAST(JSON_UNQUOTE(JSON_EXTRACT(opened.metadata, '$.error_code')) AS SIGNED) = %d THEN 'keyword'
+		         WHEN CAST(JSON_UNQUOTE(JSON_EXTRACT(opened.metadata, '$.http_code')) AS SIGNED) >= 500 THEN 'server'
+		         WHEN CAST(JSON_UNQUOTE(JSON_EXTRACT(opened.metadata, '$.http_code')) AS SIGNED) = 403 THEN 'blocked'
+		         WHEN CAST(JSON_UNQUOTE(JSON_EXTRACT(opened.metadata, '$.http_code')) AS SIGNED) >= 400 THEN 'client'
+		         WHEN CAST(JSON_UNQUOTE(JSON_EXTRACT(opened.metadata, '$.error_code')) AS SIGNED) > 0 THEN 'intermittent'
+		         ELSE 'unknown'
+		       END AS class,
+		       COUNT(*) AS count
+		  FROM jetmon_event_transitions outcome
+		  JOIN jetmon_event_transitions opened
+		    ON opened.event_id = outcome.event_id
+		   AND opened.reason = ?
+		 WHERE outcome.reason IN (?, ?)
+		   AND outcome.changed_at >= ?
+		   AND outcome.changed_at <= ?
+		 GROUP BY outcome.reason, class
+		 ORDER BY count DESC, outcome, class
+		 LIMIT %d`,
+		checker.ErrorSSL,
+		checker.ErrorTLSExpired,
+		checker.ErrorTimeout,
+		checker.ErrorRedirect,
+		checker.ErrorKeyword,
+		limit,
+	)
+	rows, err := conn.QueryContext(ctx, query,
+		eventstore.ReasonOpened,
+		eventstore.ReasonFalseAlarm,
+		eventstore.ReasonProbeCleared,
+		window.Since,
+		window.Until,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query false-alarm classes: %w", err)
+	}
+	defer rows.Close()
+
+	var out []telemetryClassCount
+	for rows.Next() {
+		var row telemetryClassCount
+		if err := rows.Scan(&row.Outcome, &row.Class, &row.Count); err != nil {
+			return nil, fmt.Errorf("scan false-alarm class: %w", err)
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate false-alarm classes: %w", err)
+	}
+	return out, nil
+}
+
+func queryTelemetryWPCOM(ctx context.Context, conn *sql.DB, window telemetryWindow, reasonCounts map[string]int64) (telemetryWPCOMReport, error) {
+	report := telemetryWPCOMReport{
+		ExpectedDownTransitions:     reasonCounts[eventstore.ReasonVerifierConfirmed],
+		ExpectedRecoveryTransitions: reasonCounts[eventstore.ReasonVerifierCleared] + reasonCounts[eventstore.ReasonProbeCleared],
+	}
+	err := conn.QueryRowContext(ctx, `
+		SELECT COUNT(*),
+		       COALESCE(SUM(CASE WHEN detail LIKE 'status=2 %' THEN 1 ELSE 0 END), 0),
+		       COALESCE(SUM(CASE WHEN detail LIKE 'status=1 %' THEN 1 ELSE 0 END), 0)
+		  FROM jetmon_audit_log
+		 WHERE event_type = ?
+		   AND created_at >= ?
+		   AND created_at <= ?`,
+		audit.EventWPCOMSent, window.Since, window.Until,
+	).Scan(&report.Attempts, &report.DownAttempts, &report.RecoveryAttempts)
+	if err != nil {
+		return telemetryWPCOMReport{}, fmt.Errorf("query WPCOM attempts: %w", err)
+	}
+
+	err = conn.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		  FROM jetmon_audit_log
+		 WHERE event_type = ?
+		   AND created_at >= ?
+		   AND created_at <= ?`,
+		audit.EventWPCOMRetry, window.Since, window.Until,
+	).Scan(&report.Retries)
+	if err != nil {
+		return telemetryWPCOMReport{}, fmt.Errorf("query WPCOM retries: %w", err)
+	}
+
+	err = conn.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		  FROM jetmon_audit_log
+		 WHERE event_type IN (?, ?)
+		   AND created_at >= ?
+		   AND created_at <= ?`,
+		audit.EventMaintenanceActive, audit.EventAlertSuppressed, window.Since, window.Until,
+	).Scan(&report.Suppressed)
+	if err != nil {
+		return telemetryWPCOMReport{}, fmt.Errorf("query WPCOM suppressions: %w", err)
+	}
+
+	expectedAttempts := report.ExpectedDownTransitions + report.ExpectedRecoveryTransitions
+	report.AttemptDelta = expectedAttempts - report.Attempts - report.Suppressed
+	if report.Attempts > 0 {
+		report.RetryRatePercent = float64(report.Retries) * 100 / float64(report.Attempts)
+	}
+	return report, nil
+}
+
+func queryTelemetryExplanationGaps(ctx context.Context, conn *sql.DB, window telemetryWindow) ([]telemetryGap, error) {
+	gapQueries := []struct {
+		name     string
+		severity string
+		detail   string
+		query    string
+		args     []any
+	}{
+		{
+			name:     "opened_missing_failure_metadata",
+			severity: "amber",
+			detail:   "opened transitions should explain the local failure with http_code or error_code plus rtt_ms",
+			query: `
+				SELECT COUNT(*)
+				  FROM jetmon_event_transitions
+				 WHERE reason = ?
+				   AND changed_at >= ?
+				   AND changed_at <= ?
+				   AND (metadata IS NULL
+				    OR (JSON_EXTRACT(metadata, '$.http_code') IS NULL AND JSON_EXTRACT(metadata, '$.error_code') IS NULL)
+				    OR JSON_EXTRACT(metadata, '$.rtt_ms') IS NULL)`,
+			args: []any{eventstore.ReasonOpened, window.Since, window.Until},
+		},
+		{
+			name:     "confirmed_down_missing_verifier_results",
+			severity: "amber",
+			detail:   "verifier-confirmed transitions should include verifier_results for operator explanations",
+			query: `
+				SELECT COUNT(*)
+				  FROM jetmon_event_transitions
+				 WHERE reason = ?
+				   AND changed_at >= ?
+				   AND changed_at <= ?
+				   AND (metadata IS NULL OR JSON_EXTRACT(metadata, '$.verifier_results') IS NULL)`,
+			args: []any{eventstore.ReasonVerifierConfirmed, window.Since, window.Until},
+		},
+		{
+			name:     "false_alarm_missing_verifier_counts",
+			severity: "amber",
+			detail:   "false-alarm transitions should include verifier healthy/confirmed counts",
+			query: `
+				SELECT COUNT(*)
+				  FROM jetmon_event_transitions
+				 WHERE reason = ?
+				   AND changed_at >= ?
+				   AND changed_at <= ?
+				   AND (metadata IS NULL
+				    OR JSON_EXTRACT(metadata, '$.verifier_healthy') IS NULL
+				    OR JSON_EXTRACT(metadata, '$.verifier_confirmed') IS NULL)`,
+			args: []any{eventstore.ReasonFalseAlarm, window.Since, window.Until},
+		},
+		{
+			name:     "verifier_reply_missing_outcome",
+			severity: "amber",
+			detail:   "verifier reply audit rows should include metadata.success so agreement can be measured",
+			query: `
+				SELECT COUNT(*)
+				  FROM jetmon_audit_log
+				 WHERE event_type = ?
+				   AND detail = 'veriflier reply'
+				   AND created_at >= ?
+				   AND created_at <= ?
+				   AND (metadata IS NULL OR JSON_EXTRACT(metadata, '$.success') IS NULL)`,
+			args: []any{audit.EventVeriflierSent, window.Since, window.Until},
+		},
+	}
+
+	var gaps []telemetryGap
+	for _, gapQuery := range gapQueries {
+		var count int64
+		if err := conn.QueryRowContext(ctx, gapQuery.query, gapQuery.args...).Scan(&count); err != nil {
+			return nil, fmt.Errorf("query telemetry gap %s: %w", gapQuery.name, err)
+		}
+		if count > 0 {
+			gaps = append(gaps, telemetryGap{
+				Name:     gapQuery.name,
+				Severity: gapQuery.severity,
+				Count:    count,
+				Detail:   gapQuery.detail,
+			})
+		}
+	}
+	return gaps, nil
+}
+
+func telemetrySummaryFromReasons(counts map[string]int64) telemetrySummary {
+	return telemetrySummary{
+		Opened:             counts[eventstore.ReasonOpened],
+		ConfirmedDown:      counts[eventstore.ReasonVerifierConfirmed],
+		VerifierCleared:    counts[eventstore.ReasonVerifierCleared],
+		ProbeCleared:       counts[eventstore.ReasonProbeCleared],
+		VerifierFalseAlarm: counts[eventstore.ReasonFalseAlarm],
+		ManualOverride:     counts[eventstore.ReasonManualOverride],
+		AutoTimeout:        counts[eventstore.ReasonAutoTimeout],
+	}
+}
+
+func derivedTelemetryGaps(wpcom telemetryWPCOMReport, verifier telemetryVerifierReport) []telemetryGap {
+	var gaps []telemetryGap
+	if wpcom.AttemptDelta != 0 {
+		gaps = append(gaps, telemetryGap{
+			Name:     "wpcom_attempt_delta",
+			Severity: "amber",
+			Count:    absInt64(wpcom.AttemptDelta),
+			Detail:   "WPCOM attempts differ from down/recovery transitions after maintenance and cooldown suppressions",
+		})
+	}
+	if verifier.Replies == 0 && wpcom.ExpectedDownTransitions > 0 {
+		gaps = append(gaps, telemetryGap{
+			Name:     "no_verifier_replies_for_event_window",
+			Severity: "amber",
+			Count:    wpcom.ExpectedDownTransitions,
+			Detail:   "verifier-confirmed transitions exist but no verifier reply audit rows were recorded in the same window",
+		})
+	}
+	return gaps
+}
+
+func suggestTelemetryNextActions(report telemetryReport) []string {
+	var actions []string
+	for _, gap := range report.ExplanationGaps {
+		switch gap.Name {
+		case "wpcom_attempt_delta":
+			actions = append(actions, "Review WPCOM audit rows against event transitions for the same window; suppressions or missing audit writes may explain the delta.")
+		case "opened_missing_failure_metadata", "confirmed_down_missing_verifier_results", "false_alarm_missing_verifier_counts", "verifier_reply_missing_outcome":
+			actions = append(actions, "Fix telemetry metadata gaps before relying on this report for customer-facing explanations.")
+		case "no_verifier_replies_for_event_window":
+			actions = append(actions, "Check verifier audit logging and verifier configuration; transition outcomes need matching verifier reply context.")
+		}
+	}
+	if report.Summary.Opened == 0 {
+		actions = append(actions, "No events opened in this window; widen --since before drawing production conclusions.")
+	}
+	if report.Verifier.Replies > 0 && report.Verifier.MissingOutcome > 0 {
+		actions = append(actions, "Inspect verifier reply metadata; missing success fields prevent agreement reporting.")
+	}
+	if len(actions) == 0 {
+		actions = append(actions, "Telemetry looks internally consistent for this window; compare rates across longer windows as v2 traffic grows.")
+	}
+	return uniqueStrings(actions)
+}
+
+func renderTelemetryReport(out io.Writer, report telemetryReport, output string) error {
+	if output == "json" {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	}
+	renderTelemetryReportText(out, report)
+	return nil
+}
+
+func renderTelemetryReportText(out io.Writer, report telemetryReport) {
+	fmt.Fprintf(out, "## Production Telemetry Report\n")
+	fmt.Fprintf(out, "INFO generated_at=%s window=%s..%s\n",
+		report.GeneratedAt.Format(time.RFC3339),
+		report.Window.Since.Format(time.RFC3339),
+		report.Window.Until.Format(time.RFC3339),
+	)
+	fmt.Fprintf(out, "INFO events opened=%d confirmed_down=%d verifier_cleared=%d probe_cleared=%d false_alarm=%d manual_override=%d auto_timeout=%d\n",
+		report.Summary.Opened,
+		report.Summary.ConfirmedDown,
+		report.Summary.VerifierCleared,
+		report.Summary.ProbeCleared,
+		report.Summary.VerifierFalseAlarm,
+		report.Summary.ManualOverride,
+		report.Summary.AutoTimeout,
+	)
+
+	fmt.Fprintln(out, "## Detection Timing")
+	for _, timing := range report.Timings {
+		fmt.Fprintf(out, "INFO timing=%s count=%d avg_ms=%d max_ms=%d\n", timing.Name, timing.Count, timing.AvgMS, timing.MaxMS)
+	}
+
+	fmt.Fprintln(out, "## Verifier Agreement")
+	fmt.Fprintf(out, "INFO verifier_replies=%d confirm_down=%d disagree=%d missing_outcome=%d confirm_percent=%.1f\n",
+		report.Verifier.Replies,
+		report.Verifier.ConfirmDown,
+		report.Verifier.Disagree,
+		report.Verifier.MissingOutcome,
+		report.Verifier.ConfirmPercent,
+	)
+	for _, host := range report.Verifier.Hosts {
+		fmt.Fprintf(out, "INFO verifier_host=%q replies=%d confirm_down=%d disagree=%d missing_outcome=%d confirm_percent=%.1f\n",
+			host.Host,
+			host.Replies,
+			host.ConfirmDown,
+			host.Disagree,
+			host.MissingOutcome,
+			host.ConfirmPercent,
+		)
+	}
+
+	fmt.Fprintln(out, "## False Alarm Classes")
+	if len(report.FalseAlarmClasses) == 0 {
+		fmt.Fprintln(out, "INFO false_alarm_classes=none")
+	}
+	for _, row := range report.FalseAlarmClasses {
+		fmt.Fprintf(out, "INFO outcome=%s class=%s count=%d\n", row.Outcome, row.Class, row.Count)
+	}
+
+	fmt.Fprintln(out, "## WPCOM Parity")
+	fmt.Fprintf(out, "INFO expected_down=%d expected_recovery=%d attempts=%d down_attempts=%d recovery_attempts=%d retries=%d suppressed=%d attempt_delta=%d retry_rate=%.1f%%\n",
+		report.WPCOM.ExpectedDownTransitions,
+		report.WPCOM.ExpectedRecoveryTransitions,
+		report.WPCOM.Attempts,
+		report.WPCOM.DownAttempts,
+		report.WPCOM.RecoveryAttempts,
+		report.WPCOM.Retries,
+		report.WPCOM.Suppressed,
+		report.WPCOM.AttemptDelta,
+		report.WPCOM.RetryRatePercent,
+	)
+
+	fmt.Fprintln(out, "## Explanation Gaps")
+	if len(report.ExplanationGaps) == 0 {
+		fmt.Fprintln(out, "PASS explanation_gaps=0")
+	}
+	for _, gap := range report.ExplanationGaps {
+		level := "WARN"
+		if gap.Severity == "red" {
+			level = "FAIL"
+		}
+		fmt.Fprintf(out, "%s gap=%s count=%d detail=%q\n", level, gap.Name, gap.Count, gap.Detail)
+	}
+	for _, action := range report.SuggestedNextActions {
+		fmt.Fprintf(out, "INFO suggested_next_action=%q\n", action)
+	}
+}
+
+func uniqueStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func absInt64(v int64) int64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}

--- a/cmd/jetmon2/telemetry_report.go
+++ b/cmd/jetmon2/telemetry_report.go
@@ -22,6 +22,7 @@ import (
 const (
 	defaultTelemetryQueryTimeout = 30 * time.Second
 	maxTelemetryQueryTimeout     = 5 * time.Minute
+	telemetryWindowEdgeLookback  = time.Minute
 )
 
 type telemetryReportOptions struct {
@@ -37,10 +38,17 @@ type telemetryWindow struct {
 	Until time.Time `json:"until"`
 }
 
+type telemetryWindowEdge struct {
+	LookbackSeconds            int64 `json:"lookback_seconds"`
+	WPCOMEligibleTransitions   int64 `json:"wpcom_eligible_transitions"`
+	VerifierOutcomeTransitions int64 `json:"verifier_outcome_transitions"`
+}
+
 type telemetryReport struct {
 	Command              string                  `json:"command"`
 	GeneratedAt          time.Time               `json:"generated_at"`
 	Window               telemetryWindow         `json:"window"`
+	WindowEdge           telemetryWindowEdge     `json:"window_edge"`
 	TelemetryStatus      string                  `json:"telemetry_status"`
 	Highlights           []string                `json:"highlights,omitempty"`
 	ExplanationGapRows   int64                   `json:"explanation_gap_rows"`
@@ -270,6 +278,10 @@ func buildTelemetryReport(ctx context.Context, conn *sql.DB, now time.Time, opts
 	if err != nil {
 		return telemetryReport{}, err
 	}
+	windowEdge, err := queryTelemetryWindowEdge(ctx, conn, window, telemetryWindowEdgeLookback)
+	if err != nil {
+		return telemetryReport{}, err
+	}
 	gaps, err := queryTelemetryExplanationGaps(ctx, conn, window)
 	if err != nil {
 		return telemetryReport{}, err
@@ -280,6 +292,7 @@ func buildTelemetryReport(ctx context.Context, conn *sql.DB, now time.Time, opts
 		Command:           "telemetry report",
 		GeneratedAt:       now.UTC(),
 		Window:            window,
+		WindowEdge:        windowEdge,
 		Summary:           telemetrySummaryFromReasons(reasonCounts),
 		Timings:           timings,
 		Verifier:          verifier,
@@ -546,6 +559,36 @@ func queryTelemetryWPCOM(ctx context.Context, conn *sql.DB, window telemetryWind
 	return report, nil
 }
 
+func queryTelemetryWindowEdge(ctx context.Context, conn *sql.DB, window telemetryWindow, lookback time.Duration) (telemetryWindowEdge, error) {
+	if lookback <= 0 {
+		lookback = telemetryWindowEdgeLookback
+	}
+	edgeStart := window.Until.Add(-lookback)
+	if edgeStart.Before(window.Since) {
+		edgeStart = window.Since
+	}
+
+	edge := telemetryWindowEdge{LookbackSeconds: int64(window.Until.Sub(edgeStart) / time.Second)}
+	err := conn.QueryRowContext(ctx, `
+		SELECT COALESCE(SUM(CASE WHEN reason IN (?, ?, ?) THEN 1 ELSE 0 END), 0),
+		       COALESCE(SUM(CASE WHEN reason IN (?, ?) THEN 1 ELSE 0 END), 0)
+		  FROM jetmon_event_transitions
+		 WHERE changed_at >= ?
+		   AND changed_at < ?`,
+		eventstore.ReasonVerifierConfirmed,
+		eventstore.ReasonVerifierCleared,
+		eventstore.ReasonProbeCleared,
+		eventstore.ReasonVerifierConfirmed,
+		eventstore.ReasonFalseAlarm,
+		edgeStart,
+		window.Until,
+	).Scan(&edge.WPCOMEligibleTransitions, &edge.VerifierOutcomeTransitions)
+	if err != nil {
+		return telemetryWindowEdge{}, fmt.Errorf("query telemetry window edge: %w", err)
+	}
+	return edge, nil
+}
+
 func queryTelemetryExplanationGaps(ctx context.Context, conn *sql.DB, window telemetryWindow) ([]telemetryGap, error) {
 	gapQueries := []struct {
 		name     string
@@ -689,6 +732,9 @@ func telemetryReportHighlights(report telemetryReport) []string {
 	var highlights []string
 	if report.WPCOM.AttemptDelta != 0 {
 		highlights = append(highlights, fmt.Sprintf("WPCOM attempt delta is %d after expected suppressions.", report.WPCOM.AttemptDelta))
+		if report.WindowEdge.WPCOMEligibleTransitions > 0 {
+			highlights = append(highlights, fmt.Sprintf("%d WPCOM-eligible transition(s) landed in the final %ds of the window; rerun with a later --until before treating the delta as missing telemetry.", report.WindowEdge.WPCOMEligibleTransitions, report.WindowEdge.LookbackSeconds))
+		}
 	}
 	for _, gap := range report.ExplanationGaps {
 		switch gap.Name {
@@ -718,6 +764,9 @@ func suggestTelemetryNextActions(report telemetryReport) []string {
 	for _, gap := range report.ExplanationGaps {
 		switch gap.Name {
 		case "wpcom_attempt_delta":
+			if report.WindowEdge.WPCOMEligibleTransitions > 0 {
+				actions = append(actions, "Rerun the report with a later --until to rule out window-edge WPCOM audit lag before investigating missing notifications.")
+			}
 			actions = append(actions, "Review WPCOM audit rows against event transitions for the same window; suppressions or missing audit writes may explain the delta.")
 		case "opened_missing_failure_metadata", "confirmed_down_missing_verifier_results", "false_alarm_missing_verifier_counts", "verifier_reply_missing_outcome":
 			actions = append(actions, "Fix telemetry metadata gaps before relying on this report for customer-facing explanations.")
@@ -767,6 +816,11 @@ func renderTelemetryReportText(out io.Writer, report telemetryReport) {
 		report.GeneratedAt.Format(time.RFC3339),
 		report.Window.Since.Format(time.RFC3339),
 		report.Window.Until.Format(time.RFC3339),
+	)
+	fmt.Fprintf(out, "INFO window_edge_lookback=%ds wpcom_eligible_transitions=%d verifier_outcome_transitions=%d\n",
+		report.WindowEdge.LookbackSeconds,
+		report.WindowEdge.WPCOMEligibleTransitions,
+		report.WindowEdge.VerifierOutcomeTransitions,
 	)
 	fmt.Fprintf(out, "INFO events opened=%d confirmed_down=%d verifier_cleared=%d probe_cleared=%d false_alarm=%d manual_override=%d auto_timeout=%d\n",
 		report.Summary.Opened,

--- a/cmd/jetmon2/telemetry_report.go
+++ b/cmd/jetmon2/telemetry_report.go
@@ -41,8 +41,9 @@ type telemetryReport struct {
 	Command              string                  `json:"command"`
 	GeneratedAt          time.Time               `json:"generated_at"`
 	Window               telemetryWindow         `json:"window"`
-	Status               string                  `json:"status"`
+	TelemetryStatus      string                  `json:"telemetry_status"`
 	Highlights           []string                `json:"highlights,omitempty"`
+	ExplanationGapRows   int64                   `json:"explanation_gap_rows"`
 	Summary              telemetrySummary        `json:"summary"`
 	Timings              []telemetryTiming       `json:"timings"`
 	Verifier             telemetryVerifierReport `json:"verifier"`
@@ -286,7 +287,8 @@ func buildTelemetryReport(ctx context.Context, conn *sql.DB, now time.Time, opts
 		WPCOM:             wpcom,
 		ExplanationGaps:   gaps,
 	}
-	report.Status = telemetryReportStatus(report.ExplanationGaps)
+	report.TelemetryStatus = telemetryReportStatus(report.ExplanationGaps)
+	report.ExplanationGapRows = telemetryExplanationGapRows(report.ExplanationGaps)
 	report.Highlights = telemetryReportHighlights(report)
 	report.SuggestedNextActions = suggestTelemetryNextActions(report)
 	return report, nil
@@ -675,13 +677,29 @@ func telemetryReportStatus(gaps []telemetryGap) string {
 	return status
 }
 
+func telemetryExplanationGapRows(gaps []telemetryGap) int64 {
+	var total int64
+	for _, gap := range gaps {
+		total += gap.Count
+	}
+	return total
+}
+
 func telemetryReportHighlights(report telemetryReport) []string {
 	var highlights []string
-	if len(report.ExplanationGaps) > 0 {
-		highlights = append(highlights, fmt.Sprintf("%d explanation gap(s) need follow-up before using this report for customer-facing explanations.", len(report.ExplanationGaps)))
-	}
 	if report.WPCOM.AttemptDelta != 0 {
 		highlights = append(highlights, fmt.Sprintf("WPCOM attempt delta is %d after expected suppressions.", report.WPCOM.AttemptDelta))
+	}
+	for _, gap := range report.ExplanationGaps {
+		switch gap.Name {
+		case "no_verifier_replies_for_event_window":
+			highlights = append(highlights, fmt.Sprintf("No verifier reply audit rows were recorded for %d verifier-confirmed transition(s).", gap.Count))
+		case "verifier_reply_missing_outcome":
+			highlights = append(highlights, fmt.Sprintf("Verifier reply outcome is missing for %d audit row(s).", gap.Count))
+		}
+	}
+	if len(report.ExplanationGaps) > 0 {
+		highlights = append(highlights, fmt.Sprintf("%d explanation gap type(s) across %d row(s) need follow-up before using this report for customer-facing explanations.", len(report.ExplanationGaps), report.ExplanationGapRows))
 	}
 	if report.Verifier.Replies > 0 {
 		highlights = append(highlights, fmt.Sprintf("Verifier agreement is %.1f%% across %d replies.", report.Verifier.ConfirmPercent, report.Verifier.Replies))
@@ -734,11 +752,12 @@ func renderTelemetryReport(out io.Writer, report telemetryReport, output string)
 
 func renderTelemetryReportText(out io.Writer, report telemetryReport) {
 	fmt.Fprintf(out, "## Production Telemetry Report\n")
-	statusLevel := telemetryReportStatusLevel(report.Status)
-	fmt.Fprintf(out, "%s status=%s explanation_gaps=%d suggested_actions=%d\n",
+	statusLevel := telemetryReportStatusLevel(report.TelemetryStatus)
+	fmt.Fprintf(out, "%s telemetry_status=%s explanation_gap_types=%d explanation_gap_rows=%d suggested_actions=%d\n",
 		statusLevel,
-		report.Status,
+		report.TelemetryStatus,
 		len(report.ExplanationGaps),
+		report.ExplanationGapRows,
 		len(report.SuggestedNextActions),
 	)
 	for _, highlight := range report.Highlights {

--- a/cmd/jetmon2/telemetry_report_test.go
+++ b/cmd/jetmon2/telemetry_report_test.go
@@ -90,6 +90,7 @@ func TestRenderTelemetryReportText(t *testing.T) {
 			Since: time.Date(2026, 4, 30, 16, 0, 0, 0, time.UTC),
 			Until: time.Date(2026, 4, 30, 18, 0, 0, 0, time.UTC),
 		},
+		WindowEdge:      telemetryWindowEdge{LookbackSeconds: 60},
 		TelemetryStatus: "pass",
 		Highlights:      []string{"Telemetry looks internally consistent for this window."},
 		Summary:         telemetrySummary{Opened: 5, ConfirmedDown: 2, ProbeCleared: 1},
@@ -124,6 +125,7 @@ func TestRenderTelemetryReportText(t *testing.T) {
 		"PASS telemetry_status=pass explanation_gap_types=0 explanation_gap_rows=0",
 		"INFO highlight=\"Telemetry looks internally consistent for this window.\"",
 		"window_end=exclusive",
+		"INFO window_edge_lookback=60s wpcom_eligible_transitions=0 verifier_outcome_transitions=0",
 		"INFO events opened=5 confirmed_down=2",
 		"INFO timing=first_failure_to_down count=2 avg_ms=1500 max_ms=2500",
 		"INFO verifier_replies=6 confirm_down=4 disagree=2",
@@ -143,6 +145,10 @@ func TestRenderTelemetryReportWarnTextSimulation(t *testing.T) {
 		Window: telemetryWindow{
 			Since: time.Date(2026, 4, 30, 16, 0, 0, 0, time.UTC),
 			Until: time.Date(2026, 4, 30, 18, 0, 0, 0, time.UTC),
+		},
+		WindowEdge: telemetryWindowEdge{
+			LookbackSeconds:          60,
+			WPCOMEligibleTransitions: 1,
 		},
 		Summary: telemetrySummary{Opened: 3, ConfirmedDown: 2},
 		Verifier: telemetryVerifierReport{
@@ -175,9 +181,11 @@ func TestRenderTelemetryReportWarnTextSimulation(t *testing.T) {
 	for _, want := range []string{
 		"WARN telemetry_status=warn explanation_gap_types=2 explanation_gap_rows=7",
 		"INFO highlight=\"WPCOM attempt delta is 1 after expected suppressions.\"",
+		"INFO highlight=\"1 WPCOM-eligible transition(s) landed in the final 60s of the window; rerun with a later --until before treating the delta as missing telemetry.\"",
 		"INFO highlight=\"Verifier reply outcome is missing for 6 audit row(s).\"",
 		"WARN gap=wpcom_attempt_delta count=1",
 		"WARN gap=verifier_reply_missing_outcome count=6",
+		"INFO suggested_next_action=\"Rerun the report with a later --until to rule out window-edge WPCOM audit lag before investigating missing notifications.\"",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("warn simulation missing %q:\n%s", want, got)
@@ -219,6 +227,41 @@ func TestRenderTelemetryReportJSON(t *testing.T) {
 	}
 	if err := renderTelemetryReport(&out, report, "yaml"); err == nil {
 		t.Fatal("renderTelemetryReport(yaml) error = nil, want error")
+	}
+}
+
+func TestQueryTelemetryWindowEdgeUsesActualShortWindowLookback(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqlDB.Close()
+
+	window := telemetryWindow{
+		Since: time.Date(2026, 4, 30, 17, 59, 30, 0, time.UTC),
+		Until: time.Date(2026, 4, 30, 18, 0, 0, 0, time.UTC),
+	}
+	mock.ExpectQuery(`(?s)SELECT COALESCE\(SUM\(CASE WHEN reason IN.*changed_at >= \?.*changed_at < \?`).
+		WithArgs(
+			eventstore.ReasonVerifierConfirmed,
+			eventstore.ReasonVerifierCleared,
+			eventstore.ReasonProbeCleared,
+			eventstore.ReasonVerifierConfirmed,
+			eventstore.ReasonFalseAlarm,
+			window.Since,
+			window.Until,
+		).
+		WillReturnRows(sqlmock.NewRows([]string{"wpcom_eligible", "verifier_outcomes"}).AddRow(int64(2), int64(1)))
+
+	edge, err := queryTelemetryWindowEdge(context.Background(), sqlDB, window, telemetryWindowEdgeLookback)
+	if err != nil {
+		t.Fatalf("queryTelemetryWindowEdge() error = %v", err)
+	}
+	if edge.LookbackSeconds != 30 || edge.WPCOMEligibleTransitions != 2 || edge.VerifierOutcomeTransitions != 1 {
+		t.Fatalf("edge = %+v, want 30s actual lookback with counts 2/1", edge)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sql expectations: %v", err)
 	}
 }
 
@@ -308,6 +351,18 @@ func expectTelemetryReportQueries(t *testing.T, mock sqlmock.Sqlmock, start, end
 	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*event_type IN.*created_at >= \?.*created_at < \?`).
 		WithArgs(audit.EventMaintenanceActive, audit.EventAlertSuppressed, start, end).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(1)))
+
+	mock.ExpectQuery(`(?s)SELECT COALESCE\(SUM\(CASE WHEN reason IN.*changed_at >= \?.*changed_at < \?`).
+		WithArgs(
+			eventstore.ReasonVerifierConfirmed,
+			eventstore.ReasonVerifierCleared,
+			eventstore.ReasonProbeCleared,
+			eventstore.ReasonVerifierConfirmed,
+			eventstore.ReasonFalseAlarm,
+			end.Add(-telemetryWindowEdgeLookback),
+			end,
+		).
+		WillReturnRows(sqlmock.NewRows([]string{"wpcom_eligible", "verifier_outcomes"}).AddRow(int64(0), int64(0)))
 
 	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*reason = \?.*changed_at >= \?.*changed_at < \?.*http_code`).
 		WithArgs(eventstore.ReasonOpened, start, end).

--- a/cmd/jetmon2/telemetry_report_test.go
+++ b/cmd/jetmon2/telemetry_report_test.go
@@ -72,6 +72,9 @@ func TestBuildTelemetryReport(t *testing.T) {
 	if len(report.ExplanationGaps) != 0 {
 		t.Fatalf("ExplanationGaps = %+v, want none", report.ExplanationGaps)
 	}
+	if report.Status != "pass" || len(report.Highlights) == 0 {
+		t.Fatalf("Status/Highlights = %q/%+v, want pass with highlights", report.Status, report.Highlights)
+	}
 	if len(report.SuggestedNextActions) == 0 || !strings.Contains(report.SuggestedNextActions[0], "consistent") {
 		t.Fatalf("SuggestedNextActions = %+v, want consistency guidance", report.SuggestedNextActions)
 	}
@@ -87,7 +90,9 @@ func TestRenderTelemetryReportText(t *testing.T) {
 			Since: time.Date(2026, 4, 30, 16, 0, 0, 0, time.UTC),
 			Until: time.Date(2026, 4, 30, 18, 0, 0, 0, time.UTC),
 		},
-		Summary: telemetrySummary{Opened: 5, ConfirmedDown: 2, ProbeCleared: 1},
+		Status:     "pass",
+		Highlights: []string{"Telemetry looks internally consistent for this window."},
+		Summary:    telemetrySummary{Opened: 5, ConfirmedDown: 2, ProbeCleared: 1},
 		Timings: []telemetryTiming{{
 			Name:  "first_failure_to_down",
 			Count: 2,
@@ -116,6 +121,9 @@ func TestRenderTelemetryReportText(t *testing.T) {
 	got := out.String()
 	for _, want := range []string{
 		"## Production Telemetry Report",
+		"PASS status=pass explanation_gaps=0",
+		"INFO highlight=\"Telemetry looks internally consistent for this window.\"",
+		"window_end=exclusive",
 		"INFO events opened=5 confirmed_down=2",
 		"INFO timing=first_failure_to_down count=2 avg_ms=1500 max_ms=2500",
 		"INFO verifier_replies=6 confirm_down=4 disagree=2",
@@ -150,15 +158,18 @@ func TestRenderTelemetryReportJSON(t *testing.T) {
 	if got.Command != "telemetry report" || got.Summary.ConfirmedDown != 2 {
 		t.Fatalf("decoded report = %+v, want telemetry report with confirmed_down=2", got)
 	}
+	if err := renderTelemetryReport(&out, report, "yaml"); err == nil {
+		t.Fatal("renderTelemetryReport(yaml) error = nil, want error")
+	}
 }
 
 func TestTelemetryFlagUsageUsesLongDashes(t *testing.T) {
-	opts := telemetryReportOptions{Since: "24h", Output: "text", Limit: 10}
+	opts := telemetryReportOptions{Since: "24h", Output: "text", Limit: 10, QueryTimeout: 30 * time.Second}
 	var out bytes.Buffer
 	fs := newTelemetryReportFlagSet(&opts, &out)
 	fs.Usage()
 	got := out.String()
-	for _, want := range []string{"--limit", "--output", "--since", "--until"} {
+	for _, want := range []string{"--limit", "--output", "--query-timeout", "--since", "--until"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("usage missing %q:\n%s", want, got)
 		}
@@ -177,6 +188,12 @@ func TestTelemetryValidation(t *testing.T) {
 	}
 	if err := validateTelemetryLimit(101); err == nil {
 		t.Fatal("validateTelemetryLimit(101) error = nil, want error")
+	}
+	if err := validateTelemetryQueryTimeout(-time.Second); err == nil {
+		t.Fatal("validateTelemetryQueryTimeout(-1s) error = nil, want error")
+	}
+	if err := validateTelemetryQueryTimeout(maxTelemetryQueryTimeout + time.Second); err == nil {
+		t.Fatal("validateTelemetryQueryTimeout(too long) error = nil, want error")
 	}
 }
 

--- a/cmd/jetmon2/telemetry_report_test.go
+++ b/cmd/jetmon2/telemetry_report_test.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Automattic/jetmon/internal/audit"
+	"github.com/Automattic/jetmon/internal/eventstore"
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestResolveTelemetryWindow(t *testing.T) {
+	now := time.Date(2026, 4, 30, 18, 0, 0, 0, time.UTC)
+	window, err := resolveTelemetryWindow(now, "2h", "")
+	if err != nil {
+		t.Fatalf("resolveTelemetryWindow() error = %v", err)
+	}
+	if !window.Since.Equal(now.Add(-2*time.Hour)) || !window.Until.Equal(now) {
+		t.Fatalf("window = %+v, want last 2h ending now", window)
+	}
+
+	window, err = resolveTelemetryWindow(now, "2026-04-30T10:00:00Z", "2026-04-30T12:00:00Z")
+	if err != nil {
+		t.Fatalf("resolveTelemetryWindow(RFC3339) error = %v", err)
+	}
+	if got := window.Since.Format(time.RFC3339); got != "2026-04-30T10:00:00Z" {
+		t.Fatalf("Since = %s", got)
+	}
+	if got := window.Until.Format(time.RFC3339); got != "2026-04-30T12:00:00Z" {
+		t.Fatalf("Until = %s", got)
+	}
+
+	if _, err := resolveTelemetryWindow(now, "2026-04-30T12:00:00Z", "2026-04-30T10:00:00Z"); err == nil {
+		t.Fatal("resolveTelemetryWindow(inverted) error = nil, want error")
+	}
+}
+
+func TestBuildTelemetryReport(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqlDB.Close()
+
+	now := time.Date(2026, 4, 30, 18, 0, 0, 0, time.UTC)
+	start := now.Add(-2 * time.Hour)
+	expectTelemetryReportQueries(t, mock, start, now)
+
+	report, err := buildTelemetryReport(context.Background(), sqlDB, now, telemetryReportOptions{Since: "2h", Limit: 5})
+	if err != nil {
+		t.Fatalf("buildTelemetryReport() error = %v", err)
+	}
+	if report.Summary.Opened != 5 || report.Summary.ConfirmedDown != 2 || report.Summary.VerifierFalseAlarm != 1 {
+		t.Fatalf("Summary = %+v, want opened=5 confirmed=2 false_alarm=1", report.Summary)
+	}
+	if len(report.Timings) != 4 || report.Timings[0].Name != "first_failure_to_down" || report.Timings[0].AvgMS != 1500 {
+		t.Fatalf("Timings = %+v, want first timing avg 1500", report.Timings)
+	}
+	if report.Verifier.Replies != 6 || report.Verifier.ConfirmDown != 4 || len(report.Verifier.Hosts) != 2 {
+		t.Fatalf("Verifier = %+v, want replies=6 confirm=4 hosts=2", report.Verifier)
+	}
+	if len(report.FalseAlarmClasses) != 2 || report.FalseAlarmClasses[0].Class != "server" {
+		t.Fatalf("FalseAlarmClasses = %+v, want server first", report.FalseAlarmClasses)
+	}
+	if report.WPCOM.AttemptDelta != 0 || report.WPCOM.Retries != 1 || report.WPCOM.RetryRatePercent == 0 {
+		t.Fatalf("WPCOM = %+v, want retry with no delta", report.WPCOM)
+	}
+	if len(report.ExplanationGaps) != 0 {
+		t.Fatalf("ExplanationGaps = %+v, want none", report.ExplanationGaps)
+	}
+	if len(report.SuggestedNextActions) == 0 || !strings.Contains(report.SuggestedNextActions[0], "consistent") {
+		t.Fatalf("SuggestedNextActions = %+v, want consistency guidance", report.SuggestedNextActions)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sql expectations: %v", err)
+	}
+}
+
+func TestRenderTelemetryReportText(t *testing.T) {
+	report := telemetryReport{
+		GeneratedAt: time.Date(2026, 4, 30, 18, 0, 0, 0, time.UTC),
+		Window: telemetryWindow{
+			Since: time.Date(2026, 4, 30, 16, 0, 0, 0, time.UTC),
+			Until: time.Date(2026, 4, 30, 18, 0, 0, 0, time.UTC),
+		},
+		Summary: telemetrySummary{Opened: 5, ConfirmedDown: 2, ProbeCleared: 1},
+		Timings: []telemetryTiming{{
+			Name:  "first_failure_to_down",
+			Count: 2,
+			AvgMS: 1500,
+			MaxMS: 2500,
+		}},
+		Verifier: telemetryVerifierReport{Replies: 6, ConfirmDown: 4, Disagree: 2, ConfirmPercent: 66.7},
+		FalseAlarmClasses: []telemetryClassCount{{
+			Outcome: eventstore.ReasonFalseAlarm,
+			Class:   "server",
+			Count:   1,
+		}},
+		WPCOM: telemetryWPCOMReport{
+			ExpectedDownTransitions:     2,
+			ExpectedRecoveryTransitions: 1,
+			Attempts:                    3,
+			Retries:                     1,
+			RetryRatePercent:            33.3,
+		},
+		SuggestedNextActions: []string{"Telemetry looks internally consistent for this window."},
+	}
+	var out bytes.Buffer
+	if err := renderTelemetryReport(&out, report, "text"); err != nil {
+		t.Fatalf("renderTelemetryReport() error = %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"## Production Telemetry Report",
+		"INFO events opened=5 confirmed_down=2",
+		"INFO timing=first_failure_to_down count=2 avg_ms=1500 max_ms=2500",
+		"INFO verifier_replies=6 confirm_down=4 disagree=2",
+		"INFO outcome=false_alarm class=server count=1",
+		"INFO expected_down=2 expected_recovery=1 attempts=3",
+		"PASS explanation_gaps=0",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("rendered report missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderTelemetryReportJSON(t *testing.T) {
+	report := telemetryReport{
+		Command:     "telemetry report",
+		GeneratedAt: time.Date(2026, 4, 30, 18, 0, 0, 0, time.UTC),
+		Window: telemetryWindow{
+			Since: time.Date(2026, 4, 30, 16, 0, 0, 0, time.UTC),
+			Until: time.Date(2026, 4, 30, 18, 0, 0, 0, time.UTC),
+		},
+		Summary: telemetrySummary{Opened: 5, ConfirmedDown: 2},
+	}
+	var out bytes.Buffer
+	if err := renderTelemetryReport(&out, report, "json"); err != nil {
+		t.Fatalf("renderTelemetryReport(json) error = %v", err)
+	}
+	var got telemetryReport
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("rendered JSON did not decode: %v\n%s", err, out.String())
+	}
+	if got.Command != "telemetry report" || got.Summary.ConfirmedDown != 2 {
+		t.Fatalf("decoded report = %+v, want telemetry report with confirmed_down=2", got)
+	}
+}
+
+func TestTelemetryFlagUsageUsesLongDashes(t *testing.T) {
+	opts := telemetryReportOptions{Since: "24h", Output: "text", Limit: 10}
+	var out bytes.Buffer
+	fs := newTelemetryReportFlagSet(&opts, &out)
+	fs.Usage()
+	got := out.String()
+	for _, want := range []string{"--limit", "--output", "--since", "--until"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("usage missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "\n  -since") || strings.Contains(got, "\n  -output") {
+		t.Fatalf("usage used single-dash long flags:\n%s", got)
+	}
+}
+
+func TestTelemetryValidation(t *testing.T) {
+	if _, err := normalizeTelemetryOutput("yaml"); err == nil {
+		t.Fatal("normalizeTelemetryOutput(yaml) error = nil, want error")
+	}
+	if err := validateTelemetryLimit(0); err == nil {
+		t.Fatal("validateTelemetryLimit(0) error = nil, want error")
+	}
+	if err := validateTelemetryLimit(101); err == nil {
+		t.Fatal("validateTelemetryLimit(101) error = nil, want error")
+	}
+}
+
+func expectTelemetryReportQueries(t *testing.T, mock sqlmock.Sqlmock, start, end time.Time) {
+	t.Helper()
+	mock.ExpectQuery(`SELECT reason, COUNT`).
+		WithArgs(start, end).
+		WillReturnRows(sqlmock.NewRows([]string{"reason", "count"}).
+			AddRow(eventstore.ReasonOpened, int64(5)).
+			AddRow(eventstore.ReasonVerifierConfirmed, int64(2)).
+			AddRow(eventstore.ReasonVerifierCleared, int64(1)).
+			AddRow(eventstore.ReasonProbeCleared, int64(1)).
+			AddRow(eventstore.ReasonFalseAlarm, int64(1)))
+
+	for _, tc := range []struct {
+		reason string
+		count  int64
+		avg    int64
+		max    int64
+	}{
+		{eventstore.ReasonVerifierConfirmed, 2, 1500, 2500},
+		{eventstore.ReasonFalseAlarm, 1, 800, 800},
+		{eventstore.ReasonProbeCleared, 1, 600, 600},
+		{eventstore.ReasonVerifierCleared, 1, 3000, 3000},
+	} {
+		mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*FROM jetmon_event_transitions outcome.*opened.reason = \?`).
+			WithArgs(eventstore.ReasonOpened, tc.reason, start, end).
+			WillReturnRows(sqlmock.NewRows([]string{"count", "avg", "max"}).AddRow(tc.count, tc.avg, tc.max))
+	}
+
+	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*FROM jetmon_audit_log.*detail = 'veriflier reply'`).
+		WithArgs(audit.EventVeriflierSent, start, end).
+		WillReturnRows(sqlmock.NewRows([]string{"count", "confirm", "disagree", "missing"}).
+			AddRow(int64(6), int64(4), int64(2), int64(0)))
+	mock.ExpectQuery(`(?s)SELECT source,.*GROUP BY source.*LIMIT 5`).
+		WithArgs(audit.EventVeriflierSent, start, end).
+		WillReturnRows(sqlmock.NewRows([]string{"source", "count", "confirm", "disagree", "missing"}).
+			AddRow("verifier-a", int64(4), int64(3), int64(1), int64(0)).
+			AddRow("verifier-b", int64(2), int64(1), int64(1), int64(0)))
+
+	mock.ExpectQuery(`(?s)SELECT outcome.reason AS outcome.*GROUP BY outcome.reason, class.*LIMIT 5`).
+		WithArgs(eventstore.ReasonOpened, eventstore.ReasonFalseAlarm, eventstore.ReasonProbeCleared, start, end).
+		WillReturnRows(sqlmock.NewRows([]string{"outcome", "class", "count"}).
+			AddRow(eventstore.ReasonFalseAlarm, "server", int64(1)).
+			AddRow(eventstore.ReasonProbeCleared, "client", int64(1)))
+
+	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*detail LIKE 'status=2 %'`).
+		WithArgs(audit.EventWPCOMSent, start, end).
+		WillReturnRows(sqlmock.NewRows([]string{"count", "down", "recovery"}).AddRow(int64(3), int64(2), int64(1)))
+	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*event_type = \?`).
+		WithArgs(audit.EventWPCOMRetry, start, end).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(1)))
+	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*event_type IN`).
+		WithArgs(audit.EventMaintenanceActive, audit.EventAlertSuppressed, start, end).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(1)))
+
+	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*reason = \?.*http_code`).
+		WithArgs(eventstore.ReasonOpened, start, end).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(0)))
+	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*reason = \?.*verifier_results`).
+		WithArgs(eventstore.ReasonVerifierConfirmed, start, end).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(0)))
+	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*reason = \?.*verifier_healthy`).
+		WithArgs(eventstore.ReasonFalseAlarm, start, end).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(0)))
+	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*event_type = \?.*\$\.success`).
+		WithArgs(audit.EventVeriflierSent, start, end).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(0)))
+}

--- a/cmd/jetmon2/telemetry_report_test.go
+++ b/cmd/jetmon2/telemetry_report_test.go
@@ -72,8 +72,8 @@ func TestBuildTelemetryReport(t *testing.T) {
 	if len(report.ExplanationGaps) != 0 {
 		t.Fatalf("ExplanationGaps = %+v, want none", report.ExplanationGaps)
 	}
-	if report.Status != "pass" || len(report.Highlights) == 0 {
-		t.Fatalf("Status/Highlights = %q/%+v, want pass with highlights", report.Status, report.Highlights)
+	if report.TelemetryStatus != "pass" || report.ExplanationGapRows != 0 || len(report.Highlights) == 0 {
+		t.Fatalf("TelemetryStatus/GapRows/Highlights = %q/%d/%+v, want pass with no gap rows and highlights", report.TelemetryStatus, report.ExplanationGapRows, report.Highlights)
 	}
 	if len(report.SuggestedNextActions) == 0 || !strings.Contains(report.SuggestedNextActions[0], "consistent") {
 		t.Fatalf("SuggestedNextActions = %+v, want consistency guidance", report.SuggestedNextActions)
@@ -90,9 +90,9 @@ func TestRenderTelemetryReportText(t *testing.T) {
 			Since: time.Date(2026, 4, 30, 16, 0, 0, 0, time.UTC),
 			Until: time.Date(2026, 4, 30, 18, 0, 0, 0, time.UTC),
 		},
-		Status:     "pass",
-		Highlights: []string{"Telemetry looks internally consistent for this window."},
-		Summary:    telemetrySummary{Opened: 5, ConfirmedDown: 2, ProbeCleared: 1},
+		TelemetryStatus: "pass",
+		Highlights:      []string{"Telemetry looks internally consistent for this window."},
+		Summary:         telemetrySummary{Opened: 5, ConfirmedDown: 2, ProbeCleared: 1},
 		Timings: []telemetryTiming{{
 			Name:  "first_failure_to_down",
 			Count: 2,
@@ -121,7 +121,7 @@ func TestRenderTelemetryReportText(t *testing.T) {
 	got := out.String()
 	for _, want := range []string{
 		"## Production Telemetry Report",
-		"PASS status=pass explanation_gaps=0",
+		"PASS telemetry_status=pass explanation_gap_types=0 explanation_gap_rows=0",
 		"INFO highlight=\"Telemetry looks internally consistent for this window.\"",
 		"window_end=exclusive",
 		"INFO events opened=5 confirmed_down=2",
@@ -137,10 +137,59 @@ func TestRenderTelemetryReportText(t *testing.T) {
 	}
 }
 
+func TestRenderTelemetryReportWarnTextSimulation(t *testing.T) {
+	report := telemetryReport{
+		GeneratedAt: time.Date(2026, 4, 30, 18, 0, 0, 0, time.UTC),
+		Window: telemetryWindow{
+			Since: time.Date(2026, 4, 30, 16, 0, 0, 0, time.UTC),
+			Until: time.Date(2026, 4, 30, 18, 0, 0, 0, time.UTC),
+		},
+		Summary: telemetrySummary{Opened: 3, ConfirmedDown: 2},
+		Verifier: telemetryVerifierReport{
+			Replies:        4,
+			ConfirmDown:    3,
+			Disagree:       1,
+			MissingOutcome: 1,
+			ConfirmPercent: 75,
+		},
+		WPCOM: telemetryWPCOMReport{
+			ExpectedDownTransitions: 2,
+			Attempts:                1,
+			AttemptDelta:            1,
+		},
+		ExplanationGaps: []telemetryGap{
+			{Name: "wpcom_attempt_delta", Severity: "amber", Count: 1, Detail: "missing WPCOM attempt"},
+			{Name: "verifier_reply_missing_outcome", Severity: "amber", Count: 6, Detail: "missing verifier outcome"},
+		},
+	}
+	report.TelemetryStatus = telemetryReportStatus(report.ExplanationGaps)
+	report.ExplanationGapRows = telemetryExplanationGapRows(report.ExplanationGaps)
+	report.Highlights = telemetryReportHighlights(report)
+	report.SuggestedNextActions = suggestTelemetryNextActions(report)
+
+	var out bytes.Buffer
+	if err := renderTelemetryReport(&out, report, "text"); err != nil {
+		t.Fatalf("renderTelemetryReport(warn) error = %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"WARN telemetry_status=warn explanation_gap_types=2 explanation_gap_rows=7",
+		"INFO highlight=\"WPCOM attempt delta is 1 after expected suppressions.\"",
+		"INFO highlight=\"Verifier reply outcome is missing for 6 audit row(s).\"",
+		"WARN gap=wpcom_attempt_delta count=1",
+		"WARN gap=verifier_reply_missing_outcome count=6",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("warn simulation missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestRenderTelemetryReportJSON(t *testing.T) {
 	report := telemetryReport{
-		Command:     "telemetry report",
-		GeneratedAt: time.Date(2026, 4, 30, 18, 0, 0, 0, time.UTC),
+		Command:         "telemetry report",
+		GeneratedAt:     time.Date(2026, 4, 30, 18, 0, 0, 0, time.UTC),
+		TelemetryStatus: "pass",
 		Window: telemetryWindow{
 			Since: time.Date(2026, 4, 30, 16, 0, 0, 0, time.UTC),
 			Until: time.Date(2026, 4, 30, 18, 0, 0, 0, time.UTC),
@@ -157,6 +206,16 @@ func TestRenderTelemetryReportJSON(t *testing.T) {
 	}
 	if got.Command != "telemetry report" || got.Summary.ConfirmedDown != 2 {
 		t.Fatalf("decoded report = %+v, want telemetry report with confirmed_down=2", got)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(out.Bytes(), &raw); err != nil {
+		t.Fatalf("rendered JSON did not decode to map: %v", err)
+	}
+	if raw["telemetry_status"] != "pass" {
+		t.Fatalf("telemetry_status JSON field = %#v, want pass", raw["telemetry_status"])
+	}
+	if _, ok := raw["status"]; ok {
+		t.Fatalf("JSON included ambiguous status field: %s", out.String())
 	}
 	if err := renderTelemetryReport(&out, report, "yaml"); err == nil {
 		t.Fatal("renderTelemetryReport(yaml) error = nil, want error")
@@ -199,7 +258,7 @@ func TestTelemetryValidation(t *testing.T) {
 
 func expectTelemetryReportQueries(t *testing.T, mock sqlmock.Sqlmock, start, end time.Time) {
 	t.Helper()
-	mock.ExpectQuery(`SELECT reason, COUNT`).
+	mock.ExpectQuery(`(?s)SELECT reason, COUNT.*changed_at >= \?.*changed_at < \?`).
 		WithArgs(start, end).
 		WillReturnRows(sqlmock.NewRows([]string{"reason", "count"}).
 			AddRow(eventstore.ReasonOpened, int64(5)).
@@ -219,47 +278,47 @@ func expectTelemetryReportQueries(t *testing.T, mock sqlmock.Sqlmock, start, end
 		{eventstore.ReasonProbeCleared, 1, 600, 600},
 		{eventstore.ReasonVerifierCleared, 1, 3000, 3000},
 	} {
-		mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*FROM jetmon_event_transitions outcome.*opened.reason = \?`).
+		mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*FROM jetmon_event_transitions outcome.*opened.reason = \?.*outcome.changed_at >= \?.*outcome.changed_at < \?`).
 			WithArgs(eventstore.ReasonOpened, tc.reason, start, end).
 			WillReturnRows(sqlmock.NewRows([]string{"count", "avg", "max"}).AddRow(tc.count, tc.avg, tc.max))
 	}
 
-	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*FROM jetmon_audit_log.*detail = 'veriflier reply'`).
+	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*FROM jetmon_audit_log.*detail = 'veriflier reply'.*created_at >= \?.*created_at < \?`).
 		WithArgs(audit.EventVeriflierSent, start, end).
 		WillReturnRows(sqlmock.NewRows([]string{"count", "confirm", "disagree", "missing"}).
 			AddRow(int64(6), int64(4), int64(2), int64(0)))
-	mock.ExpectQuery(`(?s)SELECT source,.*GROUP BY source.*LIMIT 5`).
+	mock.ExpectQuery(`(?s)SELECT source,.*created_at >= \?.*created_at < \?.*GROUP BY source.*LIMIT 5`).
 		WithArgs(audit.EventVeriflierSent, start, end).
 		WillReturnRows(sqlmock.NewRows([]string{"source", "count", "confirm", "disagree", "missing"}).
 			AddRow("verifier-a", int64(4), int64(3), int64(1), int64(0)).
 			AddRow("verifier-b", int64(2), int64(1), int64(1), int64(0)))
 
-	mock.ExpectQuery(`(?s)SELECT outcome.reason AS outcome.*GROUP BY outcome.reason, class.*LIMIT 5`).
+	mock.ExpectQuery(`(?s)SELECT outcome.reason AS outcome.*outcome.changed_at >= \?.*outcome.changed_at < \?.*GROUP BY outcome.reason, class.*LIMIT 5`).
 		WithArgs(eventstore.ReasonOpened, eventstore.ReasonFalseAlarm, eventstore.ReasonProbeCleared, start, end).
 		WillReturnRows(sqlmock.NewRows([]string{"outcome", "class", "count"}).
 			AddRow(eventstore.ReasonFalseAlarm, "server", int64(1)).
 			AddRow(eventstore.ReasonProbeCleared, "client", int64(1)))
 
-	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*detail LIKE 'status=2 %'`).
+	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*detail LIKE 'status=2 %'.*created_at >= \?.*created_at < \?`).
 		WithArgs(audit.EventWPCOMSent, start, end).
 		WillReturnRows(sqlmock.NewRows([]string{"count", "down", "recovery"}).AddRow(int64(3), int64(2), int64(1)))
-	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*event_type = \?`).
+	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*event_type = \?.*created_at >= \?.*created_at < \?`).
 		WithArgs(audit.EventWPCOMRetry, start, end).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(1)))
-	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*event_type IN`).
+	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*event_type IN.*created_at >= \?.*created_at < \?`).
 		WithArgs(audit.EventMaintenanceActive, audit.EventAlertSuppressed, start, end).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(1)))
 
-	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*reason = \?.*http_code`).
+	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*reason = \?.*changed_at >= \?.*changed_at < \?.*http_code`).
 		WithArgs(eventstore.ReasonOpened, start, end).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(0)))
-	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*reason = \?.*verifier_results`).
+	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*reason = \?.*changed_at >= \?.*changed_at < \?.*verifier_results`).
 		WithArgs(eventstore.ReasonVerifierConfirmed, start, end).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(0)))
-	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*reason = \?.*verifier_healthy`).
+	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*reason = \?.*changed_at >= \?.*changed_at < \?.*verifier_healthy`).
 		WithArgs(eventstore.ReasonFalseAlarm, start, end).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(0)))
-	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*event_type = \?.*\$\.success`).
+	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*event_type = \?.*created_at >= \?.*created_at < \?.*\$\.success`).
 		WithArgs(audit.EventVeriflierSent, start, end).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(0)))
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -109,7 +109,9 @@ because it is intentionally **not** drop-in with the Jetmon 1 wire format
 - Added `jetmon2 telemetry report`, a read-only production report that
   summarizes event lifecycle counts, detection timing, verifier agreement,
   false-alarm classes, WPCOM parity, and operator explanation gaps from durable
-  event/audit tables.
+  event/audit tables. The report starts with an overall telemetry status and
+  uses bounded, half-open query windows so scheduled runs are safer and easier
+  to compare.
 - `make all` now builds the currently implemented `jetmon2` and
   `veriflier2` binaries without requiring `protoc`; generated Veriflier
   gRPC stubs remain an explicit `make generate` step for the future

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -110,8 +110,9 @@ because it is intentionally **not** drop-in with the Jetmon 1 wire format
   summarizes event lifecycle counts, detection timing, verifier agreement,
   false-alarm classes, WPCOM parity, and operator explanation gaps from durable
   event/audit tables. The report starts with an explicit `telemetry_status`,
-  explanation-gap type/row counts, and bounded, half-open query windows so
-  scheduled runs are safer and easier to compare.
+  explanation-gap type/row counts, window-edge context for WPCOM parity, and
+  bounded, half-open query windows so scheduled runs are safer and easier to
+  compare.
 - `make all` now builds the currently implemented `jetmon2` and
   `veriflier2` binaries without requiring `protoc`; generated Veriflier
   gRPC stubs remain an explicit `make generate` step for the future

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -109,9 +109,9 @@ because it is intentionally **not** drop-in with the Jetmon 1 wire format
 - Added `jetmon2 telemetry report`, a read-only production report that
   summarizes event lifecycle counts, detection timing, verifier agreement,
   false-alarm classes, WPCOM parity, and operator explanation gaps from durable
-  event/audit tables. The report starts with an overall telemetry status and
-  uses bounded, half-open query windows so scheduled runs are safer and easier
-  to compare.
+  event/audit tables. The report starts with an explicit `telemetry_status`,
+  explanation-gap type/row counts, and bounded, half-open query windows so
+  scheduled runs are safer and easier to compare.
 - `make all` now builds the currently implemented `jetmon2` and
   `veriflier2` binaries without requiring `protoc`; generated Veriflier
   gRPC stubs remain an explicit `make generate` step for the future

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -106,6 +106,10 @@ because it is intentionally **not** drop-in with the Jetmon 1 wire format
 - Host and fleet dashboards now publish true process RSS beside Go runtime
   system memory, and `process.rss_mb` again reports operating-system resident
   memory when procfs is available.
+- Added `jetmon2 telemetry report`, a read-only production report that
+  summarizes event lifecycle counts, detection timing, verifier agreement,
+  false-alarm classes, WPCOM parity, and operator explanation gaps from durable
+  event/audit tables.
 - `make all` now builds the currently implemented `jetmon2` and
   `veriflier2` binaries without requiring `protoc`; generated Veriflier
   gRPC stubs remain an explicit `make generate` step for the future

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -381,6 +381,18 @@ Important metric groups include:
 StatsD is the primary metrics transport. Expose Graphite/StatsD data through the
 existing metrics pipeline when external systems need it.
 
+For repeatable production summaries from durable Jetmon tables, use:
+
+```bash
+./jetmon2 telemetry report --since=24h
+./jetmon2 telemetry report --since=2026-04-30T00:00:00Z --until=2026-05-01T00:00:00Z --output=json
+```
+
+The report is read-only. It summarizes event lifecycle counts, first-failure
+timings, verifier agreement, false-alarm classes, WPCOM attempt parity, and
+metadata gaps that would make operator or customer explanations weaker. It
+reports aggregate counts and classes rather than raw payloads or credentials.
+
 Use `LOG_FORMAT=json` for structured logs during investigations.
 
 ## Debugging

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -400,6 +400,9 @@ counts and classes rather than raw payloads or credentials.
 The top line reports `telemetry_status`, `explanation_gap_types`, and
 `explanation_gap_rows`. Treat `warn` or `fail` as a signal that the report found
 missing or inconsistent telemetry, not as a site-availability rollup.
+The `window_edge_lookback` line calls out transition rows at the end of the
+window that can make WPCOM parity look temporarily incomplete; rerun with a
+later `--until` before treating those edge deltas as missing audit data.
 
 Use `LOG_FORMAT=json` for structured logs during investigations.
 

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -397,6 +397,10 @@ verifier agreement, false-alarm classes, WPCOM attempt parity, and metadata gaps
 that would make operator or customer explanations weaker. It reports aggregate
 counts and classes rather than raw payloads or credentials.
 
+The top line reports `telemetry_status`, `explanation_gap_types`, and
+`explanation_gap_rows`. Treat `warn` or `fail` as a signal that the report found
+missing or inconsistent telemetry, not as a site-availability rollup.
+
 Use `LOG_FORMAT=json` for structured logs during investigations.
 
 ## Debugging

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -386,12 +386,16 @@ For repeatable production summaries from durable Jetmon tables, use:
 ```bash
 ./jetmon2 telemetry report --since=24h
 ./jetmon2 telemetry report --since=2026-04-30T00:00:00Z --until=2026-05-01T00:00:00Z --output=json
+./jetmon2 telemetry report --since=6h --query-timeout=45s
 ```
 
-The report is read-only. It summarizes event lifecycle counts, first-failure
-timings, verifier agreement, false-alarm classes, WPCOM attempt parity, and
-metadata gaps that would make operator or customer explanations weaker. It
-reports aggregate counts and classes rather than raw payloads or credentials.
+The report is read-only and runs with a bounded query timeout by default
+(`--query-timeout` is capped at 5 minutes). The time window is half-open
+(`since <= row time < until`) so adjacent scheduled reports do not double-count
+boundary rows. It summarizes event lifecycle counts, first-failure timings,
+verifier agreement, false-alarm classes, WPCOM attempt parity, and metadata gaps
+that would make operator or customer explanations weaker. It reports aggregate
+counts and classes rather than raw payloads or credentials.
 
 Use `LOG_FORMAT=json` for structured logs during investigations.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,7 +26,8 @@ No active candidate branch is queued here right now.
   false-alarm classes, WPCOM parity, and operator explanation gaps in one
   repeatable text/JSON command.
 - [x] Keep the report safe for production use by avoiding payload/credential
-  dumps and reporting only aggregate counts, durations, classes, and gap names.
+  dumps, bounding query runtime, using half-open report windows, and reporting
+  only aggregate counts, durations, classes, and gap names.
 - [ ] Revisit report thresholds and suggested actions after v2 has enough real
   production traffic to show which rates should be considered normal.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,12 +13,22 @@ migration and the operating data needed to make larger architecture decisions.
 ### Candidate follow-up branches
 
 These are scoped branches worth considering after the merged API CLI, rollout
-preflight, deliverer hardening, and API CLI fixture workflow branches:
+preflight, deliverer hardening, API CLI fixture workflow, dashboard, and
+production telemetry branches:
 
-- **`feature/production-telemetry-reports`** - turn existing StatsD and event
-  data into repeatable reports for first-failure timing, verifier agreement,
-  false-alarm classes, WPCOM parity, and operator explanation gaps after v2 has
-  enough traffic.
+No active candidate branch is queued here right now.
+
+### Production Telemetry Reports TODO
+
+- [x] Add `jetmon2 telemetry report` as a read-only production report over
+  existing event, transition, audit, and verifier telemetry tables.
+- [x] Summarize event lifecycle counts, detection timings, verifier agreement,
+  false-alarm classes, WPCOM parity, and operator explanation gaps in one
+  repeatable text/JSON command.
+- [x] Keep the report safe for production use by avoiding payload/credential
+  dumps and reporting only aggregate counts, durations, classes, and gap names.
+- [ ] Revisit report thresholds and suggested actions after v2 has enough real
+  production traffic to show which rates should be considered normal.
 
 ### Projection Drift Tooling TODO
 
@@ -168,6 +178,9 @@ preflight, deliverer hardening, and API CLI fixture workflow branches:
 
 Recently completed candidate branches:
 
+- **`feature/production-telemetry-reports`** - adds `jetmon2 telemetry report`
+  for repeatable production summaries of lifecycle timing, verifier agreement,
+  false-alarm classes, WPCOM parity, and operator explanation gaps.
 - **`feature/fleet-dashboard`** - adds `/fleet` and `/api/fleet` global
   dashboard views for monitor hosts, standalone deliverers, bucket coverage,
   stale heartbeats, delivery backlog, delivery-owner posture, projection drift,
@@ -223,8 +236,9 @@ Recently completed candidate branches:
   notification parity. StatsD now emits the core detection timings, outcome
   counters split by local failure class, and per-Veriflier-host RPC/vote
   counters, plus legacy WPCOM notification attempt/delivered/retry/error/failed
-  counters split by status. Durable report queries should wait until v2 has
-  enough real traffic to prove which questions operators actually need to ask.
+  counters split by status. `jetmon2 telemetry report` now provides the first
+  durable report surface for these questions; tune thresholds and suggested
+  actions after v2 has enough real traffic to prove which rates are normal.
 - **Watch projection drift as a production bug.** While the legacy projection
   is enabled, event mutations, transition rows, and the site-row projection
   must remain transactionally consistent. `jetmon2 rollout projection-drift`

--- a/docs/support-guide.md
+++ b/docs/support-guide.md
@@ -29,6 +29,18 @@ The timeline shows local checks, retry attempts, Veriflier requests and results,
 WPCOM notifications, status transitions, maintenance-window suppression, and
 other operational notes.
 
+For a broader production-window view, use the telemetry report:
+
+```bash
+./jetmon2 telemetry report --since=24h
+```
+
+This summarizes detection timings, Veriflier agreement, false-alarm classes,
+WPCOM attempt parity, and explanation gaps across the selected window. Use it
+to decide whether an incident looks like an isolated site issue, a noisy class
+of local failures, a verifier disagreement pattern, or an instrumentation gap
+that needs engineering follow-up.
+
 ## Explain The Incident State
 
 Jetmon 2 separates detection from confirmation:

--- a/docs/support-guide.md
+++ b/docs/support-guide.md
@@ -39,8 +39,8 @@ This summarizes detection timings, Veriflier agreement, false-alarm classes,
 WPCOM attempt parity, and explanation gaps across the selected window. Use it
 to decide whether an incident looks like an isolated site issue, a noisy class
 of local failures, a verifier disagreement pattern, or an instrumentation gap
-that needs engineering follow-up. The first lines show an overall `pass`,
-`warn`, or `fail` status for the telemetry itself before the detailed timing and
+that needs engineering follow-up. The first lines show an overall
+`telemetry_status` of `pass`, `warn`, or `fail` before the detailed timing and
 parity sections.
 
 ## Explain The Incident State

--- a/docs/support-guide.md
+++ b/docs/support-guide.md
@@ -39,7 +39,9 @@ This summarizes detection timings, Veriflier agreement, false-alarm classes,
 WPCOM attempt parity, and explanation gaps across the selected window. Use it
 to decide whether an incident looks like an isolated site issue, a noisy class
 of local failures, a verifier disagreement pattern, or an instrumentation gap
-that needs engineering follow-up.
+that needs engineering follow-up. The first lines show an overall `pass`,
+`warn`, or `fail` status for the telemetry itself before the detailed timing and
+parity sections.
 
 ## Explain The Incident State
 

--- a/docs/support-guide.md
+++ b/docs/support-guide.md
@@ -41,7 +41,9 @@ to decide whether an incident looks like an isolated site issue, a noisy class
 of local failures, a verifier disagreement pattern, or an instrumentation gap
 that needs engineering follow-up. The first lines show an overall
 `telemetry_status` of `pass`, `warn`, or `fail` before the detailed timing and
-parity sections.
+parity sections. If the report highlights window-edge WPCOM transitions, rerun
+with a later `--until` before treating the parity delta as a missing
+notification.
 
 ## Explain The Incident State
 


### PR DESCRIPTION
## Summary

Adds `jetmon2 telemetry report`, a read-only production reporting command over durable `jetmon_event_transitions` and `jetmon_audit_log` data. The report gives operators a repeatable way to inspect event lifecycle counts, first-failure timing, verifier agreement, false-alarm classes, WPCOM notification parity, and telemetry explanation gaps without writing to production tables or dumping raw payloads.

## Why

The dashboard is useful for current state, but rollout and production review need a durable report that answers questions like:

- How long did it take from first local failure to verifier-confirmed down?
- Are verifiers agreeing, disagreeing, or missing outcome metadata?
- Which local failure classes are turning into false alarms?
- Do WPCOM notification attempts line up with down/recovery transitions after expected suppressions?
- Are there telemetry gaps that would make HE/customer explanations weaker?

## Example

```text
$ ./bin/jetmon2 telemetry report --since=24h
## Production Telemetry Report
PASS telemetry_status=pass explanation_gap_types=0 explanation_gap_rows=0 suggested_actions=1
INFO highlight="Telemetry looks internally consistent for this window."
INFO generated_at=2026-04-30T18:00:00Z window=2026-04-29T18:00:00Z..2026-04-30T18:00:00Z window_end=exclusive
INFO window_edge_lookback=60s wpcom_eligible_transitions=0 verifier_outcome_transitions=0
INFO events opened=5 confirmed_down=2 verifier_cleared=1 probe_cleared=1 false_alarm=1 manual_override=0 auto_timeout=0
## Detection Timing
INFO timing=first_failure_to_down count=2 avg_ms=1500 max_ms=2500
INFO timing=first_failure_to_false_alarm count=1 avg_ms=800 max_ms=800
## Verifier Agreement
INFO verifier_replies=6 confirm_down=4 disagree=2 missing_outcome=0 confirm_percent=66.7
## WPCOM Parity
INFO expected_down=2 expected_recovery=1 attempts=3 down_attempts=2 recovery_attempts=1 retries=1 suppressed=1 attempt_delta=0 retry_rate=33.3%
## Explanation Gaps
PASS explanation_gaps=0
INFO suggested_next_action="Telemetry looks internally consistent for this window; compare rates across longer windows as v2 traffic grows."
```

JSON output is also available for automation:

```bash
./bin/jetmon2 telemetry report --since=2026-04-30T00:00:00Z --until=2026-05-01T00:00:00Z --output=json
```

## Safety and operator guardrails

- The command is read-only and only uses aggregate counts, classes, durations, gap names, and bounded host/class lists.
- Query execution is bounded by `--query-timeout` with a 30s default and 5m cap.
- Report windows are half-open (`since <= row time < until`) so adjacent scheduled runs do not double-count boundary rows.
- `telemetry_status` is explicitly about report/telemetry quality, not site or fleet availability.
- Window-edge context warns operators when WPCOM parity deltas may be caused by events landing at the end of the report window before matching audit rows arrive.

## Docs

Updates the operations guide, support guide, changelog, and roadmap with usage examples, safety notes, and the remaining follow-up to tune thresholds after real production traffic is available.

## Validation

- `go test ./cmd/jetmon2 -run 'TestTelemetry|TestBuildTelemetry|TestRenderTelemetry|TestResolveTelemetry|TestQueryTelemetryWindowEdge' -v`
- `go test ./...`
- `go vet ./...`
- `make all`
- `./bin/jetmon2 telemetry report --help`
