### PR TITLE
Add production data rollout readiness checks

### DIFF
--- a/cmd/jetmon2/rollout.go
+++ b/cmd/jetmon2/rollout.go
@@ -75,7 +75,7 @@ type hostPreflightDeps struct {
 
 func cmdRollout(args []string) {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout <guided|rehearsal-plan|host-preflight|static-plan-check|pinned-check|cutover-check|rollback-check|dynamic-check|activity-check|projection-drift|state-report> [args]")
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout <guided|rehearsal-plan|host-preflight|static-plan-check|pinned-check|cutover-check|rollback-check|dynamic-check|activity-check|projection-drift|state-report|production-data-audit|legacy-status-bootstrap> [args]")
 		os.Exit(1)
 	}
 
@@ -102,8 +102,12 @@ func cmdRollout(args []string) {
 		cmdRolloutProjectionDrift(args[1:])
 	case "state-report":
 		cmdRolloutStateReport(args[1:])
+	case "production-data-audit":
+		cmdRolloutProductionDataAudit(args[1:])
+	case "legacy-status-bootstrap":
+		cmdRolloutLegacyStatusBootstrap(args[1:])
 	default:
-		fmt.Fprintf(os.Stderr, "unknown rollout subcommand %q (want: guided, rehearsal-plan, host-preflight, static-plan-check, pinned-check, cutover-check, rollback-check, dynamic-check, activity-check, projection-drift, state-report)\n", args[0])
+		fmt.Fprintf(os.Stderr, "unknown rollout subcommand %q (want: guided, rehearsal-plan, host-preflight, static-plan-check, pinned-check, cutover-check, rollback-check, dynamic-check, activity-check, projection-drift, state-report, production-data-audit, legacy-status-bootstrap)\n", args[0])
 		os.Exit(1)
 	}
 }

