### PR TITLE
Harden PR 101 WPCOM and streaming follow-ups

### DIFF
--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -455,6 +455,10 @@ Important metric groups include:
 - Round completion time
 - Scheduler page count, selected/dispatched/completed rows, outstanding checks,
   backpressure waits, stale/duplicate results, and sampled due backlog
+- Streaming failure-pressure suppression via
+  `scheduler.streaming.pressure_suppressed.count`, which shows local
+  timeout/connect failures that were treated as monitor-side pressure instead
+  of opening noisy incident side effects for otherwise running sites
 - Scheduler phase timings for dispatch, wait, result processing,
   sidecar freshness writes, check-history inserts, SSL expiry
   writes, and event handling
@@ -464,7 +468,8 @@ Important metric groups include:
   `scheduler.*.check.method.<method>.profile.<profile>.count`, using the
   effective runtime method/profile for `HEAD` / `GET` and `legacy` /
   `simple_http` / `full`
-- WPCOM API attempts, deliveries, retries, errors, and failures
+- WPCOM API attempts, deliveries, retries, queued circuit-open responses,
+  permanent 404/410 failures, errors, and final failures
 - Veriflier response times and vote counters
 - Detection flow timing from first failure to escalation, confirmation,
   recovery, or false alarm

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -16,7 +16,10 @@ These are scoped branches worth considering after the merged API CLI, rollout
 preflight, deliverer hardening, API CLI fixture workflow, dashboard, and
 production telemetry branches:
 
-No active candidate branch is queued here right now.
+- `feature/pr-101-followups` - close out stale PR #101 by retaining only the
+  ideas not superseded by the #104 streaming engine work: permanent WPCOM
+  status handling, streaming-aware failure-storm suppression, and evidence-led
+  evaluation of any remaining `jetpack_monitor_sites` point-lookup indexes.
 
 ### v2 Prelaunch Readiness TODO
 
@@ -198,6 +201,13 @@ No active candidate branch is queued here right now.
   checks in parallel without breaking per-site ordering or retry/event
   invariants, but the 4 million failure points first toward timeout-aware
   dispatch and scaler control.
+- [ ] Redesign broad transport failure-storm suppression against the streaming
+  engine. PR #101 sampled Verifliers and suppressed noisy event/history fanout
+  during monitor-side transport waves, but that implementation targeted the
+  old round/page scheduler. A new version should preserve the v2 `Unknown`
+  principle for monitor-side impairment, avoid hiding real customer-site
+  outages, keep operator-visible audit/metrics evidence, and be validated with
+  failure-flood uptime-bench scenarios before production rollout.
 - [ ] Expand prepared request/runtime caches for the checker hot path. Cache
   parsed URL/host metadata, normalized headers, keyword rules, and reusable
   per-site request material in memory so repeated all-day checks spend less CPU
@@ -223,6 +233,12 @@ No active candidate branch is queued here right now.
   first prototype still reloads active identity/cadence from
   `jetpack_monitor_sites` plus v2 sidecar config so correctness can be
   validated before optimizing config-sync reads.
+- [ ] Evaluate whether any remaining single-column `blog_id` index is needed
+  on `jetpack_monitor_sites` after sidecar-table rollout. PR #101 added
+  `idx_monitor_blog_id` for legacy-table point writes, but current rollout
+  goals minimize changes to the hot v1 compatibility table. Use `EXPLAIN`,
+  production-like write/read traces, and sidecar-table coverage before adding
+  another index to `jetpack_monitor_sites`.
 - [ ] Add uptime-bench scenarios for streaming mode that explicitly validate
   phase-spread scheduling, bounded rollback freshness staleness, verifier
   promotion/recovery, failure-history retention, and steady-state write volume
@@ -557,6 +573,13 @@ Recently completed candidate branches:
 - **Migrate WPCOM notifications behind alert contacts/deliverer.** Do this
   only after alert contacts have proven stable in production and recipient
   parity has been verified.
