### PR TITLE
Harden rollout VM lab startup

### DIFF
--- a/docs/rollout-vm-lab.md
+++ b/docs/rollout-vm-lab.md
@@ -50,6 +50,7 @@ Create the baseline topology:
 
 ```bash
 scripts/rollout-vm-lab.sh create-topology
+scripts/rollout-vm-lab.sh start-topology
 scripts/rollout-vm-lab.sh wait-ssh db
 scripts/rollout-vm-lab.sh wait-ssh v1
 scripts/rollout-vm-lab.sh wait-ssh v2
@@ -90,7 +91,7 @@ files. It:
 - runs `rollout host-preflight` and a guided fresh-server dry-run from the v2 VM
 
 From the local workstation, the Makefile wraps artifact sync, v2 VM artifact
-staging, and remote execution:
+staging, VM startup, and remote execution:
 
 ```bash
 make rollout-vm-lab-doctor
@@ -152,6 +153,7 @@ scripts/rollout-vm-lab.sh ssh db 'sudo systemctl status mariadb --no-pager'
 Run only the v2-side rollout smoke checks:
 
 ```bash
+scripts/rollout-vm-lab.sh start-topology
 scripts/rollout-vm-lab.sh smoke-preflight
 scripts/rollout-vm-lab.sh smoke-guided-dry-run
 ```
@@ -216,7 +218,9 @@ Supported snapshot flow names are `execute-rollback`, `interrupted-resume`,
 iterating on guided behavior because each run starts from the same VM, DB,
 service, and log state. After each revert, the runner stages the current local
 `jetmon2` artifact into the v2 guest so snapshot-backed flows do not silently
-test an old binary. At the end, the runner reverts to the snapshot and enforces
+test an old binary. The staging step starts shut-off lab VMs before waiting for
+SSH, so `make rollout-vm-lab-snapshot-all-smoke` can be run directly after an
+offline snapshot. At the end, the runner reverts to the snapshot and enforces
 the safe lab state: v1 simulator active, v2 `jetmon2` stopped and disabled.
 `snapshot-run-all` replays every named flow from the same snapshot.
 

--- a/docs/rollout-vm-lab.md
+++ b/docs/rollout-vm-lab.md
@@ -67,6 +67,11 @@ This creates:
 The guests use cloud-init to create a `jetmon` user with passwordless sudo and
 the dedicated lab SSH key. The DB guest also installs MariaDB, listens on the
 libvirt network, creates `jetmon_db`, and grants `jetmon` / `jetmon`.
+`start-topology` only starts the three lab domains derived from
+`JETMON_ROLLOUT_PREFIX`: `<prefix>-db`, `<prefix>-v1`, and `<prefix>-v2`. It
+starts guests that are shut off or crashed, treats already-running guests as OK,
+and refuses ambiguous states such as paused or suspended so an operator can
+inspect libvirt before continuing.
 
 ## Prepare The Rollout Lab
 
@@ -91,7 +96,7 @@ files. It:
 - runs `rollout host-preflight` and a guided fresh-server dry-run from the v2 VM
 
 From the local workstation, the Makefile wraps artifact sync, v2 VM artifact
