### PR TITLE
Improve Jetmon v2 capacity scaling and scheduler efficiency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,6 +238,7 @@ Sites are stored in `jetpack_monitor_sites` with bucket-based sharding. The `buc
 | Column | Type | Purpose |
 |--------|------|---------|
 | `ssl_expiry_date` | DATE NULL | Updated each HTTPS check |
+| `next_check_at` | DATETIME NULL | Materialized variable-interval due time maintained after each check |
 | `check_keyword` | VARCHAR(500) NULL | String to verify in response body |
 | `maintenance_start` | DATETIME NULL | Maintenance window start |
 | `maintenance_end` | DATETIME NULL | Maintenance window end |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,7 @@ Copy `config/config-sample.json` to `config/config.json`. All keys from the orig
 - `ALERT_COOLDOWN_MINUTES`: Default cooldown between repeated alerts for the same site
 - `LEGACY_STATUS_PROJECTION_ENABLE`: Keep v1 `site_status` / `last_status_change` projection updated during shadow-v2-state migration
 - `LOG_FORMAT`: `text` (default, drop-in compatible) or `json` (structured logging)
-- `USE_VARIABLE_CHECK_INTERVALS`: Respect per-site `check_interval`; the scheduler uses a short idle poll and the SQL due predicate controls which sites are ready
+- `USE_VARIABLE_CHECK_INTERVALS`: Respect per-site `check_interval`; the scheduler uses a short idle poll and maintained `next_check_at` timestamps control which sites are ready
 - `DASHBOARD_PORT`: Internal port for the operator dashboard (0 to disable)
 - `DEBUG_PORT`: localhost-only pprof port, default 6060 (0 to disable; never exposed remotely)
 
@@ -238,6 +238,7 @@ Sites are stored in `jetpack_monitor_sites` with bucket-based sharding. The `buc
 | Column | Type | Purpose |
 |--------|------|---------|
 | `ssl_expiry_date` | DATE NULL | Updated each HTTPS check |
+| `next_check_at` | DATETIME NULL | Maintained due timestamp for variable-interval scheduling |
 | `check_keyword` | VARCHAR(500) NULL | String to verify in response body |
 | `maintenance_start` | DATETIME NULL | Maintenance window start |
 | `maintenance_end` | DATETIME NULL | Maintenance window end |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,7 @@ These interfaces must remain identical to the original Jetmon. Do not change the
 - Per-site custom headers merged from `custom_headers` JSON column
 
 **Timing Breakdown (via `net/http/httptrace`):**
-Every check records: DNS lookup, TCP connect, TLS handshake, request sent, first response byte (TTFB). All six timings are stored in the audit log and emitted as StatsD metrics. The composite RTT is retained for backwards compatibility.
+Every check records composite RTT plus DNS lookup, TCP connect, TLS handshake, and first response byte (TTFB) timings. These samples are stored in `jetmon_check_history` for trending and API statistics. Scheduler-level StatsD metrics expose phase timing and write volume so capacity tests can separate check execution, freshness writes, check-history inserts, SSL expiry updates, and event handling.
 
 **SSL Monitoring:**
 Every HTTPS check inspects `tls.ConnectionState` for:

--- a/config/config.readme
+++ b/config/config.readme
@@ -92,8 +92,11 @@ USE_VARIABLE_CHECK_INTERVALS
 Set to true to respect the check_interval column per site instead of running
 all sites every fixed-cadence pass. Recommended for production freshness
 testing because newly due sites are discovered without waiting for
-MIN_TIME_BETWEEN_ROUNDS_SEC. Default in the sample config: true. Minimal configs
-that omit the key retain the compatibility default of false.
+MIN_TIME_BETWEEN_ROUNDS_SEC. Jetmon maintains next_check_at after each completed
+check so due-site selection can use an indexed timestamp range instead of
+recomputing each row's interval on every poll. Default in the sample config:
+true. Minimal configs that omit the key retain the compatibility default of
+false.
 
 LOG_FORMAT
 Log output format. Set to "json" for structured logging (e.g. for log aggregators), or "text" for human-readable output. Default: "text".

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,3 +49,4 @@ accepted architecture decisions.
 | Document | Purpose |
 |---|---|
 | [`jetmon-v2-capacity-1000-report.md`](jetmon-v2-capacity-1000-report.md) | Capacity-benchmark report comparing the latest successful 1,000-site Jetmon v2 run with the previous failed 1,000-site run. |
+| [`jetmon-v2-scalability-test-plan.md`](jetmon-v2-scalability-test-plan.md) | Repeatable checklist for validating scheduler and check-path efficiency changes at 1k, 5k, and 10k site counts. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -218,10 +218,9 @@ orchestrator.Run()
           │     ├─ collect results (deadline-bounded)
           │     │
           │     ├─ processResults()
-          │     │     ├─ dbMarkSiteChecked()
-          │     │     ├─ dbRecordCheckHistory()
-          │     │     ├─ dbUpdateSSLExpiry() + checkSSLAlerts()
-          │     │     ├─ auditLog(EventCheck)
+          │     │     ├─ dbMarkSitesChecked()       // last_checked_at + next_check_at
+          │     │     ├─ dbRecordCheckHistories()   // RTT + DNS/TCP/TLS/TTFB samples
+          │     │     ├─ dbUpdateSSLExpiries() + checkSSLAlerts()
           │     │     └─ handleRecovery() or handleFailure()
           │     │
           │     ├─ emit StatsD metrics

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,7 +98,7 @@ This is the end-to-end path from database query to WPCOM notification.
 │    dbHeartbeat()          ── UPDATE jetmon_hosts SET last_heartbeat  │
 │    ClaimBuckets()         ── rebalance bucket ranges (each round)    │
 │    dbGetSitesForBucket()  ── SELECT sites WHERE bucket IN [min,max]  │
-│                              ORDER BY last_checked_at ASC            │
+│                              ORDER BY next_check_at / last_checked_at │
 └──────────────────────────────────────────────────────────────────────┘
                   │  []db.Site
                   ▼
@@ -396,7 +396,8 @@ Database Tables
     monitor_url           URL to check
     site_status           Legacy v1 projection; derived from v2 events
     last_status_change    Legacy v1 projection; derived from v2 transitions
-    last_checked_at       Used to order fetch by least-recently-checked
+    last_checked_at       Freshness timestamp written after every check
+    next_check_at         Materialized variable-interval due time
     ssl_expiry_date       Updated after each TLS handshake
     check_keyword         Optional body text to require
     maintenance_start/end Suppress alerts during scheduled maintenance

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,8 +97,8 @@ This is the end-to-end path from database query to WPCOM notification.
 │  orchestrator.runRound()                                             │
 │    dbHeartbeat()          ── UPDATE jetmon_hosts SET last_heartbeat  │
 │    ClaimBuckets()         ── rebalance bucket ranges (each round)    │
-│    dbGetSitesForBucket()  ── SELECT sites WHERE bucket IN [min,max]  │
-│                              ORDER BY last_checked_at ASC            │
+│    dbGetSitesForBucket()  ── SELECT due sites in DATASET_SIZE pages  │
+│                              ORDER BY next_check_at or last_checked_at│
 └──────────────────────────────────────────────────────────────────────┘
                   │  []db.Site
                   ▼
@@ -396,7 +396,8 @@ Database Tables
     monitor_url           URL to check
     site_status           Legacy v1 projection; derived from v2 events
     last_status_change    Legacy v1 projection; derived from v2 transitions
-    last_checked_at       Used to order fetch by least-recently-checked
+    last_checked_at       Last completed local check timestamp
+    next_check_at         Maintained due timestamp for variable-interval checks
     ssl_expiry_date       Updated after each TLS handshake
     check_keyword         Optional body text to require
     maintenance_start/end Suppress alerts during scheduled maintenance

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -37,6 +37,8 @@ Jetmon 2 adds these columns:
 | `timeout_seconds` | `TINYINT NULL` | Per-site timeout override |
 | `redirect_policy` | `ENUM NULL` | `follow`, `alert`, or `fail` |
 | `alert_cooldown_minutes` | `SMALLINT NULL` | Per-site alert cooldown override |
+| `last_checked_at` | `DATETIME NULL` | Last completed local check timestamp |
+| `next_check_at` | `DATETIME NULL` | Maintained due timestamp for variable-interval scheduler selection |
 
 The API can expose a derived `cli_batch` field for local API CLI test data when
 `include_cli_metadata=true` is requested and `custom_headers` contains

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -37,6 +37,8 @@ Jetmon 2 adds these columns:
 | `timeout_seconds` | `TINYINT NULL` | Per-site timeout override |
 | `redirect_policy` | `ENUM NULL` | `follow`, `alert`, or `fail` |
 | `alert_cooldown_minutes` | `SMALLINT NULL` | Per-site alert cooldown override |
+| `last_checked_at` | `DATETIME NULL` | Last completed check timestamp used by activity gates |
+| `next_check_at` | `DATETIME NULL` | Materialized variable-interval due time used by the scheduler |
 
 The API can expose a derived `cli_batch` field for local API CLI test data when
 `include_cli_metadata=true` is requested and `custom_headers` contains

--- a/docs/jetmon-v2-capacity-1000-report.md
+++ b/docs/jetmon-v2-capacity-1000-report.md
@@ -132,14 +132,10 @@ the active count grows:
 1. Run the same 30-minute test at 5,000 active sites before changing code again.
    At 1,000 sites the measured bottleneck is no longer correctness, and the CPU
    profile has enough headroom to justify the next batch.
-2. Add or expose per-round scheduler metrics in Jetmon v2:
-   - due rows selected per round;
-   - DB fetch duration and rows returned;
-   - checks dispatched, completed, failed, and skipped;
-   - check queue depth and worker utilization;
-   - DB write duration for site updates and check history inserts;
-   - round duration and idle time;
-   - stale/due backlog by bucket.
+2. Use [`jetmon-v2-scalability-test-plan.md`](jetmon-v2-scalability-test-plan.md)
+   for the next 1k/5k/10k runs. It lists the scheduler metrics, EXPLAIN checks,
+   host/process counters, and dependency metrics needed to compare this branch
+   against the successful 1,000-site baseline.
 3. Keep watching DB CPU before app CPU. `jetmon2` p95 CPU is only about 4% of a
    core, but MySQL p95 counter-rate is already about 34% of a core at 1,000
    active sites. If DB CPU scales linearly, it will become limiting before the Go

--- a/docs/jetmon-v2-scalability-test-plan.md
+++ b/docs/jetmon-v2-scalability-test-plan.md
@@ -28,6 +28,13 @@ these changes from the previous successful 1,000-site baseline.
    testing memory-pressure drain.
 5. Confirm `USE_VARIABLE_CHECK_INTERVALS=true`.
 6. Confirm API-enabled test hosts set `DELIVERY_OWNER_HOST` explicitly.
+7. Confirm the exact activated `monitor_url` pattern resolves and returns HTTP
+   200 from the Jetmon service host and the Veriflier host. Do not test a
+   similar hostname by hand; query one activated row from
+   `jetpack_monitor_sites`, then run `dig` and `curl` for that exact hostname.
+   A mismatch between the capacity runner URL pattern and the target DNS
+   `generated_sites.host_pattern` will look like a Jetmon false-down storm and
+   will make event handling, not checking, dominate the run.
 
 ## Query Plan Checks
 
@@ -99,6 +106,15 @@ Phase timing and write volume:
 - `scheduler.page.mark_checked.error.count`
 - `scheduler.page.history.error.count`
 - `scheduler.page.ssl.error.count`
+- `scheduler.page.check.success.count`
+- `scheduler.page.check.failure.count`
+- `scheduler.page.check.http_failure.count`
+- `scheduler.page.check.timeout.count`
+- `scheduler.page.check.connect_error.count`
+- `scheduler.page.check.ssl_error.count`
+- `scheduler.page.check.redirect.count`
+- `scheduler.page.check.keyword.count`
+- `scheduler.page.check.tls_deprecated.count`
 - `scheduler.round.dispatch.time`
 - `scheduler.round.wait.time`
 - `scheduler.round.process.time`
@@ -112,6 +128,16 @@ Phase timing and write volume:
 - `scheduler.round.mark_checked.error.count`
 - `scheduler.round.history.error.count`
 - `scheduler.round.ssl.error.count`
+- `scheduler.round.check.success.count`
+- `scheduler.round.check.failure.count`
+- `scheduler.round.check.http_failure.count`
+- `scheduler.round.check.timeout.count`
+- `scheduler.round.check.connect_error.count`
+- `scheduler.round.check.ssl_error.count`
+- `scheduler.round.check.redirect.count`
+- `scheduler.round.check.keyword.count`
+- `scheduler.round.check.tls_deprecated.count`
+- `eventstore.mutation.retry.count`
 
 Host/process signals:
 
@@ -142,6 +168,13 @@ Dependency signals:
 - `ssl.row.count` should be high only during initial certificate backfills or
   real renewal waves. Sustained high SSL rows means certificate dates are
   changing or stored with incompatible precision.
+- Healthy capacity targets should have `check.success.count` close to
+  `completed.count`. A high `check.connect_error.count` means the monitor could
+  not connect to the activated URLs; first verify the exact DB URL pattern and
+  DNS delegation before treating it as a Jetmon throughput regression.
+- `eventstore.mutation.retry.count` should normally be zero. Any non-zero value
+  means MySQL returned a deadlock or lock-wait timeout and Jetmon retried the
+  event mutation; sustained retries point to event/projection write contention.
 - Shared HTTP transport impact should show up in process FD count, monitor CPU,
   DNS/TCP/TLS timing, and check latency rather than in scheduler row counts.
 - If MySQL CPU remains high while freshness is good, compare

--- a/docs/jetmon-v2-scalability-test-plan.md
+++ b/docs/jetmon-v2-scalability-test-plan.md
@@ -1,0 +1,167 @@
+# Jetmon v2 Scalability Test Plan
+
+This is the repeatable checklist for validating scheduler and check-path
+efficiency changes after the successful 1,000-site capacity run.
+
+## Current Branch Under Test
+
+`feature/jetmon-v2-scalability-efficiency` adds these scaling changes on top of
+the completed 1,000-site capacity branch:
+
+- Maintained `next_check_at` timestamps for indexed variable-interval due
+  selection.
+- One-minute sampling for exact due-count and projection-drift reporting in
+  variable-interval mode.
+- Shared bounded HTTP transport for local site checks.
+- Batched `ssl_expiry_date` writes when observed certificate dates change.
+
+Do not stack larger persistence changes, such as async check-history writes, on
+top of this branch before a real capacity run. The next test should isolate
+these changes from the previous successful 1,000-site baseline.
+
+## Pre-Test Checks
+
+1. Confirm migrations have run through migration 30.
+2. Confirm the test service is running this branch's `jetmon2` binary.
+3. Confirm the Veriflier service is reachable from the monitor host.
+4. Confirm `WORKER_MAX_MEM_MB=0` for capacity tests unless intentionally
+   testing memory-pressure drain.
+5. Confirm `USE_VARIABLE_CHECK_INTERVALS=true`.
+6. Confirm API-enabled test hosts set `DELIVERY_OWNER_HOST` explicitly.
+
+## Query Plan Checks
+
+Capture `EXPLAIN` for both scheduler modes before the capacity run.
+
+Variable-interval selection should use `idx_monitor_next_check_blog_bucket` and
+should not show `Using filesort`:
+
+```sql
+EXPLAIN
+SELECT jetpack_monitor_site_id, blog_id, bucket_no, monitor_url,
+       monitor_active, site_status, last_status_change, check_interval,
+       last_checked_at, next_check_at
+  FROM jetpack_monitor_sites
+ WHERE monitor_active = 1
+   AND bucket_no BETWEEN 0 AND 999
+   AND (next_check_at IS NULL OR next_check_at <= NOW())
+ ORDER BY next_check_at ASC, blog_id ASC
+ LIMIT 100;
+```
+
+Fixed-cadence selection should continue to use
+`idx_monitor_last_checked_blog_bucket` and should not show `Using filesort`:
+
+```sql
+EXPLAIN
+SELECT jetpack_monitor_site_id, blog_id, bucket_no, monitor_url,
+       monitor_active, site_status, last_status_change, check_interval,
+       last_checked_at, next_check_at
+  FROM jetpack_monitor_sites
+ WHERE monitor_active = 1
+   AND bucket_no BETWEEN 0 AND 999
+ ORDER BY last_checked_at ASC, blog_id ASC
+ LIMIT 100;
+```
+
+## StatsD Signals To Capture
+
+Freshness and scheduler pressure:
+
+- `scheduler.round.pages.count`
+- `scheduler.round.selected.count`
+- `scheduler.round.dispatched.count`
+- `scheduler.round.completed.count`
+- `scheduler.round.outstanding.count`
+- `scheduler.round.due_count_sampled.count`
+- `scheduler.round.due_start.count`
+- `scheduler.round.due_remaining.count`
+- `scheduler.round.selected_never_checked.count`
+- `scheduler.round.selected_oldest_age_sec`
+- `scheduler.dispatch.backpressure_wait.count`
+- `scheduler.result.stale.count`
+- `scheduler.result.duplicate.count`
+- `scheduler.fetch.error.count`
+- `scheduler.due_count.error.count`
+
+Phase timing and write volume:
+
+- `scheduler.page.dispatch.time`
+- `scheduler.page.wait.time`
+- `scheduler.page.process.time`
+- `scheduler.page.mark_checked.time`
+- `scheduler.page.history.time`
+- `scheduler.page.ssl.time`
+- `scheduler.page.events.time`
+- `scheduler.page.mark_checked.row.count`
+- `scheduler.page.history.row.count`
+- `scheduler.page.ssl.row.count`
+- `scheduler.page.mark_checked.error.count`
+- `scheduler.page.history.error.count`
+- `scheduler.page.ssl.error.count`
+- `scheduler.round.dispatch.time`
+- `scheduler.round.wait.time`
+- `scheduler.round.process.time`
+- `scheduler.round.mark_checked.time`
+- `scheduler.round.history.time`
+- `scheduler.round.ssl.time`
+- `scheduler.round.events.time`
+- `scheduler.round.mark_checked.row.count`
+- `scheduler.round.history.row.count`
+- `scheduler.round.ssl.row.count`
+- `scheduler.round.mark_checked.error.count`
+- `scheduler.round.history.error.count`
+- `scheduler.round.ssl.error.count`
+
+Host/process signals:
+
+- `round.complete.time`
+- `round.sites.count`
+- `round.sps.count`
+- `worker.queue.active`
+- `worker.queue.queue_size`
+- `retry.queue.size`
+- RSS memory
+- Go runtime system memory
+- process file descriptor count
+
+Dependency signals:
+
+- MySQL CPU, I/O, network, and slow-query counters
+- StatsD/Graphite CPU
+- Veriflier CPU/RSS/FDs
+- monitor host CPU/RSS/FDs
+
+## Expected Interpretation
+
+- `due_count_sampled.count=0` means exact due-count gauges were intentionally
+  skipped on that short variable-interval poll. It does not mean no sites were
+  due.
+- `due_remaining` should only be interpreted on polls where
+  `due_count_sampled.count=1`.
+- `ssl.row.count` should be high only during initial certificate backfills or
+  real renewal waves. Sustained high SSL rows means certificate dates are
+  changing or stored with incompatible precision.
+- Shared HTTP transport impact should show up in process FD count, monitor CPU,
+  DNS/TCP/TLS timing, and check latency rather than in scheduler row counts.
+- If MySQL CPU remains high while freshness is good, compare
+  `history.row.count`, `history.time`, and table growth before implementing
+  async or lower-resolution history storage.
+
+## Next Capacity Ladder
+
+Run each step for the same duration and compare against the latest successful
+1,000-site baseline:
+
+1. 1,000 sites after this branch to isolate regressions.
+2. 5,000 sites to find the next visible bottleneck.
+3. 10,000 sites if freshness, FD count, and MySQL CPU remain healthy.
+
+For each step, preserve:
+
+- uptime-bench report directory
+- Prometheus/Graphite window export
+- service logs for the exact test window
+- `EXPLAIN` output
+- row counts for `jetmon_check_history`
+- open-event count before and after test-site deactivation

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -46,10 +46,12 @@ Scheduler behavior:
 - A full worker queue applies backpressure; checks remain pending instead of
   being dropped.
 - With `USE_VARIABLE_CHECK_INTERVALS=true`, Jetmon polls for newly due work on a