+- **Handle permanent WPCOM status failures without tripping the global
+  circuit.** PR #101 identified a useful hardening idea: per-notification
+  permanent WPCOM responses such as 404/410 should be reported and audited, but
+  should not open the shared WPCOM circuit breaker or generate pointless retry
+  pressure. Rebuild this as a focused follow-up against current `v2`, with typed
+  status errors, bounded drop logging, metrics, and tests for retry/circuit
+  behavior.
 - **Adopt consumer-specific OpenAPI generator validation when one is chosen.**
   The route-driven `GET /api/v1/openapi.json` endpoint now includes
   handler-derived request/response component schemas, and `make test` validates

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -233,12 +233,16 @@ production telemetry branches:
   first prototype still reloads active identity/cadence from
   `jetpack_monitor_sites` plus v2 sidecar config so correctness can be
   validated before optimizing config-sync reads.
-- [ ] Evaluate whether any remaining single-column `blog_id` index is needed
+- [x] Evaluate whether any remaining single-column `blog_id` index is needed
   on `jetpack_monitor_sites` after sidecar-table rollout. PR #101 added
   `idx_monitor_blog_id` for legacy-table point writes, but current rollout
   goals minimize changes to the hot v1 compatibility table. Use `EXPLAIN`,
   production-like write/read traces, and sidecar-table coverage before adding
-  another index to `jetpack_monitor_sites`.
+  another index to `jetpack_monitor_sites`. Current `v2` does not add
+  `idx_monitor_blog_id`: migration 27 is intentionally a no-op, v2-owned
+  point lookups use sidecar tables keyed by `blog_id`, and the legacy table
+  remains v1-shaped for rollout safety. Reopen only with query-plan evidence
+  from production-like traces.
 - [ ] Add uptime-bench scenarios for streaming mode that explicitly validate
   phase-spread scheduling, bounded rollback freshness staleness, verifier
   promotion/recovery, failure-history retention, and steady-state write volume
@@ -577,9 +581,8 @@ Recently completed candidate branches:
   circuit.** PR #101 identified a useful hardening idea: per-notification
   permanent WPCOM responses such as 404/410 should be reported and audited, but
   should not open the shared WPCOM circuit breaker or generate pointless retry