--- a/cmd/jetmon2/rollout_production_data.go
+++ b/cmd/jetmon2/rollout_production_data.go
@@ -1,0 +1,357 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Automattic/jetmon/internal/config"
+	"github.com/Automattic/jetmon/internal/db"
+	"github.com/Automattic/jetmon/internal/eventstore"
+)
+
+const legacyStatusBootstrapSource = "rollout:legacy-status-bootstrap"
+
+type productionDataAuditDeps struct {
+	BuildLegacySiteTableAudit func(context.Context, int, int) (db.LegacySiteTableAudit, error)
+}
+
+type legacyStatusBootstrapDeps struct {
+	BuildLegacySiteTableAudit func(context.Context, int, int) (db.LegacySiteTableAudit, error)
+	ListLegacyNonRunningSites func(context.Context, int, int, int64, int) ([]db.LegacyNonRunningSite, error)
+	OpenLegacyStatusEvent     func(context.Context, db.LegacyNonRunningSite) (bool, error)
+}
+
+type productionDataAuditEvaluation struct {
+	Blockers []string
+	Warnings []string
+}
+
+type legacyStatusBootstrapOptions struct {
+	BucketMin             int
+	BucketMax             int
+	BatchSize             int
+	Execute               bool
+	AllowDuplicateBlogIDs bool
+}
+
+type legacyStatusBootstrapSummary struct {
+	Candidates int64
+	Opened     int64
+	Existing   int64
+	DryRun     bool
+}
+
+func cmdRolloutProductionDataAudit(args []string) {
+	fs := flag.NewFlagSet("rollout production-data-audit", flag.ExitOnError)
+	bucketMin := fs.Int("bucket-min", -1, "inclusive bucket minimum (default pinned range or 0)")
+	bucketMax := fs.Int("bucket-max", -1, "inclusive bucket maximum (default pinned range or BUCKET_TOTAL-1)")
+	output := rolloutOutputFlag(fs)
+	_ = fs.Parse(args)
+	if fs.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout production-data-audit [--bucket-min=N --bucket-max=N] [--output=text|json]")
+		os.Exit(1)
+	}
+	outputFormat, err := normalizeRolloutOutput(*output)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL %v\n", err)
+		os.Exit(2)
+	}
+
+	if err := runRolloutCommandOutput(os.Stdout, "rollout production-data-audit", outputFormat, func(out io.Writer) error {
+		cfg, err := loadRolloutConfigAndDB(out)
+		if err != nil {
+			return err
+		}
+		deps := productionDataAuditDeps{
+			BuildLegacySiteTableAudit: db.BuildLegacySiteTableAudit,
+		}
+		return runProductionDataAudit(context.Background(), out, cfg, *bucketMin, *bucketMax, deps)
+	}); err != nil {
+		exitRolloutCommandError(err, outputFormat)
+	}
+}
+
+func cmdRolloutLegacyStatusBootstrap(args []string) {
+	fs := flag.NewFlagSet("rollout legacy-status-bootstrap", flag.ExitOnError)
+	bucketMin := fs.Int("bucket-min", -1, "inclusive bucket minimum (default pinned range or 0)")
+	bucketMax := fs.Int("bucket-max", -1, "inclusive bucket maximum (default pinned range or BUCKET_TOTAL-1)")
+	batchSize := fs.Int("batch-size", 1000, "rows to scan per bootstrap page")
+	execute := fs.Bool("execute", false, "write missing v2 events; default is read-only dry-run")
+	allowDuplicateBlogIDs := fs.Bool("allow-duplicate-blog-ids", false, "allow bootstrap even when active duplicate blog_id rows exist")
+	output := rolloutOutputFlag(fs)
+	_ = fs.Parse(args)
+	if fs.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 rollout legacy-status-bootstrap [--bucket-min=N --bucket-max=N] [--batch-size=N] [--execute] [--allow-duplicate-blog-ids] [--output=text|json]")
+		os.Exit(1)
+	}
+	outputFormat, err := normalizeRolloutOutput(*output)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL %v\n", err)
+		os.Exit(2)
+	}
+
+	if err := runRolloutCommandOutput(os.Stdout, "rollout legacy-status-bootstrap", outputFormat, func(out io.Writer) error {
+		cfg, err := loadRolloutConfigAndDB(out)
+		if err != nil {
+			return err
+		}
+		store := eventstore.New(db.DB())
+		deps := legacyStatusBootstrapDeps{
+			BuildLegacySiteTableAudit: db.BuildLegacySiteTableAudit,
+			ListLegacyNonRunningSites: db.ListLegacyNonRunningSites,
+			OpenLegacyStatusEvent: func(ctx context.Context, site db.LegacyNonRunningSite) (bool, error) {
+				return openLegacyStatusEvent(ctx, store, site)
+			},
+		}
+		opts := legacyStatusBootstrapOptions{
+			BucketMin:             *bucketMin,
+			BucketMax:             *bucketMax,
+			BatchSize:             *batchSize,
+			Execute:               *execute,
+			AllowDuplicateBlogIDs: *allowDuplicateBlogIDs,
+		}
+		return runLegacyStatusBootstrap(context.Background(), out, cfg, opts, deps)
+	}); err != nil {
+		exitRolloutCommandError(err, outputFormat)
+	}
+}
+
+func runProductionDataAudit(ctx context.Context, out io.Writer, cfg *config.Config, bucketMin, bucketMax int, deps productionDataAuditDeps) error {
+	if cfg == nil {
+		return errors.New("config is not loaded")
+	}
+	if deps.BuildLegacySiteTableAudit == nil {
+		return errors.New("legacy table audit query is not configured")
+	}
+	minBucket, maxBucket, err := resolveRolloutBucketRange(cfg, bucketMin, bucketMax)
+	if err != nil {
+		return err
+	}
+	audit, err := deps.BuildLegacySiteTableAudit(ctx, minBucket, maxBucket)
+	if err != nil {
+		return err
+	}
+	eval := evaluateProductionDataAudit(cfg, audit)
+	renderProductionDataAudit(out, cfg, audit, eval)
+	if len(eval.Blockers) > 0 {
+		return fmt.Errorf("production data audit found %d blocker(s)", len(eval.Blockers))
+	}
+	return nil
+}
+
+func evaluateProductionDataAudit(cfg *config.Config, audit db.LegacySiteTableAudit) productionDataAuditEvaluation {
+	var eval productionDataAuditEvaluation
+	if cfg != nil && audit.ObservedBucketMax != nil && *audit.ObservedBucketMax >= cfg.BucketTotal {
+		eval.Blockers = append(eval.Blockers, fmt.Sprintf("observed bucket max %d is outside BUCKET_TOTAL=%d", *audit.ObservedBucketMax, cfg.BucketTotal))
+	}
+	if cfg != nil && audit.ObservedBucketMin != nil && audit.ObservedBucketMax != nil {
+		observedTotal := *audit.ObservedBucketMax - *audit.ObservedBucketMin + 1
+		if *audit.ObservedBucketMin == 0 && observedTotal != cfg.BucketTotal {
+			eval.Warnings = append(eval.Warnings, fmt.Sprintf("observed legacy bucket space is 0-%d but BUCKET_TOTAL=%d", *audit.ObservedBucketMax, cfg.BucketTotal))
+		}
+	}
+	if unexpected := unexpectedValueCounts(audit.MonitorActiveValues, map[int]bool{0: true, 1: true}); len(unexpected) > 0 {
+		eval.Blockers = append(eval.Blockers, "monitor_active has unexpected value(s): "+unexpected)
+	}
+	if unexpected := unexpectedValueCounts(audit.SiteStatusValues, map[int]bool{0: true, 1: true, 2: true}); len(unexpected) > 0 {
+		eval.Blockers = append(eval.Blockers, "site_status has unexpected value(s): "+unexpected)
+	}
+	if audit.ActiveDuplicateBlogs.Groups > 0 {
+		eval.Blockers = append(eval.Blockers, fmt.Sprintf("active duplicate blog_id rows groups=%d rows=%d max_rows_per_blog=%d", audit.ActiveDuplicateBlogs.Groups, audit.ActiveDuplicateBlogs.Rows, audit.ActiveDuplicateBlogs.MaxRowsPerBlog))
+	}
+	if audit.ActiveDuplicateBlogs.StatusConflicts > 0 {
+		eval.Blockers = append(eval.Blockers, fmt.Sprintf("active duplicate blog_id rows have status conflicts groups=%d", audit.ActiveDuplicateBlogs.StatusConflicts))
+	}
+	if audit.ActiveNonRunningRows > 0 {
+		eval.Warnings = append(eval.Warnings, fmt.Sprintf("active non-running legacy rows=%d; run legacy-status-bootstrap before projection-drift is a hard gate", audit.ActiveNonRunningRows))
+	}
+	if audit.ActiveMalformedURLRows > 0 {
+		eval.Warnings = append(eval.Warnings, fmt.Sprintf("active malformed monitor_url rows=%d; clean up or explicitly accept these before cutover", audit.ActiveMalformedURLRows))
+	}
+	if audit.ActiveNullStatusChange > 0 {
+		eval.Warnings = append(eval.Warnings, fmt.Sprintf("active rows with NULL last_status_change=%d; bootstrap will use current time for those rows", audit.ActiveNullStatusChange))
+	}
+	return eval
+}
+
+func renderProductionDataAudit(out io.Writer, cfg *config.Config, audit db.LegacySiteTableAudit, eval productionDataAuditEvaluation) {
+	fmt.Fprintf(out, "INFO audit_range=%d-%d configured_bucket_total=%d\n", audit.BucketMin, audit.BucketMax, cfg.BucketTotal)
+	if audit.ObservedBucketMin != nil && audit.ObservedBucketMax != nil {
+		fmt.Fprintf(out, "INFO observed_bucket_space=%d-%d distinct=%d active_distinct=%d\n", *audit.ObservedBucketMin, *audit.ObservedBucketMax, audit.ObservedBucketDistinct, audit.ActiveBucketDistinct)
+	} else {
+		fmt.Fprintln(out, "WARN observed_bucket_space=empty")
+	}
+	fmt.Fprintf(out, "INFO legacy_rows_total=%d active=%d\n", audit.TotalRows, audit.ActiveRows)
+	fmt.Fprintf(out, "INFO active_bucket_load distinct=%d min=%d max=%d avg=%.2f\n", audit.ActiveBucketLoad.Distinct, audit.ActiveBucketLoad.MinRows, audit.ActiveBucketLoad.MaxRows, audit.ActiveBucketLoad.AvgRows)
+	fmt.Fprintf(out, "INFO monitor_active_values=%s\n", formatValueCounts(audit.MonitorActiveValues))
+	fmt.Fprintf(out, "INFO site_status_values=%s\n", formatValueCounts(audit.SiteStatusValues))
+	fmt.Fprintf(out, "INFO check_interval_values=%s\n", formatValueCounts(audit.CheckIntervalValues))
+	fmt.Fprintf(out, "INFO active_nonrunning=%d active_null_last_status_change=%d\n", audit.ActiveNonRunningRows, audit.ActiveNullStatusChange)
+	fmt.Fprintf(out, "INFO active_malformed_urls=%d url_near_column_limit=%d max_url_length=%d\n", audit.ActiveMalformedURLRows, audit.ActiveURLNearColumnLimit, audit.MaxURLLength)
+	fmt.Fprintf(out, "INFO duplicate_blog_ids_all groups=%d rows=%d max_rows_per_blog=%d status_conflicts=%d\n", audit.DuplicateBlogs.Groups, audit.DuplicateBlogs.Rows, audit.DuplicateBlogs.MaxRowsPerBlog, audit.DuplicateBlogs.StatusConflicts)
+	fmt.Fprintf(out, "INFO duplicate_blog_ids_active groups=%d rows=%d max_rows_per_blog=%d status_conflicts=%d\n", audit.ActiveDuplicateBlogs.Groups, audit.ActiveDuplicateBlogs.Rows, audit.ActiveDuplicateBlogs.MaxRowsPerBlog, audit.ActiveDuplicateBlogs.StatusConflicts)
+	for _, warning := range eval.Warnings {
+		fmt.Fprintf(out, "WARN production_data_audit=%q\n", warning)
+	}
+	for _, blocker := range eval.Blockers {
+		fmt.Fprintf(out, "FAIL production_data_audit=%q\n", blocker)
+	}
+	if len(eval.Blockers) == 0 {
+		fmt.Fprintln(out, "PASS production_data_audit=ready")
+		return
+	}
+	fmt.Fprintln(out, "FAIL production_data_audit=blocked")
+}
+
+func runLegacyStatusBootstrap(ctx context.Context, out io.Writer, cfg *config.Config, opts legacyStatusBootstrapOptions, deps legacyStatusBootstrapDeps) error {
+	if cfg == nil {
+		return errors.New("config is not loaded")
+	}
+	if opts.BatchSize <= 0 {
+		return errors.New("--batch-size must be > 0")
+	}
+	if deps.BuildLegacySiteTableAudit == nil || deps.ListLegacyNonRunningSites == nil {
+		return errors.New("legacy status bootstrap queries are not configured")
+	}
+	minBucket, maxBucket, err := resolveRolloutBucketRange(cfg, opts.BucketMin, opts.BucketMax)
+	if err != nil {
+		return err
+	}
+	audit, err := deps.BuildLegacySiteTableAudit(ctx, minBucket, maxBucket)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "INFO bootstrap_range=%d-%d execute=%t\n", minBucket, maxBucket, opts.Execute)
+	if audit.ActiveDuplicateBlogs.Groups > 0 && !opts.AllowDuplicateBlogIDs {
+		fmt.Fprintf(out, "FAIL bootstrap_blocked_by_duplicate_blog_ids groups=%d rows=%d\n", audit.ActiveDuplicateBlogs.Groups, audit.ActiveDuplicateBlogs.Rows)
+		return errors.New("legacy status bootstrap requires endpoint identity support or --allow-duplicate-blog-ids")
+	}
+	if audit.ActiveDuplicateBlogs.Groups > 0 {
+		fmt.Fprintf(out, "WARN bootstrap_duplicate_blog_ids_allowed groups=%d rows=%d\n", audit.ActiveDuplicateBlogs.Groups, audit.ActiveDuplicateBlogs.Rows)
+	}
+
+	if !opts.Execute {
+		fmt.Fprintf(out, "INFO bootstrap_candidates=%d\n", audit.ActiveNonRunningRows)
+		fmt.Fprintln(out, "PASS legacy_status_bootstrap=dry_run")
+		return nil
+	}
+	if deps.OpenLegacyStatusEvent == nil {
+		return errors.New("legacy status event opener is not configured")
+	}
+	summary := legacyStatusBootstrapSummary{DryRun: false}
+	var after int64
+	for {
+		page, err := deps.ListLegacyNonRunningSites(ctx, minBucket, maxBucket, after, opts.BatchSize)
+		if err != nil {
+			return err
+		}
+		if len(page) == 0 {
+			break
+		}
+		for _, site := range page {
+			summary.Candidates++
+			opened, err := deps.OpenLegacyStatusEvent(ctx, site)
+			if err != nil {
+				return fmt.Errorf("bootstrap monitor_site_id=%d blog_id=%d: %w", site.MonitorSiteID, site.BlogID, err)
+			}
+			if opened {
+				summary.Opened++
+			} else {
+				summary.Existing++
+			}
+			after = site.MonitorSiteID
+		}
+		if len(page) < opts.BatchSize {
+			break
+		}
+	}
+	fmt.Fprintf(out, "PASS legacy_status_bootstrap=complete candidates=%d opened=%d existing=%d\n", summary.Candidates, summary.Opened, summary.Existing)
+	return nil
+}
+
+func openLegacyStatusEvent(ctx context.Context, store *eventstore.Store, site db.LegacyNonRunningSite) (bool, error) {
+	if store == nil {
+		return false, errors.New("event store is nil")
+	}
+	state, severity, ok := legacyStatusEventShape(site.SiteStatus)
+	if !ok {
+		return false, fmt.Errorf("unsupported legacy site_status=%d", site.SiteStatus)
+	}
+	meta, err := legacyStatusBootstrapMetadata(site)
+	if err != nil {
+		return false, err
+	}
+	tx, err := store.Begin(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	res, err := tx.Open(ctx, eventstore.OpenInput{
+		Identity:  eventstore.Identity{BlogID: site.BlogID, CheckType: "http"},
+		Severity:  severity,
+		State:     state,
+		Source:    legacyStatusBootstrapSource,
+		Metadata:  meta,
+		StartedAt: site.LastStatusChange,
+	})
+	if err != nil {
+		return false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return res.Opened, nil
+}
+
+func legacyStatusEventShape(status int) (string, uint8, bool) {
+	switch status {
+	case 0:
+		return eventstore.StateSeemsDown, eventstore.SeveritySeemsDown, true
+	case 2:
+		return eventstore.StateDown, eventstore.SeverityDown, true
+	default:
+		return "", 0, false
+	}
+}
+
+func legacyStatusBootstrapMetadata(site db.LegacyNonRunningSite) (json.RawMessage, error) {
+	meta := map[string]any{
+		"source":             "jetpack_monitor_sites",
+		"monitor_site_id":    site.MonitorSiteID,
+		"bucket_no":          site.BucketNo,
+		"legacy_site_status": site.SiteStatus,
+		"bootstrapped_at":    time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	if site.LastStatusChange != nil {
+		meta["legacy_last_status_change"] = site.LastStatusChange.UTC().Format(time.RFC3339Nano)
+	}
+	return json.Marshal(meta)
+}
+
+func unexpectedValueCounts(counts []db.ValueCount, allowed map[int]bool) string {
+	var values []string
+	for _, row := range counts {
+		if !allowed[row.Value] {
+			values = append(values, fmt.Sprintf("%d(total=%d active=%d)", row.Value, row.Total, row.Active))
+		}
+	}
+	return strings.Join(values, ",")
+}
+
+func formatValueCounts(counts []db.ValueCount) string {
+	if len(counts) == 0 {
+		return "none"
+	}
+	parts := make([]string, 0, len(counts))
+	for _, row := range counts {
+		parts = append(parts, fmt.Sprintf("%d:total=%d,active=%d", row.Value, row.Total, row.Active))
+	}
+	return strings.Join(parts, ";")
+}

--- a/cmd/jetmon2/rollout_test.go
+++ b/cmd/jetmon2/rollout_test.go
@@ -8,12 +8,14 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/Automattic/jetmon/internal/config"
 	"github.com/Automattic/jetmon/internal/db"
+	"github.com/Automattic/jetmon/internal/eventstore"
 )
 
 func TestRunRolloutCommandOutputJSON(t *testing.T) {
@@ -2052,6 +2054,140 @@ func TestBuildRolloutStateReportDynamicIssues(t *testing.T) {
 	}
 	if !strings.Contains(report.SuggestedNextAction, "Fix jetmon_hosts bucket coverage") {
 		t.Fatalf("suggested action = %q", report.SuggestedNextAction)
+	}
+}
+
+func TestRunProductionDataAuditFlagsProductionShape(t *testing.T) {
+	cfg := &config.Config{BucketTotal: 512}
+	minBucket, maxBucket := 0, 511
+	audit := db.LegacySiteTableAudit{
+		BucketMin:              minBucket,
+		BucketMax:              maxBucket,
+		TotalRows:              1000,
+		ActiveRows:             100,
+		ObservedBucketMin:      &minBucket,
+		ObservedBucketMax:      &maxBucket,
+		ObservedBucketDistinct: 512,
+		ActiveBucketDistinct:   512,
+		ActiveBucketLoad:       db.BucketLoadSummary{Distinct: 512, MinRows: 1, MaxRows: 3, AvgRows: 2},
+		MonitorActiveValues:    []db.ValueCount{{Value: 0, Total: 900}, {Value: 1, Total: 100, Active: 100}},
+		SiteStatusValues:       []db.ValueCount{{Value: 1, Total: 990, Active: 90}, {Value: 2, Total: 10, Active: 10}},
+		CheckIntervalValues:    []db.ValueCount{{Value: 5, Total: 1000, Active: 100}},
+		ActiveNonRunningRows:   10,
+		ActiveMalformedURLRows: 2,
+		ActiveNullStatusChange: 4,
+		ActiveDuplicateBlogs:   db.DuplicateBlogSummary{Groups: 1, Rows: 2, MaxRowsPerBlog: 2},
+	}
+	deps := productionDataAuditDeps{
+		BuildLegacySiteTableAudit: func(context.Context, int, int) (db.LegacySiteTableAudit, error) {
+			return audit, nil
+		},
+	}
+
+	var out bytes.Buffer
+	err := runProductionDataAudit(context.Background(), &out, cfg, -1, -1, deps)
+	if err == nil {
+		t.Fatal("runProductionDataAudit returned nil, want duplicate blog_id blocker")
+	}
+	text := out.String()
+	for _, want := range []string{
+		"INFO legacy_rows_total=1000 active=100",
+		"WARN production_data_audit=\"active non-running legacy rows=10",
+		"FAIL production_data_audit=\"active duplicate blog_id rows groups=1 rows=2",
+		"FAIL production_data_audit=blocked",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("audit output missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestRunLegacyStatusBootstrapDryRunBlocksDuplicateBlogs(t *testing.T) {
+	cfg := &config.Config{BucketTotal: 10}
+	audit := db.LegacySiteTableAudit{
+		BucketMin:            0,
+		BucketMax:            9,
+		ActiveNonRunningRows: 3,
+		ActiveDuplicateBlogs: db.DuplicateBlogSummary{Groups: 1, Rows: 2},
+	}
+	deps := legacyStatusBootstrapDeps{
+		BuildLegacySiteTableAudit: func(context.Context, int, int) (db.LegacySiteTableAudit, error) {
+			return audit, nil
+		},
+		ListLegacyNonRunningSites: func(context.Context, int, int, int64, int) ([]db.LegacyNonRunningSite, error) {
+			t.Fatal("ListLegacyNonRunningSites should not run when duplicate blog IDs block bootstrap")
+			return nil, nil
+		},
+	}
+
+	var out bytes.Buffer
+	err := runLegacyStatusBootstrap(context.Background(), &out, cfg, legacyStatusBootstrapOptions{BucketMin: 0, BucketMax: 9, BatchSize: 1000}, deps)
+	if err == nil {
+		t.Fatal("runLegacyStatusBootstrap returned nil, want duplicate blog_id blocker")
+	}
+	if !strings.Contains(out.String(), "FAIL bootstrap_blocked_by_duplicate_blog_ids groups=1 rows=2") {
+		t.Fatalf("bootstrap output = %s", out.String())
+	}
+}
+
+func TestRunLegacyStatusBootstrapExecutesIdempotentPages(t *testing.T) {
+	cfg := &config.Config{BucketTotal: 10}
+	audit := db.LegacySiteTableAudit{BucketMin: 0, BucketMax: 9, ActiveNonRunningRows: 3}
+	var opened []int64
+	deps := legacyStatusBootstrapDeps{
+		BuildLegacySiteTableAudit: func(context.Context, int, int) (db.LegacySiteTableAudit, error) {
+			return audit, nil
+		},
+		ListLegacyNonRunningSites: func(_ context.Context, _, _ int, after int64, _ int) ([]db.LegacyNonRunningSite, error) {
+			switch after {
+			case 0:
+				return []db.LegacyNonRunningSite{
+					{MonitorSiteID: 10, BlogID: 100, BucketNo: 1, SiteStatus: 0},
+					{MonitorSiteID: 11, BlogID: 101, BucketNo: 1, SiteStatus: 2},
+				}, nil
+			case 11:
+				return []db.LegacyNonRunningSite{
+					{MonitorSiteID: 12, BlogID: 102, BucketNo: 1, SiteStatus: 2},
+				}, nil
+			default:
+				return nil, nil
+			}
+		},
+		OpenLegacyStatusEvent: func(_ context.Context, site db.LegacyNonRunningSite) (bool, error) {
+			opened = append(opened, site.BlogID)
+			return site.BlogID != 101, nil
+		},
+	}
+
+	var out bytes.Buffer
+	err := runLegacyStatusBootstrap(context.Background(), &out, cfg, legacyStatusBootstrapOptions{BucketMin: 0, BucketMax: 9, BatchSize: 2, Execute: true}, deps)
+	if err != nil {
+		t.Fatalf("runLegacyStatusBootstrap: %v\n%s", err, out.String())
+	}
+	if !reflect.DeepEqual(opened, []int64{100, 101, 102}) {
+		t.Fatalf("opened blogs = %#v", opened)
+	}
+	if !strings.Contains(out.String(), "PASS legacy_status_bootstrap=complete candidates=3 opened=2 existing=1") {
+		t.Fatalf("bootstrap output = %s", out.String())
+	}
+}
+
+func TestLegacyStatusEventShape(t *testing.T) {
+	tests := []struct {
+		status   int
+		state    string
+		severity uint8
+		ok       bool
+	}{
+		{status: 0, state: eventstore.StateSeemsDown, severity: eventstore.SeveritySeemsDown, ok: true},
+		{status: 2, state: eventstore.StateDown, severity: eventstore.SeverityDown, ok: true},
+		{status: 1, ok: false},
+	}
+	for _, tt := range tests {
+		state, severity, ok := legacyStatusEventShape(tt.status)
+		if state != tt.state || severity != tt.severity || ok != tt.ok {
+			t.Fatalf("legacyStatusEventShape(%d) = (%q,%d,%t), want (%q,%d,%t)", tt.status, state, severity, ok, tt.state, tt.severity, tt.ok)
+		}
 	}
 }
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -362,6 +362,20 @@ production telemetry branches:
 - [x] Add a rollout state report that summarizes ownership mode, bucket
   coverage, drift, recent activity, delivery owner state, and suggested next
   action.
+- [x] Add `jetmon2 rollout production-data-audit` so production rehearsals can
+  inspect the real v1 `jetpack_monitor_sites` shape before a host window:
+  observed bucket space, active/non-active counts, status and interval
+  distributions, malformed URL counts, existing non-running projections, and
+  duplicate active `blog_id` rows.
+- [x] Add an explicit `jetmon2 rollout legacy-status-bootstrap` write step for
+  existing v1 non-running rows so v2 event state can be seeded before
+  `projection-drift` is treated as a hard rollout gate. The command is dry-run
+  by default and refuses duplicate active `blog_id` rows unless the operator
+  deliberately overrides the guardrail.
+- [ ] Move monitor runtime/config/event identity from per-`blog_id` state to
+  explicit endpoint identity, using the existing `jetpack_monitor_site_id` row
+  as the durable source during migration. This is required for the small but
+  real production cohort where one `blog_id` has multiple active monitor URLs.
 
 ### Rollout Host Preflight Polish TODO
 

--- a/docs/rollout-quick-reference.md
+++ b/docs/rollout-quick-reference.md
@@ -232,6 +232,25 @@ When `projection-drift` fails, start with the summary and cause lines before
 the row table. The command is read-only and gives repair guidance; it does not
 change `site_status` automatically.
 
+## Production Data Audit
+
+Before the first host window, run the read-only production-data audit against
+the approved bucket range:
+
+```bash
+./jetmon2 rollout production-data-audit --bucket-min=0 --bucket-max=<max>
+```
+
+Resolve hard blockers before rollout. In particular, active duplicate
+`blog_id` rows are not safe for the current per-blog runtime identity model.
+Existing active non-running v1 projections are expected in production, but they
+must be represented in v2 events before `projection-drift` becomes a hard gate:
+
+```bash
+./jetmon2 rollout legacy-status-bootstrap --bucket-min=0 --bucket-max=<max>
+./jetmon2 rollout legacy-status-bootstrap --bucket-min=0 --bucket-max=<max> --execute
+```
+
 ## Automation
 
 Rollout gate commands support JSON output:

--- a/docs/v1-to-v2-migration.md
+++ b/docs/v1-to-v2-migration.md
@@ -111,6 +111,30 @@ GROUP BY bucket_no
 ORDER BY bucket_no;
 ```
 
+Run the production-data audit before approving the first host window. This
+read-only gate summarizes the real legacy table shape without printing monitor
+URLs, including active row count, observed bucket space, status distribution,
+check-interval distribution, malformed URL counts, active duplicate `blog_id`
+rows, and existing non-running v1 projections:
+
+```bash
+./jetmon2 rollout production-data-audit --bucket-min=0 --bucket-max=<max>
+```
+
+If the audit reports existing active non-running rows, bootstrap matching v2
+events before treating `projection-drift` as a hard gate. The bootstrap is
+read-only unless `--execute` is provided:
+
+```bash
+./jetmon2 rollout legacy-status-bootstrap --bucket-min=0 --bucket-max=<max>
+./jetmon2 rollout legacy-status-bootstrap --bucket-min=0 --bucket-max=<max> --execute
+```
+
+Do not force the bootstrap past active duplicate `blog_id` blockers during the
+initial rollout. Current v2 rollout state is still keyed by `blog_id`; duplicate
+active rows need endpoint-identity support or explicit data cleanup before they
+can be handled safely.
+
 Export the approved host-to-bucket plan to CSV before touching any hosts:
 
 ```csv
@@ -789,6 +813,11 @@ Only remove v1 after rollout signoff.
 
 - [ ] v1 host inventory complete
 - [ ] bucket ranges complete and non-overlapping
+- [ ] `rollout production-data-audit` reviewed for the production table
+- [ ] existing non-running v1 rows bootstrapped with
+      `rollout legacy-status-bootstrap --execute` if present
+- [ ] active duplicate `blog_id` rows resolved or endpoint-identity support
+      approved before rollout
 - [ ] `rollout static-plan-check` passes for the approved v1 bucket plan
 - [ ] DB backup and restore path confirmed
 - [ ] v2 binaries built and tested

--- a/internal/db/rollout_audit.go
+++ b/internal/db/rollout_audit.go
@@ -1,0 +1,270 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// ValueCount summarizes one integer value across the full legacy table range
+// and the active subset of that range.
+type ValueCount struct {
+	Value  int
+	Total  int64
+	Active int64
+}
+
+// BucketLoadSummary summarizes row distribution across populated buckets.
+type BucketLoadSummary struct {
+	Distinct int
+	MinRows  int64
+	MaxRows  int64
+	AvgRows  float64
+}
+
+// DuplicateBlogSummary describes monitor rows that share the same blog_id.
+type DuplicateBlogSummary struct {
+	Groups          int64
+	Rows            int64
+	MaxRowsPerBlog  int64
+	StatusConflicts int64
+}
+
+// LegacySiteTableAudit captures production-data readiness signals from the
+// v1-shaped jetpack_monitor_sites table without exposing individual site URLs.
+type LegacySiteTableAudit struct {
+	BucketMin int
+	BucketMax int
+
+	TotalRows  int64
+	ActiveRows int64
+
+	ObservedBucketMin      *int
+	ObservedBucketMax      *int
+	ObservedBucketDistinct int
+	ActiveBucketDistinct   int
+	ActiveBucketLoad       BucketLoadSummary
+
+	MonitorActiveValues []ValueCount
+	SiteStatusValues    []ValueCount
+	CheckIntervalValues []ValueCount
+
+	ActiveNonRunningRows     int64
+	ActiveNullStatusChange   int64
+	ActiveMalformedURLRows   int64
+	ActiveURLNearColumnLimit int64
+	MaxURLLength             int64
+
+	DuplicateBlogs       DuplicateBlogSummary
+	ActiveDuplicateBlogs DuplicateBlogSummary
+}
+
+// LegacyNonRunningSite is one active v1 row whose legacy projection already
+// says the site is not running before v2 owns the range.
+type LegacyNonRunningSite struct {
+	MonitorSiteID    int64
+	BlogID           int64
+	BucketNo         int
+	SiteStatus       int
+	LastStatusChange *time.Time
+}
+
+// BuildLegacySiteTableAudit reads aggregate legacy-table signals for a bucket
+// range. It is intentionally count-only so operators can safely share output.
+func BuildLegacySiteTableAudit(ctx context.Context, bucketMin, bucketMax int) (LegacySiteTableAudit, error) {
+	audit := LegacySiteTableAudit{
+		BucketMin: bucketMin,
+		BucketMax: bucketMax,
+	}
+	err := db.QueryRowContext(ctx, `
+		SELECT
+			COUNT(*),
+			COALESCE(SUM(monitor_active = 1), 0),
+			COALESCE(SUM(monitor_active = 1 AND site_status <> 1), 0),
+			COALESCE(SUM(monitor_active = 1 AND last_status_change IS NULL), 0),
+			COALESCE(SUM(monitor_active = 1 AND LOWER(monitor_url) NOT REGEXP '^https?://[^/?#[:space:]]+'), 0),
+			COALESCE(SUM(monitor_active = 1 AND CHAR_LENGTH(monitor_url) >= 250), 0),
+			COALESCE(MAX(CHAR_LENGTH(monitor_url)), 0)
+		  FROM jetpack_monitor_sites
+		 WHERE bucket_no BETWEEN ? AND ?`,
+		bucketMin, bucketMax,
+	).Scan(
+		&audit.TotalRows,
+		&audit.ActiveRows,
+		&audit.ActiveNonRunningRows,
+		&audit.ActiveNullStatusChange,
+		&audit.ActiveMalformedURLRows,
+		&audit.ActiveURLNearColumnLimit,
+		&audit.MaxURLLength,
+	)
+	if err != nil {
+		return audit, fmt.Errorf("query legacy site table totals: %w", err)
+	}
+
+	var minBucket, maxBucket sql.NullInt64
+	err = db.QueryRowContext(ctx, `
+		SELECT MIN(bucket_no), MAX(bucket_no), COUNT(DISTINCT bucket_no),
+		       COALESCE(COUNT(DISTINCT CASE WHEN monitor_active = 1 THEN bucket_no END), 0)
+		  FROM jetpack_monitor_sites
+		 WHERE bucket_no BETWEEN ? AND ?`,
+		bucketMin, bucketMax,
+	).Scan(&minBucket, &maxBucket, &audit.ObservedBucketDistinct, &audit.ActiveBucketDistinct)
+	if err != nil {
+		return audit, fmt.Errorf("query legacy bucket coverage: %w", err)
+	}
+	if minBucket.Valid {
+		v := int(minBucket.Int64)
+		audit.ObservedBucketMin = &v
+	}
+	if maxBucket.Valid {
+		v := int(maxBucket.Int64)
+		audit.ObservedBucketMax = &v
+	}
+
+	load, err := queryActiveBucketLoad(ctx, bucketMin, bucketMax)
+	if err != nil {
+		return audit, err
+	}
+	audit.ActiveBucketLoad = load
+
+	audit.MonitorActiveValues, err = queryLegacyValueCounts(ctx, bucketMin, bucketMax, "monitor_active")
+	if err != nil {
+		return audit, err
+	}
+	audit.SiteStatusValues, err = queryLegacyValueCounts(ctx, bucketMin, bucketMax, "site_status")
+	if err != nil {
+		return audit, err
+	}
+	audit.CheckIntervalValues, err = queryLegacyValueCounts(ctx, bucketMin, bucketMax, "check_interval")
+	if err != nil {
+		return audit, err
+	}
+
+	audit.DuplicateBlogs, err = queryDuplicateBlogSummary(ctx, bucketMin, bucketMax, false)
+	if err != nil {
+		return audit, err
+	}
+	audit.ActiveDuplicateBlogs, err = queryDuplicateBlogSummary(ctx, bucketMin, bucketMax, true)
+	if err != nil {
+		return audit, err
+	}
+
+	return audit, nil
+}
+
+func queryLegacyValueCounts(ctx context.Context, bucketMin, bucketMax int, column string) ([]ValueCount, error) {
+	switch column {
+	case "monitor_active", "site_status", "check_interval":
+	default:
+		return nil, fmt.Errorf("unsupported legacy value-count column %q", column)
+	}
+	rows, err := db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT %s AS value,
+		       COUNT(*) AS total_rows,
+		       COALESCE(SUM(monitor_active = 1), 0) AS active_rows
+		  FROM jetpack_monitor_sites
+		 WHERE bucket_no BETWEEN ? AND ?
+		 GROUP BY %s
+		 ORDER BY %s ASC`, column, column, column),
+		bucketMin, bucketMax,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query %s value counts: %w", column, err)
+	}
+	defer rows.Close()
+
+	var out []ValueCount
+	for rows.Next() {
+		var row ValueCount
+		if err := rows.Scan(&row.Value, &row.Total, &row.Active); err != nil {
+			return nil, fmt.Errorf("scan %s value counts: %w", column, err)
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+func queryActiveBucketLoad(ctx context.Context, bucketMin, bucketMax int) (BucketLoadSummary, error) {
+	var out BucketLoadSummary
+	err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*), COALESCE(MIN(rows_per_bucket), 0), COALESCE(MAX(rows_per_bucket), 0), COALESCE(AVG(rows_per_bucket), 0)
+		  FROM (
+			SELECT bucket_no, COUNT(*) AS rows_per_bucket
+			  FROM jetpack_monitor_sites
+			 WHERE monitor_active = 1
+			   AND bucket_no BETWEEN ? AND ?
+			 GROUP BY bucket_no
+		  ) active_buckets`,
+		bucketMin, bucketMax,
+	).Scan(&out.Distinct, &out.MinRows, &out.MaxRows, &out.AvgRows)
+	if err != nil {
+		return out, fmt.Errorf("query active bucket load: %w", err)
+	}
+	return out, nil
+}
+
+func queryDuplicateBlogSummary(ctx context.Context, bucketMin, bucketMax int, activeOnly bool) (DuplicateBlogSummary, error) {
+	filter := ""
+	if activeOnly {
+		filter = "AND monitor_active = 1"
+	}
+	query := fmt.Sprintf(`
+		SELECT COUNT(*), COALESCE(SUM(row_count), 0), COALESCE(MAX(row_count), 0), COALESCE(SUM(status_conflict), 0)
+		  FROM (
+			SELECT blog_id,
+			       COUNT(*) AS row_count,
+			       CASE WHEN COUNT(DISTINCT site_status) > 1 THEN 1 ELSE 0 END AS status_conflict
+			  FROM jetpack_monitor_sites
+			 WHERE bucket_no BETWEEN ? AND ?
+			   %s
+			 GROUP BY blog_id
+			HAVING COUNT(*) > 1
+		  ) duplicate_blogs`, filter)
+	var out DuplicateBlogSummary
+	err := db.QueryRowContext(ctx, query, bucketMin, bucketMax).
+		Scan(&out.Groups, &out.Rows, &out.MaxRowsPerBlog, &out.StatusConflicts)
+	if err != nil {
+		return out, fmt.Errorf("query duplicate blog summary: %w", err)
+	}
+	return out, nil
+}
+
+// ListLegacyNonRunningSites pages active legacy rows whose v1 projection is not
+// SITE_RUNNING. The page cursor is jetpack_monitor_site_id so duplicate blog_id
+// rows are not skipped.
+func ListLegacyNonRunningSites(ctx context.Context, bucketMin, bucketMax int, afterMonitorSiteID int64, limit int) ([]LegacyNonRunningSite, error) {
+	if limit <= 0 {
+		limit = 1000
+	}
+	rows, err := db.QueryContext(ctx, `
+		SELECT jetpack_monitor_site_id, blog_id, bucket_no, site_status, last_status_change
+		  FROM jetpack_monitor_sites
+		 WHERE monitor_active = 1
+		   AND site_status IN (0, 2)
+		   AND bucket_no BETWEEN ? AND ?
+		   AND jetpack_monitor_site_id > ?
+		 ORDER BY jetpack_monitor_site_id ASC
+		 LIMIT ?`,
+		bucketMin, bucketMax, afterMonitorSiteID, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query legacy non-running sites: %w", err)
+	}
+	defer rows.Close()
+
+	var out []LegacyNonRunningSite
+	for rows.Next() {
+		var row LegacyNonRunningSite
+		var lastStatusChange sql.NullTime
+		if err := rows.Scan(&row.MonitorSiteID, &row.BlogID, &row.BucketNo, &row.SiteStatus, &lastStatusChange); err != nil {
+			return nil, fmt.Errorf("scan legacy non-running site: %w", err)
+		}
+		if lastStatusChange.Valid {
+			t := lastStatusChange.Time.UTC()
+			row.LastStatusChange = &t
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}

--- a/internal/eventstore/eventstore.go
+++ b/internal/eventstore/eventstore.go
@@ -33,6 +33,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 )
 
 // State labels written to jetmon_events.state and jetmon_event_transitions.state_*.
@@ -102,11 +103,12 @@ type Identity struct {
 
 // OpenInput carries the fields needed to open (or reopen) an event.
 type OpenInput struct {
-	Identity Identity
-	Severity uint8
-	State    string
-	Source   string          // who detected the failure: "local", "veriflier:us-west", …
-	Metadata json.RawMessage // optional check-type-specific payload
+	Identity  Identity
+	Severity  uint8
+	State     string
+	Source    string          // who detected the failure: "local", "veriflier:us-west", …
+	Metadata  json.RawMessage // optional check-type-specific payload
+	StartedAt *time.Time      // optional legacy/bootstrap incident start time
 }
 
 // OpenResult describes the outcome of an Open call.
@@ -200,11 +202,12 @@ func (t *Tx) Open(ctx context.Context, in OpenInput) (OpenResult, error) {
 	// LAST_INSERT_ID(id) on the UPDATE branch makes the driver return the
 	// existing row's id. RowsAffected is 1 on insert, 2 on update (per the
 	// MySQL driver convention). We only write an "opened" transition on insert.
-	res, err := t.tx.ExecContext(ctx, `
+	insertSQL := `
 		INSERT INTO jetmon_events
 			(blog_id, endpoint_id, check_type, discriminator, severity, state, metadata)
 		VALUES (?, ?, ?, ?, ?, ?, ?)
-		ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id)`,
+		ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id)`
+	args := []any{
 		in.Identity.BlogID,
 		nullableEndpoint(in.Identity.EndpointID),
 		in.Identity.CheckType,
@@ -212,7 +215,25 @@ func (t *Tx) Open(ctx context.Context, in OpenInput) (OpenResult, error) {
 		in.Severity,
 		in.State,
 		nullableJSON(in.Metadata),
-	)
+	}
+	if in.StartedAt != nil {
+		insertSQL = `
+			INSERT INTO jetmon_events
+				(blog_id, endpoint_id, check_type, discriminator, severity, state, started_at, metadata)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+			ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id)`
+		args = []any{
+			in.Identity.BlogID,
+			nullableEndpoint(in.Identity.EndpointID),
+			in.Identity.CheckType,
+			nullableDiscriminator(in.Identity.Discriminator),
+			in.Severity,
+			in.State,
+			in.StartedAt.UTC(),
+			nullableJSON(in.Metadata),
+		}
+	}
+	res, err := t.tx.ExecContext(ctx, insertSQL, args...)
 	if err != nil {
 		return OpenResult{}, fmt.Errorf("insert event: %w", err)
 	}
@@ -242,6 +263,7 @@ func (t *Tx) Open(ctx context.Context, in OpenInput) (OpenResult, error) {
 			reason:         ReasonOpened,
 			source:         in.Source,
 			metadata:       in.Metadata,
+			changedAt:      in.StartedAt,
 		}); err != nil {
 			return OpenResult{}, err
 		}
@@ -642,12 +664,28 @@ type transitionInput struct {
 	reason         string
 	source         string
 	metadata       json.RawMessage
+	changedAt      *time.Time
 }
 
 func writeTransition(ctx context.Context, tx *sql.Tx, t transitionInput) error {
 	source := t.source
 	if source == "" {
 		source = "local"
+	}
+	if t.changedAt != nil {
+		_, err := tx.ExecContext(ctx, `
+			INSERT INTO jetmon_event_transitions
+				(event_id, blog_id, severity_before, severity_after,
+				 state_before, state_after, reason, source, metadata, changed_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			t.eventID, t.blogID, nullableUint8(t.severityBefore), nullableUint8(t.severityAfter),
+			nullableString(t.stateBefore), nullableString(t.stateAfter),
+			t.reason, source, nullableJSON(t.metadata), t.changedAt.UTC(),
+		)
+		if err != nil {
+			return fmt.Errorf("insert transition: %w", err)
+		}
+		return nil
 	}
 	_, err := tx.ExecContext(ctx, `
 		INSERT INTO jetmon_event_transitions


### PR DESCRIPTION
## Summary

Adds rollout tooling for the real production `jetpack_monitor_sites` shape before a v1-to-v2 host cutover. The new `rollout production-data-audit` command reports bucket coverage, active row counts, status and interval distributions, malformed URL counts, existing non-running v1 projections, and active duplicate `blog_id` rows without printing monitor URLs.

Adds `rollout legacy-status-bootstrap` as an explicit dry-run-by-default write step for seeding v2 events from existing v1 non-running `site_status` rows. The write path requires `--execute`, preserves `last_status_change` as the event start when present, and refuses duplicate active `blog_id` rows unless the operator deliberately overrides that guardrail.

Updates the rollout runbook, quick reference, and roadmap so Systems can run the production-data audit and bootstrap before treating `projection-drift` as a hard gate.

## Why

A production table dump showed the legacy table is still v1-shaped, which is good for the sidecar-table rollout design, but it also surfaced existing non-running rows and a small cohort of duplicate active `blog_id` rows. Without this tooling, a fresh v2 event store would make those existing non-running rows look like projection drift, and duplicate active `blog_id` rows could be collapsed by the current per-blog runtime identity model.

## Operator examples

```bash
./jetmon2 rollout production-data-audit --bucket-min=0 --bucket-max=<max>
./jetmon2 rollout legacy-status-bootstrap --bucket-min=0 --bucket-max=<max>
./jetmon2 rollout legacy-status-bootstrap --bucket-min=0 --bucket-max=<max> --execute
```

## Validation

`go test ./...`