-  short idle interval and uses each site's `check_interval` to decide what to
-  check. `MIN_TIME_BETWEEN_ROUNDS_SEC` is only the fixed-cadence pass interval
-  when variable intervals are disabled. Use this mode for production-like
-  freshness and capacity tests.
+  short idle interval and uses each site's maintained `next_check_at` timestamp
+  to decide what to check. `next_check_at` is recalculated from
+  `last_checked_at + check_interval` whenever a check completes or
+  `check_interval` changes. `MIN_TIME_BETWEEN_ROUNDS_SEC` is only the
+  fixed-cadence pass interval when variable intervals are disabled. Use this
+  mode for production-like freshness and capacity tests.
 - Watch the `scheduler.round.*` StatsD metrics during capacity tests. In
   particular, `due_start`, `selected`, `completed`, `outstanding`, and
   `due_remaining` show whether freshness pressure is clearing or building.

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -55,6 +55,9 @@ Scheduler behavior:
 - Watch the `scheduler.round.*` StatsD metrics during capacity tests. In
   particular, `due_start`, `selected`, `completed`, `outstanding`, and
   `due_remaining` show whether freshness pressure is clearing or building.
+  Exact `due_start` / `due_remaining` and legacy projection-drift checks are
+  sampled about once per minute in variable-interval mode so broad operator
+  reporting queries do not run on every short scheduler poll.
 
 See [../config/config.readme](../config/config.readme) for the full option
 reference.

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -57,7 +57,9 @@ Scheduler behavior:
   `due_remaining` show whether freshness pressure is clearing or building.
   Exact `due_start` / `due_remaining` and legacy projection-drift checks are
   sampled about once per minute in variable-interval mode so broad operator
-  reporting queries do not run on every short scheduler poll.
+  reporting queries do not run on every short scheduler poll. Use
+  `scheduler.round.due_count_sampled.count` to distinguish sampled polls from
+  intentionally skipped reporting polls.
 
 See [../config/config.readme](../config/config.readme) for the full option
 reference.
@@ -391,6 +393,13 @@ Important metric groups include:
 - Worker pool capacity and active goroutines
 - Sites processed per second
 - Round completion time
+- Scheduler page count, selected/dispatched/completed rows, outstanding checks,
+  backpressure waits, stale/duplicate results, and sampled due backlog
+- Scheduler phase timings for dispatch, wait, result processing,
+  `last_checked_at`/`next_check_at` writes, check-history inserts, SSL expiry
+  writes, and event handling
+- Scheduler write row/error counters for freshness, check history, and SSL
+  expiry updates
 - WPCOM API attempts, deliveries, retries, errors, and failures
 - Veriflier response times and vote counters
 - Detection flow timing from first failure to escalation, confirmation,
@@ -401,6 +410,9 @@ Important metric groups include:
 
 StatsD is the primary metrics transport. Expose Graphite/StatsD data through the
 existing metrics pipeline when external systems need it.
+
+For repeatable capacity and scalability tests, use
+[`jetmon-v2-scalability-test-plan.md`](jetmon-v2-scalability-test-plan.md).
 
 For repeatable production summaries from durable Jetmon tables, use:
 

--- a/docs/project.md
+++ b/docs/project.md
@@ -147,6 +147,8 @@ Each check result — including the granular DNS/TCP/TLS/TTFB breakdown — is w
 **Alert Deduplication and Cooldown**
 Add a `alert_cooldown_minutes` column to `jetpack_monitor_sites`, defaulting to a global `ALERT_COOLDOWN_MINUTES` config value. After an alert fires for a site, subsequent alerts for the same site are suppressed until the cooldown expires, even if the site flaps up and down repeatedly. The suppression is recorded in the audit log. Prevents alert fatigue on flapping sites without requiring manual maintenance window configuration.
 
+Add a `next_check_at` column to `jetpack_monitor_sites` for variable-interval scheduling. Jetmon maintains it after every check from `last_checked_at + max(check_interval, 1) minutes`, allowing due-site selection to use an indexed range predicate instead of recalculating the interval expression for every active row.
+
 **TLS Version and Cipher Reporting**
 Alongside SSL certificate expiry monitoring, inspect `tls.ConnectionState` for the negotiated TLS version and cipher suite. Flag sites still serving TLS 1.0 or TLS 1.1 (deprecated) via a dedicated alert threshold, and record the TLS version and cipher in the audit log. Zero additional network requests — this data is present in every existing HTTPS connection alongside the certificate chain.
 

--- a/docs/project.md
+++ b/docs/project.md
@@ -124,10 +124,10 @@ Jetmon 1's HEAD-only verification was a major source of customer-visible false p
 For sites with a `check_keyword` value set in the database, perform a GET request and search the response body for the configured string. A missing keyword on an otherwise-200 response counts as a failure and enters the same retry and confirmation pipeline as an HTTP error. Builds directly on the GET request mode used by v2 checks.
 
 **Maintenance Windows**
-Add `maintenance_start` and `maintenance_end` (nullable `DATETIME`) columns to `jetpack_monitor_sites`. During a maintenance window, checks continue and RTT data is collected, but status-change notifications are suppressed. The check result is logged internally so the audit trail is complete, but no alert fires. Configurable via the WPCOM API or direct DB write.
+Add `maintenance_start` and `maintenance_end` (nullable `DATETIME`) columns to `jetpack_monitor_sites`. During a maintenance window, checks continue and RTT data is collected, but status-change notifications are suppressed. Check-history samples and suppression audit entries remain available so operators can explain what happened, but no alert fires. Configurable via the WPCOM API or direct DB write.
 
 **Granular Timing Breakdown**
-Go's `net/http/httptrace` provides discrete callbacks for DNS start/done, TCP connect start/done, TLS handshake start/done, request written, and first response byte. Each check records all six timings at no additional cost. The single composite "RTT" is retained for backwards compatibility; the component timings are emitted as new StatsD metrics and stored for the operator dashboard and audit log.
+Go's `net/http/httptrace` provides discrete callbacks for DNS start/done, TCP connect start/done, TLS handshake start/done, request written, and first response byte. Each check records composite RTT plus DNS, TCP, TLS, and TTFB timings. The raw samples are stored in `jetmon_check_history` for response-time trending and API statistics; scheduler-level StatsD metrics report round/page phase timing and write volume.
 
 **Per-Site Request Headers**
 Add a `custom_headers` JSON column to `jetpack_monitor_sites`. The check engine merges these into the outgoing request, allowing sites that require an `Authorization` header or a specific `Host` value to be checked correctly.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -73,7 +73,7 @@ No active candidate branch is queued here right now.
 - [ ] If MySQL CPU remains the limiting factor after batched writes, evaluate
   an asynchronous bounded check-history writer or lower-resolution history
   retention for healthy probes while keeping `last_checked_at` synchronous.
-- [ ] Add a maintained `next_check_at` column and scheduler index so variable
+- [x] Add a maintained `next_check_at` column and scheduler index so variable
   interval due selection uses a simple indexed range predicate instead of
   computing `DATE_ADD(last_checked_at, INTERVAL GREATEST(check_interval, 1)
   MINUTE)` during every scheduler fetch.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -79,9 +79,12 @@ No active candidate branch is queued here right now.
   MINUTE)` during every scheduler fetch. The scheduler now recalculates
   `next_check_at` when checks complete or `check_interval` changes, and
   migration backfills existing rows before adding the index.
-- [ ] Move exact due-count and projection-drift checks out of the hot scheduler
+- [x] Move exact due-count and projection-drift checks out of the hot scheduler
   loop, or run them on a slower background cadence, so operator reporting does
-  not add broad database reads to every 5-second variable-interval pass.
+  not add broad database reads to every 5-second variable-interval pass. In
+  variable-interval mode, exact due counts and projection-drift counts are now
+  sampled on a slower operator-reporting cadence while fixed-cadence mode keeps
+  exact per-round counts.
 - [ ] Prototype a bounded asynchronous check-history writer and rollup model:
   keep `last_checked_at` synchronous, preserve raw rows for failures/recent
   windows, and store long-term latency/error aggregates to avoid raw history

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -84,9 +84,11 @@ No active candidate branch is queued here right now.
   keep `last_checked_at` synchronous, preserve raw rows for failures/recent
   windows, and store long-term latency/error aggregates to avoid raw history
   becoming the 10k/100k-site storage and I/O wall.
-- [ ] Prototype a shared or per-worker HTTP transport/client pool that reduces
-  allocation, socket, DNS, TCP, and TLS churn while preserving enough probe
-  timing visibility for uptime diagnostics.
+- [x] Replace per-check HTTP transport allocation with a shared bounded
+  transport while keeping per-check clients for timeout and redirect-policy
+  isolation. This is the conservative first step: connection reuse is available
+  when the response body is consumed, but the checker still avoids reading full
+  customer pages only to preserve keep-alives.
 - [ ] Add a 5k/10k capacity ladder that records freshness, p95 age, MySQL CPU,
   MySQL I/O/network, `jetmon2` CPU/RSS/FDs, StatsD CPU, Veriflier CPU, and
   check-history row growth after each major scalability change.
@@ -94,10 +96,10 @@ No active candidate branch is queued here right now.
   explains expected throughput from active site count, check interval,
   `NUM_WORKERS`, and timeout settings. This is deferred until the retest shows
   which sizing formula best matches real Jetmon v2 behavior.
-- [ ] Evaluate replacing per-check HTTP transports with a reused transport or
-  bounded client pool if the retest still shows open file descriptor growth.
-  This is deferred behind the scheduler fix because the 1,000-site miss matched
-  the scheduler cap exactly, while FD growth was only a watch item.
+- [ ] After the next capacity retest, evaluate whether checker idle-connection
+  limits, response-body draining, or keep-alive policy need additional tuning.
+  This remains data-dependent because more aggressive connection reuse can hide
+  DNS/TCP/TLS failure modes or add page-body I/O.
 
 ### Projection Drift Tooling TODO
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -73,10 +73,12 @@ No active candidate branch is queued here right now.
 - [ ] If MySQL CPU remains the limiting factor after batched writes, evaluate
   an asynchronous bounded check-history writer or lower-resolution history
   retention for healthy probes while keeping `last_checked_at` synchronous.
-- [ ] Add a maintained `next_check_at` column and scheduler index so variable
+- [x] Add a maintained `next_check_at` column and scheduler index so variable
   interval due selection uses a simple indexed range predicate instead of
   computing `DATE_ADD(last_checked_at, INTERVAL GREATEST(check_interval, 1)
-  MINUTE)` during every scheduler fetch.
+  MINUTE)` during every scheduler fetch. The scheduler now recalculates
+  `next_check_at` when checks complete or `check_interval` changes, and
+  migration backfills existing rows before adding the index.
 - [ ] Move exact due-count and projection-drift checks out of the hot scheduler
   loop, or run them on a slower background cadence, so operator reporting does
   not add broad database reads to every 5-second variable-interval pass.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -97,6 +97,15 @@ No active candidate branch is queued here right now.
   timing visibility for uptime diagnostics. The checker now shares one bounded
   `http.Transport` across checks while keeping each check's timeout and
   redirect policy scoped to its own `http.Client`.
+- [x] Add scheduler outcome counters and event-mutation deadlock/lock-wait
+  retry instrumentation so capacity runs can distinguish true Jetmon
+  throughput regressions from target setup failures such as DNS/URL-pattern
+  mismatches.
+- [ ] Retest the scalability-efficiency branch after the capacity harness
+  verifies the exact activated `monitor_url` samples from Monitor and Veriflier
+  hosts, then compare freshness, check outcome mix, event mutation retries,
+  MySQL CPU/I/O, Jetmon CPU/RSS/FDs, and Veriflier resource usage against the
+  prior successful 1,000-site baseline.
 - [ ] Add a 5k/10k capacity ladder that records freshness, p95 age, MySQL CPU,
   MySQL I/O/network, `jetmon2` CPU/RSS/FDs, StatsD CPU, Veriflier CPU, and
   check-history row growth after each major scalability change.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -51,6 +51,8 @@ No active candidate branch is queued here right now.
   not dominated by one UPDATE plus one INSERT per site.
 - [x] Avoid rewriting unchanged `ssl_expiry_date` values on every HTTPS check
   while still evaluating TLS-expiry alert state for each observed certificate.
+- [x] Batch changed `ssl_expiry_date` writes so first-run certificate backfills
+  and certificate-renewal waves do not issue one UPDATE per HTTPS site.
 - [x] Remove the `COALESCE(last_checked_at, ...)` scheduler ordering expression
   so MySQL can use the nullable `last_checked_at` ordering more directly while
   preserving NULL-first behavior.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -89,9 +89,11 @@ No active candidate branch is queued here right now.
   keep `last_checked_at` synchronous, preserve raw rows for failures/recent
   windows, and store long-term latency/error aggregates to avoid raw history
   becoming the 10k/100k-site storage and I/O wall.
-- [ ] Prototype a shared or per-worker HTTP transport/client pool that reduces
+- [x] Prototype a shared or per-worker HTTP transport/client pool that reduces
   allocation, socket, DNS, TCP, and TLS churn while preserving enough probe
-  timing visibility for uptime diagnostics.
+  timing visibility for uptime diagnostics. The checker now shares one bounded
+  `http.Transport` across checks while keeping each check's timeout and
+  redirect policy scoped to its own `http.Client`.
 - [ ] Add a 5k/10k capacity ladder that records freshness, p95 age, MySQL CPU,
   MySQL I/O/network, `jetmon2` CPU/RSS/FDs, StatsD CPU, Veriflier CPU, and
   check-history row growth after each major scalability change.
@@ -99,10 +101,10 @@ No active candidate branch is queued here right now.
   explains expected throughput from active site count, check interval,
   `NUM_WORKERS`, and timeout settings. This is deferred until the retest shows
   which sizing formula best matches real Jetmon v2 behavior.
-- [ ] Evaluate replacing per-check HTTP transports with a reused transport or
+- [x] Evaluate replacing per-check HTTP transports with a reused transport or
   bounded client pool if the retest still shows open file descriptor growth.