-  pressure. Rebuild this as a focused follow-up against current `v2`, with typed
-  status errors, bounded drop logging, metrics, and tests for retry/circuit
-  behavior.
+  pressure. The focused follow-up adds typed WPCOM status errors, bounded queue
+  drop logging, permanent-failure metrics, and retry/circuit tests.
 - **Adopt consumer-specific OpenAPI generator validation when one is chosen.**
   The route-driven `GET /api/v1/openapi.json` endpoint now includes
   handler-derived request/response component schemas, and `make test` validates

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -22,6 +22,7 @@ import (
 const (
 	EventWPCOMSent         = "wpcom_sent"
 	EventWPCOMRetry        = "wpcom_retry"
+	EventWPCOMFailure      = "wpcom_failure"
 	EventRetryDispatched   = "retry_dispatched"
 	EventVeriflierSent     = "veriflier_sent"
 	EventMaintenanceActive = "maintenance_active"

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -62,6 +62,7 @@ const failedCheckRetryInterval = time.Minute
 const maxPostRecoveryTransientFailureWindow = 5 * time.Minute
 const minPostFalseAlarmTransientFailureWindow = 5 * time.Minute
 const maxPostFalseAlarmTransientFailureWindow = 10 * time.Minute
+const wpcomPermanentFailureLogInterval = 10 * time.Second
 
 // VariableIntervalPollInterval returns the idle scheduler poll interval used
 // when per-site check intervals are enabled. The SQL due predicate prevents
@@ -262,6 +263,9 @@ type Orchestrator struct {
 	lastProjectionDriftAt time.Time
 
 	wpcomNotifyDisabledLogOnce sync.Once
+	wpcomPermanentMu           sync.Mutex
+	wpcomPermanentLastLog      time.Time
+	wpcomPermanentSuppressed   int
 
 	ctx    stdctx.Context
 	cancel stdctx.CancelFunc
@@ -1953,8 +1957,33 @@ func (o *Orchestrator) sendNotification(site db.Site, res checker.Result, status
 	if err := wpcomNotifyFunc(o.wpcom, n); err != nil {
 		emitCounter("wpcom.notification.error.count", 1)
 		emitCounter("wpcom.notification.status."+wpcomStatus+".error.count", 1)
-		emitCounter("wpcom.notification.retry.count", 1)
 		log.Printf("orchestrator: wpcom notify failed for blog_id=%d: %v", site.BlogID, err)
+
+		if errors.Is(err, wpcom.ErrCircuitOpen) {
+			emitCounter("wpcom.notification.queued.count", 1)
+			emitCounter("wpcom.notification.status."+wpcomStatus+".queued.count", 1)
+			return
+		}
+
+		if wpcom.IsPermanentStatusError(err) {
+			emitCounter("wpcom.notification.permanent_failure.count", 1)
+			emitCounter("wpcom.notification.status."+wpcomStatus+".permanent_failure.count", 1)
+			if statusCode, ok := wpcom.HTTPStatusCode(err); ok {
+				emitCounter(fmt.Sprintf("wpcom.notification.http.%d.permanent_failure.count", statusCode), 1)
+			}
+			emitCounter("wpcom.notification.failed.count", 1)
+			emitCounter("wpcom.notification.status."+wpcomStatus+".failed.count", 1)
+			o.logWPCOMPermanentFailure(site.BlogID, err)
+			o.auditLog(audit.Entry{
+				BlogID:    site.BlogID,
+				EventType: audit.EventWPCOMFailure,
+				Source:    "local",
+				Detail:    err.Error(),
+			})
+			return
+		}
+
+		emitCounter("wpcom.notification.retry.count", 1)
 		o.auditLog(audit.Entry{
 			BlogID:    site.BlogID,
 			EventType: audit.EventWPCOMRetry,
@@ -1969,6 +1998,12 @@ func (o *Orchestrator) sendNotification(site db.Site, res checker.Result, status
 			emitCounter("wpcom.notification.failed.count", 1)
 			emitCounter("wpcom.notification.status."+wpcomStatus+".failed.count", 1)
 			log.Printf("orchestrator: wpcom notify retry failed for blog_id=%d: %v", site.BlogID, retryErr)
+			o.auditLog(audit.Entry{
+				BlogID:    site.BlogID,
+				EventType: audit.EventWPCOMFailure,
+				Source:    "local",
+				Detail:    retryErr.Error(),
+			})
 			return
 		}
 		emitCounter("wpcom.notification.retry.delivered.count", 1)
@@ -1978,6 +2013,33 @@ func (o *Orchestrator) sendNotification(site db.Site, res checker.Result, status
 	if err := dbUpdateLastAlertSent(o.ctx, site.BlogID, nowFunc().UTC()); err != nil {
 		log.Printf("orchestrator: update last alert sent blog_id=%d: %v", site.BlogID, err)
 	}
+}
+
+func (o *Orchestrator) logWPCOMPermanentFailure(blogID int64, err error) {
+	if o == nil {
+		log.Printf("orchestrator: wpcom notify permanent failure for blog_id=%d: %v", blogID, err)
+		return
+	}
+	o.wpcomPermanentMu.Lock()
+	defer o.wpcomPermanentMu.Unlock()
+
+	now := nowFunc()
+	if o.wpcomPermanentLastLog.IsZero() || now.Sub(o.wpcomPermanentLastLog) >= wpcomPermanentFailureLogInterval {
+		if o.wpcomPermanentSuppressed > 0 {
+			log.Printf(
+				"orchestrator: wpcom notify permanent failure for blog_id=%d: %v (suppressed %d similar permanent failures)",
+				blogID,
+				err,
+				o.wpcomPermanentSuppressed,
+			)
+		} else {
+			log.Printf("orchestrator: wpcom notify permanent failure for blog_id=%d: %v", blogID, err)
+		}
+		o.wpcomPermanentLastLog = now
+		o.wpcomPermanentSuppressed = 0
+		return
+	}
+	o.wpcomPermanentSuppressed++
 }
 
 // checkSSLAlerts manages a site-level tls_expiry event that tracks the cert's

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -260,6 +260,116 @@ func TestSendNotificationRetriesAndUpdatesAlertTimestamp(t *testing.T) {
 	}
 }
 
+func TestSendNotificationDoesNotRetryWhenWPCOMCircuitOpen(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+
+	setTestConfig(t)
+
+	rec := newRecordingMetrics()
+	metricsClientFunc = func() metricsClient { return rec }
+
+	var notifyCalls int
+	wpcomNotifyFunc = func(_ *wpcom.Client, _ wpcom.Notification) error {
+		notifyCalls++
+		return fmt.Errorf("%w, notification queued", wpcom.ErrCircuitOpen)
+	}
+
+	var updateAlertCalled bool
+	dbUpdateLastAlertSent = func(context.Context, int64, time.Time) error {
+		updateAlertCalled = true
+		return nil
+	}
+
+	o := &Orchestrator{
+		wpcom:    &wpcom.Client{},
+		hostname: "local-host",
+		ctx:      context.Background(),
+	}
+
+	res := checkerResultFailure(123)
+	o.sendNotification(db.Site{BlogID: 123, MonitorURL: "https://example.com"}, res, statusConfirmedDown, res.Timestamp, nil)
+
+	if notifyCalls != 1 {
+		t.Fatalf("notify calls = %d, want 1 for circuit-open queue response", notifyCalls)
+	}
+	if updateAlertCalled {
+		t.Fatal("dbUpdateLastAlertSent should not be called while WPCOM circuit is open")
+	}
+	for stat, want := range map[string]int{
+		"wpcom.notification.attempt.count":                         1,
+		"wpcom.notification.status.confirmed_down.attempt.count":   1,
+		"wpcom.notification.error.count":                           1,
+		"wpcom.notification.status.confirmed_down.error.count":     1,
+		"wpcom.notification.queued.count":                          1,
+		"wpcom.notification.status.confirmed_down.queued.count":    1,
+		"wpcom.notification.retry.count":                           0,
+		"wpcom.notification.failed.count":                          0,
+		"wpcom.notification.delivered.count":                       0,
+		"wpcom.notification.status.confirmed_down.delivered.count": 0,
+	} {
+		if got := rec.counter(stat); got != want {
+			t.Fatalf("%s = %d, want %d", stat, got, want)
+		}
+	}
+}
+
+func TestSendNotificationDoesNotRetryPermanentWPCOMFailure(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+
+	setTestConfig(t)
+
+	rec := newRecordingMetrics()
+	metricsClientFunc = func() metricsClient { return rec }
+
+	var notifyCalls int
+	wpcomNotifyFunc = func(_ *wpcom.Client, _ wpcom.Notification) error {
+		notifyCalls++
+		return wpcom.StatusError{StatusCode: http.StatusNotFound}
+	}
+
+	var updateAlertCalled bool
+	dbUpdateLastAlertSent = func(context.Context, int64, time.Time) error {
+		updateAlertCalled = true
+		return nil
+	}
+
+	o := &Orchestrator{
+		wpcom:    &wpcom.Client{},
+		hostname: "local-host",
+		ctx:      context.Background(),
+	}
+
+	res := checkerResultFailure(123)
+	o.sendNotification(db.Site{BlogID: 123, MonitorURL: "https://example.com"}, res, statusConfirmedDown, res.Timestamp, nil)
+
+	if notifyCalls != 1 {
+		t.Fatalf("notify calls = %d, want 1 for permanent failure", notifyCalls)
+	}
+	if updateAlertCalled {
+		t.Fatal("dbUpdateLastAlertSent should not be called for permanent failure")
+	}
+	for stat, want := range map[string]int{
+		"wpcom.notification.attempt.count":                                 1,
+		"wpcom.notification.status.confirmed_down.attempt.count":           1,
+		"wpcom.notification.error.count":                                   1,
+		"wpcom.notification.status.confirmed_down.error.count":             1,
+		"wpcom.notification.permanent_failure.count":                       1,
+		"wpcom.notification.status.confirmed_down.permanent_failure.count": 1,
+		"wpcom.notification.http.404.permanent_failure.count":              1,
+		"wpcom.notification.failed.count":                                  1,
+		"wpcom.notification.status.confirmed_down.failed.count":            1,
+		"wpcom.notification.retry.count":                                   0,
+		"wpcom.notification.delivered.count":                               0,
+		"wpcom.notification.status.confirmed_down.delivered.count":         0,
+	} {
+		if got := rec.counter(stat); got != want {
+			t.Fatalf("%s = %d, want %d", stat, got, want)
+		}
+	}
+}
+
 func TestSendNotificationSkipsWhenWPCOMDisabled(t *testing.T) {
 	restore := stubOrchestratorDeps()
 	defer restore()

--- a/internal/orchestrator/streaming.go
+++ b/internal/orchestrator/streaming.go
@@ -342,6 +342,7 @@ type streamingStats struct {
 	sideEffectPaused   int
 	resultPaused       int
 	dispatchLimited    int
+	pressureSuppressed int
 	latencyTotal       time.Duration
 	latencyCount       int
 	successLatency     time.Duration
@@ -782,7 +783,11 @@ func (o *Orchestrator) runStreamingEngine() {
 		}
 		pressureActive := failurePressureActive || hotPathPressure
 		o.totalChecked++
-		if streamingSideEffectsNeeded(target, res, pendingSideEffects, sideEffectStatus, o.retries, pressureActive) {
+		suppressedByPressure := streamingSideEffectsSuppressedByPressure(target, res, pendingSideEffects, sideEffectStatus, o.retries, pressureActive)
+		if suppressedByPressure {
+			stats.pressureSuppressed++
+		}
+		if !suppressedByPressure && streamingSideEffectsNeeded(target, res, pendingSideEffects, sideEffectStatus, o.retries, pressureActive) {
 			job := streamingSideEffectJob{site: target.site, res: res}
 			if !sideEffects.tryEnqueue(job) {
 				stats.sideEffectWaits++
@@ -1118,9 +1123,11 @@ func streamingSideEffectsNeeded(target *streamingTarget, res checker.Result, pen
 	if target == nil {
 		return false
 	}
+	if streamingSideEffectsSuppressedByPressure(target, res, pending, statusCache, retries, pressure) {
+		return false
+	}
 	blogID := target.site.BlogID
-	pendingForSite := pending[blogID] > 0
-	if pendingForSite {
+	if pending[blogID] > 0 {
 		return true
 	}
 	status := target.site.SiteStatus
@@ -1128,9 +1135,6 @@ func streamingSideEffectsNeeded(target *streamingTarget, res checker.Result, pen
 		status = cached
 	}
 	retrying := retries != nil && retries.get(blogID) != nil
-	if pressure && status == statusRunning && !retrying && streamingLocalPressureFailure(res) {
-		return false
-	}
 	if res.IsFailure() || res.TLSVersion != 0 || res.SSLExpiry != nil {
 		return true
 	}
@@ -1138,6 +1142,22 @@ func streamingSideEffectsNeeded(target *streamingTarget, res checker.Result, pen
 		return true
 	}
 	return retrying
+}
+
+func streamingSideEffectsSuppressedByPressure(target *streamingTarget, res checker.Result, pending map[int64]int, statusCache map[int64]int, retries *retryQueue, pressure bool) bool {
+	if !pressure || target == nil {
+		return false
+	}
+	blogID := target.site.BlogID
+	if pending[blogID] > 0 {
+		return false
+	}
+	status := target.site.SiteStatus
+	if cached, ok := statusCache[blogID]; ok {
+		status = cached
+	}
+	retrying := retries != nil && retries.get(blogID) != nil
+	return status == statusRunning && !retrying && streamingLocalPressureFailure(res)
 }
 
 func streamingLocalPressureFailure(res checker.Result) bool {
@@ -1333,6 +1353,7 @@ func (o *Orchestrator) reportStreamingStats(cfg *config.Config, planner *streami
 		m.Increment("scheduler.streaming.result_backpressure_pause.count", stats.resultPaused)
 		m.Increment("scheduler.streaming.side_effect_backpressure_pause.count", stats.sideEffectPaused)
 		m.Increment("scheduler.streaming.dispatch_budget_limited.count", stats.dispatchLimited)
+		m.Increment("scheduler.streaming.pressure_suppressed.count", stats.pressureSuppressed)
 		m.Increment("scheduler.streaming.stale_result.count", stats.staleResults)
 		m.Increment("scheduler.streaming.check.success.count", stats.checkSuccesses)
 		m.Increment("scheduler.streaming.check.failure.count", stats.checkFailures)
@@ -1360,7 +1381,7 @@ func (o *Orchestrator) reportStreamingStats(cfg *config.Config, planner *streami
 		metrics.WriteStatsFiles(sps, queueDepth, o.totalChecked)
 	}
 
-	log.Printf("orchestrator: streaming summary active=%d required_rate=%.2f/s selected=%d dispatched=%d completed=%d side_effects=%d pending=%d active_checks=%d queue_depth=%d result_depth=%d side_effect_depth=%d workers=%d worker_target=%d sps=%d elapsed=%s max_lag=%s avg_latency=%s scale_latency=%s successes=%d failures=%d failure_pressure=%t error_timeout=%d error_connect=%d error_ssl=%d error_redirect=%d error_keyword=%d error_body_read=%d error_tls_expired=%d error_tls_deprecated=%d error_other=%d history_rows=%d ssl_rows=%d stale_results=%d backpressure_waits=%d side_effect_waits=%d result_pauses=%d side_effect_pauses=%d dispatch_limited=%d",
+	log.Printf("orchestrator: streaming summary active=%d required_rate=%.2f/s selected=%d dispatched=%d completed=%d side_effects=%d pending=%d active_checks=%d queue_depth=%d result_depth=%d side_effect_depth=%d workers=%d worker_target=%d sps=%d elapsed=%s max_lag=%s avg_latency=%s scale_latency=%s successes=%d failures=%d failure_pressure=%t pressure_suppressed=%d error_timeout=%d error_connect=%d error_ssl=%d error_redirect=%d error_keyword=%d error_body_read=%d error_tls_expired=%d error_tls_deprecated=%d error_other=%d history_rows=%d ssl_rows=%d stale_results=%d backpressure_waits=%d side_effect_waits=%d result_pauses=%d side_effect_pauses=%d dispatch_limited=%d",
 		planner.activeCount(),
 		planner.requiredChecksPerSecond(),
 		stats.selected,
@@ -1382,6 +1403,7 @@ func (o *Orchestrator) reportStreamingStats(cfg *config.Config, planner *streami
 		stats.checkSuccesses,
 		stats.checkFailures,
 		pressureActive || streamingFailurePressure(stats),
+		stats.pressureSuppressed,
 		stats.errorTimeouts,
 		stats.errorConnects,
 		stats.errorSSL,

--- a/internal/orchestrator/streaming_test.go
+++ b/internal/orchestrator/streaming_test.go
@@ -793,20 +793,35 @@ func TestStreamingSideEffectsNeededSuppressesNewLocalFailuresUnderPressure(t *te
 	target := &streamingTarget{site: db.Site{BlogID: 42, SiteStatus: statusRunning}}
 	timeout := checker.Result{BlogID: 42, ErrorCode: checker.ErrorTimeout}
 
+	if !streamingSideEffectsSuppressedByPressure(target, timeout, nil, nil, nil, true) {
+		t.Fatal("new local timeout under pressure should be counted as pressure-suppressed")
+	}
 	if streamingSideEffectsNeeded(target, timeout, nil, nil, nil, true) {
 		t.Fatal("new local timeout under pressure should not open event side effects")
+	}
+	if streamingSideEffectsSuppressedByPressure(target, timeout, nil, nil, nil, false) {
+		t.Fatal("local timeout without pressure should not be counted as pressure-suppressed")
 	}
 	if !streamingSideEffectsNeeded(target, checker.Result{BlogID: 42, HTTPCode: 500}, nil, nil, nil, true) {
 		t.Fatal("HTTP failures should still flow through side effects under pressure")
 	}
+	if streamingSideEffectsSuppressedByPressure(target, checker.Result{BlogID: 42, HTTPCode: 500}, nil, nil, nil, true) {
+		t.Fatal("HTTP failures should not be counted as pressure-suppressed")
+	}
 	if !streamingSideEffectsNeeded(target, timeout, map[int64]int{42: 1}, nil, nil, true) {
 		t.Fatal("pending side effects should preserve ordering under pressure")
+	}
+	if streamingSideEffectsSuppressedByPressure(target, timeout, map[int64]int{42: 1}, nil, nil, true) {
+		t.Fatal("pending side effects should not be counted as pressure-suppressed")
 	}
 
 	retries := newRetryQueue()
 	retries.record(checker.Result{BlogID: 42, URL: "http://example.com", Timestamp: time.Now()})
 	if !streamingSideEffectsNeeded(target, timeout, nil, nil, retries, true) {
 		t.Fatal("existing retry state should continue through side effects under pressure")
+	}
+	if streamingSideEffectsSuppressedByPressure(target, timeout, nil, nil, retries, true) {
+		t.Fatal("existing retry state should not be counted as pressure-suppressed")
 	}
 }
 

--- a/internal/wpcom/client.go
+++ b/internal/wpcom/client.go
@@ -3,6 +3,7 @@ package wpcom
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -13,10 +14,41 @@ import (
 const (
 	notifyEndpoint = "https://public-api.wordpress.com/wpcom/v2/jetpack-monitor/status-change"
 
-	cbMaxFailures  = 5
-	cbResetTimeout = 60 * time.Second
-	queueMaxSize   = 1000
+	cbMaxFailures        = 5
+	cbResetTimeout       = 60 * time.Second
+	queueMaxSize         = 1000
+	queueDropLogInterval = 10 * time.Second
 )
+
+var ErrCircuitOpen = errors.New("wpcom circuit open")
+
+// StatusError reports an HTTP response status returned by WPCOM.
+type StatusError struct {
+	StatusCode int
+}
+
+func (e StatusError) Error() string {
+	return fmt.Sprintf("wpcom returned %d", e.StatusCode)
+}
+
+// HTTPStatusCode extracts a WPCOM HTTP response status from err.
+func HTTPStatusCode(err error) (int, bool) {
+	var statusErr StatusError
+	if !errors.As(err, &statusErr) {
+		return 0, false
+	}
+	return statusErr.StatusCode, true
+}
+
+// IsPermanentStatusError reports whether err is a per-notification WPCOM
+// failure that retrying or opening the global circuit breaker cannot fix.
+func IsPermanentStatusError(err error) bool {
+	status, ok := HTTPStatusCode(err)
+	if !ok {
+		return false
+	}
+	return status == http.StatusNotFound || status == http.StatusGone
+}
 
 // CheckEntry represents a single check result included in a notification.
 type CheckEntry struct {
@@ -50,6 +82,9 @@ type Client struct {
 	circuitOpen   bool
 	circuitOpenAt time.Time
 	queue         []queuedNotification
+
+	lastQueueDropLog    time.Time
+	queueDropSuppressed int
 }
 
 type queuedNotification struct {
@@ -87,16 +122,19 @@ func (c *Client) Notify(n Notification) error {
 		} else {
 			c.enqueue(n)
 			c.mu.Unlock()
-			return fmt.Errorf("wpcom circuit open, notification queued")
+			return fmt.Errorf("%w, notification queued", ErrCircuitOpen)
 		}
 	} else {
 		c.mu.Unlock()
 	}
 
 	if err := c.send(n); err != nil {
+		if IsPermanentStatusError(err) {
+			return err
+		}
 		c.mu.Lock()
 		c.failures++
-		if c.failures >= cbMaxFailures {
+		if c.failures >= cbMaxFailures && !c.circuitOpen {
 			c.circuitOpen = true
 			c.circuitOpenAt = time.Now()
 			log.Printf("wpcom: circuit breaker opened after %d failures", c.failures)
@@ -135,17 +173,36 @@ func (c *Client) send(n Notification) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("wpcom returned %d", resp.StatusCode)
+		return StatusError{StatusCode: resp.StatusCode}
 	}
 	return nil
 }
 
 func (c *Client) enqueue(n Notification) {
 	if len(c.queue) >= queueMaxSize {
-		log.Printf("wpcom: queue full, dropping oldest notification for blog_id=%d", c.queue[0].n.BlogID)
+		c.logQueueDrop(c.queue[0].n.BlogID)
 		c.queue = c.queue[1:]
 	}
 	c.queue = append(c.queue, queuedNotification{n: n, queuedAt: time.Now()})
+}
+
+func (c *Client) logQueueDrop(blogID int64) {
+	now := time.Now()
+	if c.lastQueueDropLog.IsZero() || now.Sub(c.lastQueueDropLog) >= queueDropLogInterval {
+		if c.queueDropSuppressed > 0 {
+			log.Printf(
+				"wpcom: queue full, dropping oldest notification for blog_id=%d (suppressed %d similar drops)",
+				blogID,
+				c.queueDropSuppressed,
+			)
+		} else {
+			log.Printf("wpcom: queue full, dropping oldest notification for blog_id=%d", blogID)
+		}
+		c.lastQueueDropLog = now
+		c.queueDropSuppressed = 0
+		return
+	}
+	c.queueDropSuppressed++
 }
 
 // sendFlush sends previously queued notifications without holding the mutex.

--- a/internal/wpcom/client_test.go
+++ b/internal/wpcom/client_test.go
@@ -2,6 +2,7 @@ package wpcom
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -152,6 +153,52 @@ func TestNotifyOpensCircuitAfterMaxFailures(t *testing.T) {
 	}
 }
 
+func TestNotifyPermanentNotFoundDoesNotOpenCircuit(t *testing.T) {
+	c, close := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	defer close()
+
+	for range cbMaxFailures + 2 {
+		err := c.Notify(testNotification(1))
+		if err == nil {
+			t.Fatal("Notify() expected not-found error")
+		}
+		if !IsPermanentStatusError(err) {
+			t.Fatalf("Notify() error = %v, want permanent status error", err)
+		}
+		status, ok := HTTPStatusCode(err)
+		if !ok || status != http.StatusNotFound {
+			t.Fatalf("HTTPStatusCode() = %d, %v; want %d, true", status, ok, http.StatusNotFound)
+		}
+	}
+
+	if c.IsCircuitOpen() {
+		t.Fatal("circuit should stay closed for permanent per-notification failures")
+	}
+	if c.failures != 0 {
+		t.Fatalf("failures = %d after permanent failures, want 0", c.failures)
+	}
+	if c.QueueDepth() != 0 {
+		t.Fatalf("QueueDepth() = %d after permanent failures, want 0", c.QueueDepth())
+	}
+}
+
+func TestNotifyGoneIsPermanent(t *testing.T) {
+	c, close := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusGone)
+	})
+	defer close()
+
+	err := c.Notify(testNotification(1))
+	if err == nil {
+		t.Fatal("Notify() expected gone error")
+	}
+	if !IsPermanentStatusError(err) {
+		t.Fatalf("Notify() error = %v, want permanent status error", err)
+	}
+}
+
 func TestNotifyQueuesAndReturnsErrorWhenCircuitOpen(t *testing.T) {
 	c, close := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -164,6 +211,9 @@ func TestNotifyQueuesAndReturnsErrorWhenCircuitOpen(t *testing.T) {
 	err := c.Notify(testNotification(42))
 	if err == nil {
 		t.Fatal("Notify() expected error when circuit is open")
+	}
+	if !errors.Is(err, ErrCircuitOpen) {
+		t.Fatalf("Notify() error = %v, want ErrCircuitOpen", err)
 	}
 	if c.QueueDepth() != 1 {
 		t.Fatalf("QueueDepth() = %d, want 1", c.QueueDepth())


### PR DESCRIPTION
## Summary

This draft PR closes the useful follow-up items from superseded PR #101 that still apply to current `v2`. PR #101 targeted the older round/page scheduler path and was superseded by the streaming monitor engine from #104, so this branch keeps the applicable hardening without reviving stale scheduler code.

## What Changed

- Rebased `feature/pr-101-followups` on latest `v2` after #111 and resolved the roadmap conflict.
- Added typed WPCOM HTTP status errors so 404/410 responses are treated as permanent per-notification failures.
- Prevented permanent WPCOM 404/410 responses from opening the shared WPCOM circuit breaker, queueing, or triggering pointless immediate retries.
- Added WPCOM permanent-failure metrics, HTTP-status-specific permanent-failure metrics, and `wpcom_failure` audit rows so operators still have a clear evidence trail.
- Exposed `wpcom.ErrCircuitOpen` and updated the orchestrator to count already-queued circuit-open responses as queued instead of retrying into the open circuit.
- Added bounded WPCOM queue-drop logging to avoid log floods during broad WPCOM outages.
- Added `scheduler.streaming.pressure_suppressed.count` and streaming summary output for local timeout/connect failures that are suppressed under monitor-side pressure.
- Confirmed current `v2` does not add the old `idx_monitor_blog_id` legacy-table index; the roadmap now records that this should stay evidence-led and sidecar-first.

## Validation

- `go test ./internal/wpcom ./internal/orchestrator`
- `go test ./...`