### PR TITLE
Avoid repeated Veriflier confirmation for down sites

### DIFF
--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -539,6 +539,11 @@ Verifliers that fail to respond are excluded from confirmation requests. If the
 healthy set drops below `PEER_OFFLINE_LIMIT`, Jetmon cannot issue new downtime
 confirmations.
 
+Once a site is already projected as confirmed down, subsequent local failures do
+not re-enter Veriflier confirmation. Jetmon keeps checking for recovery and
+emits `detection.down.still_down.*` counters for the ongoing failed
+observations without duplicating confirmed-down notifications.
+
 Manual check:
 
 ```bash

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1474,6 +1474,14 @@ func (o *Orchestrator) handleFailure(site db.Site, res checker.Result) bool {
 		return false
 	}
 
+	if site.SiteStatus == statusConfirmedDown {
+		o.retries.clear(site.BlogID)
+		class := failureClass(res)
+		emitCounter("detection.down.still_down.count", 1)
+		emitCounter("detection.down.still_down."+class+".count", 1)
+		return true
+	}
+
 	entry := o.retries.record(res)
 	class := failureClass(res)
 	emitCounter("detection.failure."+class+".count", 1)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2744,6 +2744,58 @@ func TestHandleFailureDoesNotNotifyWPCOMBeforeConfirmation(t *testing.T) {
 	}
 }
 
+func TestHandleFailureDoesNotReverifyAlreadyConfirmedDownSite(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+
+	cfg := setTestConfig(t)
+	cfg.NumOfChecks = 1
+
+	rec := newRecordingMetrics()
+	metricsClientFunc = func() metricsClient { return rec }
+	wpcomNotifyFunc = func(_ *wpcom.Client, _ wpcom.Notification) error {
+		t.Fatal("already-confirmed down failure should not send another notification")
+		return nil
+	}
+	veriflierCheckFunc = func(_ *veriflier.VeriflierClient, _ context.Context, _ veriflier.CheckRequest) (*veriflier.CheckResult, error) {
+		t.Fatal("already-confirmed down failure should not re-enter Veriflier confirmation")
+		return nil, nil
+	}
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		hostname: "local-host",
+		ctx:      context.Background(),
+		veriflierClients: []*veriflier.VeriflierClient{
+			veriflier.NewVeriflierClient("v1", ""),
+		},
+	}
+	o.retries.record(checkerResultFailure(42))
+
+	active := o.handleFailure(db.Site{
+		BlogID:     42,
+		MonitorURL: "https://example.com",
+		SiteStatus: statusConfirmedDown,
+	}, checkerResultFailure(42))
+
+	if !active {
+		t.Fatal("already-confirmed down failure should report an active failure")
+	}
+	if entry := o.retries.get(42); entry != nil {
+		t.Fatalf("stale retry entry should be cleared for already-confirmed down site: %+v", entry)
+	}
+	if got := rec.counter("detection.down.still_down.count"); got != 1 {
+		t.Fatalf("still-down counter = %d, want 1", got)
+	}
+	if got := rec.counter("detection.down.still_down.server.count"); got != 1 {
+		t.Fatalf("still-down server counter = %d, want 1", got)
+	}
+	if got := rec.counter("detection.verifier.escalation.count"); got != 0 {
+		t.Fatalf("verifier escalation counter = %d, want 0", got)
+	}
+}
+
 func TestEscalateToVerifliersEmitsConfirmedMetrics(t *testing.T) {
 	restore := stubOrchestratorDeps()
 	defer restore()


### PR DESCRIPTION
## Summary

This PR handles the non-blocking follow-up from the staged HEAD/GET rollout work by preventing already-confirmed-down sites from re-entering the Veriflier confirmation path on every subsequent failed local check.

Changes:

- Clears stale retry state when a site is already projected as confirmed down.
- Keeps recovery checks active while skipping duplicate Veriflier confirmation, confirmed-down logs, and repeated WPCOM notification attempts for persistent outages.
- Adds `detection.down.still_down.*` counters so ongoing failed observations remain visible without creating duplicate confirmation work.
- Documents the still-down behavior in the operations guide.
- Adds orchestrator test coverage that verifies no Veriflier call or WPCOM notification is made for an already-confirmed-down local failure.

## Test

- `go test ./internal/orchestrator`