-  This is deferred behind the scheduler fix because the 1,000-site miss matched
-  the scheduler cap exactly, while FD growth was only a watch item.
+  The checker now uses a shared bounded transport; capacity tests still need to
+  confirm FD, CPU, and latency impact under 5k/10k site loads.
 
 ### Projection Drift Tooling TODO
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -77,9 +77,9 @@ No active candidate branch is queued here right now.
   interval due selection uses a simple indexed range predicate instead of
   computing `DATE_ADD(last_checked_at, INTERVAL GREATEST(check_interval, 1)
   MINUTE)` during every scheduler fetch.
-- [ ] Move exact due-count and projection-drift checks out of the hot scheduler
-  loop, or run them on a slower background cadence, so operator reporting does
-  not add broad database reads to every 5-second variable-interval pass.
+- [x] Move exact due-count and projection-drift checks onto a slower scheduler
+  reporting cadence so operator diagnostics do not add broad database reads to
+  every 5-second variable-interval pass.
 - [ ] Prototype a bounded asynchronous check-history writer and rollup model:
   keep `last_checked_at` synchronous, preserve raw rows for failures/recent
   windows, and store long-term latency/error aggregates to avoid raw history

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -41,7 +41,8 @@ No active candidate branch is queued here right now.
   available results instead of dropping checks.
 - [x] Add scheduler metrics for due-start, selected, dispatched, completed,
   outstanding, due-remaining, page count, backpressure waits, stale results,
-  duplicate results, never-checked selections, and oldest selected age.
+  duplicate results, never-checked selections, oldest selected age, and whether
+  exact due-count gauges were sampled on this variable-interval poll.
 - [x] Add per-page scheduler phase timings for dispatch, wait, result
   processing, `last_checked_at` writes, check-history writes, SSL updates, and
   event handling so the next capacity retest can identify the exact slow