-staging, VM startup, and remote execution:
+staging, VM startup for the three lab domains, and remote execution:
 
 ```bash
 make rollout-vm-lab-doctor

--- a/docs/rollout-vm-lab.md
+++ b/docs/rollout-vm-lab.md
@@ -69,9 +69,10 @@ the dedicated lab SSH key. The DB guest also installs MariaDB, listens on the
 libvirt network, creates `jetmon_db`, and grants `jetmon` / `jetmon`.
 `start-topology` only starts the three lab domains derived from
 `JETMON_ROLLOUT_PREFIX`: `<prefix>-db`, `<prefix>-v1`, and `<prefix>-v2`. It
-starts guests that are shut off or crashed, treats already-running guests as OK,
-and refuses ambiguous states such as paused or suspended so an operator can
-inspect libvirt before continuing.
+starts guests that are cleanly shut off, treats already-running guests as OK,
+and refuses unexpected states such as crashed, paused, or suspended so an
+operator can inspect libvirt before continuing. If the prefix does not match
+the complete db/v1/v2 lab topology, the command fails before starting anything.
 
 ## Prepare The Rollout Lab
 

--- a/scripts/rollout-vm-lab.sh
+++ b/scripts/rollout-vm-lab.sh
@@ -36,6 +36,7 @@ Commands:
   fetch-image                    Download the configured Ubuntu cloud image.
   create <role> [name]           Create one VM. Roles: db, v1, v2, generic.
   create-topology                Create db, v1, and v2 lab VMs.
+  start-topology                 Start db, v1, and v2 lab VMs if needed.
   seed-db                        Seed v1-compatible site data into the DB VM.
   install-v1-sim                 Install/start the v1 simulator service.
   install-v2                     Stage jetmon2, config, and systemd unit on v2.
@@ -310,6 +311,25 @@ create_topology() {
 	create_vm db db
 	create_vm v1 v1
 	create_vm v2 v2
+}
+
+start_vm() {
+	local vm="$1"
+	local state
+	virsh_cmd dominfo "$vm" >/dev/null
+	state="$(virsh_cmd domstate "$vm" 2>/dev/null || true)"
+	if [[ "$state" == "running" ]]; then
+		pass "vm_running=$vm"
+		return 0
+	fi
+	virsh_cmd start "$vm" >/dev/null
+	pass "vm_started=$vm"
+}
+
+start_topology() {
+	start_vm "$(vm_name db)"
+	start_vm "$(vm_name v1)"
+	start_vm "$(vm_name v2)"
 }
 
 vm_ip() {
@@ -587,6 +607,7 @@ install_v2() {
 	[[ -x "$JETMON2_BINARY" ]] || fail "missing executable jetmon2 binary: $JETMON2_BINARY"
 	[[ -f "$JETMON2_SERVICE" ]] || fail "missing systemd unit: $JETMON2_SERVICE"
 	[[ -f "$JETMON2_LOGROTATE" ]] || fail "missing logrotate file: $JETMON2_LOGROTATE"
+	start_topology
 	wait_ssh "$v2_vm"
 	wait_ssh "$v1_vm"
 	wait_ssh "$db_vm"
@@ -1432,6 +1453,7 @@ main() {
 		create_vm "$@"
 		;;
 	create-topology) create_topology "$@" ;;
+	start-topology) start_topology "$@" ;;
 	seed-db) seed_db "$@" ;;
 	install-v1-sim) install_v1_sim "$@" ;;
 	install-v2) install_v2 "$@" ;;

--- a/scripts/rollout-vm-lab.sh
+++ b/scripts/rollout-vm-lab.sh
@@ -318,15 +318,25 @@ start_vm() {
 	local state
 	virsh_cmd dominfo "$vm" >/dev/null
 	state="$(virsh_cmd domstate "$vm" 2>/dev/null || true)"
-	if [[ "$state" == "running" ]]; then
-		pass "vm_running=$vm"
-		return 0
-	fi
-	virsh_cmd start "$vm" >/dev/null
-	pass "vm_started=$vm"
+	case "$state" in
+	running | blocked)
+		pass "vm_running=$vm state=\"$state\""
+		;;
+	"shut off" | crashed)
+		virsh_cmd start "$vm" >/dev/null
+		pass "vm_started=$vm previous_state=\"$state\""
+		;;
+	"")
+		fail "could not determine VM state: $vm"
+		;;
+	*)
+		fail "VM is not in a safe auto-start state: $vm state=\"$state\""
+		;;
+	esac
 }
 
 start_topology() {
+	log "start_topology prefix=$PREFIX vms=$(vm_name db),$(vm_name v1),$(vm_name v2)"
 	start_vm "$(vm_name db)"
 	start_vm "$(vm_name v1)"
 	start_vm "$(vm_name v2)"

--- a/scripts/rollout-vm-lab.sh
+++ b/scripts/rollout-vm-lab.sh
@@ -313,16 +313,38 @@ create_topology() {
 	create_vm v2 v2
 }
 
+require_vm_domain() {
+	local vm="$1"
+	if ! virsh_cmd dominfo "$vm" >/dev/null 2>&1; then
+		fail "missing VM domain: $vm; run create-topology first or check JETMON_ROLLOUT_PREFIX=$PREFIX"
+	fi
+}
+
+topology_vms() {
+	printf '%s\n' "$(vm_name db)" "$(vm_name v1)" "$(vm_name v2)"
+}
+
+require_topology_domains() {
+	local vm missing=0
+	while IFS= read -r vm; do
+		if ! virsh_cmd dominfo "$vm" >/dev/null 2>&1; then
+			warn "missing_vm_domain=$vm"
+			missing=1
+		fi
+	done < <(topology_vms)
+	[[ "$missing" == "0" ]] || fail "topology is incomplete; run create-topology first or check JETMON_ROLLOUT_PREFIX=$PREFIX"
+}
+
 start_vm() {
 	local vm="$1"
 	local state
-	virsh_cmd dominfo "$vm" >/dev/null
+	require_vm_domain "$vm"
 	state="$(virsh_cmd domstate "$vm" 2>/dev/null || true)"
 	case "$state" in
 	running | blocked)
 		pass "vm_running=$vm state=\"$state\""
 		;;
-	"shut off" | crashed)
+	"shut off")
 		virsh_cmd start "$vm" >/dev/null
 		pass "vm_started=$vm previous_state=\"$state\""
 		;;
@@ -337,9 +359,10 @@ start_vm() {
 
 start_topology() {
 	log "start_topology prefix=$PREFIX vms=$(vm_name db),$(vm_name v1),$(vm_name v2)"
-	start_vm "$(vm_name db)"
-	start_vm "$(vm_name v1)"
-	start_vm "$(vm_name v2)"
+	require_topology_domains
+	while IFS= read -r vm; do
+		start_vm "$vm"
+	done < <(topology_vms)
 }
 
 vm_ip() {


### PR DESCRIPTION
## Summary

This hardens the rollout VM lab so snapshot-backed rehearsal targets can start from an offline lab topology without hanging in the staging step.

The lab harness now adds `start-topology` and calls it from `install-v2`, so the db/v1/v2 lab guests are started before SSH waits and artifact staging begin. The helper is intentionally narrow: it only touches the three prefix-derived lab domains, validates that the complete db/v1/v2 topology exists before starting anything, auto-starts only cleanly `shut off` VMs, and refuses unexpected states such as `crashed`, `paused`, or `suspended` for operator inspection.

The VM lab docs were updated to make that behavior explicit near the setup instructions and snapshot-backed flow notes.

## Why

During rollout readiness rehearsal, `make rollout-vm-lab-snapshot-all-smoke` assumed the VMs were already running before staging v2. When the baseline snapshots left domains shut off, the target could sit quietly waiting for SSH. This change makes the rehearsal target self-contained while keeping VM lifecycle automation tightly scoped and easy to audit.

## Example output

Powered-off lab topology now starts explicitly before staging:

```text
INFO start_topology prefix=jetmon-rollout vms=jetmon-rollout-db,jetmon-rollout-v1,jetmon-rollout-v2
PASS vm_started=jetmon-rollout-db previous_state="shut off"
PASS vm_started=jetmon-rollout-v1 previous_state="shut off"
PASS vm_started=jetmon-rollout-v2 previous_state="shut off"
```

Wrong prefix or missing topology fails before any start attempts:

```text
INFO start_topology prefix=jetmon-missing vms=jetmon-missing-db,jetmon-missing-v1,jetmon-missing-v2
WARN missing_vm_domain=jetmon-missing-db
WARN missing_vm_domain=jetmon-missing-v1
WARN missing_vm_domain=jetmon-missing-v2
FAIL topology is incomplete; run create-topology first or check JETMON_ROLLOUT_PREFIX=jetmon-missing
```

Unsafe libvirt states are refused for inspection:

```text
FAIL VM is not in a safe auto-start state: jetmon-rollout-v2 state="paused"
```

## Validation

- `bash -n scripts/rollout-vm-lab.sh`
- `git diff --check`
- `make rollout-vm-lab-stage-v2` from a powered-off topology
- bad-prefix `start-topology` simulation
- paused-VM `start-topology` simulation
- `make rollout-vm-lab-snapshot-execute-smoke`
- `make rollout-docs-verify`