### PR TITLE
Harden Jetmon v2 against DNS-related post-recovery false positives

### DIFF
--- a/cmd/jetmon2/main.go
+++ b/cmd/jetmon2/main.go
@@ -95,6 +95,7 @@ func runServe() {
 	log.Printf("config: legacy_status_projection=%s", enabledLabel(cfg.LegacyStatusProjectionEnable))
 	log.Printf("config: bucket_ownership=%s", bucketOwnershipLabel(cfg))
 	log.Printf("config: scheduler=%s", schedulerConfigLabel(cfg))
+	log.Printf("config: check_dns_resolvers=%s", checkDNSResolversLabel(checker.ConfiguredResolverServers()))
 	log.Printf("config: wpcom_notify=%s", enabledLabel(cfg.WPCOMNotifyEnable))
 	log.Printf("config: email_transport=%s", emailTransportLabel(cfg))
 	if !emailTransportDelivers(cfg) {
@@ -400,6 +401,13 @@ func enabledLabel(b bool) string {
 		return "enabled"
 	}
 	return "disabled"
+}
+
+func checkDNSResolversLabel(servers []string) string {
+	if len(servers) == 0 {
+		return "system"
+	}
+	return "configured [" + strings.Join(servers, ",") + "]"
 }
 
 func bucketOwnershipLabel(cfg *config.Config) string {

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -121,6 +121,15 @@ func ConfigureResolverServers(rawServers []string) error {
 	return nil
 }
 
+// ConfiguredResolverServers returns the normalized resolver override currently
+// installed for checks. An empty slice means checks are using the host resolver
+// configuration.
+func ConfiguredResolverServers() []string {
+	configuredResolverMu.RLock()
+	defer configuredResolverMu.RUnlock()
+	return append([]string(nil), configuredResolverServers...)
+}
+
 type checkDNSCache struct {
 	mu         sync.RWMutex
 	ttl        time.Duration

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -764,6 +764,10 @@ func TestConfigureResolverServersInstallsOverride(t *testing.T) {
 	if len(got) != 1 || got[0] != "10.0.0.176:5353" {
 		t.Fatalf("directResolverServers() = %#v, want configured resolver", got)
 	}
+	configured := ConfiguredResolverServers()
+	if len(configured) != 1 || configured[0] != "10.0.0.176:5353" {
+		t.Fatalf("ConfiguredResolverServers() = %#v, want configured resolver", configured)
+	}
 }
 
 func TestHTTPIPPoolTransportPreservesHostHeader(t *testing.T) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -59,6 +59,8 @@ const eventMutationMaxAttempts = 3
 const eventMutationRetryBaseDelay = 25 * time.Millisecond
 const failedCheckRetryInterval = time.Minute
 const maxPostRecoveryTransientFailureWindow = 5 * time.Minute
+const minPostFalseAlarmTransientFailureWindow = 5 * time.Minute
+const maxPostFalseAlarmTransientFailureWindow = 10 * time.Minute
 
 // VariableIntervalPollInterval returns the idle scheduler poll interval used
 // when per-site check intervals are enabled. The SQL due predicate prevents
@@ -1324,13 +1326,18 @@ func (o *Orchestrator) handleFailure(site db.Site, res checker.Result) bool {
 		return false
 	}
 
-	if o.shouldSuppressPostRecoveryTransientFailure(site, res) {
+	if suppressed, reason, window := o.postRecoveryTransientSuppression(site, res); suppressed {
 		class := failureClass(res)
 		emitCounter("detection.post_recovery_transient_suppressed.count", 1)
 		emitCounter("detection.post_recovery_transient_suppressed."+class+".count", 1)
 		metaMap := checkResultMetadata(site, res, resultCheckedAt(res))
-		metaMap["suppressed_after_recent_recovery"] = true
-		metaMap["post_recovery_window_seconds"] = int(postRecoveryTransientFailureWindow(site) / time.Second)
+		if reason == "false_alarm" {
+			metaMap["suppressed_after_recent_false_alarm"] = true
+		} else {
+			metaMap["suppressed_after_recent_recovery"] = true
+		}
+		metaMap["suppressed_after"] = reason
+		metaMap["post_recovery_window_seconds"] = int(window / time.Second)
 		meta, _ := json.Marshal(metaMap)
 		o.auditLog(audit.Entry{
 			BlogID:    site.BlogID,
@@ -1387,13 +1394,37 @@ func (o *Orchestrator) handleFailure(site db.Site, res checker.Result) bool {
 }
 
 func (o *Orchestrator) shouldSuppressPostRecoveryTransientFailure(site db.Site, res checker.Result) bool {
+	suppressed, _, _ := o.postRecoveryTransientSuppression(site, res)
+	return suppressed
+}
+
+func (o *Orchestrator) postRecoveryTransientSuppression(site db.Site, res checker.Result) (bool, string, time.Duration) {
 	if o == nil || o.retries == nil || !postRecoveryTransientFailure(res) {
-		return false
+		return false, "", 0
 	}
 	if o.retries.get(site.BlogID) != nil {
-		return false
+		return false, "", 0
 	}
-	return o.retries.recentlyRecovered(site.BlogID, resultCheckedAt(res), postRecoveryTransientFailureWindow(site))
+	return postRecoveryTransientSuppression(site, res, o.retries)
+}
+
+func postRecoveryTransientSuppression(site db.Site, res checker.Result, retries *retryQueue) (bool, string, time.Duration) {
+	if retries == nil || !postRecoveryTransientFailure(res) {
+		return false, "", 0
+	}
+	if retries.get(site.BlogID) != nil {
+		return false, "", 0
+	}
+	checkedAt := resultCheckedAt(res)
+	falseAlarmWindow := postFalseAlarmTransientFailureWindow(site)
+	if retries.recentlyFalseAlarmed(site.BlogID, checkedAt, falseAlarmWindow) {
+		return true, "false_alarm", falseAlarmWindow
+	}
+	recoveryWindow := postRecoveryTransientFailureWindow(site)
+	if retries.recentlyRecovered(site.BlogID, checkedAt, recoveryWindow) {
+		return true, "recovery", recoveryWindow
+	}
+	return false, "", 0
 }
 
 func postRecoveryTransientFailure(res checker.Result) bool {
@@ -1410,6 +1441,17 @@ func postRecoveryTransientFailureWindow(site db.Site) time.Duration {
 	}
 	if window > maxPostRecoveryTransientFailureWindow {
 		return maxPostRecoveryTransientFailureWindow
+	}
+	return window
+}
+
+func postFalseAlarmTransientFailureWindow(site db.Site) time.Duration {
+	window := siteCheckInterval(site) * 2
+	if window < minPostFalseAlarmTransientFailureWindow {
+		return minPostFalseAlarmTransientFailureWindow
+	}
+	if window > maxPostFalseAlarmTransientFailureWindow {
+		return maxPostFalseAlarmTransientFailureWindow
 	}
 	return window
 }
@@ -1565,7 +1607,7 @@ func (o *Orchestrator) escalateToVerifliers(site db.Site, entry *retryEntry) {
 			}
 		}
 		o.retries.clear(site.BlogID)
-		o.retries.markRecovered(site.BlogID, falseAlarmAt)
+		o.retries.markFalseAlarm(site.BlogID, falseAlarmAt)
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1138,6 +1138,12 @@ func checkResultMetadata(site db.Site, res checker.Result, firstFailAt time.Time
 	}
 	if res.DNSFailureKind != "" {
 		metadata["dns_error_kind"] = res.DNSFailureKind
+		if servers := checker.ConfiguredResolverServers(); len(servers) > 0 {
+			metadata["dns_resolver_source"] = "configured"
+			metadata["check_dns_resolvers"] = servers
+		} else {
+			metadata["dns_resolver_source"] = "system"
+		}
 	}
 	if res.DNSFailureName != "" {
 		metadata["dns_error_name"] = res.DNSFailureName
@@ -1352,12 +1358,16 @@ func (o *Orchestrator) handleFailure(site db.Site, res checker.Result) bool {
 	entry := o.retries.record(res)
 	class := failureClass(res)
 	emitCounter("detection.failure."+class+".count", 1)
+	lowConfidenceDNS := lowConfidenceDNSFailure(res)
 
 	// Open a Seems Down event on the first failure we don't already have an
 	// id for. The schema's idempotent dedup_key means re-detecting the same
 	// failure would update the same row, so this is also a self-healing retry
 	// path if a previous Open failed to commit.
-	if entry.eventID == 0 {
+	if entry.eventID == 0 && lowConfidenceDNS {
+		emitCounter("detection.low_confidence_dns.awaiting_verifier.count", 1)
+		emitCounter("detection.low_confidence_dns.awaiting_verifier."+metricSegment(res.DNSFailureKind)+".count", 1)
+	} else if entry.eventID == 0 {
 		id, opened, err := o.openSeemsDown(site, res, entry.firstFailAt)
 		if err != nil {
 			log.Printf("orchestrator: open seems-down event blog_id=%d: %v", site.BlogID, err)
@@ -1376,6 +1386,10 @@ func (o *Orchestrator) handleFailure(site db.Site, res checker.Result) bool {
 		metaMap["attempt"] = entry.failCount
 		metaMap["of"] = config.Get().NumOfChecks
 		metaMap["event_id"] = entry.eventID
+		if lowConfidenceDNS {
+			metaMap["low_confidence_dns_failure"] = true
+			metaMap["customer_visible_event_deferred_until_verifier_confirmation"] = true
+		}
 		meta, _ := json.Marshal(metaMap)
 		o.auditLog(audit.Entry{
 			BlogID:    site.BlogID,
@@ -1390,6 +1404,9 @@ func (o *Orchestrator) handleFailure(site db.Site, res checker.Result) bool {
 
 	// Escalate to verifliers.
 	o.escalateToVerifliers(site, entry)
+	if lowConfidenceDNS {
+		return entry.eventID > 0
+	}
 	return true
 }
 
@@ -1418,6 +1435,7 @@ func postRecoveryTransientSuppression(site db.Site, res checker.Result, retries 
 	checkedAt := resultCheckedAt(res)
 	falseAlarmWindow := postFalseAlarmTransientFailureWindow(site)
 	if retries.recentlyFalseAlarmed(site.BlogID, checkedAt, falseAlarmWindow) {
+		retries.markFalseAlarm(site.BlogID, checkedAt)
 		return true, "false_alarm", falseAlarmWindow
 	}
 	recoveryWindow := postRecoveryTransientFailureWindow(site)
@@ -1432,6 +1450,10 @@ func postRecoveryTransientFailure(res checker.Result) bool {
 		return false
 	}
 	return res.ErrorCode == checker.ErrorConnect || res.ErrorCode == checker.ErrorTimeout
+}
+
+func lowConfidenceDNSFailure(res checker.Result) bool {
+	return postRecoveryTransientFailure(res) && res.DNSFailureKind != ""
 }
 
 func postRecoveryTransientFailureWindow(site db.Site) time.Duration {
@@ -1618,6 +1640,10 @@ func (o *Orchestrator) confirmDown(site db.Site, entry *retryEntry, vResults []v
 		}
 		return
 	}
+	if entry == nil {
+		log.Printf("orchestrator: confirmed down blog_id=%d without retry entry", site.BlogID)
+		return
+	}
 
 	newStatus := statusConfirmedDown
 	changeTime := nowFunc().UTC()
@@ -1627,20 +1653,29 @@ func (o *Orchestrator) confirmDown(site db.Site, entry *retryEntry, vResults []v
 
 	log.Printf("orchestrator: blog_id=%d confirmed down", site.BlogID)
 
+	meta := confirmedDownMetadata(site, entry, vResults, entry.eventID == 0)
+
 	// Promote the open Seems Down event to Down with reason=verifier_confirmed
-	// and project site_status=SITE_CONFIRMED_DOWN in the same tx. If we have no
-	// event id (open failed earlier or eventstore unavailable), fall back to
-	// the bare projection write.
+	// and project site_status=SITE_CONFIRMED_DOWN in the same tx. Low-confidence
+	// local DNS failures intentionally skip the Seems Down event, so verifier
+	// confirmation opens the customer-visible incident directly as Down.
 	if entry.eventID > 0 {
-		meta, _ := json.Marshal(map[string]any{
-			"verifier_results":   summarizeVerifierResults(vResults),
-			"verifier_confirmed": len(vResults),
-		})
 		if err := o.promoteToDown(site.BlogID, entry.eventID, changeTime, meta); err != nil {
 			log.Printf("orchestrator: promote event blog_id=%d event_id=%d: %v", site.BlogID, entry.eventID, err)
 		}
-	} else if config.LegacyStatusProjectionEnabled() {
-		_ = dbUpdateSiteStatus(o.ctx, site.BlogID, newStatus, changeTime)
+	} else {
+		eventID, opened, err := o.openConfirmedDown(site, changeTime, meta)
+		if err != nil {
+			log.Printf("orchestrator: open confirmed-down event blog_id=%d: %v", site.BlogID, err)
+			if config.LegacyStatusProjectionEnabled() {
+				_ = dbUpdateSiteStatus(o.ctx, site.BlogID, newStatus, changeTime)
+			}
+		} else {
+			entry.eventID = eventID
+			if opened {
+				emitCounter("detection.down.open_after_verifier.count", 1)
+			}
+		}
 	}
 
 	if inMaintenance(site) {
@@ -1662,6 +1697,31 @@ func (o *Orchestrator) confirmDown(site db.Site, entry *retryEntry, vResults []v
 	}
 
 	o.retries.clear(site.BlogID)
+}
+
+func confirmedDownMetadata(site db.Site, entry *retryEntry, vResults []veriflier.CheckResult, directOpen bool) json.RawMessage {
+	metaMap := checkResultMetadata(site, entry.lastResult, entry.firstFailAt)
+	metaMap["verifier_results"] = summarizeVerifierResults(vResults)
+	metaMap["verifier_confirmed"] = verifierConfirmationCount(vResults)
+	if directOpen {
+		metaMap["opened_after_verifier_confirmation"] = true
+	}
+	if lowConfidenceDNSFailure(entry.lastResult) {
+		metaMap["low_confidence_dns_failure"] = true
+		metaMap["customer_visible_event_deferred_until_verifier_confirmation"] = true
+	}
+	meta, _ := json.Marshal(metaMap)
+	return meta
+}
+
+func verifierConfirmationCount(vResults []veriflier.CheckResult) int {
+	count := 0
+	for _, res := range vResults {
+		if !res.Success {
+			count++
+		}
+	}
+	return count
 }
 
 func (o *Orchestrator) swallowMaintenanceFailure(site db.Site, res checker.Result) {
@@ -2200,6 +2260,63 @@ func (o *Orchestrator) openSeemsDownOnce(site db.Site, res checker.Result, first
 	// was already projected when the event first opened.
 	if out.Opened && config.LegacyStatusProjectionEnabled() && tx.Tx() != nil {
 		if err := db.UpdateSiteStatusTx(o.ctx, tx.Tx(), site.BlogID, statusDown, nowFunc().UTC()); err != nil {
+			return 0, false, fmt.Errorf("project site_status: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, false, fmt.Errorf("commit: %w", err)
+	}
+	return out.EventID, out.Opened, nil
+}
+
+// openConfirmedDown opens a Down event directly for failures that were kept
+// out of the customer-visible Seems Down state until verifier confirmation.
+func (o *Orchestrator) openConfirmedDown(site db.Site, changeTime time.Time, meta json.RawMessage) (int64, bool, error) {
+	var eventID int64
+	var opened bool
+	err := o.withEventMutationRetry(site.BlogID, "open_confirmed_down", func() error {
+		id, didOpen, err := o.openConfirmedDownOnce(site, changeTime, meta)
+		if err != nil {
+			return err
+		}
+		eventID = id
+		opened = didOpen
+		return nil
+	})
+	return eventID, opened, err
+}
+
+func (o *Orchestrator) openConfirmedDownOnce(site db.Site, changeTime time.Time, meta json.RawMessage) (int64, bool, error) {
+	tx, err := o.ev().Begin(o.ctx)
+	if err != nil {
+		return 0, false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	out, err := tx.Open(o.ctx, eventstore.OpenInput{
+		Identity: eventstore.Identity{BlogID: site.BlogID, CheckType: checkTypeHTTP},
+		Severity: eventstore.SeverityDown,
+		State:    eventstore.StateDown,
+		Source:   o.hostname,
+		Metadata: meta,
+	})
+	if err != nil {
+		return 0, false, err
+	}
+
+	projectConfirmedDown := out.Opened
+	if !out.Opened && (out.CurrentSeverity != eventstore.SeverityDown || out.CurrentState != eventstore.StateDown) {
+		if _, err := tx.Promote(o.ctx, out.EventID,
+			eventstore.SeverityDown, eventstore.StateDown,
+			eventstore.ReasonVerifierConfirmed, o.hostname, meta); err != nil {
+			return 0, false, fmt.Errorf("promote existing event: %w", err)
+		}
+		projectConfirmedDown = true
+	}
+
+	if projectConfirmedDown && config.LegacyStatusProjectionEnabled() && tx.Tx() != nil {
+		if err := db.UpdateSiteStatusTx(o.ctx, tx.Tx(), site.BlogID, statusConfirmedDown, changeTime); err != nil {
 			return 0, false, fmt.Errorf("project site_status: %w", err)
 		}
 	}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -58,6 +58,7 @@ const schedulerBroadReportInterval = time.Minute
 const eventMutationMaxAttempts = 3
 const eventMutationRetryBaseDelay = 25 * time.Millisecond
 const failedCheckRetryInterval = time.Minute
+const maxPostRecoveryTransientFailureWindow = 5 * time.Minute
 
 // VariableIntervalPollInterval returns the idle scheduler poll interval used
 // when per-site check intervals are enabled. The SQL due predicate prevents
@@ -1279,7 +1280,7 @@ func (o *Orchestrator) handleRecovery(site db.Site, res checker.Result) {
 	}
 	o.retries.clear(site.BlogID)
 
-	if site.SiteStatus != statusRunning {
+	if site.SiteStatus != statusRunning || knownEventID > 0 {
 		changeTime := nowFunc().UTC()
 		log.Printf("orchestrator: blog_id=%d recovered", site.BlogID)
 		if entry != nil && site.SiteStatus == statusDown {
@@ -1313,13 +1314,32 @@ func (o *Orchestrator) handleRecovery(site db.Site, res checker.Result) {
 				Detail:    "recovery cooldown active",
 			})
 		}
+		o.retries.markRecovered(site.BlogID, changeTime)
 	}
 }
 
-func (o *Orchestrator) handleFailure(site db.Site, res checker.Result) {
+func (o *Orchestrator) handleFailure(site db.Site, res checker.Result) bool {
 	if inMaintenance(site) {
 		o.swallowMaintenanceFailure(site, res)
-		return
+		return false
+	}
+
+	if o.shouldSuppressPostRecoveryTransientFailure(site, res) {
+		class := failureClass(res)
+		emitCounter("detection.post_recovery_transient_suppressed.count", 1)
+		emitCounter("detection.post_recovery_transient_suppressed."+class+".count", 1)
+		metaMap := checkResultMetadata(site, res, resultCheckedAt(res))
+		metaMap["suppressed_after_recent_recovery"] = true
+		metaMap["post_recovery_window_seconds"] = int(postRecoveryTransientFailureWindow(site) / time.Second)
+		meta, _ := json.Marshal(metaMap)
+		o.auditLog(audit.Entry{
+			BlogID:    site.BlogID,
+			EventType: audit.EventAlertSuppressed,
+			Source:    o.hostname,
+			Detail:    "post-recovery transient failure suppressed",
+			Metadata:  meta,
+		})
+		return false
 	}
 
 	entry := o.retries.record(res)
@@ -1358,11 +1378,40 @@ func (o *Orchestrator) handleFailure(site db.Site, res checker.Result) {
 			Detail:    fmt.Sprintf("retry %d of %d", entry.failCount, config.Get().NumOfChecks),
 			Metadata:  meta,
 		})
-		return
+		return entry.eventID > 0
 	}
 
 	// Escalate to verifliers.
 	o.escalateToVerifliers(site, entry)
+	return true
+}
+
+func (o *Orchestrator) shouldSuppressPostRecoveryTransientFailure(site db.Site, res checker.Result) bool {
+	if o == nil || o.retries == nil || !postRecoveryTransientFailure(res) {
+		return false
+	}
+	if o.retries.get(site.BlogID) != nil {
+		return false
+	}
+	return o.retries.recentlyRecovered(site.BlogID, resultCheckedAt(res), postRecoveryTransientFailureWindow(site))
+}
+
+func postRecoveryTransientFailure(res checker.Result) bool {
+	if !res.IsFailure() || res.HTTPCode > 0 {
+		return false
+	}
+	return res.ErrorCode == checker.ErrorConnect || res.ErrorCode == checker.ErrorTimeout
+}
+
+func postRecoveryTransientFailureWindow(site db.Site) time.Duration {
+	window := siteCheckInterval(site)
+	if window < failedCheckRetryInterval {
+		return failedCheckRetryInterval
+	}
+	if window > maxPostRecoveryTransientFailureWindow {
+		return maxPostRecoveryTransientFailureWindow
+	}
+	return window
 }
 
 func (o *Orchestrator) escalateToVerifliers(site db.Site, entry *retryEntry) {
@@ -1495,9 +1544,10 @@ func (o *Orchestrator) escalateToVerifliers(site db.Site, entry *retryEntry) {
 		// Verifliers did not confirm — false positive. Close the Seems Down
 		// event with reason=false_alarm and reset site_status in the same tx.
 		log.Printf("orchestrator: blog_id=%d verifliers did not confirm down (%d/%d)", site.BlogID, confirmations, quorum)
+		falseAlarmAt := nowFunc().UTC()
 		emitCounter("detection.verifier.false_alarm.count", 1)
 		emitCounter("detection.verifier.false_alarm."+failureClass(entry.lastResult)+".count", 1)
-		emitTimingSince("detection.seems_down_to_false_alarm.time", entry.firstFailAt, nowFunc().UTC())
+		emitTimingSince("detection.seems_down_to_false_alarm.time", entry.firstFailAt, falseAlarmAt)
 		_ = dbRecordFalsePositive(site.BlogID, entry.lastResult.HTTPCode, entry.lastResult.ErrorCode,
 			entry.lastResult.RTT.Milliseconds())
 
@@ -1509,12 +1559,13 @@ func (o *Orchestrator) escalateToVerifliers(site db.Site, entry *retryEntry) {
 				"verifier_confirmed": confirmations,
 			})
 			if err := o.closeEvent(site.BlogID, entry.eventID,
-				eventstore.ReasonFalseAlarm, statusRunning, nowFunc().UTC(), meta); err != nil {
+				eventstore.ReasonFalseAlarm, statusRunning, falseAlarmAt, meta); err != nil {
 				log.Printf("orchestrator: close false-alarm event blog_id=%d event_id=%d: %v",
 					site.BlogID, entry.eventID, err)
 			}
 		}
 		o.retries.clear(site.BlogID)
+		o.retries.markRecovered(site.BlogID, falseAlarmAt)
 	}
 }
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -558,6 +558,7 @@ func stubOrchestratorDeps() func() {
 	origDBMarkHostDraining := dbMarkHostDraining
 	origDBGetSites := dbGetSitesForBucket
 	origDBUpdateStatus := dbUpdateSiteStatus
+	origDBGetSiteStatus := dbGetSiteStatus
 	origDBUpdateLastAlert := dbUpdateLastAlertSent
 	origDBRecordFalsePositive := dbRecordFalsePositive
 	origDBMarkSiteChecked := dbMarkSiteChecked
@@ -579,6 +580,7 @@ func stubOrchestratorDeps() func() {
 	dbMarkHostDraining = func(context.Context, string) error { return nil }
 	dbGetSitesForBucket = func(context.Context, int, int, int, bool) ([]db.Site, error) { return nil, nil }
 	dbUpdateSiteStatus = func(context.Context, int64, int, time.Time) error { return nil }
+	dbGetSiteStatus = func(context.Context, int64) (int, error) { return statusRunning, nil }
 	dbUpdateLastAlertSent = func(context.Context, int64, time.Time) error { return nil }
 	dbRecordFalsePositive = func(int64, int, int, int64) error { return nil }
 	dbMarkSiteChecked = func(context.Context, int64, time.Time, time.Time) error { return nil }
@@ -602,6 +604,7 @@ func stubOrchestratorDeps() func() {
 		dbMarkHostDraining = origDBMarkHostDraining
 		dbGetSitesForBucket = origDBGetSites
 		dbUpdateSiteStatus = origDBUpdateStatus
+		dbGetSiteStatus = origDBGetSiteStatus
 		dbUpdateLastAlertSent = origDBUpdateLastAlert
 		dbRecordFalsePositive = origDBRecordFalsePositive
 		dbMarkSiteChecked = origDBMarkSiteChecked
@@ -652,6 +655,19 @@ func checkerResultFailure(blogID int64) checker.Result {
 		ErrorCode: checker.ErrorConnect,
 		RTT:       100 * time.Millisecond,
 		Timestamp: time.Now().UTC(),
+	}
+}
+
+func checkerResultTransportFailure(blogID int64, at time.Time) checker.Result {
+	return checker.Result{
+		BlogID:      blogID,
+		URL:         "https://example.com",
+		Success:     false,
+		HTTPCode:    0,
+		ErrorCode:   checker.ErrorConnect,
+		ErrorDetail: "dial tcp: connection refused",
+		RTT:         10 * time.Millisecond,
+		Timestamp:   at.UTC(),
 	}
 }
 
@@ -821,6 +837,9 @@ func TestHandleRecoverySendsNotificationWhenSiteWasDown(t *testing.T) {
 	if o.retries.get(1) != nil {
 		t.Fatal("retry entry should be cleared after recovery")
 	}
+	if !o.retries.recentlyRecovered(1, time.Now().UTC(), postRecoveryTransientFailureWindow(db.Site{BlogID: 1, CheckInterval: 5})) {
+		t.Fatal("recovery should mark site for post-recovery transient dampening")
+	}
 }
 
 func TestHandleRecoveryIsNoopWhenSiteAlreadyRunning(t *testing.T) {
@@ -927,6 +946,81 @@ func TestHandleFailureBelowThresholdDoesNotEscalate(t *testing.T) {
 	}
 	if o.retries.get(1) == nil {
 		t.Fatal("retry entry should exist after first failure")
+	}
+}
+
+func TestHandleFailureSuppressesFirstPostRecoveryTransportFailure(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	cfg := setTestConfig(t)
+	cfg.NumOfChecks = 1
+
+	var escalated bool
+	veriflierCheckFunc = func(_ *veriflier.VeriflierClient, _ context.Context, _ veriflier.CheckRequest) (*veriflier.CheckResult, error) {
+		escalated = true
+		return &veriflier.CheckResult{Success: false}, nil
+	}
+
+	recoveredAt := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		hostname: "local",
+		ctx:      context.Background(),
+	}
+	o.retries.markRecovered(42, recoveredAt)
+
+	active := o.handleFailure(
+		db.Site{BlogID: 42, MonitorURL: "https://example.com", CheckInterval: 3, SiteStatus: statusRunning},
+		checkerResultTransportFailure(42, recoveredAt.Add(2*time.Minute)),
+	)
+
+	if active {
+		t.Fatal("first post-recovery transport failure should not make the site non-running")
+	}
+	if escalated {
+		t.Fatal("first post-recovery transport failure escalated despite dampening")
+	}
+	if entry := o.retries.get(42); entry != nil {
+		t.Fatalf("suppressed failure created retry state: %+v", entry)
+	}
+}
+
+func TestHandleFailureEscalatesPostRecoveryTransportFailureAfterWindow(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	cfg := setTestConfig(t)
+	cfg.NumOfChecks = 1
+	cfg.PeerOfflineLimit = 1
+
+	var escalated bool
+	veriflierCheckFunc = func(c *veriflier.VeriflierClient, _ context.Context, req veriflier.CheckRequest) (*veriflier.CheckResult, error) {
+		escalated = true
+		return &veriflier.CheckResult{
+			BlogID:   req.BlogID,
+			Host:     c.Addr(),
+			Success:  false,
+			HTTPCode: 0,
+		}, nil
+	}
+
+	recoveredAt := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		hostname: "local",
+		ctx:      context.Background(),
+		veriflierClients: []*veriflier.VeriflierClient{
+			veriflier.NewVeriflierClient("v1", ""),
+		},
+	}
+	o.retries.markRecovered(42, recoveredAt)
+	site := db.Site{BlogID: 42, MonitorURL: "https://example.com", CheckInterval: 3, SiteStatus: statusRunning}
+
+	o.handleFailure(site, checkerResultTransportFailure(42, recoveredAt.Add(postRecoveryTransientFailureWindow(site)+time.Second)))
+
+	if !escalated {
+		t.Fatal("transport failure after post-recovery suppression window should continue the normal retry pipeline")
 	}
 }
 
@@ -2456,6 +2550,12 @@ func TestEscalateToVerifliersEmitsFalseAlarmMetrics(t *testing.T) {
 	}
 	if got := rec.timingCount("detection.seems_down_to_false_alarm.time"); got != 1 {
 		t.Fatalf("false alarm timing count = %d, want 1", got)
+	}
+	if entry := o.retries.get(654); entry != nil {
+		t.Fatalf("retry entry after false alarm = %+v, want nil", entry)
+	}
+	if !o.retries.recentlyRecovered(654, nowFunc().UTC(), postRecoveryTransientFailureWindow(db.Site{BlogID: 654, CheckInterval: 5})) {
+		t.Fatal("false alarm should mark the site recently recovered for transient suppression")
 	}
 }
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -671,6 +671,15 @@ func checkerResultTransportFailure(blogID int64, at time.Time) checker.Result {
 	}
 }
 
+func checkerResultDNSFailure(blogID int64, at time.Time) checker.Result {
+	res := checkerResultTransportFailure(blogID, at)
+	res.ErrorDetail = "lookup example.test on 127.0.0.53:53: no such host"
+	res.DNSFailureKind = "nxdomain"
+	res.DNSFailureName = "example.test"
+	res.DNSFailureServer = "127.0.0.53:53"
+	return res
+}
+
 func TestCheckResultMetadataIncludesObservationAndDiagnostics(t *testing.T) {
 	previous := time.Date(2026, 5, 3, 11, 57, 0, 0, time.UTC)
 	firstFail := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
@@ -708,6 +717,9 @@ func TestCheckResultMetadataIncludesObservationAndDiagnostics(t *testing.T) {
 	}
 	if meta["dns_error_kind"] != "nxdomain" || meta["dns_error_name"] != "example.invalid" {
 		t.Fatalf("dns metadata = kind:%v name:%v, want nxdomain/example.invalid", meta["dns_error_kind"], meta["dns_error_name"])
+	}
+	if meta["dns_resolver_source"] != "system" {
+		t.Fatalf("dns_resolver_source = %v, want system", meta["dns_resolver_source"])
 	}
 	if meta["redirect_policy"] != "alert" || meta["redirect_count"] != 1 {
 		t.Fatalf("redirect metadata = policy:%v count:%v, want alert/1", meta["redirect_policy"], meta["redirect_count"])
@@ -949,6 +961,96 @@ func TestHandleFailureBelowThresholdDoesNotEscalate(t *testing.T) {
 	}
 }
 
+func TestHandleFailureDefersLowConfidenceDNSFailureEventUntilVerifierConfirmation(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	cfg := setTestConfig(t)
+	cfg.NumOfChecks = 3
+
+	rec := newRecordingMetrics()
+	metricsClientFunc = func() metricsClient { return rec }
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		hostname: "local",
+		ctx:      context.Background(),
+	}
+
+	active := o.handleFailure(
+		db.Site{BlogID: 1, MonitorURL: "https://example.com", SiteStatus: statusRunning},
+		checkerResultDNSFailure(1, time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)),
+	)
+
+	if active {
+		t.Fatal("low-confidence local DNS failure below verifier threshold should not make the site non-running")
+	}
+	if entry := o.retries.get(1); entry == nil || entry.eventID != 0 {
+		t.Fatalf("retry entry = %+v, want retry without customer-visible event", entry)
+	}
+	if got := rec.counter("detection.seems_down.open.count"); got != 0 {
+		t.Fatalf("seems-down open counter = %d, want 0", got)
+	}
+	if got := rec.counter("detection.low_confidence_dns.awaiting_verifier.count"); got != 1 {
+		t.Fatalf("low-confidence DNS counter = %d, want 1", got)
+	}
+}
+
+func TestHandleFailureOpensConfirmedDownAfterVerifierConfirmsDeferredDNSFailure(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	cfg := setTestConfig(t)
+	cfg.NumOfChecks = 1
+	cfg.PeerOfflineLimit = 1
+
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqlDB.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO jetmon_events").
+		WithArgs(int64(1), nil, checkTypeHTTP, nil, eventstore.SeverityDown, eventstore.StateDown, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(501, 1))
+	mock.ExpectExec("INSERT INTO jetmon_event_transitions").
+		WithArgs(int64(501), int64(1), nil, eventstore.SeverityDown, nil, eventstore.StateDown, eventstore.ReasonOpened, "local-host", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	veriflierCheckFunc = func(c *veriflier.VeriflierClient, _ context.Context, req veriflier.CheckRequest) (*veriflier.CheckResult, error) {
+		return &veriflier.CheckResult{
+			BlogID:    req.BlogID,
+			Host:      c.Addr(),
+			Success:   false,
+			RequestID: req.RequestID,
+		}, nil
+	}
+
+	o := &Orchestrator{
+		events:   eventstore.New(sqlDB),
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		hostname: "local-host",
+		ctx:      context.Background(),
+		veriflierClients: []*veriflier.VeriflierClient{
+			veriflier.NewVeriflierClient("v1", ""),
+		},
+	}
+
+	active := o.handleFailure(
+		db.Site{BlogID: 1, MonitorURL: "https://example.com", SiteStatus: statusRunning},
+		checkerResultDNSFailure(1, time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)),
+	)
+
+	if !active {
+		t.Fatal("verifier-confirmed DNS failure should become active after the Down event opens")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
 func TestHandleFailureSuppressesFirstPostRecoveryTransportFailure(t *testing.T) {
 	restore := stubOrchestratorDeps()
 	defer restore()
@@ -1056,6 +1158,46 @@ func TestHandleFailureSuppressesPostFalseAlarmTransportFailurePastRecoveryWindow
 	}
 	if entry := o.retries.get(42); entry != nil {
 		t.Fatalf("suppressed post-false-alarm failure created retry state: %+v", entry)
+	}
+}
+
+func TestHandleFailureRefreshesPostFalseAlarmSuppressionWindow(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	cfg := setTestConfig(t)
+	cfg.NumOfChecks = 1
+
+	var escalated bool
+	veriflierCheckFunc = func(_ *veriflier.VeriflierClient, _ context.Context, _ veriflier.CheckRequest) (*veriflier.CheckResult, error) {
+		escalated = true
+		return &veriflier.CheckResult{Success: false}, nil
+	}
+
+	falseAlarmAt := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		hostname: "local",
+		ctx:      context.Background(),
+	}
+	o.retries.markFalseAlarm(42, falseAlarmAt)
+	site := db.Site{BlogID: 42, MonitorURL: "https://example.com", CheckInterval: 3, SiteStatus: statusRunning}
+	falseAlarmWindow := postFalseAlarmTransientFailureWindow(site)
+
+	firstSuppressedAt := falseAlarmAt.Add(5 * time.Minute)
+	if active := o.handleFailure(site, checkerResultTransportFailure(42, firstSuppressedAt)); active {
+		t.Fatal("first post-false-alarm transient failure should stay suppressed")
+	}
+
+	secondSuppressedAt := falseAlarmAt.Add(falseAlarmWindow + 30*time.Second)
+	if active := o.handleFailure(site, checkerResultTransportFailure(42, secondSuppressedAt)); active {
+		t.Fatal("suppression window should roll forward while transient failures continue")
+	}
+	if escalated {
+		t.Fatal("rolling false-alarm dampening escalated despite refreshed suppression window")
+	}
+	if entry := o.retries.get(42); entry != nil {
+		t.Fatalf("suppressed rolling post-false-alarm failure created retry state: %+v", entry)
 	}
 }
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1024,6 +1024,79 @@ func TestHandleFailureEscalatesPostRecoveryTransportFailureAfterWindow(t *testin
 	}
 }
 
+func TestHandleFailureSuppressesPostFalseAlarmTransportFailurePastRecoveryWindow(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	cfg := setTestConfig(t)
+	cfg.NumOfChecks = 1
+
+	var escalated bool
+	veriflierCheckFunc = func(_ *veriflier.VeriflierClient, _ context.Context, _ veriflier.CheckRequest) (*veriflier.CheckResult, error) {
+		escalated = true
+		return &veriflier.CheckResult{Success: false}, nil
+	}
+
+	falseAlarmAt := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		hostname: "local",
+		ctx:      context.Background(),
+	}
+	o.retries.markFalseAlarm(42, falseAlarmAt)
+	site := db.Site{BlogID: 42, MonitorURL: "https://example.com", CheckInterval: 3, SiteStatus: statusRunning}
+
+	active := o.handleFailure(site, checkerResultTransportFailure(42, falseAlarmAt.Add(postRecoveryTransientFailureWindow(site)+time.Second)))
+
+	if active {
+		t.Fatal("post-false-alarm transport failure should stay suppressed beyond the normal recovery window")
+	}
+	if escalated {
+		t.Fatal("post-false-alarm transport failure escalated despite false-alarm dampening")
+	}
+	if entry := o.retries.get(42); entry != nil {
+		t.Fatalf("suppressed post-false-alarm failure created retry state: %+v", entry)
+	}
+}
+
+func TestHandleFailureEscalatesPostFalseAlarmTransportFailureAfterFalseAlarmWindow(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	cfg := setTestConfig(t)
+	cfg.NumOfChecks = 1
+	cfg.PeerOfflineLimit = 1
+
+	var escalated bool
+	veriflierCheckFunc = func(c *veriflier.VeriflierClient, _ context.Context, req veriflier.CheckRequest) (*veriflier.CheckResult, error) {
+		escalated = true
+		return &veriflier.CheckResult{
+			BlogID:   req.BlogID,
+			Host:     c.Addr(),
+			Success:  false,
+			HTTPCode: 0,
+		}, nil
+	}
+
+	falseAlarmAt := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		hostname: "local",
+		ctx:      context.Background(),
+		veriflierClients: []*veriflier.VeriflierClient{
+			veriflier.NewVeriflierClient("v1", ""),
+		},
+	}
+	o.retries.markFalseAlarm(42, falseAlarmAt)
+	site := db.Site{BlogID: 42, MonitorURL: "https://example.com", CheckInterval: 3, SiteStatus: statusRunning}
+
+	o.handleFailure(site, checkerResultTransportFailure(42, falseAlarmAt.Add(postFalseAlarmTransientFailureWindow(site)+time.Second)))
+
+	if !escalated {
+		t.Fatal("transport failure after post-false-alarm suppression window should continue the normal retry pipeline")
+	}
+}
+
 func TestProcessResultsMarksChecked(t *testing.T) {
 	restore := stubOrchestratorDeps()
 	defer restore()
@@ -2554,8 +2627,11 @@ func TestEscalateToVerifliersEmitsFalseAlarmMetrics(t *testing.T) {
 	if entry := o.retries.get(654); entry != nil {
 		t.Fatalf("retry entry after false alarm = %+v, want nil", entry)
 	}
-	if !o.retries.recentlyRecovered(654, nowFunc().UTC(), postRecoveryTransientFailureWindow(db.Site{BlogID: 654, CheckInterval: 5})) {
-		t.Fatal("false alarm should mark the site recently recovered for transient suppression")
+	if !o.retries.recentlyFalseAlarmed(654, nowFunc().UTC(), postFalseAlarmTransientFailureWindow(db.Site{BlogID: 654, CheckInterval: 5})) {
+		t.Fatal("false alarm should mark the site for false-alarm transient suppression")
+	}
+	if o.retries.recentlyRecovered(654, nowFunc().UTC(), postRecoveryTransientFailureWindow(db.Site{BlogID: 654, CheckInterval: 5})) {
+		t.Fatal("false alarm should not mark the site as a normal recovery")
 	}
 }
 

--- a/internal/orchestrator/retry.go
+++ b/internal/orchestrator/retry.go
@@ -21,15 +21,17 @@ type retryEntry struct {
 // retryQueue holds sites awaiting local retry or veriflier escalation.
 // It persists between rounds — never flushed at round start.
 type retryQueue struct {
-	mu               sync.Mutex
-	entries          map[int64]*retryEntry
-	recentRecoveries map[int64]time.Time
+	mu                sync.Mutex
+	entries           map[int64]*retryEntry
+	recentRecoveries  map[int64]time.Time
+	recentFalseAlarms map[int64]time.Time
 }
 
 func newRetryQueue() *retryQueue {
 	return &retryQueue{
-		entries:          make(map[int64]*retryEntry),
-		recentRecoveries: make(map[int64]time.Time),
+		entries:           make(map[int64]*retryEntry),
+		recentRecoveries:  make(map[int64]time.Time),
+		recentFalseAlarms: make(map[int64]time.Time),
 	}
 }
 
@@ -70,25 +72,42 @@ func (q *retryQueue) markRecovered(blogID int64, recoveredAt time.Time) {
 }
 
 func (q *retryQueue) recentlyRecovered(blogID int64, at time.Time, window time.Duration) bool {
+	return q.recentlyMarked(q.recentRecoveries, blogID, at, window)
+}
+
+func (q *retryQueue) markFalseAlarm(blogID int64, falseAlarmAt time.Time) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if falseAlarmAt.IsZero() {
+		falseAlarmAt = time.Now().UTC()
+	}
+	q.recentFalseAlarms[blogID] = falseAlarmAt.UTC()
+}
+
+func (q *retryQueue) recentlyFalseAlarmed(blogID int64, at time.Time, window time.Duration) bool {
+	return q.recentlyMarked(q.recentFalseAlarms, blogID, at, window)
+}
+
+func (q *retryQueue) recentlyMarked(markers map[int64]time.Time, blogID int64, at time.Time, window time.Duration) bool {
 	if window <= 0 {
 		return false
 	}
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	recoveredAt, ok := q.recentRecoveries[blogID]
+	markedAt, ok := markers[blogID]
 	if !ok {
 		return false
 	}
 	if at.IsZero() {
 		at = time.Now().UTC()
 	}
-	if at.Before(recoveredAt) {
+	if at.Before(markedAt) {
 		return true
 	}
-	if at.Sub(recoveredAt.UTC()) <= window {
+	if at.Sub(markedAt.UTC()) <= window {
 		return true
 	}
-	delete(q.recentRecoveries, blogID)
+	delete(markers, blogID)
 	return false
 }
 

--- a/internal/orchestrator/retry.go
+++ b/internal/orchestrator/retry.go
@@ -21,12 +21,16 @@ type retryEntry struct {
 // retryQueue holds sites awaiting local retry or veriflier escalation.
 // It persists between rounds — never flushed at round start.
 type retryQueue struct {
-	mu      sync.Mutex
-	entries map[int64]*retryEntry
+	mu               sync.Mutex
+	entries          map[int64]*retryEntry
+	recentRecoveries map[int64]time.Time
 }
 
 func newRetryQueue() *retryQueue {
-	return &retryQueue{entries: make(map[int64]*retryEntry)}
+	return &retryQueue{
+		entries:          make(map[int64]*retryEntry),
+		recentRecoveries: make(map[int64]time.Time),
+	}
 }
 
 // record adds a failed check result to the queue. Returns the updated entry.
@@ -54,6 +58,38 @@ func (q *retryQueue) clear(blogID int64) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	delete(q.entries, blogID)
+}
+
+func (q *retryQueue) markRecovered(blogID int64, recoveredAt time.Time) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if recoveredAt.IsZero() {
+		recoveredAt = time.Now().UTC()
+	}
+	q.recentRecoveries[blogID] = recoveredAt.UTC()
+}
+
+func (q *retryQueue) recentlyRecovered(blogID int64, at time.Time, window time.Duration) bool {
+	if window <= 0 {
+		return false
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	recoveredAt, ok := q.recentRecoveries[blogID]
+	if !ok {
+		return false
+	}
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+	if at.Before(recoveredAt) {
+		return true
+	}
+	if at.Sub(recoveredAt.UTC()) <= window {
+		return true
+	}
+	delete(q.recentRecoveries, blogID)
+	return false
 }
 
 // get returns the entry for a site, or nil if not in the queue.

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -88,6 +88,22 @@ func TestRetryQueueRecentlyRecoveredExpires(t *testing.T) {
 	}
 }
 
+func TestRetryQueueRecentlyFalseAlarmedExpiresSeparately(t *testing.T) {
+	q := newRetryQueue()
+	falseAlarmAt := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
+	q.markFalseAlarm(42, falseAlarmAt)
+
+	if !q.recentlyFalseAlarmed(42, falseAlarmAt.Add(4*time.Minute), 5*time.Minute) {
+		t.Fatal("recentlyFalseAlarmed returned false inside window")
+	}
+	if q.recentlyRecovered(42, falseAlarmAt.Add(4*time.Minute), 5*time.Minute) {
+		t.Fatal("false-alarm marker should not count as a normal recovery marker")
+	}
+	if q.recentlyFalseAlarmed(42, falseAlarmAt.Add(6*time.Minute), 5*time.Minute) {
+		t.Fatal("recentlyFalseAlarmed returned true after window")
+	}
+}
+
 func TestRetryQueueSize(t *testing.T) {
 	q := newRetryQueue()
 	if q.size() != 0 {

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -56,14 +56,35 @@ func TestRetryQueueClear(t *testing.T) {
 	q := newRetryQueue()
 	q.record(checker.Result{BlogID: 1, Timestamp: time.Now()})
 	q.record(checker.Result{BlogID: 2, Timestamp: time.Now()})
+	recoveredAt := time.Now().UTC()
+	q.markRecovered(1, recoveredAt)
 
 	q.clear(1)
 
 	if q.get(1) != nil {
 		t.Fatalf("get() after clear returned entry, want nil")
 	}
+	if !q.recentlyRecovered(1, recoveredAt.Add(time.Minute), 2*time.Minute) {
+		t.Fatalf("recent recovery marker should survive retry clear")
+	}
 	if q.get(2) == nil {
 		t.Fatalf("get() for uncleared entry returned nil")
+	}
+}
+
+func TestRetryQueueRecentlyRecoveredExpires(t *testing.T) {
+	q := newRetryQueue()
+	recoveredAt := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
+	q.markRecovered(42, recoveredAt)
+
+	if !q.recentlyRecovered(42, recoveredAt.Add(30*time.Second), time.Minute) {
+		t.Fatal("recentlyRecovered returned false inside window")
+	}
+	if q.recentlyRecovered(42, recoveredAt.Add(2*time.Minute), time.Minute) {
+		t.Fatal("recentlyRecovered returned true after window")
+	}
+	if q.recentlyRecovered(42, recoveredAt.Add(30*time.Second), time.Minute) {
+		t.Fatal("expired marker should be removed")
 	}
 }
 

--- a/internal/orchestrator/streaming.go
+++ b/internal/orchestrator/streaming.go
@@ -937,9 +937,7 @@ func (o *Orchestrator) runStreamingEngine() {
 				sideEffectStatus[report.blogID] = report.status
 				if target, ok := planner.targets[report.blogID]; ok {
 					target.site.SiteStatus = report.status
-					if report.resultFailure && report.status != statusDown && !target.inFlight && !target.queued {
-						planner.scheduleAtNextPhaseAfter(target, report.checkedAt)
-					}
+					rescheduleStreamingAfterSideEffect(planner, target, report)
 				}
 			}
 		case reload := <-reloadResults:
@@ -1021,7 +1019,7 @@ func (o *Orchestrator) dispatchStreamingPending(cfg *config.Config, pending []*s
 	dispatched := 0
 	for len(pending) > 0 && dispatched < budget {
 		target := pending[0]
-		if !target.active || target.inFlight {
+		if !target.active || target.inFlight || !target.queued {
 			target.queued = false
 			pending = pending[1:]
 			continue
@@ -1160,13 +1158,21 @@ func streamingAllowImmediateRetry(target *streamingTarget, res checker.Result, r
 }
 
 func streamingSuppressPostRecoveryImmediateRetry(target *streamingTarget, res checker.Result, retries *retryQueue) bool {
-	if target == nil || retries == nil || !postRecoveryTransientFailure(res) {
+	if target == nil || retries == nil {
 		return false
 	}
-	if retries.get(target.site.BlogID) != nil {
-		return false
+	suppressed, _, _ := postRecoveryTransientSuppression(target.site, res, retries)
+	return suppressed
+}
+
+func rescheduleStreamingAfterSideEffect(planner *streamingPlanner, target *streamingTarget, report streamingSideEffectReport) {
+	if planner == nil || target == nil {
+		return
 	}
-	return retries.recentlyRecovered(target.site.BlogID, resultCheckedAt(res), postRecoveryTransientFailureWindow(target.site))
+	if report.resultFailure && report.status != statusDown && !target.inFlight {
+		target.queued = false
+		planner.scheduleAtNextPhaseAfter(target, report.checkedAt)
+	}
 }
 
 func (o *Orchestrator) queueStreamingProjection(cfg *config.Config, target *streamingTarget, resultAt, projectedAt time.Time, pending map[int64]db.SiteCheck) {

--- a/internal/orchestrator/streaming.go
+++ b/internal/orchestrator/streaming.go
@@ -1139,9 +1139,15 @@ func streamingLocalPressureFailure(res checker.Result) bool {
 
 func streamingAllowImmediateRetry(target *streamingTarget, res checker.Result, retries *retryQueue, pressure bool) bool {
 	if !pressure {
-		return true
+		if target == nil {
+			return false
+		}
+		return !streamingSuppressPostRecoveryImmediateRetry(target, res, retries)
 	}
 	if target == nil {
+		return false
+	}
+	if streamingSuppressPostRecoveryImmediateRetry(target, res, retries) {
 		return false
 	}
 	if !streamingLocalPressureFailure(res) {
@@ -1151,6 +1157,16 @@ func streamingAllowImmediateRetry(target *streamingTarget, res checker.Result, r
 		return true
 	}
 	return retries != nil && retries.get(target.site.BlogID) != nil
+}
+
+func streamingSuppressPostRecoveryImmediateRetry(target *streamingTarget, res checker.Result, retries *retryQueue) bool {
+	if target == nil || retries == nil || !postRecoveryTransientFailure(res) {
+		return false
+	}
+	if retries.get(target.site.BlogID) != nil {
+		return false
+	}
+	return retries.recentlyRecovered(target.site.BlogID, resultCheckedAt(res), postRecoveryTransientFailureWindow(target.site))
 }
 
 func (o *Orchestrator) queueStreamingProjection(cfg *config.Config, target *streamingTarget, resultAt, projectedAt time.Time, pending map[int64]db.SiteCheck) {

--- a/internal/orchestrator/streaming.go
+++ b/internal/orchestrator/streaming.go
@@ -1067,8 +1067,8 @@ func (o *Orchestrator) processStreamingSideEffects(site db.Site, res checker.Res
 		o.handleRecovery(site, res)
 		site.SiteStatus = statusRunning
 	} else {
-		o.handleFailure(site, res)
-		if o.retries.get(site.BlogID) != nil {
+		failureActive := o.handleFailure(site, res)
+		if retry := o.retries.get(site.BlogID); retry != nil && (failureActive || retry.eventID > 0) {
 			site.SiteStatus = statusDown
 		} else if status, err := dbGetSiteStatus(o.ctx, site.BlogID); err != nil {
 			log.Printf("orchestrator: streaming refresh site status blog_id=%d: %v", site.BlogID, err)

--- a/internal/orchestrator/streaming_test.go
+++ b/internal/orchestrator/streaming_test.go
@@ -213,6 +213,23 @@ func TestStreamingAllowImmediateRetryUnderPressure(t *testing.T) {
 	}
 }
 
+func TestStreamingAllowImmediateRetrySkipsSuppressedPostRecoveryFailure(t *testing.T) {
+	retries := newRetryQueue()
+	recoveredAt := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
+	retries.markRecovered(42, recoveredAt)
+	target := &streamingTarget{site: db.Site{BlogID: 42, CheckInterval: 3, SiteStatus: statusRunning}}
+	res := checkerResultTransportFailure(42, recoveredAt.Add(2*time.Minute))
+
+	if streamingAllowImmediateRetry(target, res, retries, false) {
+		t.Fatal("suppressed post-recovery transport failure should return to normal cadence")
+	}
+
+	retries.record(checker.Result{BlogID: 42, URL: "http://example.com", Timestamp: recoveredAt})
+	if !streamingAllowImmediateRetry(target, res, retries, false) {
+		t.Fatal("existing retry state should keep immediate retry")
+	}
+}
+
 func TestStreamingWorkerTargetScalesFromRequiredRate(t *testing.T) {
 	planner := &streamingPlanner{targets: make(map[int64]*streamingTarget)}
 	for i := int64(1); i <= 1200; i++ {

--- a/internal/orchestrator/streaming_test.go
+++ b/internal/orchestrator/streaming_test.go
@@ -230,6 +230,65 @@ func TestStreamingAllowImmediateRetrySkipsSuppressedPostRecoveryFailure(t *testi
 	}
 }
 
+func TestStreamingAllowImmediateRetrySkipsSuppressedPostFalseAlarmFailure(t *testing.T) {
+	retries := newRetryQueue()
+	falseAlarmAt := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
+	retries.markFalseAlarm(42, falseAlarmAt)
+	target := &streamingTarget{site: db.Site{BlogID: 42, CheckInterval: 3, SiteStatus: statusRunning}}
+	res := checkerResultTransportFailure(42, falseAlarmAt.Add(postRecoveryTransientFailureWindow(target.site)+time.Second))
+
+	if streamingAllowImmediateRetry(target, res, retries, false) {
+		t.Fatal("suppressed post-false-alarm transport failure should return to normal cadence")
+	}
+}
+
+func TestRescheduleStreamingAfterSideEffectCancelsQueuedRetry(t *testing.T) {
+	checkedAt := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
+	planner := &streamingPlanner{
+		targets: make(map[int64]*streamingTarget),
+	}
+	target := &streamingTarget{
+		site:   db.Site{BlogID: 42, CheckInterval: 3, SiteStatus: statusRunning},
+		dueAt:  checkedAt.Add(failedCheckRetryInterval),
+		active: true,
+		queued: true,
+	}
+	planner.targets[42] = target
+
+	rescheduleStreamingAfterSideEffect(planner, target, streamingSideEffectReport{
+		blogID:        42,
+		status:        statusRunning,
+		resultFailure: true,
+		checkedAt:     checkedAt,
+	})
+
+	if target.queued {
+		t.Fatal("queued immediate retry should be canceled after side effects keep the site running")
+	}
+	if target.dueAt.Equal(checkedAt.Add(failedCheckRetryInterval)) {
+		t.Fatalf("dueAt = %s, want normal phase instead of immediate retry point", target.dueAt)
+	}
+}
+
+func TestDispatchStreamingPendingSkipsCanceledQueuedEntry(t *testing.T) {
+	o := &Orchestrator{}
+	stats := &streamingStats{}
+	target := &streamingTarget{
+		site:   db.Site{BlogID: 42, CheckInterval: 3, SiteStatus: statusRunning},
+		active: true,
+		queued: false,
+	}
+
+	remaining := o.dispatchStreamingPending(&config.Config{}, []*streamingTarget{target}, 1, stats)
+
+	if len(remaining) != 0 {
+		t.Fatalf("remaining pending = %d, want canceled entry drained", len(remaining))
+	}
+	if stats.dispatched != 0 {
+		t.Fatalf("dispatched = %d, want canceled entry skipped", stats.dispatched)
+	}
+}
+
 func TestStreamingWorkerTargetScalesFromRequiredRate(t *testing.T) {
 	planner := &streamingPlanner{targets: make(map[int64]*streamingTarget)}
 	for i := int64(1); i <= 1200; i++ {

--- a/internal/orchestrator/streaming_test.go
+++ b/internal/orchestrator/streaming_test.go
@@ -1,12 +1,14 @@
 package orchestrator
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/Automattic/jetmon/internal/checker"
 	"github.com/Automattic/jetmon/internal/config"
 	"github.com/Automattic/jetmon/internal/db"
+	"github.com/Automattic/jetmon/internal/wpcom"
 )
 
 func TestStreamingPhaseStaysInsideInterval(t *testing.T) {
@@ -716,6 +718,34 @@ func TestStreamingSideEffectsNeededSuppressesNewLocalFailuresUnderPressure(t *te
 	retries.record(checker.Result{BlogID: 42, URL: "http://example.com", Timestamp: time.Now()})
 	if !streamingSideEffectsNeeded(target, timeout, nil, nil, retries, true) {
 		t.Fatal("existing retry state should continue through side effects under pressure")
+	}
+}
+
+func TestProcessStreamingSideEffectsKeepsSuppressedPostRecoveryFailureRunning(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	cfg := setTestConfig(t)
+	cfg.NumOfChecks = 1
+
+	recoveredAt := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		hostname: "local",
+		ctx:      context.Background(),
+	}
+	o.retries.markRecovered(42, recoveredAt)
+
+	_, updated := o.processStreamingSideEffects(
+		db.Site{BlogID: 42, MonitorURL: "https://example.com", CheckInterval: 3, SiteStatus: statusRunning},
+		checkerResultTransportFailure(42, recoveredAt.Add(2*time.Minute)),
+	)
+
+	if updated.SiteStatus != statusRunning {
+		t.Fatalf("SiteStatus = %d, want running for suppressed post-recovery transient failure", updated.SiteStatus)
+	}
+	if entry := o.retries.get(42); entry != nil {
+		t.Fatalf("suppressed post-recovery transient failure created retry state: %+v", entry)
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR hardens Jetmon v2 against the post-recovery false positives seen in the TLS advisory uptime-bench scenarios when local DNS briefly returned NXDOMAIN or resolver errors after a target recovered.

The change keeps real downtime detectable while lowering confidence in local monitor-only DNS failures. When the local monitor sees a DNS-shaped failure with no HTTP response, Jetmon now defers customer-visible HTTP downtime until Veriflier confirmation. If Verifliers agree that the site is down, Jetmon opens the confirmed outage directly as `Down`; if they do not agree, the transient local failure remains non-customer-visible.

## What changed

- Treat local DNS timeout/connect failures with no HTTP status as low-confidence downtime candidates.
- Defer customer-visible HTTP `Seems Down` events for those low-confidence DNS failures until Verifliers confirm.
- Preserve resolver evidence in retry and confirmed-down metadata, including whether checks used configured or system resolvers.
- Refresh the false-alarm dampening marker while suppressing transient post-recovery blips so the dampening window rolls forward during unstable recovery periods.
- Add metrics for low-confidence DNS failures awaiting Veriflier confirmation.
- Add regression tests for post-recovery suppression, DNS metadata, retry behavior, and verifier-confirmed promotion paths.

## Focused validation

- `go test ./...`
- Deployed the branch to the Jetmon v2 test service and ran the focused uptime-bench post-recovery false-positive suite.
- Latest focused report: `20260512T220614Z-75m-jetmon-v2-post-recovery-fp-clean-dns`
- Result: Jetmon v2 passed `4/4` scenarios with no false positives, no TLS advisory false outages, and expected TLS advisory detection preserved.