--- a/internal/api/handlers_sites_write.go
+++ b/internal/api/handlers_sites_write.go
@@ -583,6 +583,8 @@ func buildUpdateSetClause(body updateSiteRequest) ([]string, []any, error) {
 	if body.CheckInterval != nil {
 		clauses = append(clauses, "check_interval = ?")
 		args = append(args, *body.CheckInterval)
+		clauses = append(clauses, "next_check_at = CASE WHEN last_checked_at IS NULL THEN NULL ELSE DATE_ADD(last_checked_at, INTERVAL GREATEST(?, 1) MINUTE) END")
+		args = append(args, *body.CheckInterval)
 	}
 	if body.MaintenanceStart != nil {
 		t, err := parseMaintenanceTime(*body.MaintenanceStart, "maintenance_start")

--- a/internal/api/handlers_sites_write_test.go
+++ b/internal/api/handlers_sites_write_test.go
@@ -451,7 +451,7 @@ func TestBuildUpdateSetClauseHandlesAllFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if len(clauses) != 9 || len(args) != 9 {
-		t.Errorf("expected 9 clauses, got clauses=%d args=%d", len(clauses), len(args))
+	if len(clauses) != 10 || len(args) != 10 {
+		t.Errorf("expected 10 clauses, got clauses=%d args=%d", len(clauses), len(args))
 	}
 }

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -12,6 +12,16 @@ import (
 	"time"
 )
 
+var sharedTransport = &http.Transport{
+	Proxy:                 http.ProxyFromEnvironment,
+	TLSClientConfig:       &tls.Config{InsecureSkipVerify: false},
+	MaxIdleConns:          256,
+	MaxIdleConnsPerHost:   16,
+	IdleConnTimeout:       90 * time.Second,
+	TLSHandshakeTimeout:   10 * time.Second,
+	ExpectContinueTimeout: time.Second,
+}
+
 // ErrorCode mirrors the status change email types from the original Jetmon.
 const (
 	ErrorNone          = 0
@@ -132,23 +142,14 @@ func Check(ctx context.Context, req Request) Result {
 	}
 	ctx = httptrace.WithClientTrace(ctx, trace)
 
-	headers := make(map[string]string)
-	for k, v := range req.CustomHeaders {
-		headers[k] = v
-	}
-
 	redirectCount := 0
 	redirectPolicyStr := string(req.RedirectPolicy)
 	if redirectPolicyStr == "" {
 		redirectPolicyStr = string(RedirectFollow)
 	}
 
-	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: false},
-	}
-
 	client := &http.Client{
-		Transport: transport,
+		Transport: sharedTransport,
 		CheckRedirect: func(r *http.Request, via []*http.Request) error {
 			redirectCount++
 			if redirectPolicyStr == string(RedirectFail) {
@@ -169,7 +170,7 @@ func Check(ctx context.Context, req Request) Result {
 	}
 
 	httpReq.Header.Set("User-Agent", "jetmon/2.0 (Jetpack Site Uptime Monitor by WordPress.com)")
-	for k, v := range headers {
+	for k, v := range req.CustomHeaders {
 		httpReq.Header.Set(k, v)
 	}
 

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptrace"
 	"strings"
@@ -32,6 +33,25 @@ const (
 	RedirectAlert  RedirectPolicy = "alert"
 	RedirectFail   RedirectPolicy = "fail"
 )
+
+// defaultTransport is shared across checks so the checker does not allocate a
+// fresh connection pool for every probe. The http.Client stays per request so
+// timeout and redirect policy remain isolated to that site check.
+var defaultTransport = newCheckTransport()
+
+func newCheckTransport() *http.Transport {
+	return &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		TLSClientConfig:     &tls.Config{InsecureSkipVerify: false},
+		TLSHandshakeTimeout: 10 * time.Second,
+		IdleConnTimeout:     30 * time.Second,
+		MaxIdleConns:        1024,
+		MaxIdleConnsPerHost: 8,
+	}
+}
 
 // Request holds the parameters for a single HTTP check.
 type Request struct {
@@ -143,12 +163,8 @@ func Check(ctx context.Context, req Request) Result {
 		redirectPolicyStr = string(RedirectFollow)
 	}
 
-	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: false},
-	}
-
 	client := &http.Client{
-		Transport: transport,
+		Transport: defaultTransport,
 		CheckRedirect: func(r *http.Request, via []*http.Request) error {
 			redirectCount++
 			if redirectPolicyStr == string(RedirectFail) {

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -2,8 +2,10 @@ package checker
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -340,6 +342,40 @@ func TestCheckCustomHeadersForwarded(t *testing.T) {
 	}
 	if receivedHeader != "hello" {
 		t.Fatalf("X-Custom-Test = %q, want hello", receivedHeader)
+	}
+}
+
+func TestCheckReusesSharedTransportForReadableResponses(t *testing.T) {
+	oldTransport := defaultTransport
+	defaultTransport = newCheckTransport()
+	t.Cleanup(func() {
+		defaultTransport.CloseIdleConnections()
+		defaultTransport = oldTransport
+	})
+
+	var newConns atomic.Int64
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	srv.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			newConns.Add(1)
+		}
+	}
+	srv.Start()
+	defer srv.Close()
+
+	kw := "ok"
+	for i := 0; i < 2; i++ {
+		res := Check(context.Background(), Request{BlogID: int64(i + 1), URL: srv.URL, TimeoutSeconds: 5, Keyword: &kw})
+		if !res.Success {
+			t.Fatalf("check %d Success = false, want true (error_code=%d)", i+1, res.ErrorCode)
+		}
+	}
+
+	if got := newConns.Load(); got != 1 {
+		t.Fatalf("new connections = %d, want 1 from shared transport reuse", got)
 	}
 }
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -25,6 +25,7 @@ type Site struct {
 	LastStatusChange *time.Time
 	CheckInterval    int
 	LastCheckedAt    *time.Time
+	NextCheckAt      *time.Time
 
 	SSLExpiryDate        *time.Time
 	CheckKeyword         *string

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -442,6 +442,13 @@ var migrations = []migration{
 	// a full scan/filesort at larger table sizes.
 	{27, `ALTER TABLE jetpack_monitor_sites
 		ADD INDEX idx_monitor_last_checked_blog_bucket (monitor_active, last_checked_at, blog_id, bucket_no)`},
+
+	// Migration 28 materializes the next variable-interval due time so the
+	// scheduler no longer computes DATE_ADD(last_checked_at, INTERVAL
+	// check_interval MINUTE) for every active row during every fetch.
+	{28, `ALTER TABLE jetpack_monitor_sites
+		ADD COLUMN next_check_at DATETIME NULL AFTER last_checked_at,
+		ADD INDEX idx_monitor_next_check_blog_bucket (monitor_active, next_check_at, blog_id, bucket_no)`},
 }
 
 // Migrate applies all pending migrations idempotently.

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -442,6 +442,27 @@ var migrations = []migration{
 	// a full scan/filesort at larger table sizes.
 	{27, `ALTER TABLE jetpack_monitor_sites
 		ADD INDEX idx_monitor_last_checked_blog_bucket (monitor_active, last_checked_at, blog_id, bucket_no)`},
+
+	// Migration 28 adds a maintained due timestamp for variable-interval
+	// scheduling. This lets the scheduler use a simple indexed range predicate
+	// instead of computing DATE_ADD(last_checked_at, INTERVAL check_interval)
+	// for every candidate row on every poll.
+	{28, `ALTER TABLE jetpack_monitor_sites
+		ADD COLUMN next_check_at DATETIME NULL AFTER last_checked_at`},
+
+	// Migration 29 backfills next_check_at for already-checked rows. Rows that
+	// have never been checked stay NULL and are due immediately, matching the
+	// existing last_checked_at IS NULL behavior.
+	{29, `UPDATE jetpack_monitor_sites
+		SET next_check_at = DATE_ADD(last_checked_at, INTERVAL GREATEST(check_interval, 1) MINUTE)
+		WHERE last_checked_at IS NOT NULL
+		  AND next_check_at IS NULL`},
+
+	// Migration 30 supports variable-interval scheduling's hot path:
+	// active rows whose maintained due timestamp is NULL or due now, ordered by
+	// next_check_at and blog_id.
+	{30, `ALTER TABLE jetpack_monitor_sites
+		ADD INDEX idx_monitor_next_check_blog_bucket (monitor_active, next_check_at, blog_id, bucket_no)`},
 }
 
 // Migrate applies all pending migrations idempotently.

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -449,6 +449,54 @@ func UpdateSSLExpiry(ctx context.Context, blogID int64, expiry time.Time) error 
 	return err
 }
 
+// SiteSSLExpiry records one observed certificate expiry update.
+type SiteSSLExpiry struct {
+	BlogID int64
+	Expiry time.Time
+}
+
+// UpdateSSLExpiries records observed certificate expiry dates for a batch of
+// sites. Certificate expiry changes are usually sparse after warm-up, but
+// batching prevents first-run or certificate-churn sweeps from issuing one
+// UPDATE per HTTPS site.
+func UpdateSSLExpiries(ctx context.Context, expiries []SiteSSLExpiry) error {
+	if len(expiries) == 0 {
+		return nil
+	}
+	expiries = append([]SiteSSLExpiry(nil), expiries...)
+	sort.Slice(expiries, func(i, j int) bool {
+		return expiries[i].BlogID < expiries[j].BlogID
+	})
+	for start := 0; start < len(expiries); start += batchWriteChunkSize {
+		end := min(start+batchWriteChunkSize, len(expiries))
+		if err := updateSSLExpiriesChunk(ctx, expiries[start:end]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func updateSSLExpiriesChunk(ctx context.Context, expiries []SiteSSLExpiry) error {
+	var query strings.Builder
+	query.WriteString("UPDATE jetpack_monitor_sites SET ssl_expiry_date = CASE blog_id")
+	args := make([]any, 0, len(expiries)*3)
+	for _, expiry := range expiries {
+		query.WriteString(" WHEN ? THEN ?")
+		args = append(args, expiry.BlogID, expiry.Expiry)
+	}
+	query.WriteString(" END WHERE blog_id IN (")
+	for i, expiry := range expiries {
+		if i > 0 {
+			query.WriteByte(',')
+		}
+		query.WriteByte('?')
+		args = append(args, expiry.BlogID)
+	}
+	query.WriteByte(')')
+	_, err := db.ExecContext(ctx, query.String(), args...)
+	return err
+}
+
 // ClaimBuckets registers this host in jetmon_hosts, claiming uncovered bucket
 // ranges from expired peers. Returns the claimed min/max bucket numbers.
 func ClaimBuckets(hostID string, bucketTotal, bucketTarget int, graceSec int) (int, int, error) {

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -17,7 +17,7 @@ func GetSitesForBucket(ctx context.Context, bucketMin, bucketMax, batchSize int,
 	query := `
 		SELECT
 			jetpack_monitor_site_id, blog_id, bucket_no, monitor_url,
-			monitor_active, site_status, last_status_change, check_interval, last_checked_at,
+			monitor_active, site_status, last_status_change, check_interval, last_checked_at, next_check_at,
 			ssl_expiry_date, check_keyword, maintenance_start, maintenance_end,
 			custom_headers, timeout_seconds, redirect_policy, alert_cooldown_minutes, last_alert_sent_at
 		FROM jetpack_monitor_sites
@@ -26,15 +26,19 @@ func GetSitesForBucket(ctx context.Context, bucketMin, bucketMax, batchSize int,
 	if useVariableIntervals {
 		query += `
 		  AND (
-			last_checked_at IS NULL
-			OR DATE_ADD(last_checked_at, INTERVAL GREATEST(check_interval, 1) MINUTE) <= NOW()
+			next_check_at IS NULL
+			OR next_check_at <= NOW()
 		  )`
 	}
-	query += `
+	orderColumn := "last_checked_at"
+	if useVariableIntervals {
+		orderColumn = "next_check_at"
+	}
+	query += fmt.Sprintf(`
 		ORDER BY
-			last_checked_at ASC,
+			%s ASC,
 			blog_id ASC
-		LIMIT ?`
+		LIMIT ?`, orderColumn)
 
 	rows, err := db.QueryContext(ctx, query, bucketMin, bucketMax, batchSize)
 	if err != nil {
@@ -48,7 +52,7 @@ func GetSitesForBucket(ctx context.Context, bucketMin, bucketMax, batchSize int,
 		var redirectPolicy sql.NullString
 		err := rows.Scan(
 			&s.ID, &s.BlogID, &s.BucketNo, &s.MonitorURL,
-			&s.MonitorActive, &s.SiteStatus, &s.LastStatusChange, &s.CheckInterval, &s.LastCheckedAt,
+			&s.MonitorActive, &s.SiteStatus, &s.LastStatusChange, &s.CheckInterval, &s.LastCheckedAt, &s.NextCheckAt,
 			&s.SSLExpiryDate, &s.CheckKeyword, &s.MaintenanceStart, &s.MaintenanceEnd,
 			&s.CustomHeaders, &s.TimeoutSeconds, &redirectPolicy, &s.AlertCooldownMinutes, &s.LastAlertSentAt,
 		)
@@ -113,8 +117,8 @@ func CountDueSitesForBucketRange(ctx context.Context, bucketMin, bucketMax int, 
 	if useVariableIntervals {
 		query += `
 		   AND (
-			last_checked_at IS NULL
-			OR DATE_ADD(last_checked_at, INTERVAL GREATEST(check_interval, 1) MINUTE) <= NOW()
+			next_check_at IS NULL
+			OR next_check_at <= NOW()
 		   )`
 	}
 
@@ -361,19 +365,20 @@ func SummarizeLegacyProjectionDrift(ctx context.Context, bucketMin, bucketMax, l
 	return out, rows.Err()
 }
 
-// MarkSiteChecked records when a site was last checked.
-func MarkSiteChecked(ctx context.Context, blogID int64, checkedAt time.Time) error {
+// MarkSiteChecked records when a site was last checked and when it is next due.
+func MarkSiteChecked(ctx context.Context, blogID int64, checkedAt, nextCheckAt time.Time) error {
 	_, err := db.ExecContext(ctx,
-		`UPDATE jetpack_monitor_sites SET last_checked_at = ? WHERE blog_id = ?`,
-		checkedAt.UTC(), blogID,
+		`UPDATE jetpack_monitor_sites SET last_checked_at = ?, next_check_at = ? WHERE blog_id = ?`,
+		checkedAt.UTC(), nextCheckAt.UTC(), blogID,
 	)
 	return err
 }
 
 // SiteCheck records one site freshness update.
 type SiteCheck struct {
-	BlogID    int64
-	CheckedAt time.Time
+	BlogID      int64
+	CheckedAt   time.Time
+	NextCheckAt time.Time
 }
 
 // MarkSitesChecked records last_checked_at for a batch of sites. Batching this
@@ -399,10 +404,15 @@ func MarkSitesChecked(ctx context.Context, checks []SiteCheck) error {
 func markSitesCheckedChunk(ctx context.Context, checks []SiteCheck) error {
 	var query strings.Builder
 	query.WriteString("UPDATE jetpack_monitor_sites SET last_checked_at = CASE blog_id")
-	args := make([]any, 0, len(checks)*3)
+	args := make([]any, 0, len(checks)*5)
 	for _, check := range checks {
 		query.WriteString(" WHEN ? THEN ?")
 		args = append(args, check.BlogID, check.CheckedAt.UTC())
+	}
+	query.WriteString(" END, next_check_at = CASE blog_id")
+	for _, check := range checks {
+		query.WriteString(" WHEN ? THEN ?")
+		args = append(args, check.BlogID, check.NextCheckAt.UTC())
 	}
 	query.WriteString(" END WHERE blog_id IN (")
 	for i, check := range checks {

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -17,7 +17,7 @@ func GetSitesForBucket(ctx context.Context, bucketMin, bucketMax, batchSize int,
 	query := `
 		SELECT
 			jetpack_monitor_site_id, blog_id, bucket_no, monitor_url,
-			monitor_active, site_status, last_status_change, check_interval, last_checked_at,
+			monitor_active, site_status, last_status_change, check_interval, last_checked_at, next_check_at,
 			ssl_expiry_date, check_keyword, maintenance_start, maintenance_end,
 			custom_headers, timeout_seconds, redirect_policy, alert_cooldown_minutes, last_alert_sent_at
 		FROM jetpack_monitor_sites
@@ -26,14 +26,20 @@ func GetSitesForBucket(ctx context.Context, bucketMin, bucketMax, batchSize int,
 	if useVariableIntervals {
 		query += `
 		  AND (
-			last_checked_at IS NULL
-			OR DATE_ADD(last_checked_at, INTERVAL GREATEST(check_interval, 1) MINUTE) <= NOW()
+			next_check_at IS NULL
+			OR next_check_at <= NOW()
 		  )`
-	}
-	query += `
+		query += `
+		ORDER BY
+			next_check_at ASC,
+			blog_id ASC`
+	} else {
+		query += `
 		ORDER BY
 			last_checked_at ASC,
-			blog_id ASC
+			blog_id ASC`
+	}
+	query += `
 		LIMIT ?`
 
 	rows, err := db.QueryContext(ctx, query, bucketMin, bucketMax, batchSize)
@@ -48,7 +54,7 @@ func GetSitesForBucket(ctx context.Context, bucketMin, bucketMax, batchSize int,
 		var redirectPolicy sql.NullString
 		err := rows.Scan(
 			&s.ID, &s.BlogID, &s.BucketNo, &s.MonitorURL,
-			&s.MonitorActive, &s.SiteStatus, &s.LastStatusChange, &s.CheckInterval, &s.LastCheckedAt,
+			&s.MonitorActive, &s.SiteStatus, &s.LastStatusChange, &s.CheckInterval, &s.LastCheckedAt, &s.NextCheckAt,
 			&s.SSLExpiryDate, &s.CheckKeyword, &s.MaintenanceStart, &s.MaintenanceEnd,
 			&s.CustomHeaders, &s.TimeoutSeconds, &redirectPolicy, &s.AlertCooldownMinutes, &s.LastAlertSentAt,
 		)
@@ -113,8 +119,8 @@ func CountDueSitesForBucketRange(ctx context.Context, bucketMin, bucketMax int, 
 	if useVariableIntervals {
 		query += `
 		   AND (
-			last_checked_at IS NULL
-			OR DATE_ADD(last_checked_at, INTERVAL GREATEST(check_interval, 1) MINUTE) <= NOW()
+			next_check_at IS NULL
+			OR next_check_at <= NOW()
 		   )`
 	}
 
@@ -364,8 +370,11 @@ func SummarizeLegacyProjectionDrift(ctx context.Context, bucketMin, bucketMax, l
 // MarkSiteChecked records when a site was last checked.
 func MarkSiteChecked(ctx context.Context, blogID int64, checkedAt time.Time) error {
 	_, err := db.ExecContext(ctx,
-		`UPDATE jetpack_monitor_sites SET last_checked_at = ? WHERE blog_id = ?`,
-		checkedAt.UTC(), blogID,
+		`UPDATE jetpack_monitor_sites
+		    SET last_checked_at = ?,
+		        next_check_at = DATE_ADD(?, INTERVAL GREATEST(check_interval, 1) MINUTE)
+		  WHERE blog_id = ?`,
+		checkedAt.UTC(), checkedAt.UTC(), blogID,
 	)
 	return err
 }
@@ -399,12 +408,17 @@ func MarkSitesChecked(ctx context.Context, checks []SiteCheck) error {
 func markSitesCheckedChunk(ctx context.Context, checks []SiteCheck) error {
 	var query strings.Builder
 	query.WriteString("UPDATE jetpack_monitor_sites SET last_checked_at = CASE blog_id")
-	args := make([]any, 0, len(checks)*3)
+	args := make([]any, 0, len(checks)*5)
 	for _, check := range checks {
 		query.WriteString(" WHEN ? THEN ?")
 		args = append(args, check.BlogID, check.CheckedAt.UTC())
 	}
-	query.WriteString(" END WHERE blog_id IN (")
+	query.WriteString(" END, next_check_at = DATE_ADD(CASE blog_id")
+	for _, check := range checks {
+		query.WriteString(" WHEN ? THEN ?")
+		args = append(args, check.BlogID, check.CheckedAt.UTC())
+	}
+	query.WriteString(" END, INTERVAL GREATEST(check_interval, 1) MINUTE) WHERE blog_id IN (")
 	for i, check := range checks {
 		if i > 0 {
 			query.WriteByte(',')

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -339,6 +339,28 @@ func TestRecordCheckHistoriesBatchesInserts(t *testing.T) {
 	}
 }
 
+func TestUpdateSSLExpiriesBatchesUpdates(t *testing.T) {
+	mock, cleanup := withMockDB(t)
+	defer cleanup()
+
+	first := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	second := first.AddDate(0, 1, 0)
+	mock.ExpectExec("UPDATE jetpack_monitor_sites SET ssl_expiry_date = CASE blog_id").
+		WithArgs(int64(7), first, int64(42), second, int64(7), int64(42)).
+		WillReturnResult(sqlmock.NewResult(0, 2))
+
+	err := UpdateSSLExpiries(context.Background(), []SiteSSLExpiry{
+		{BlogID: 42, Expiry: second},
+		{BlogID: 7, Expiry: first},
+	})
+	if err != nil {
+		t.Fatalf("UpdateSSLExpiries: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
 func TestUpdateSiteStatusTx(t *testing.T) {
 	mock, cleanup := withMockDB(t)
 	defer cleanup()

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -112,12 +112,12 @@ func TestGetSitesForBucketScansRowsAndDefaultRedirectPolicy(t *testing.T) {
 	now := time.Now().UTC()
 	rows := sqlmock.NewRows([]string{
 		"jetpack_monitor_site_id", "blog_id", "bucket_no", "monitor_url",
-		"monitor_active", "site_status", "last_status_change", "check_interval", "last_checked_at",
+		"monitor_active", "site_status", "last_status_change", "check_interval", "last_checked_at", "next_check_at",
 		"ssl_expiry_date", "check_keyword", "maintenance_start", "maintenance_end",
 		"custom_headers", "timeout_seconds", "redirect_policy", "alert_cooldown_minutes", "last_alert_sent_at",
 	}).AddRow(
 		int64(1), int64(42), 7, "https://site.example",
-		true, 1, now, 5, now,
+		true, 1, now, 5, now, now.Add(5*time.Minute),
 		nil, nil, nil, nil,
 		nil, nil, nil, nil, nil,
 	)
@@ -140,6 +140,28 @@ func TestGetSitesForBucketScansRowsAndDefaultRedirectPolicy(t *testing.T) {
 	}
 }
 
+func TestGetSitesForBucketVariableIntervalsUsesNextCheckAt(t *testing.T) {
+	mock, cleanup := withMockDB(t)
+	defer cleanup()
+
+	rows := sqlmock.NewRows([]string{
+		"jetpack_monitor_site_id", "blog_id", "bucket_no", "monitor_url",
+		"monitor_active", "site_status", "last_status_change", "check_interval", "last_checked_at", "next_check_at",
+		"ssl_expiry_date", "check_keyword", "maintenance_start", "maintenance_end",
+		"custom_headers", "timeout_seconds", "redirect_policy", "alert_cooldown_minutes", "last_alert_sent_at",
+	})
+	mock.ExpectQuery("next_check_at").
+		WithArgs(0, 99, 50).
+		WillReturnRows(rows)
+
+	if _, err := GetSitesForBucket(context.Background(), 0, 99, 50, true); err != nil {
+		t.Fatalf("GetSitesForBucket: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
 func TestCountActiveSitesForBucketRange(t *testing.T) {
 	mock, cleanup := withMockDB(t)
 	defer cleanup()
@@ -154,6 +176,26 @@ func TestCountActiveSitesForBucketRange(t *testing.T) {
 	}
 	if count != 42 {
 		t.Fatalf("CountActiveSitesForBucketRange = %d, want 42", count)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestCountDueSitesForBucketRangeVariableIntervalsUsesNextCheckAt(t *testing.T) {
+	mock, cleanup := withMockDB(t)
+	defer cleanup()
+
+	mock.ExpectQuery("next_check_at").
+		WithArgs(10, 19).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(9))
+
+	count, err := CountDueSitesForBucketRange(context.Background(), 10, 19, true)
+	if err != nil {
+		t.Fatalf("CountDueSitesForBucketRange: %v", err)
+	}
+	if count != 9 {
+		t.Fatalf("CountDueSitesForBucketRange = %d, want 9", count)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet sql expectations: %v", err)
@@ -189,8 +231,8 @@ func TestSimpleMutationQueries(t *testing.T) {
 	mock.ExpectExec("UPDATE jetpack_monitor_sites SET site_status").
 		WithArgs(2, now, int64(42)).
 		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec("UPDATE jetpack_monitor_sites SET last_checked_at").
-		WithArgs(now, int64(42)).
+	mock.ExpectExec("UPDATE jetpack_monitor_sites").
+		WithArgs(now, now, int64(42)).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("UPDATE jetpack_monitor_sites SET last_alert_sent_at").
 		WithArgs(now, int64(42)).
@@ -253,7 +295,11 @@ func TestMarkSitesCheckedBatchesUpdates(t *testing.T) {
 	first := time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)
 	second := first.Add(time.Minute)
 	mock.ExpectExec("UPDATE jetpack_monitor_sites SET last_checked_at = CASE blog_id").
-		WithArgs(int64(7), first, int64(42), second, int64(7), int64(42)).
+		WithArgs(
+			int64(7), first, int64(42), second,
+			int64(7), first, int64(42), second,
+			int64(7), int64(42),
+		).
 		WillReturnResult(sqlmock.NewResult(0, 2))
 
 	err := MarkSitesChecked(context.Background(), []SiteCheck{

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -112,12 +112,12 @@ func TestGetSitesForBucketScansRowsAndDefaultRedirectPolicy(t *testing.T) {
 	now := time.Now().UTC()
 	rows := sqlmock.NewRows([]string{
 		"jetpack_monitor_site_id", "blog_id", "bucket_no", "monitor_url",
-		"monitor_active", "site_status", "last_status_change", "check_interval", "last_checked_at",
+		"monitor_active", "site_status", "last_status_change", "check_interval", "last_checked_at", "next_check_at",
 		"ssl_expiry_date", "check_keyword", "maintenance_start", "maintenance_end",
 		"custom_headers", "timeout_seconds", "redirect_policy", "alert_cooldown_minutes", "last_alert_sent_at",
 	}).AddRow(
 		int64(1), int64(42), 7, "https://site.example",
-		true, 1, now, 5, now,
+		true, 1, now, 5, now, now.Add(5*time.Minute),
 		nil, nil, nil, nil,
 		nil, nil, nil, nil, nil,
 	)
@@ -134,6 +134,9 @@ func TestGetSitesForBucketScansRowsAndDefaultRedirectPolicy(t *testing.T) {
 	}
 	if sites[0].BlogID != 42 || sites[0].RedirectPolicy != "follow" {
 		t.Fatalf("site = %+v", sites[0])
+	}
+	if sites[0].NextCheckAt == nil || !sites[0].NextCheckAt.Equal(now.Add(5*time.Minute)) {
+		t.Fatalf("NextCheckAt = %v, want %s", sites[0].NextCheckAt, now.Add(5*time.Minute))
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet sql expectations: %v", err)
@@ -181,16 +184,37 @@ func TestCountRecentlyCheckedActiveSitesForBucketRange(t *testing.T) {
 	}
 }
 
+func TestCountDueSitesForBucketRangeUsesNextCheckAtForVariableIntervals(t *testing.T) {
+	mock, cleanup := withMockDB(t)
+	defer cleanup()
+
+	mock.ExpectQuery("next_check_at <= NOW").
+		WithArgs(10, 19).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(5))
+
+	count, err := CountDueSitesForBucketRange(context.Background(), 10, 19, true)
+	if err != nil {
+		t.Fatalf("CountDueSitesForBucketRange: %v", err)
+	}
+	if count != 5 {
+		t.Fatalf("CountDueSitesForBucketRange = %d, want 5", count)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
 func TestSimpleMutationQueries(t *testing.T) {
 	mock, cleanup := withMockDB(t)
 	defer cleanup()
 
 	now := time.Now().UTC()
+	next := now.Add(5 * time.Minute)
 	mock.ExpectExec("UPDATE jetpack_monitor_sites SET site_status").
 		WithArgs(2, now, int64(42)).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("UPDATE jetpack_monitor_sites SET last_checked_at").
-		WithArgs(now, int64(42)).
+		WithArgs(now, next, int64(42)).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("UPDATE jetpack_monitor_sites SET last_alert_sent_at").
 		WithArgs(now, int64(42)).
@@ -217,7 +241,7 @@ func TestSimpleMutationQueries(t *testing.T) {
 	if err := UpdateSiteStatus(context.Background(), 42, 2, now); err != nil {
 		t.Fatalf("UpdateSiteStatus: %v", err)
 	}
-	if err := MarkSiteChecked(context.Background(), 42, now); err != nil {
+	if err := MarkSiteChecked(context.Background(), 42, now, next); err != nil {
 		t.Fatalf("MarkSiteChecked: %v", err)
 	}
 	if err := UpdateLastAlertSent(context.Background(), 42, now); err != nil {
@@ -252,13 +276,15 @@ func TestMarkSitesCheckedBatchesUpdates(t *testing.T) {
 
 	first := time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)
 	second := first.Add(time.Minute)
+	firstNext := first.Add(5 * time.Minute)
+	secondNext := second.Add(5 * time.Minute)
 	mock.ExpectExec("UPDATE jetpack_monitor_sites SET last_checked_at = CASE blog_id").
-		WithArgs(int64(7), first, int64(42), second, int64(7), int64(42)).
+		WithArgs(int64(7), first, int64(42), second, int64(7), firstNext, int64(42), secondNext, int64(7), int64(42)).
 		WillReturnResult(sqlmock.NewResult(0, 2))
 
 	err := MarkSitesChecked(context.Background(), []SiteCheck{
-		{BlogID: 42, CheckedAt: second},
-		{BlogID: 7, CheckedAt: first},
+		{BlogID: 42, CheckedAt: second, NextCheckAt: secondNext},
+		{BlogID: 7, CheckedAt: first, NextCheckAt: firstNext},
 	})
 	if err != nil {
 		t.Fatalf("MarkSitesChecked: %v", err)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -633,6 +633,13 @@ func dueForOperatorReport(last, now time.Time) bool {
 	return last.IsZero() || !now.Before(last.Add(schedulerOperatorReportInterval))
 }
 
+func boolMetric(v bool) int {
+	if v {
+		return 1
+	}
+	return 0
+}
+
 func (o *Orchestrator) finishRound(cfg *config.Config, summary roundSummary) {
 	// Emit metrics and update stats files.
 	roundDuration := time.Since(o.roundStart)
@@ -668,6 +675,7 @@ func (o *Orchestrator) finishRound(cfg *config.Config, summary roundSummary) {
 		m.Gauge("scheduler.round.dispatched.count", summary.dispatched)
 		m.Gauge("scheduler.round.completed.count", summary.completed)
 		m.Gauge("scheduler.round.outstanding.count", summary.outstanding)
+		m.Gauge("scheduler.round.due_count_sampled.count", boolMetric(summary.dueCountSampled))
 		if summary.dueCountSampled {
 			m.Gauge("scheduler.round.due_start.count", summary.dueAtStart)
 			m.Gauge("scheduler.round.due_remaining.count", summary.dueRemaining)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -762,8 +762,9 @@ func (o *Orchestrator) markResultsChecked(records []siteCheckResult, summary *re
 	checks := make([]db.SiteCheck, 0, len(records))
 	for _, record := range records {
 		checks = append(checks, db.SiteCheck{
-			BlogID:    record.blogID,
-			CheckedAt: resultCheckedAt(record.res),
+			BlogID:      record.blogID,
+			CheckedAt:   resultCheckedAt(record.res),
+			NextCheckAt: nextCheckAt(record.site, record.res),
 		})
 	}
 
@@ -772,7 +773,7 @@ func (o *Orchestrator) markResultsChecked(records []siteCheckResult, summary *re
 		summary.markCheckedErrors++
 		log.Printf("orchestrator: batch mark checked sites=%d: %v", len(checks), err)
 		for _, check := range checks {
-			if err := dbMarkSiteChecked(o.ctx, check.BlogID, check.CheckedAt); err != nil {
+			if err := dbMarkSiteChecked(o.ctx, check.BlogID, check.CheckedAt, check.NextCheckAt); err != nil {
 				summary.markCheckedErrors++
 				log.Printf("orchestrator: mark checked blog_id=%d: %v", check.BlogID, err)
 				continue
@@ -834,6 +835,14 @@ func resultCheckedAt(res checker.Result) time.Time {
 		return nowFunc().UTC()
 	}
 	return res.Timestamp.UTC()
+}
+
+func nextCheckAt(site db.Site, res checker.Result) time.Time {
+	interval := site.CheckInterval
+	if interval < 1 {
+		interval = 1
+	}
+	return resultCheckedAt(res).Add(time.Duration(interval) * time.Minute)
 }
 
 func shouldUpdateSSLExpiry(stored *time.Time, observed time.Time) bool {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -50,6 +50,7 @@ const verifierRPCHeadroom = 5 * time.Second
 const schedulerBackpressurePollInterval = 10 * time.Millisecond
 const schedulerVariableIntervalPollInterval = 5 * time.Second
 const schedulerBacklogPollInterval = 5 * time.Second
+const schedulerBroadReportInterval = time.Minute
 
 // VariableIntervalPollInterval returns the idle scheduler poll interval used
 // when per-site check intervals are enabled. The SQL due predicate prevents
@@ -108,6 +109,7 @@ type roundSummary struct {
 	oldestSelectedAge time.Duration
 	dueAtStart        int
 	dueRemaining      int
+	dueCountsSampled  bool
 	dueCountErrors    int
 	fetchErrors       int
 	interrupted       bool
@@ -193,6 +195,9 @@ type Orchestrator struct {
 	statsMu      sync.RWMutex
 	lastRoundSPS int
 	lastRoundDur time.Duration
+
+	lastDueCountAt        time.Time
+	lastProjectionDriftAt time.Time
 
 	ctx    stdctx.Context
 	cancel stdctx.CancelFunc
@@ -325,13 +330,20 @@ func (o *Orchestrator) runRound() roundSummary {
 			log.Printf("orchestrator: bucket rebalance failed: %v", err)
 		}
 	}
-	o.checkLegacyProjectionDrift(cfg)
+	now := nowFunc()
+	dueCountsSampled := o.shouldSampleDueCounts(now)
+	if o.shouldSampleProjectionDrift(cfg, now) {
+		o.checkLegacyProjectionDrift(cfg)
+	}
 
-	if due, err := dbCountDueSites(o.ctx, o.bucketMin, o.bucketMax, cfg.UseVariableCheckIntervals); err != nil {
-		summary.dueCountErrors++
-		log.Printf("orchestrator: count due sites failed: %v", err)
-	} else {
-		summary.dueAtStart = due
+	if dueCountsSampled {
+		summary.dueCountsSampled = true
+		if due, err := dbCountDueSites(o.ctx, o.bucketMin, o.bucketMax, cfg.UseVariableCheckIntervals); err != nil {
+			summary.dueCountErrors++
+			log.Printf("orchestrator: count due sites failed: %v", err)
+		} else {
+			summary.dueAtStart = due
+		}
 	}
 
 	pageSize := cfg.DatasetSize
@@ -374,14 +386,14 @@ func (o *Orchestrator) runRound() roundSummary {
 		}
 	}
 
-	if cfg.UseVariableCheckIntervals {
+	if cfg.UseVariableCheckIntervals && dueCountsSampled {
 		if due, err := dbCountDueSites(o.ctx, o.bucketMin, o.bucketMax, true); err != nil {
 			summary.dueCountErrors++
 			log.Printf("orchestrator: count remaining due sites failed: %v", err)
 		} else {
 			summary.dueRemaining = due
 		}
-	} else {
+	} else if !cfg.UseVariableCheckIntervals {
 		summary.dueRemaining = max(0, summary.dueAtStart-summary.completed)
 	}
 
@@ -575,6 +587,32 @@ func recordPageResult(siteMap map[int64]db.Site, results map[int64]checker.Resul
 	results[res.BlogID] = res
 }
 
+func (o *Orchestrator) shouldSampleDueCounts(now time.Time) bool {
+	if o.lastDueCountAt.IsZero() || now.Before(o.lastDueCountAt) || now.Sub(o.lastDueCountAt) >= schedulerBroadReportInterval {
+		o.lastDueCountAt = now
+		return true
+	}
+	return false
+}
+
+func (o *Orchestrator) shouldSampleProjectionDrift(cfg *config.Config, now time.Time) bool {
+	if !cfg.LegacyStatusProjectionEnable {
+		return false
+	}
+	if o.lastProjectionDriftAt.IsZero() || now.Before(o.lastProjectionDriftAt) || now.Sub(o.lastProjectionDriftAt) >= schedulerBroadReportInterval {
+		o.lastProjectionDriftAt = now
+		return true
+	}
+	return false
+}
+
+func boolInt(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}
+
 func schedulerSleepDuration(cfg *config.Config, summary roundSummary, elapsed time.Duration) time.Duration {
 	if summary.interrupted {
 		return 0
@@ -627,8 +665,11 @@ func (o *Orchestrator) finishRound(cfg *config.Config, summary roundSummary) {
 		m.Gauge("scheduler.round.dispatched.count", summary.dispatched)
 		m.Gauge("scheduler.round.completed.count", summary.completed)
 		m.Gauge("scheduler.round.outstanding.count", summary.outstanding)
-		m.Gauge("scheduler.round.due_start.count", summary.dueAtStart)
-		m.Gauge("scheduler.round.due_remaining.count", summary.dueRemaining)
+		m.Gauge("scheduler.round.due_count_sampled.count", boolInt(summary.dueCountsSampled))
+		if summary.dueCountsSampled {
+			m.Gauge("scheduler.round.due_start.count", summary.dueAtStart)
+			m.Gauge("scheduler.round.due_remaining.count", summary.dueRemaining)
+		}
 		m.Gauge("scheduler.round.selected_never_checked.count", summary.neverChecked)
 		m.Gauge("scheduler.round.selected_oldest_age_sec", int(summary.oldestSelectedAge.Seconds()))
 		m.Increment("scheduler.dispatch.backpressure_wait.count", summary.backpressureWaits)
@@ -667,8 +708,9 @@ func logRoundSummary(summary roundSummary, roundDuration time.Duration, sps int)
 		return
 	}
 	log.Printf(
-		"orchestrator: round summary pages=%d due_start=%d selected=%d dispatched=%d completed=%d outstanding=%d due_remaining=%d backpressure_waits=%d stale_results=%d duplicate_results=%d never_checked=%d oldest_selected_age_sec=%d dispatch=%s wait=%s process=%s mark_checked=%s history=%s ssl=%s events=%s mark_checked_rows=%d history_rows=%d mark_checked_errors=%d history_errors=%d duration=%s sps=%d",
+		"orchestrator: round summary pages=%d due_count_sampled=%t due_start=%d selected=%d dispatched=%d completed=%d outstanding=%d due_remaining=%d backpressure_waits=%d stale_results=%d duplicate_results=%d never_checked=%d oldest_selected_age_sec=%d dispatch=%s wait=%s process=%s mark_checked=%s history=%s ssl=%s events=%s mark_checked_rows=%d history_rows=%d mark_checked_errors=%d history_errors=%d duration=%s sps=%d",
 		summary.pagesFetched,
+		summary.dueCountsSampled,
 		summary.dueAtStart,
 		summary.selected,
 		summary.dispatched,

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -50,6 +50,7 @@ const verifierRPCHeadroom = 5 * time.Second
 const schedulerBackpressurePollInterval = 10 * time.Millisecond
 const schedulerVariableIntervalPollInterval = 5 * time.Second
 const schedulerBacklogPollInterval = 5 * time.Second
+const schedulerOperatorReportInterval = time.Minute
 
 // VariableIntervalPollInterval returns the idle scheduler poll interval used
 // when per-site check intervals are enabled. The SQL due predicate prevents
@@ -108,6 +109,7 @@ type roundSummary struct {
 	oldestSelectedAge time.Duration
 	dueAtStart        int
 	dueRemaining      int
+	dueCountSampled   bool
 	dueCountErrors    int
 	fetchErrors       int
 	interrupted       bool
@@ -138,6 +140,9 @@ func (s *roundSummary) add(other roundSummary) {
 	s.neverChecked += other.neverChecked
 	s.dueCountErrors += other.dueCountErrors
 	s.fetchErrors += other.fetchErrors
+	if other.dueCountSampled {
+		s.dueCountSampled = true
+	}
 	s.dispatchDuration += other.dispatchDuration
 	s.waitDuration += other.waitDuration
 	s.processDuration += other.processDuration
@@ -193,6 +198,9 @@ type Orchestrator struct {
 	statsMu      sync.RWMutex
 	lastRoundSPS int
 	lastRoundDur time.Duration
+
+	lastDueCountAt        time.Time
+	lastProjectionDriftAt time.Time
 
 	ctx    stdctx.Context
 	cancel stdctx.CancelFunc
@@ -306,6 +314,7 @@ func (o *Orchestrator) Stop() {
 func (o *Orchestrator) runRound() roundSummary {
 	cfg := config.Get()
 	summary := roundSummary{}
+	reportNow := nowFunc().UTC()
 	if o.roundStart.IsZero() {
 		o.roundStart = time.Now()
 	}
@@ -325,13 +334,18 @@ func (o *Orchestrator) runRound() roundSummary {
 			log.Printf("orchestrator: bucket rebalance failed: %v", err)
 		}
 	}
-	o.checkLegacyProjectionDrift(cfg)
+	o.checkLegacyProjectionDrift(cfg, reportNow)
 
-	if due, err := dbCountDueSites(o.ctx, o.bucketMin, o.bucketMax, cfg.UseVariableCheckIntervals); err != nil {
-		summary.dueCountErrors++
-		log.Printf("orchestrator: count due sites failed: %v", err)
-	} else {
-		summary.dueAtStart = due
+	sampleDueCount := !cfg.UseVariableCheckIntervals || o.shouldSampleDueCount(reportNow)
+	if sampleDueCount {
+		o.lastDueCountAt = reportNow
+		if due, err := dbCountDueSites(o.ctx, o.bucketMin, o.bucketMax, cfg.UseVariableCheckIntervals); err != nil {
+			summary.dueCountErrors++
+			log.Printf("orchestrator: count due sites failed: %v", err)
+		} else {
+			summary.dueAtStart = due
+			summary.dueCountSampled = true
+		}
 	}
 
 	pageSize := cfg.DatasetSize
@@ -375,7 +389,9 @@ func (o *Orchestrator) runRound() roundSummary {
 	}
 
 	if cfg.UseVariableCheckIntervals {
-		if due, err := dbCountDueSites(o.ctx, o.bucketMin, o.bucketMax, true); err != nil {
+		if !sampleDueCount {
+			summary.dueRemaining = 0
+		} else if due, err := dbCountDueSites(o.ctx, o.bucketMin, o.bucketMax, true); err != nil {
 			summary.dueCountErrors++
 			log.Printf("orchestrator: count remaining due sites failed: %v", err)
 		} else {
@@ -592,6 +608,18 @@ func schedulerSleepDuration(cfg *config.Config, summary roundSummary, elapsed ti
 	return minInterval - elapsed
 }
 
+func (o *Orchestrator) shouldSampleDueCount(now time.Time) bool {
+	return dueForOperatorReport(o.lastDueCountAt, now)
+}
+
+func (o *Orchestrator) shouldCheckProjectionDrift(now time.Time) bool {
+	return dueForOperatorReport(o.lastProjectionDriftAt, now)
+}
+
+func dueForOperatorReport(last, now time.Time) bool {
+	return last.IsZero() || !now.Before(last.Add(schedulerOperatorReportInterval))
+}
+
 func (o *Orchestrator) finishRound(cfg *config.Config, summary roundSummary) {
 	// Emit metrics and update stats files.
 	roundDuration := time.Since(o.roundStart)
@@ -627,8 +655,10 @@ func (o *Orchestrator) finishRound(cfg *config.Config, summary roundSummary) {
 		m.Gauge("scheduler.round.dispatched.count", summary.dispatched)
 		m.Gauge("scheduler.round.completed.count", summary.completed)
 		m.Gauge("scheduler.round.outstanding.count", summary.outstanding)
-		m.Gauge("scheduler.round.due_start.count", summary.dueAtStart)
-		m.Gauge("scheduler.round.due_remaining.count", summary.dueRemaining)
+		if summary.dueCountSampled {
+			m.Gauge("scheduler.round.due_start.count", summary.dueAtStart)
+			m.Gauge("scheduler.round.due_remaining.count", summary.dueRemaining)
+		}
 		m.Gauge("scheduler.round.selected_never_checked.count", summary.neverChecked)
 		m.Gauge("scheduler.round.selected_oldest_age_sec", int(summary.oldestSelectedAge.Seconds()))
 		m.Increment("scheduler.dispatch.backpressure_wait.count", summary.backpressureWaits)
@@ -667,8 +697,9 @@ func logRoundSummary(summary roundSummary, roundDuration time.Duration, sps int)
 		return
 	}
 	log.Printf(
-		"orchestrator: round summary pages=%d due_start=%d selected=%d dispatched=%d completed=%d outstanding=%d due_remaining=%d backpressure_waits=%d stale_results=%d duplicate_results=%d never_checked=%d oldest_selected_age_sec=%d dispatch=%s wait=%s process=%s mark_checked=%s history=%s ssl=%s events=%s mark_checked_rows=%d history_rows=%d mark_checked_errors=%d history_errors=%d duration=%s sps=%d",
+		"orchestrator: round summary pages=%d due_count_sampled=%t due_start=%d selected=%d dispatched=%d completed=%d outstanding=%d due_remaining=%d backpressure_waits=%d stale_results=%d duplicate_results=%d never_checked=%d oldest_selected_age_sec=%d dispatch=%s wait=%s process=%s mark_checked=%s history=%s ssl=%s events=%s mark_checked_rows=%d history_rows=%d mark_checked_errors=%d history_errors=%d duration=%s sps=%d",
 		summary.pagesFetched,
+		summary.dueCountSampled,
 		summary.dueAtStart,
 		summary.selected,
 		summary.dispatched,
@@ -1320,10 +1351,14 @@ func (o *Orchestrator) isAlertSuppressed(site db.Site) bool {
 	return time.Since(*site.LastAlertSentAt) < time.Duration(cooldown)*time.Minute
 }
 
-func (o *Orchestrator) checkLegacyProjectionDrift(cfg *config.Config) {
+func (o *Orchestrator) checkLegacyProjectionDrift(cfg *config.Config, now time.Time) {
 	if !cfg.LegacyStatusProjectionEnable {
 		return
 	}
+	if !o.shouldCheckProjectionDrift(now) {
+		return
+	}
+	o.lastProjectionDriftAt = now
 	count, err := dbCountProjectionDrift(o.ctx, o.bucketMin, o.bucketMax)
 	if err != nil {
 		log.Printf("orchestrator: legacy projection drift check failed: %v", err)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -71,6 +71,7 @@ var (
 	dbRecordCheckHistory   = db.RecordCheckHistory
 	dbRecordCheckHistories = db.RecordCheckHistories
 	dbUpdateSSLExpiry      = db.UpdateSSLExpiry
+	dbUpdateSSLExpiries    = db.UpdateSSLExpiries
 	dbUpdateSiteStatus     = db.UpdateSiteStatus
 	dbRecordFalsePositive  = db.RecordFalsePositive
 	dbUpdateLastAlertSent  = db.UpdateLastAlertSent
@@ -124,8 +125,10 @@ type roundSummary struct {
 
 	markCheckedRows   int
 	historyRows       int
+	sslRows           int
 	markCheckedErrors int
 	historyErrors     int
+	sslErrors         int
 }
 
 func (s *roundSummary) add(other roundSummary) {
@@ -152,8 +155,10 @@ func (s *roundSummary) add(other roundSummary) {
 	s.eventDuration += other.eventDuration
 	s.markCheckedRows += other.markCheckedRows
 	s.historyRows += other.historyRows
+	s.sslRows += other.sslRows
 	s.markCheckedErrors += other.markCheckedErrors
 	s.historyErrors += other.historyErrors
+	s.sslErrors += other.sslErrors
 	if other.oldestSelectedAge > s.oldestSelectedAge {
 		s.oldestSelectedAge = other.oldestSelectedAge
 	}
@@ -166,8 +171,10 @@ type resultProcessSummary struct {
 	processed           int
 	markCheckedRows     int
 	historyRows         int
+	sslRows             int
 	markCheckedErrors   int
 	historyErrors       int
+	sslErrors           int
 	markCheckedDuration time.Duration
 	historyDuration     time.Duration
 	sslDuration         time.Duration
@@ -458,8 +465,10 @@ process:
 	summary.completed += processSummary.processed
 	summary.markCheckedRows += processSummary.markCheckedRows
 	summary.historyRows += processSummary.historyRows
+	summary.sslRows += processSummary.sslRows
 	summary.markCheckedErrors += processSummary.markCheckedErrors
 	summary.historyErrors += processSummary.historyErrors
+	summary.sslErrors += processSummary.sslErrors
 	summary.markCheckedDuration += processSummary.markCheckedDuration
 	summary.historyDuration += processSummary.historyDuration
 	summary.sslDuration += processSummary.sslDuration
@@ -484,13 +493,15 @@ func emitPageMetrics(summary roundSummary) {
 	m.Timing("scheduler.page.events.time", summary.eventDuration)
 	m.Increment("scheduler.page.mark_checked.row.count", summary.markCheckedRows)
 	m.Increment("scheduler.page.history.row.count", summary.historyRows)
+	m.Increment("scheduler.page.ssl.row.count", summary.sslRows)
 	m.Increment("scheduler.page.mark_checked.error.count", summary.markCheckedErrors)
 	m.Increment("scheduler.page.history.error.count", summary.historyErrors)
+	m.Increment("scheduler.page.ssl.error.count", summary.sslErrors)
 }
 
 func logPageSummary(pageNumber, sites int, summary roundSummary) {
 	log.Printf(
-		"orchestrator: page summary page=%d sites=%d dispatched=%d completed=%d outstanding=%d dispatch=%s wait=%s process=%s mark_checked=%s history=%s ssl=%s events=%s mark_checked_rows=%d history_rows=%d mark_checked_errors=%d history_errors=%d",
+		"orchestrator: page summary page=%d sites=%d dispatched=%d completed=%d outstanding=%d dispatch=%s wait=%s process=%s mark_checked=%s history=%s ssl=%s events=%s mark_checked_rows=%d history_rows=%d ssl_rows=%d mark_checked_errors=%d history_errors=%d ssl_errors=%d",
 		pageNumber,
 		sites,
 		summary.dispatched,
@@ -505,8 +516,10 @@ func logPageSummary(pageNumber, sites int, summary roundSummary) {
 		summary.eventDuration.Round(time.Millisecond),
 		summary.markCheckedRows,
 		summary.historyRows,
+		summary.sslRows,
 		summary.markCheckedErrors,
 		summary.historyErrors,
+		summary.sslErrors,
 	)
 }
 
@@ -675,8 +688,10 @@ func (o *Orchestrator) finishRound(cfg *config.Config, summary roundSummary) {
 		m.Timing("scheduler.round.events.time", summary.eventDuration)
 		m.Increment("scheduler.round.mark_checked.row.count", summary.markCheckedRows)
 		m.Increment("scheduler.round.history.row.count", summary.historyRows)
+		m.Increment("scheduler.round.ssl.row.count", summary.sslRows)
 		m.Increment("scheduler.round.mark_checked.error.count", summary.markCheckedErrors)
 		m.Increment("scheduler.round.history.error.count", summary.historyErrors)
+		m.Increment("scheduler.round.ssl.error.count", summary.sslErrors)
 
 		if cfg.StatsdSendMemUsage {
 			m.EmitMemStats()
@@ -697,7 +712,7 @@ func logRoundSummary(summary roundSummary, roundDuration time.Duration, sps int)
 		return
 	}
 	log.Printf(
-		"orchestrator: round summary pages=%d due_count_sampled=%t due_start=%d selected=%d dispatched=%d completed=%d outstanding=%d due_remaining=%d backpressure_waits=%d stale_results=%d duplicate_results=%d never_checked=%d oldest_selected_age_sec=%d dispatch=%s wait=%s process=%s mark_checked=%s history=%s ssl=%s events=%s mark_checked_rows=%d history_rows=%d mark_checked_errors=%d history_errors=%d duration=%s sps=%d",
+		"orchestrator: round summary pages=%d due_count_sampled=%t due_start=%d selected=%d dispatched=%d completed=%d outstanding=%d due_remaining=%d backpressure_waits=%d stale_results=%d duplicate_results=%d never_checked=%d oldest_selected_age_sec=%d dispatch=%s wait=%s process=%s mark_checked=%s history=%s ssl=%s events=%s mark_checked_rows=%d history_rows=%d ssl_rows=%d mark_checked_errors=%d history_errors=%d ssl_errors=%d duration=%s sps=%d",
 		summary.pagesFetched,
 		summary.dueCountSampled,
 		summary.dueAtStart,
@@ -720,8 +735,10 @@ func logRoundSummary(summary roundSummary, roundDuration time.Duration, sps int)
 		summary.eventDuration.Round(time.Millisecond),
 		summary.markCheckedRows,
 		summary.historyRows,
+		summary.sslRows,
 		summary.markCheckedErrors,
 		summary.historyErrors,
+		summary.sslErrors,
 		roundDuration.Round(time.Millisecond),
 		sps,
 	)
@@ -738,17 +755,20 @@ func (o *Orchestrator) processResults(results map[int64]checker.Result, sites ma
 	o.recordResultHistories(records, &summary)
 
 	sslStart := time.Now()
+	sslUpdates := make([]db.SiteSSLExpiry, 0)
 	for _, record := range records {
 		// Update SSL expiry if available.
 		if record.res.SSLExpiry != nil {
 			if shouldUpdateSSLExpiry(record.site.SSLExpiryDate, *record.res.SSLExpiry) {
-				if err := dbUpdateSSLExpiry(o.ctx, record.blogID, *record.res.SSLExpiry); err != nil {
-					log.Printf("orchestrator: update ssl expiry blog_id=%d: %v", record.blogID, err)
-				}
+				sslUpdates = append(sslUpdates, db.SiteSSLExpiry{
+					BlogID: record.blogID,
+					Expiry: *record.res.SSLExpiry,
+				})
 			}
 			o.checkSSLAlerts(record.site, *record.res.SSLExpiry)
 		}
 	}
+	o.updateSSLExpiries(sslUpdates, &summary)
 	summary.sslDuration += time.Since(sslStart)
 
 	eventStart := time.Now()
@@ -763,6 +783,26 @@ func (o *Orchestrator) processResults(results map[int64]checker.Result, sites ma
 	}
 	summary.eventDuration += time.Since(eventStart)
 	return summary
+}
+
+func (o *Orchestrator) updateSSLExpiries(updates []db.SiteSSLExpiry, summary *resultProcessSummary) {
+	if len(updates) == 0 {
+		return
+	}
+	if err := dbUpdateSSLExpiries(o.ctx, updates); err != nil {
+		summary.sslErrors++
+		log.Printf("orchestrator: batch update ssl expiries rows=%d: %v", len(updates), err)
+		for _, update := range updates {
+			if err := dbUpdateSSLExpiry(o.ctx, update.BlogID, update.Expiry); err != nil {
+				summary.sslErrors++
+				log.Printf("orchestrator: update ssl expiry blog_id=%d: %v", update.BlogID, err)
+				continue
+			}
+			summary.sslRows++
+		}
+		return
+	}
+	summary.sslRows += len(updates)
 }
 
 func knownSiteResults(results map[int64]checker.Result, sites map[int64]db.Site) []siteCheckResult {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-sql-driver/mysql"
+
 	"github.com/Automattic/jetmon/internal/audit"
 	"github.com/Automattic/jetmon/internal/checker"
 	"github.com/Automattic/jetmon/internal/config"
@@ -51,6 +53,8 @@ const schedulerBackpressurePollInterval = 10 * time.Millisecond
 const schedulerVariableIntervalPollInterval = 5 * time.Second
 const schedulerBacklogPollInterval = 5 * time.Second
 const schedulerOperatorReportInterval = time.Minute
+const eventMutationMaxAttempts = 3
+const eventMutationRetryBaseDelay = 25 * time.Millisecond
 
 // VariableIntervalPollInterval returns the idle scheduler poll interval used
 // when per-site check intervals are enabled. The SQL due predicate prevents
@@ -129,6 +133,16 @@ type roundSummary struct {
 	markCheckedErrors int
 	historyErrors     int
 	sslErrors         int
+
+	checkSuccesses     int
+	checkFailures      int
+	checkHTTPFailures  int
+	checkTimeouts      int
+	checkConnectErrors int
+	checkSSLErrors     int
+	checkRedirects     int
+	checkKeywords      int
+	checkTLSDeprecated int
 }
 
 func (s *roundSummary) add(other roundSummary) {
@@ -159,6 +173,15 @@ func (s *roundSummary) add(other roundSummary) {
 	s.markCheckedErrors += other.markCheckedErrors
 	s.historyErrors += other.historyErrors
 	s.sslErrors += other.sslErrors
+	s.checkSuccesses += other.checkSuccesses
+	s.checkFailures += other.checkFailures
+	s.checkHTTPFailures += other.checkHTTPFailures
+	s.checkTimeouts += other.checkTimeouts
+	s.checkConnectErrors += other.checkConnectErrors
+	s.checkSSLErrors += other.checkSSLErrors
+	s.checkRedirects += other.checkRedirects
+	s.checkKeywords += other.checkKeywords
+	s.checkTLSDeprecated += other.checkTLSDeprecated
 	if other.oldestSelectedAge > s.oldestSelectedAge {
 		s.oldestSelectedAge = other.oldestSelectedAge
 	}
@@ -168,13 +191,24 @@ func (s *roundSummary) add(other roundSummary) {
 }
 
 type resultProcessSummary struct {
-	processed           int
-	markCheckedRows     int
-	historyRows         int
-	sslRows             int
-	markCheckedErrors   int
-	historyErrors       int
-	sslErrors           int
+	processed         int
+	markCheckedRows   int
+	historyRows       int
+	sslRows           int
+	markCheckedErrors int
+	historyErrors     int
+	sslErrors         int
+
+	checkSuccesses     int
+	checkFailures      int
+	checkHTTPFailures  int
+	checkTimeouts      int
+	checkConnectErrors int
+	checkSSLErrors     int
+	checkRedirects     int
+	checkKeywords      int
+	checkTLSDeprecated int
+
 	markCheckedDuration time.Duration
 	historyDuration     time.Duration
 	sslDuration         time.Duration
@@ -469,6 +503,15 @@ process:
 	summary.markCheckedErrors += processSummary.markCheckedErrors
 	summary.historyErrors += processSummary.historyErrors
 	summary.sslErrors += processSummary.sslErrors
+	summary.checkSuccesses += processSummary.checkSuccesses
+	summary.checkFailures += processSummary.checkFailures
+	summary.checkHTTPFailures += processSummary.checkHTTPFailures
+	summary.checkTimeouts += processSummary.checkTimeouts
+	summary.checkConnectErrors += processSummary.checkConnectErrors
+	summary.checkSSLErrors += processSummary.checkSSLErrors
+	summary.checkRedirects += processSummary.checkRedirects
+	summary.checkKeywords += processSummary.checkKeywords
+	summary.checkTLSDeprecated += processSummary.checkTLSDeprecated
 	summary.markCheckedDuration += processSummary.markCheckedDuration
 	summary.historyDuration += processSummary.historyDuration
 	summary.sslDuration += processSummary.sslDuration
@@ -497,11 +540,20 @@ func emitPageMetrics(summary roundSummary) {
 	m.Increment("scheduler.page.mark_checked.error.count", summary.markCheckedErrors)
 	m.Increment("scheduler.page.history.error.count", summary.historyErrors)
 	m.Increment("scheduler.page.ssl.error.count", summary.sslErrors)
+	m.Increment("scheduler.page.check.success.count", summary.checkSuccesses)
+	m.Increment("scheduler.page.check.failure.count", summary.checkFailures)
+	m.Increment("scheduler.page.check.http_failure.count", summary.checkHTTPFailures)
+	m.Increment("scheduler.page.check.timeout.count", summary.checkTimeouts)
+	m.Increment("scheduler.page.check.connect_error.count", summary.checkConnectErrors)
+	m.Increment("scheduler.page.check.ssl_error.count", summary.checkSSLErrors)
+	m.Increment("scheduler.page.check.redirect.count", summary.checkRedirects)
+	m.Increment("scheduler.page.check.keyword.count", summary.checkKeywords)
+	m.Increment("scheduler.page.check.tls_deprecated.count", summary.checkTLSDeprecated)
 }
 
 func logPageSummary(pageNumber, sites int, summary roundSummary) {
 	log.Printf(
-		"orchestrator: page summary page=%d sites=%d dispatched=%d completed=%d outstanding=%d dispatch=%s wait=%s process=%s mark_checked=%s history=%s ssl=%s events=%s mark_checked_rows=%d history_rows=%d ssl_rows=%d mark_checked_errors=%d history_errors=%d ssl_errors=%d",
+		"orchestrator: page summary page=%d sites=%d dispatched=%d completed=%d outstanding=%d dispatch=%s wait=%s process=%s mark_checked=%s history=%s ssl=%s events=%s checks_success=%d checks_failure=%d checks_http_failure=%d checks_timeout=%d checks_connect_error=%d checks_ssl_error=%d checks_redirect=%d checks_keyword=%d checks_tls_deprecated=%d mark_checked_rows=%d history_rows=%d ssl_rows=%d mark_checked_errors=%d history_errors=%d ssl_errors=%d",
 		pageNumber,
 		sites,
 		summary.dispatched,
@@ -514,6 +566,15 @@ func logPageSummary(pageNumber, sites int, summary roundSummary) {
 		summary.historyDuration.Round(time.Millisecond),
 		summary.sslDuration.Round(time.Millisecond),
 		summary.eventDuration.Round(time.Millisecond),
+		summary.checkSuccesses,
+		summary.checkFailures,
+		summary.checkHTTPFailures,
+		summary.checkTimeouts,
+		summary.checkConnectErrors,
+		summary.checkSSLErrors,
+		summary.checkRedirects,
+		summary.checkKeywords,
+		summary.checkTLSDeprecated,
 		summary.markCheckedRows,
 		summary.historyRows,
 		summary.sslRows,
@@ -700,6 +761,15 @@ func (o *Orchestrator) finishRound(cfg *config.Config, summary roundSummary) {
 		m.Increment("scheduler.round.mark_checked.error.count", summary.markCheckedErrors)
 		m.Increment("scheduler.round.history.error.count", summary.historyErrors)
 		m.Increment("scheduler.round.ssl.error.count", summary.sslErrors)
+		m.Increment("scheduler.round.check.success.count", summary.checkSuccesses)
+		m.Increment("scheduler.round.check.failure.count", summary.checkFailures)
+		m.Increment("scheduler.round.check.http_failure.count", summary.checkHTTPFailures)
+		m.Increment("scheduler.round.check.timeout.count", summary.checkTimeouts)
+		m.Increment("scheduler.round.check.connect_error.count", summary.checkConnectErrors)
+		m.Increment("scheduler.round.check.ssl_error.count", summary.checkSSLErrors)
+		m.Increment("scheduler.round.check.redirect.count", summary.checkRedirects)
+		m.Increment("scheduler.round.check.keyword.count", summary.checkKeywords)
+		m.Increment("scheduler.round.check.tls_deprecated.count", summary.checkTLSDeprecated)
 
 		if cfg.StatsdSendMemUsage {
 			m.EmitMemStats()
@@ -720,7 +790,7 @@ func logRoundSummary(summary roundSummary, roundDuration time.Duration, sps int)
 		return
 	}
 	log.Printf(
-		"orchestrator: round summary pages=%d due_count_sampled=%t due_start=%d selected=%d dispatched=%d completed=%d outstanding=%d due_remaining=%d backpressure_waits=%d stale_results=%d duplicate_results=%d never_checked=%d oldest_selected_age_sec=%d dispatch=%s wait=%s process=%s mark_checked=%s history=%s ssl=%s events=%s mark_checked_rows=%d history_rows=%d ssl_rows=%d mark_checked_errors=%d history_errors=%d ssl_errors=%d duration=%s sps=%d",
+		"orchestrator: round summary pages=%d due_count_sampled=%t due_start=%d selected=%d dispatched=%d completed=%d outstanding=%d due_remaining=%d backpressure_waits=%d stale_results=%d duplicate_results=%d never_checked=%d oldest_selected_age_sec=%d dispatch=%s wait=%s process=%s mark_checked=%s history=%s ssl=%s events=%s checks_success=%d checks_failure=%d checks_http_failure=%d checks_timeout=%d checks_connect_error=%d checks_ssl_error=%d checks_redirect=%d checks_keyword=%d checks_tls_deprecated=%d mark_checked_rows=%d history_rows=%d ssl_rows=%d mark_checked_errors=%d history_errors=%d ssl_errors=%d duration=%s sps=%d",
 		summary.pagesFetched,
 		summary.dueCountSampled,
 		summary.dueAtStart,
@@ -741,6 +811,15 @@ func logRoundSummary(summary roundSummary, roundDuration time.Duration, sps int)
 		summary.historyDuration.Round(time.Millisecond),
 		summary.sslDuration.Round(time.Millisecond),
 		summary.eventDuration.Round(time.Millisecond),
+		summary.checkSuccesses,
+		summary.checkFailures,
+		summary.checkHTTPFailures,
+		summary.checkTimeouts,
+		summary.checkConnectErrors,
+		summary.checkSSLErrors,
+		summary.checkRedirects,
+		summary.checkKeywords,
+		summary.checkTLSDeprecated,
 		summary.markCheckedRows,
 		summary.historyRows,
 		summary.sslRows,
@@ -757,6 +836,9 @@ func (o *Orchestrator) processResults(results map[int64]checker.Result, sites ma
 	summary := resultProcessSummary{processed: len(records)}
 	if len(records) == 0 {
 		return summary
+	}
+	for _, record := range records {
+		addCheckOutcome(&summary, record.res)
 	}
 
 	o.markResultsChecked(records, &summary)
@@ -791,6 +873,32 @@ func (o *Orchestrator) processResults(results map[int64]checker.Result, sites ma
 	}
 	summary.eventDuration += time.Since(eventStart)
 	return summary
+}
+
+func addCheckOutcome(summary *resultProcessSummary, res checker.Result) {
+	if res.Success {
+		summary.checkSuccesses++
+	} else {
+		summary.checkFailures++
+	}
+
+	if !res.Success && res.HTTPCode >= 400 {
+		summary.checkHTTPFailures++
+	}
+	switch res.ErrorCode {
+	case checker.ErrorTimeout:
+		summary.checkTimeouts++
+	case checker.ErrorConnect:
+		summary.checkConnectErrors++
+	case checker.ErrorSSL, checker.ErrorTLSExpired:
+		summary.checkSSLErrors++
+	case checker.ErrorRedirect:
+		summary.checkRedirects++
+	case checker.ErrorKeyword:
+		summary.checkKeywords++
+	case checker.ErrorTLSDeprecated:
+		summary.checkTLSDeprecated++
+	}
 }
 
 func (o *Orchestrator) updateSSLExpiries(updates []db.SiteSSLExpiry, summary *resultProcessSummary) {
@@ -976,12 +1084,12 @@ func (o *Orchestrator) handleFailure(site db.Site, res checker.Result) {
 	// failure would update the same row, so this is also a self-healing retry
 	// path if a previous Open failed to commit.
 	if entry.eventID == 0 {
-		id, err := o.openSeemsDown(site, res)
+		id, opened, err := o.openSeemsDown(site, res)
 		if err != nil {
 			log.Printf("orchestrator: open seems-down event blog_id=%d: %v", site.BlogID, err)
 		} else {
 			entry.eventID = id
-			if entry.failCount == 1 {
+			if opened || entry.failCount == 1 {
 				emitCounter("detection.seems_down.open.count", 1)
 				emitCounter("detection.seems_down.open."+class+".count", 1)
 				emitTimingSince("detection.first_failure_to_seems_down.time", entry.firstFailAt, nowFunc().UTC())
@@ -1328,6 +1436,12 @@ func (o *Orchestrator) checkSSLAlerts(site db.Site, expiry time.Time) {
 // warnings don't affect the Up/Down state of the site (Layer 2 issue, not a
 // Layer 4 outage).
 func (o *Orchestrator) openOrUpdateSSLExpiry(blogID int64, severity uint8, state string, daysUntil int, meta json.RawMessage) error {
+	return o.withEventMutationRetry(blogID, "open_update_ssl_expiry", func() error {
+		return o.openOrUpdateSSLExpiryOnce(blogID, severity, state, daysUntil, meta)
+	})
+}
+
+func (o *Orchestrator) openOrUpdateSSLExpiryOnce(blogID int64, severity uint8, state string, daysUntil int, meta json.RawMessage) error {
 	tx, err := o.ev().Begin(o.ctx)
 	if err != nil {
 		return err
@@ -1362,6 +1476,12 @@ func (o *Orchestrator) openOrUpdateSSLExpiry(blogID int64, severity uint8, state
 // closeSSLExpiryIfOpen closes an open tls_expiry event for the site, if any.
 // No-op if no event exists.
 func (o *Orchestrator) closeSSLExpiryIfOpen(blogID int64) error {
+	return o.withEventMutationRetry(blogID, "close_ssl_expiry", func() error {
+		return o.closeSSLExpiryIfOpenOnce(blogID)
+	})
+}
+
+func (o *Orchestrator) closeSSLExpiryIfOpenOnce(blogID int64) error {
 	tx, err := o.ev().Begin(o.ctx)
 	if err != nil {
 		return err
@@ -1522,14 +1642,74 @@ func metricSegment(s string) string {
 	return out
 }
 
+func (o *Orchestrator) withEventMutationRetry(blogID int64, operation string, fn func() error) error {
+	ctx := o.ctx
+	if ctx == nil {
+		ctx = stdctx.Background()
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= eventMutationMaxAttempts; attempt++ {
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if !isRetryableMySQLError(err) || attempt == eventMutationMaxAttempts {
+			return err
+		}
+		emitCounter("eventstore.mutation.retry.count", 1)
+		emitCounter("eventstore.mutation."+metricSegment(operation)+".retry.count", 1)
+		wait := time.Duration(attempt) * eventMutationRetryBaseDelay
+		log.Printf("orchestrator: retrying event mutation blog_id=%d operation=%s attempt=%d/%d wait=%s err=%v",
+			blogID, operation, attempt+1, eventMutationMaxAttempts, wait, err)
+		timer := time.NewTimer(wait)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		}
+	}
+	return lastErr
+}
+
+func isRetryableMySQLError(err error) bool {
+	var mysqlErr *mysql.MySQLError
+	if !errors.As(err, &mysqlErr) {
+		return false
+	}
+	switch mysqlErr.Number {
+	case 1205, 1213:
+		return true
+	default:
+		return false
+	}
+}
+
 // openSeemsDown opens (or re-detects) a Seems Down event for an HTTP-failing
 // site and projects v1 site_status=SITE_DOWN in the same transaction. Returns
 // the event id. Idempotent: a re-detection of the same identity returns the
 // existing event's id with no transition row written and no projection update.
-func (o *Orchestrator) openSeemsDown(site db.Site, res checker.Result) (int64, error) {
+func (o *Orchestrator) openSeemsDown(site db.Site, res checker.Result) (int64, bool, error) {
+	var eventID int64
+	var opened bool
+	err := o.withEventMutationRetry(site.BlogID, "open_seems_down", func() error {
+		id, didOpen, err := o.openSeemsDownOnce(site, res)
+		if err != nil {
+			return err
+		}
+		eventID = id
+		opened = didOpen
+		return nil
+	})
+	return eventID, opened, err
+}
+
+func (o *Orchestrator) openSeemsDownOnce(site db.Site, res checker.Result) (int64, bool, error) {
 	tx, err := o.ev().Begin(o.ctx)
 	if err != nil {
-		return 0, err
+		return 0, false, err
 	}
 	defer func() { _ = tx.Rollback() }()
 
@@ -1548,7 +1728,7 @@ func (o *Orchestrator) openSeemsDown(site db.Site, res checker.Result) (int64, e
 		Metadata: meta,
 	})
 	if err != nil {
-		return 0, err
+		return 0, false, err
 	}
 
 	// Project v1 site_status=SITE_DOWN only on the actual insert. A re-detection
@@ -1556,19 +1736,25 @@ func (o *Orchestrator) openSeemsDown(site db.Site, res checker.Result) (int64, e
 	// was already projected when the event first opened.
 	if out.Opened && config.LegacyStatusProjectionEnabled() && tx.Tx() != nil {
 		if err := db.UpdateSiteStatusTx(o.ctx, tx.Tx(), site.BlogID, statusDown, nowFunc().UTC()); err != nil {
-			return 0, fmt.Errorf("project site_status: %w", err)
+			return 0, false, fmt.Errorf("project site_status: %w", err)
 		}
 	}
 
 	if err := tx.Commit(); err != nil {
-		return 0, fmt.Errorf("commit: %w", err)
+		return 0, false, fmt.Errorf("commit: %w", err)
 	}
-	return out.EventID, nil
+	return out.EventID, out.Opened, nil
 }
 
 // promoteToDown bumps an open Seems Down event to Down (severity 4) and
 // projects site_status=SITE_CONFIRMED_DOWN in the same transaction.
 func (o *Orchestrator) promoteToDown(blogID, eventID int64, changeTime time.Time, meta json.RawMessage) error {
+	return o.withEventMutationRetry(blogID, "promote_to_down", func() error {
+		return o.promoteToDownOnce(blogID, eventID, changeTime, meta)
+	})
+}
+
+func (o *Orchestrator) promoteToDownOnce(blogID, eventID int64, changeTime time.Time, meta json.RawMessage) error {
 	tx, err := o.ev().Begin(o.ctx)
 	if err != nil {
 		return err
@@ -1592,6 +1778,12 @@ func (o *Orchestrator) promoteToDown(blogID, eventID int64, changeTime time.Time
 // closeEvent closes an open event with the given resolution reason and projects
 // site_status to the given v1 value in the same transaction.
 func (o *Orchestrator) closeEvent(blogID, eventID int64, reason string, projectedStatus int, changeTime time.Time, meta json.RawMessage) error {
+	return o.withEventMutationRetry(blogID, "close_event", func() error {
+		return o.closeEventOnce(blogID, eventID, reason, projectedStatus, changeTime, meta)
+	})
+}
+
+func (o *Orchestrator) closeEventOnce(blogID, eventID int64, reason string, projectedStatus int, changeTime time.Time, meta json.RawMessage) error {
 	tx, err := o.ev().Begin(o.ctx)
 	if err != nil {
 		return err
@@ -1617,6 +1809,12 @@ func (o *Orchestrator) closeEvent(blogID, eventID int64, reason string, projecte
 // inside the transaction. site_status is projected back to SITE_RUNNING in the
 // same tx.
 func (o *Orchestrator) closeRecoveredEvent(blogID, knownEventID int64, changeTime time.Time) error {
+	return o.withEventMutationRetry(blogID, "close_recovered_event", func() error {
+		return o.closeRecoveredEventOnce(blogID, knownEventID, changeTime)
+	})
+}
+
+func (o *Orchestrator) closeRecoveredEventOnce(blogID, knownEventID int64, changeTime time.Time) error {
 	tx, err := o.ev().Begin(o.ctx)
 	if err != nil {
 		return err

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -376,7 +376,7 @@ func stubOrchestratorDeps() func() {
 	dbUpdateSiteStatus = func(context.Context, int64, int, time.Time) error { return nil }
 	dbUpdateLastAlertSent = func(context.Context, int64, time.Time) error { return nil }
 	dbRecordFalsePositive = func(int64, int, int, int64) error { return nil }
-	dbMarkSiteChecked = func(context.Context, int64, time.Time) error { return nil }
+	dbMarkSiteChecked = func(context.Context, int64, time.Time, time.Time) error { return nil }
 	dbMarkSitesChecked = func(context.Context, []db.SiteCheck) error { return nil }
 	dbRecordCheckHistory = func(int64, int, int, int64, int64, int64, int64, int64) error { return nil }
 	dbRecordCheckHistories = func(context.Context, []db.CheckHistoryRow) error { return nil }
@@ -590,11 +590,15 @@ func TestProcessResultsMarksChecked(t *testing.T) {
 	setTestConfig(t)
 
 	var markedBlogID int64
+	var markedAt time.Time
+	var markedNext time.Time
 	dbMarkSitesChecked = func(_ context.Context, checks []db.SiteCheck) error {
 		if len(checks) != 1 {
 			t.Fatalf("batch checks = %d, want 1", len(checks))
 		}
 		markedBlogID = checks[0].BlogID
+		markedAt = checks[0].CheckedAt
+		markedNext = checks[0].NextCheckAt
 		return nil
 	}
 
@@ -606,11 +610,18 @@ func TestProcessResultsMarksChecked(t *testing.T) {
 	}
 
 	res := checkerResultSuccess(42)
-	sites := map[int64]db.Site{42: {BlogID: 42, SiteStatus: statusRunning}}
+	res.Timestamp = time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	sites := map[int64]db.Site{42: {BlogID: 42, SiteStatus: statusRunning, CheckInterval: 7}}
 	o.processResults(map[int64]checker.Result{42: res}, sites)
 
 	if markedBlogID != 42 {
 		t.Fatalf("MarkSitesChecked blog_id = %d, want 42", markedBlogID)
+	}
+	if !markedAt.Equal(res.Timestamp) {
+		t.Fatalf("MarkSitesChecked checked_at = %s, want %s", markedAt, res.Timestamp)
+	}
+	if want := res.Timestamp.Add(7 * time.Minute); !markedNext.Equal(want) {
+		t.Fatalf("MarkSitesChecked next_check_at = %s, want %s", markedNext, want)
 	}
 }
 
@@ -627,7 +638,7 @@ func TestProcessResultsFallsBackWhenBatchWritesFail(t *testing.T) {
 	}
 
 	var fallbackMarked int64
-	dbMarkSiteChecked = func(_ context.Context, blogID int64, _ time.Time) error {
+	dbMarkSiteChecked = func(_ context.Context, blogID int64, _, _ time.Time) error {
 		fallbackMarked = blogID
 		return nil
 	}
@@ -1390,7 +1401,7 @@ func TestProcessResultsLogsErrorsFromDB(t *testing.T) {
 	dbMarkSitesChecked = func(context.Context, []db.SiteCheck) error {
 		return fmt.Errorf("batch mark checked error")
 	}
-	dbMarkSiteChecked = func(context.Context, int64, time.Time) error {
+	dbMarkSiteChecked = func(context.Context, int64, time.Time, time.Time) error {
 		return fmt.Errorf("mark checked error")
 	}
 	dbRecordCheckHistories = func(context.Context, []db.CheckHistoryRow) error {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1113,6 +1113,8 @@ func TestRunRoundSamplesBroadOperatorCountsOnCadence(t *testing.T) {
 		driftCalls++
 		return 0, nil
 	}
+	rec := newRecordingMetrics()
+	metricsClientFunc = func() metricsClient { return rec }
 
 	o := &Orchestrator{
 		ctx:        context.Background(),
@@ -1126,6 +1128,9 @@ func TestRunRoundSamplesBroadOperatorCountsOnCadence(t *testing.T) {
 	if driftCalls != 1 {
 		t.Fatalf("first round drift calls = %d, want 1", driftCalls)
 	}
+	if got := rec.gauge("scheduler.round.due_count_sampled.count"); got != 1 {
+		t.Fatalf("first round due_count_sampled metric = %d, want 1", got)
+	}
 
 	base = base.Add(5 * time.Second)
 	o.runRound()
@@ -1135,6 +1140,9 @@ func TestRunRoundSamplesBroadOperatorCountsOnCadence(t *testing.T) {
 	if driftCalls != 1 {
 		t.Fatalf("second round drift calls = %d, want still 1", driftCalls)
 	}
+	if got := rec.gauge("scheduler.round.due_count_sampled.count"); got != 0 {
+		t.Fatalf("second round due_count_sampled metric = %d, want 0", got)
+	}
 
 	base = base.Add(schedulerOperatorReportInterval)
 	o.runRound()
@@ -1143,6 +1151,9 @@ func TestRunRoundSamplesBroadOperatorCountsOnCadence(t *testing.T) {
 	}
 	if driftCalls != 2 {
 		t.Fatalf("cadence round drift calls = %d, want 2", driftCalls)
+	}
+	if got := rec.gauge("scheduler.round.due_count_sampled.count"); got != 1 {
+		t.Fatalf("cadence round due_count_sampled metric = %d, want 1", got)
 	}
 }
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1075,6 +1075,60 @@ func TestRunRoundWaitsUnderPoolBackpressureInsteadOfDropping(t *testing.T) {
 	}
 }
 
+func TestRunRoundSamplesBroadOperatorCountsOnCadence(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	cfg := setTestConfig(t)
+	cfg.UseVariableCheckIntervals = true
+	cfg.LegacyStatusProjectionEnable = true
+	cfg.WorkerMaxMemMB = 0
+
+	base := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	nowFunc = func() time.Time { return base }
+
+	var dueCountCalls int
+	dbCountDueSites = func(context.Context, int, int, bool) (int, error) {
+		dueCountCalls++
+		return 0, nil
+	}
+	var driftCalls int
+	dbCountProjectionDrift = func(context.Context, int, int) (int, error) {
+		driftCalls++
+		return 0, nil
+	}
+
+	o := &Orchestrator{
+		ctx:        context.Background(),
+		hostname:   "host-a",
+		roundStart: base,
+	}
+	o.runRound()
+	if dueCountCalls != 2 {
+		t.Fatalf("first round due count calls = %d, want 2", dueCountCalls)
+	}
+	if driftCalls != 1 {
+		t.Fatalf("first round drift calls = %d, want 1", driftCalls)
+	}
+
+	base = base.Add(5 * time.Second)
+	o.runRound()
+	if dueCountCalls != 2 {
+		t.Fatalf("second round due count calls = %d, want still 2", dueCountCalls)
+	}
+	if driftCalls != 1 {
+		t.Fatalf("second round drift calls = %d, want still 1", driftCalls)
+	}
+
+	base = base.Add(schedulerOperatorReportInterval)
+	o.runRound()
+	if dueCountCalls != 4 {
+		t.Fatalf("cadence round due count calls = %d, want 4", dueCountCalls)
+	}
+	if driftCalls != 2 {
+		t.Fatalf("cadence round drift calls = %d, want 2", driftCalls)
+	}
+}
+
 func TestSchedulerSleepDurationUsesShortPollForVariableIntervals(t *testing.T) {
 	cfg := &config.Config{
 		MinTimeBetweenRoundsSec:   300,
@@ -1189,7 +1243,7 @@ func TestCheckLegacyProjectionDriftEmitsGaugeAndWarningCounter(t *testing.T) {
 	}
 
 	o := &Orchestrator{ctx: context.Background(), bucketMin: 10, bucketMax: 20}
-	o.checkLegacyProjectionDrift(cfg)
+	o.checkLegacyProjectionDrift(cfg, time.Now())
 
 	if got := rec.gauge("projection.drift.count"); got != 3 {
 		t.Fatalf("projection.drift.count = %d, want 3", got)
@@ -1212,7 +1266,7 @@ func TestCheckLegacyProjectionDriftSkipsWhenProjectionDisabled(t *testing.T) {
 	}
 
 	o := &Orchestrator{ctx: context.Background()}
-	o.checkLegacyProjectionDrift(cfg)
+	o.checkLegacyProjectionDrift(cfg, time.Now())
 	if called {
 		t.Fatal("drift check should be skipped when legacy projection is disabled")
 	}
@@ -1231,7 +1285,7 @@ func TestCheckLegacyProjectionDriftEmitsErrorCounter(t *testing.T) {
 	}
 
 	o := &Orchestrator{ctx: context.Background()}
-	o.checkLegacyProjectionDrift(cfg)
+	o.checkLegacyProjectionDrift(cfg, time.Now())
 	if got := rec.counter("projection.drift.check_error.count"); got != 1 {
 		t.Fatalf("projection.drift.check_error.count = %d, want 1", got)
 	}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -361,6 +361,7 @@ func stubOrchestratorDeps() func() {
 	origDBRecordCheckHistory := dbRecordCheckHistory
 	origDBRecordCheckHistories := dbRecordCheckHistories
 	origDBUpdateSSLExpiry := dbUpdateSSLExpiry
+	origDBUpdateSSLExpiries := dbUpdateSSLExpiries
 	origDBCountDueSites := dbCountDueSites
 	origDBCountProjectionDrift := dbCountProjectionDrift
 	origNotify := wpcomNotifyFunc
@@ -381,6 +382,7 @@ func stubOrchestratorDeps() func() {
 	dbRecordCheckHistory = func(int64, int, int, int64, int64, int64, int64, int64) error { return nil }
 	dbRecordCheckHistories = func(context.Context, []db.CheckHistoryRow) error { return nil }
 	dbUpdateSSLExpiry = func(context.Context, int64, time.Time) error { return nil }
+	dbUpdateSSLExpiries = func(context.Context, []db.SiteSSLExpiry) error { return nil }
 	dbCountDueSites = func(context.Context, int, int, bool) (int, error) { return 0, nil }
 	dbCountProjectionDrift = func(context.Context, int, int) (int, error) { return 0, nil }
 	wpcomNotifyFunc = func(_ *wpcom.Client, _ wpcom.Notification) error { return nil }
@@ -403,6 +405,7 @@ func stubOrchestratorDeps() func() {
 		dbRecordCheckHistory = origDBRecordCheckHistory
 		dbRecordCheckHistories = origDBRecordCheckHistories
 		dbUpdateSSLExpiry = origDBUpdateSSLExpiry
+		dbUpdateSSLExpiries = origDBUpdateSSLExpiries
 		dbCountDueSites = origDBCountDueSites
 		dbCountProjectionDrift = origDBCountProjectionDrift
 		wpcomNotifyFunc = origNotify
@@ -625,6 +628,9 @@ func TestProcessResultsFallsBackWhenBatchWritesFail(t *testing.T) {
 	dbRecordCheckHistories = func(context.Context, []db.CheckHistoryRow) error {
 		return fmt.Errorf("batch history failed")
 	}
+	dbUpdateSSLExpiries = func(context.Context, []db.SiteSSLExpiry) error {
+		return fmt.Errorf("batch ssl failed")
+	}
 
 	var fallbackMarked int64
 	dbMarkSiteChecked = func(_ context.Context, blogID int64, _ time.Time) error {
@@ -636,6 +642,11 @@ func TestProcessResultsFallsBackWhenBatchWritesFail(t *testing.T) {
 		fallbackHistory = blogID
 		return nil
 	}
+	var fallbackSSL int64
+	dbUpdateSSLExpiry = func(_ context.Context, blogID int64, _ time.Time) error {
+		fallbackSSL = blogID
+		return nil
+	}
 
 	o := &Orchestrator{
 		retries:  newRetryQueue(),
@@ -644,19 +655,22 @@ func TestProcessResultsFallsBackWhenBatchWritesFail(t *testing.T) {
 		ctx:      context.Background(),
 	}
 
+	res := checkerResultSuccess(42)
+	expiry := time.Now().UTC().AddDate(0, 1, 0)
+	res.SSLExpiry = &expiry
 	summary := o.processResults(
-		map[int64]checker.Result{42: checkerResultSuccess(42)},
+		map[int64]checker.Result{42: res},
 		map[int64]db.Site{42: {BlogID: 42, SiteStatus: statusRunning}},
 	)
 
-	if fallbackMarked != 42 || fallbackHistory != 42 {
-		t.Fatalf("fallback marked/history = %d/%d, want 42/42", fallbackMarked, fallbackHistory)
+	if fallbackMarked != 42 || fallbackHistory != 42 || fallbackSSL != 42 {
+		t.Fatalf("fallback marked/history/ssl = %d/%d/%d, want 42/42/42", fallbackMarked, fallbackHistory, fallbackSSL)
 	}
-	if summary.markCheckedRows != 1 || summary.historyRows != 1 {
-		t.Fatalf("fallback rows = %d/%d, want 1/1", summary.markCheckedRows, summary.historyRows)
+	if summary.markCheckedRows != 1 || summary.historyRows != 1 || summary.sslRows != 1 {
+		t.Fatalf("fallback rows = %d/%d/%d, want 1/1/1", summary.markCheckedRows, summary.historyRows, summary.sslRows)
 	}
-	if summary.markCheckedErrors != 1 || summary.historyErrors != 1 {
-		t.Fatalf("batch errors = %d/%d, want 1/1", summary.markCheckedErrors, summary.historyErrors)
+	if summary.markCheckedErrors != 1 || summary.historyErrors != 1 || summary.sslErrors != 1 {
+		t.Fatalf("batch errors = %d/%d/%d, want 1/1/1", summary.markCheckedErrors, summary.historyErrors, summary.sslErrors)
 	}
 }
 
@@ -692,8 +706,11 @@ func TestProcessResultsUpdatesSSLExpiry(t *testing.T) {
 	setTestConfig(t)
 
 	var updatedExpiry time.Time
-	dbUpdateSSLExpiry = func(_ context.Context, _ int64, expiry time.Time) error {
-		updatedExpiry = expiry
+	dbUpdateSSLExpiries = func(_ context.Context, updates []db.SiteSSLExpiry) error {
+		if len(updates) != 1 {
+			t.Fatalf("ssl expiry updates = %d, want 1", len(updates))
+		}
+		updatedExpiry = updates[0].Expiry
 		return nil
 	}
 
@@ -1452,6 +1469,9 @@ func TestProcessResultsLogsErrorsFromDB(t *testing.T) {
 	}
 	dbRecordCheckHistory = func(int64, int, int, int64, int64, int64, int64, int64) error {
 		return fmt.Errorf("history error")
+	}
+	dbUpdateSSLExpiries = func(context.Context, []db.SiteSSLExpiry) error {
+		return fmt.Errorf("batch ssl expiry error")
 	}
 	dbUpdateSSLExpiry = func(context.Context, int64, time.Time) error {
 		return fmt.Errorf("ssl expiry error")

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1075,6 +1075,78 @@ func TestRunRoundWaitsUnderPoolBackpressureInsteadOfDropping(t *testing.T) {
 	}
 }
 
+func TestRunRoundSamplesBroadReportsOnCadence(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	cfg := setTestConfig(t)
+	cfg.DatasetSize = 10
+	cfg.UseVariableCheckIntervals = true
+	cfg.LegacyStatusProjectionEnable = true
+	cfg.WorkerMaxMemMB = 0
+
+	now := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	nowFunc = func() time.Time { return now }
+
+	var dueCalls int
+	var driftCalls int
+	dbGetSitesForBucket = func(context.Context, int, int, int, bool) ([]db.Site, error) {
+		return nil, nil
+	}
+	dbCountDueSites = func(context.Context, int, int, bool) (int, error) {
+		dueCalls++
+		return 0, nil
+	}
+	dbCountProjectionDrift = func(context.Context, int, int) (int, error) {
+		driftCalls++
+		return 0, nil
+	}
+
+	rec := newRecordingMetrics()
+	metricsClientFunc = func() metricsClient { return rec }
+
+	o := &Orchestrator{ctx: context.Background(), hostname: "host-a", roundStart: now}
+
+	first := o.runRound()
+	if !first.dueCountsSampled {
+		t.Fatal("first round dueCountsSampled = false, want true")
+	}
+	if dueCalls != 2 {
+		t.Fatalf("due count calls after first round = %d, want 2", dueCalls)
+	}
+	if driftCalls != 1 {
+		t.Fatalf("projection drift calls after first round = %d, want 1", driftCalls)
+	}
+	if got := rec.gauge("scheduler.round.due_count_sampled.count"); got != 1 {
+		t.Fatalf("due_count_sampled metric after first round = %d, want 1", got)
+	}
+
+	second := o.runRound()
+	if second.dueCountsSampled {
+		t.Fatal("second round dueCountsSampled = true before cadence elapsed, want false")
+	}
+	if dueCalls != 2 {
+		t.Fatalf("due count calls after second round = %d, want still 2", dueCalls)
+	}
+	if driftCalls != 1 {
+		t.Fatalf("projection drift calls after second round = %d, want still 1", driftCalls)
+	}
+	if got := rec.gauge("scheduler.round.due_count_sampled.count"); got != 0 {
+		t.Fatalf("due_count_sampled metric after skipped round = %d, want 0", got)
+	}
+
+	now = now.Add(schedulerBroadReportInterval)
+	third := o.runRound()
+	if !third.dueCountsSampled {
+		t.Fatal("third round dueCountsSampled = false after cadence elapsed, want true")
+	}
+	if dueCalls != 4 {
+		t.Fatalf("due count calls after third round = %d, want 4", dueCalls)
+	}
+	if driftCalls != 2 {
+		t.Fatalf("projection drift calls after third round = %d, want 2", driftCalls)
+	}
+}
+
 func TestSchedulerSleepDurationUsesShortPollForVariableIntervals(t *testing.T) {
 	cfg := &config.Config{
 		MinTimeBetweenRoundsSec:   300,

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-sql-driver/mysql"
+
 	"github.com/Automattic/jetmon/internal/checker"
 	"github.com/Automattic/jetmon/internal/config"
 	"github.com/Automattic/jetmon/internal/db"
@@ -617,6 +619,61 @@ func TestProcessResultsMarksChecked(t *testing.T) {
 	}
 }
 
+func TestProcessResultsReportsCheckOutcomes(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	setTestConfig(t)
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		hostname: "local",
+		ctx:      context.Background(),
+	}
+
+	success := checkerResultSuccess(1)
+	timeout := checkerResultFailure(2)
+	timeout.HTTPCode = 0
+	timeout.ErrorCode = checker.ErrorTimeout
+	connect := checkerResultFailure(3)
+	connect.HTTPCode = 0
+	connect.ErrorCode = checker.ErrorConnect
+	server := checkerResultFailure(4)
+	server.HTTPCode = 500
+	server.ErrorCode = checker.ErrorNone
+	deprecatedTLS := checkerResultSuccess(5)
+	deprecatedTLS.ErrorCode = checker.ErrorTLSDeprecated
+
+	summary := o.processResults(
+		map[int64]checker.Result{
+			1: success,
+			2: timeout,
+			3: connect,
+			4: server,
+			5: deprecatedTLS,
+		},
+		map[int64]db.Site{
+			1: {BlogID: 1, SiteStatus: statusRunning},
+			2: {BlogID: 2, SiteStatus: statusRunning},
+			3: {BlogID: 3, SiteStatus: statusRunning},
+			4: {BlogID: 4, SiteStatus: statusRunning},
+			5: {BlogID: 5, SiteStatus: statusRunning},
+		},
+	)
+
+	if summary.checkSuccesses != 2 || summary.checkFailures != 3 {
+		t.Fatalf("success/failure counts = %d/%d, want 2/3", summary.checkSuccesses, summary.checkFailures)
+	}
+	if summary.checkTimeouts != 1 || summary.checkConnectErrors != 1 || summary.checkHTTPFailures != 1 || summary.checkTLSDeprecated != 1 {
+		t.Fatalf("outcome counts timeout/connect/http/tls = %d/%d/%d/%d, want 1/1/1/1",
+			summary.checkTimeouts,
+			summary.checkConnectErrors,
+			summary.checkHTTPFailures,
+			summary.checkTLSDeprecated,
+		)
+	}
+}
+
 func TestProcessResultsFallsBackWhenBatchWritesFail(t *testing.T) {
 	restore := stubOrchestratorDeps()
 	defer restore()
@@ -671,6 +728,46 @@ func TestProcessResultsFallsBackWhenBatchWritesFail(t *testing.T) {
 	}
 	if summary.markCheckedErrors != 1 || summary.historyErrors != 1 || summary.sslErrors != 1 {
 		t.Fatalf("batch errors = %d/%d/%d, want 1/1/1", summary.markCheckedErrors, summary.historyErrors, summary.sslErrors)
+	}
+}
+
+func TestEventMutationRetryRetriesDeadlocks(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	setTestConfig(t)
+
+	rec := newRecordingMetrics()
+	metricsClientFunc = func() metricsClient { return rec }
+
+	o := &Orchestrator{ctx: context.Background()}
+	attempts := 0
+	err := o.withEventMutationRetry(42, "open_seems_down", func() error {
+		attempts++
+		if attempts == 1 {
+			return fmt.Errorf("wrapped: %w", &mysql.MySQLError{Number: 1213, Message: "deadlock"})
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("withEventMutationRetry: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+	if got := rec.counter("eventstore.mutation.retry.count"); got != 1 {
+		t.Fatalf("retry metric = %d, want 1", got)
+	}
+}
+
+func TestIsRetryableMySQLError(t *testing.T) {
+	if !isRetryableMySQLError(fmt.Errorf("wrapped: %w", &mysql.MySQLError{Number: 1205, Message: "lock wait"})) {
+		t.Fatal("lock wait timeout should be retryable")
+	}
+	if !isRetryableMySQLError(&mysql.MySQLError{Number: 1213, Message: "deadlock"}) {
+		t.Fatal("deadlock should be retryable")
+	}
+	if isRetryableMySQLError(&mysql.MySQLError{Number: 1062, Message: "duplicate"}) {
+		t.Fatal("duplicate key should not be retryable")
 	}
 }
 

--- a/migrations/001_jetmon2.sql
+++ b/migrations/001_jetmon2.sql
@@ -18,8 +18,10 @@ ALTER TABLE jetpack_monitor_sites
     ADD COLUMN IF NOT EXISTS redirect_policy        ENUM('follow','alert','fail') NULL DEFAULT 'follow',
     ADD COLUMN IF NOT EXISTS alert_cooldown_minutes SMALLINT UNSIGNED NULL,
     ADD COLUMN IF NOT EXISTS last_checked_at        DATETIME NULL,
+    ADD COLUMN IF NOT EXISTS next_check_at          DATETIME NULL,
     ADD COLUMN IF NOT EXISTS last_alert_sent_at     DATETIME NULL,
-    ADD INDEX IF NOT EXISTS idx_bucket_monitor_last_checked (bucket_no, monitor_active, last_checked_at);
+    ADD INDEX IF NOT EXISTS idx_bucket_monitor_last_checked (bucket_no, monitor_active, last_checked_at),
+    ADD INDEX IF NOT EXISTS idx_monitor_next_check_blog_bucket (monitor_active, next_check_at, blog_id, bucket_no);
 
 -- MySQL-coordinated bucket ownership.
 CREATE TABLE IF NOT EXISTS jetmon_hosts (


### PR DESCRIPTION
## Summary

This PR merges the Jetmon v2 capacity-scaling integration branch after the successful capacity-scout-20260503-134229Z run. It brings together the scheduler, checker transport, and capacity diagnostics work needed to keep Jetmon v2 fresh under larger active-site batches.

## Why

Recent uptime-bench capacity runs showed that Jetmon v2 could miss freshness checks under higher active-site counts. The goal of this branch is to reduce scheduler and checker overhead, improve observability around capacity bottlenecks, and keep the service healthy as active monitor counts grow.

## What changed

- Materializes next_check_at so the scheduler can query due work directly instead of repeatedly deriving due state from broad scans.
- Reuses bounded HTTP transports in the checker path to reduce connection churn and per-check overhead.
- Samples broad scheduler reporting on a cadence so diagnostic queries do not become their own capacity bottleneck.
- Batches changed SSL expiry updates to avoid unnecessary write pressure.
- Adds capacity-failure diagnostics, scheduler/capacity documentation, and tests around the new scheduler behavior.

## Capacity evidence

The latest capacity scout passed for Jetmon v2 at 1,000, 5,000, and 10,000 active monitors:

| Active monitors | Stale active rows | Missed checks | Recent checks/min | P95 check age | Oldest check age |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 1,000 | 0 | 0.00% | 973.80 | 59s | 59s |
| 5,000 | 0 | 0.00% | 2540.00 | 121s | 125s |
| 10,000 | 0 | 0.00% | 2129.20 | 267s | 289s |

The run completed all three batches, reported First problem batch: none, did not recommend stopping, and post-run verification confirmed zero active Jetmon v2 benchmark rows. Host-level CPU, memory, disk, and scrape health thresholds all passed. jetmon2 process memory stayed low, with max RSS around 33.70 MiB at 10,000 active monitors.

## Caveats / follow-up

This validates the branch as stable enough to merge into v2, but it does not mean the scaling work is finished. At 10,000 active monitors, p95 check age was 267s and oldest check age was 289s, which is still inside the 5-minute freshness window but close enough that the next capacity ladder should step carefully above 10,000, such as 12,500 or 15,000 before larger jumps. MySQL remains the hottest dependency and should stay central in the next scaling pass.

## Validation

- go test ./...
- capacity-scout-20260503-134229Z against Jetmon v2 results