### PR TITLE
Harden Veriflier throughput and overload handling

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -413,8 +413,10 @@ queue absorbs short Monitor-side bursts before returning overload.
 Monitor-side single-site `Check` calls are coalesced into small, bounded
 `CheckBatch` RPCs before they cross the network. This keeps the simple
 per-site quorum code path while avoiding one HTTP request per failed site during
-large outage waves. Explicit `CheckBatch` callers still send their supplied
-batch as-is.
+large outage waves. Light checks (`HEAD` + `legacy`, `GET` + `simple_http`) use
+a larger coalescing cap than `GET` + `full` checks because full checks can read
+response bodies and have higher tail latency at extreme rates. Explicit
+`CheckBatch` callers still send their supplied batch as-is.
 
 The Veriflier does not emit one success log line per probe. Request IDs are
 echoed back in the response and joined to monitor-side audit rows there; keeping

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -410,6 +410,11 @@ Verifier capacity is auto-sized from CPU and file-descriptor headroom. A typical
 8-core host reports `max_concurrency: 2048`; smaller hosts report less, and the
 queue absorbs short Monitor-side bursts before returning overload.
 
+The Veriflier does not emit one success log line per probe. Request IDs are
+echoed back in the response and joined to monitor-side audit rows there; keeping
+successful probe traffic out of stdout avoids log-volume bottlenecks and avoids
+writing customer URLs into high-rate container logs.
+
 The transport is JSON-over-HTTP for v2 production. `proto/veriflier.proto`
 remains as a schema reference for a possible future transport, but generated
 gRPC stubs are not required to build or deploy v2.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -410,6 +410,12 @@ Verifier capacity is auto-sized from CPU and file-descriptor headroom. A typical
 8-core host reports `max_concurrency: 2048`; smaller hosts report less, and the
 queue absorbs short Monitor-side bursts before returning overload.
 
+Monitor-side single-site `Check` calls are coalesced into small, bounded
+`CheckBatch` RPCs before they cross the network. This keeps the simple
+per-site quorum code path while avoiding one HTTP request per failed site during
+large outage waves. Explicit `CheckBatch` callers still send their supplied
+batch as-is.
+
 The Veriflier does not emit one success log line per probe. Request IDs are
 echoed back in the response and joined to monitor-side audit rows there; keeping
 successful probe traffic out of stdout avoids log-volume bottlenecks and avoids

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -415,7 +415,9 @@ Monitor-side single-site `Check` calls are coalesced into small, bounded
 per-site quorum code path while avoiding one HTTP request per failed site during
 large outage waves. Light checks (`HEAD` + `legacy`, `GET` + `simple_http`) use
 a larger coalescing cap than `GET` + `full` checks because full checks can read
-response bodies and have higher tail latency at extreme rates. Explicit
+response bodies and have higher tail latency at extreme rates. The light and
+full lanes also have independent in-flight gates so a slow body-reading batch
+does not block cheap reachability checks during a mixed rollout. Explicit
 `CheckBatch` callers still send their supplied batch as-is.
 
 The Veriflier does not emit one success log line per probe. Request IDs are

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -414,15 +414,12 @@ Monitor-side single-site `Check` calls are coalesced into small, bounded
 `CheckBatch` RPCs before they cross the network. This keeps the simple
 per-site quorum code path while avoiding one HTTP request per failed site during
 large outage waves. Light checks (`HEAD` + `legacy`, `GET` + `simple_http`) use
-a larger coalescing cap than `GET` + `full` checks and auto-scale their
-in-flight gate with CPU headroom. The gate remains bounded so a regional outage
-does not become an unbounded RPC flood, but it is large enough for cheap
-reachability checks to keep the Veriflier executor busy on larger hosts. The
-full/body-reading lane remains more conservative because those requests are
-more likely to pin response bodies and hold sockets longer. The light and full
-lanes have independent gates so a slow body-reading batch does not block cheap
-reachability checks during a mixed rollout. Explicit `CheckBatch` callers still
-send their supplied batch as-is.
+a larger coalescing cap than `GET` + `full` checks, but the cap remains modest
+so otherwise-fast checks are not held behind a rare slow request in the same
+RPC at rollout-scale rates. The light and full lanes also have independent
+in-flight gates so a slow body-reading batch does not block cheap reachability
+checks during a mixed rollout. Explicit `CheckBatch` callers still send their
+supplied batch as-is.
 
 The v2 batch deadline is treated as a soft server-side deadline with client
 response headroom. If the deadline is reached after work has been accepted, the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -414,12 +414,15 @@ Monitor-side single-site `Check` calls are coalesced into small, bounded
 `CheckBatch` RPCs before they cross the network. This keeps the simple
 per-site quorum code path while avoiding one HTTP request per failed site during
 large outage waves. Light checks (`HEAD` + `legacy`, `GET` + `simple_http`) use
-a larger coalescing cap than `GET` + `full` checks, but the cap remains modest
-so otherwise-fast checks are not held behind a rare slow request in the same
-RPC at rollout-scale rates. The light and full lanes also have independent
-in-flight gates so a slow body-reading batch does not block cheap reachability
-checks during a mixed rollout. Explicit `CheckBatch` callers still send their
-supplied batch as-is.
+a larger coalescing cap than `GET` + `full` checks and auto-scale their
+in-flight gate with CPU headroom. The gate remains bounded so a regional outage
+does not become an unbounded RPC flood, but it is large enough for cheap
+reachability checks to keep the Veriflier executor busy on larger hosts. The
+full/body-reading lane remains more conservative because those requests are
+more likely to pin response bodies and hold sockets longer. The light and full
+lanes have independent gates so a slow body-reading batch does not block cheap
+reachability checks during a mixed rollout. Explicit `CheckBatch` callers still
+send their supplied batch as-is.
 
 The v2 batch deadline is treated as a soft server-side deadline with client
 response headroom. If the deadline is reached after work has been accepted, the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -375,7 +375,7 @@ Veriflier Transport
           "protocols": ["v2-json-http"],
           "vantage": {...},
           "agent": {...},
-          "capacity": {"max_concurrency": 512, "queue_depth": 0, ...}
+          "capacity": {"max_concurrency": 2048, "queue_depth": 0, ...}
         }
 
   Optional legacy-compatible HTTP contract
@@ -405,6 +405,10 @@ registry is unavailable or empty. Monitors poll Veriflier `/v2/status` and write
 `jetmon_veriflier_agents` capacity/liveness telemetry; Veriflier hosts do not
 need DB access. Agent telemetry never creates trusted quorum votes by itself;
 operators must pre-approve each enabled vantage.
+
+Verifier capacity is auto-sized from CPU and file-descriptor headroom. A typical
+8-core host reports `max_concurrency: 2048`; smaller hosts report less, and the
+queue absorbs short Monitor-side bursts before returning overload.
 
 The transport is JSON-over-HTTP for v2 production. `proto/veriflier.proto`
 remains as a schema reference for a possible future transport, but generated

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -421,6 +421,13 @@ in-flight gates so a slow body-reading batch does not block cheap reachability
 checks during a mixed rollout. Explicit `CheckBatch` callers still send their
 supplied batch as-is.
 
+The v2 batch deadline is treated as a soft server-side deadline with a small
+client reserve. If the deadline is reached after work has been accepted, the
+Veriflier returns completed probe results plus per-request timeout results for
+unfinished probes instead of failing the whole RPC. This keeps one slow target
+from turning an otherwise successful batch into hundreds of monitor-side
+transport errors.
+
 The Veriflier does not emit one success log line per probe. Request IDs are
 echoed back in the response and joined to monitor-side audit rows there; keeping
 successful probe traffic out of stdout avoids log-volume bottlenecks and avoids

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -414,11 +414,12 @@ Monitor-side single-site `Check` calls are coalesced into small, bounded
 `CheckBatch` RPCs before they cross the network. This keeps the simple
 per-site quorum code path while avoiding one HTTP request per failed site during
 large outage waves. Light checks (`HEAD` + `legacy`, `GET` + `simple_http`) use
-a larger coalescing cap than `GET` + `full` checks because full checks can read
-response bodies and have higher tail latency at extreme rates. The light and
-full lanes also have independent in-flight gates so a slow body-reading batch
-does not block cheap reachability checks during a mixed rollout. Explicit
-`CheckBatch` callers still send their supplied batch as-is.
+a larger coalescing cap than `GET` + `full` checks, but the cap remains modest
+so otherwise-fast checks are not held behind a rare slow request in the same
+RPC at rollout-scale rates. The light and full lanes also have independent
+in-flight gates so a slow body-reading batch does not block cheap reachability
+checks during a mixed rollout. Explicit `CheckBatch` callers still send their
+supplied batch as-is.
 
 The Veriflier does not emit one success log line per probe. Request IDs are
 echoed back in the response and joined to monitor-side audit rows there; keeping

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -421,12 +421,13 @@ in-flight gates so a slow body-reading batch does not block cheap reachability
 checks during a mixed rollout. Explicit `CheckBatch` callers still send their
 supplied batch as-is.
 
-The v2 batch deadline is treated as a soft server-side deadline with a small
-client reserve. If the deadline is reached after work has been accepted, the
+The v2 batch deadline is treated as a soft server-side deadline with client
+response headroom. If the deadline is reached after work has been accepted, the
 Veriflier returns completed probe results plus per-request timeout results for
-unfinished probes instead of failing the whole RPC. This keeps one slow target
-from turning an otherwise successful batch into hundreds of monitor-side
-transport errors.
+unfinished probes before the monitor-side HTTP context expires. This keeps one
+slow target from turning an otherwise successful batch into hundreds of
+monitor-side transport errors, and applies to both light and full detection
+lanes during sustained mixed rollouts.
 
 The Veriflier does not emit one success log line per probe. Request IDs are
 echoed back in the response and joined to monitor-side audit rows there; keeping

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -54,7 +54,9 @@ const (
 
 // defaultTransport is shared across checks so the checker does not allocate a
 // fresh connection pool for every probe. The http.Client stays per request so
-// timeout and redirect policy remain isolated to that site check.
+// redirect policy remains isolated to that site check. Timeouts are carried by
+// the request context instead of http.Client.Timeout so each probe does not pay
+// for a second timer on the hot path.
 var defaultTransport = newCheckTransport()
 var defaultHTTPIPTransport = newHTTPIPPoolTransport()
 var defaultDNSCache = newCheckDNSCache(checkDNSCacheTTL, checkDNSCacheMaxEntries)
@@ -780,7 +782,6 @@ func Check(ctx context.Context, req Request) Result {
 			}
 			return nil
 		},
-		Timeout: timeout,
 	}
 
 	httpReq, err := http.NewRequestWithContext(ctx, method, req.URL, nil)

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -435,6 +435,34 @@ func TestCheckTimeout(t *testing.T) {
 	}
 }
 
+func TestCheckContextCancelsBodyRead(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		select {
+		case <-r.Context().Done():
+		case <-time.After(2 * time.Second):
+		}
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	res := Check(ctx, Request{BlogID: 1, URL: srv.URL, TimeoutSeconds: 5})
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("Check() took %s, want context cancellation to stop body read promptly", elapsed)
+	}
+	if res.ErrorCode != ErrorBodyRead {
+		t.Fatalf("ErrorCode = %d, want ErrorBodyRead after response-body cancellation", res.ErrorCode)
+	}
+	if res.BodyReadError == "" {
+		t.Fatal("BodyReadError is empty, want cancellation detail")
+	}
+}
+
 func TestCheckKeywordMatch(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -66,8 +66,9 @@ const minPostFalseAlarmTransientFailureWindow = 5 * time.Minute
 const maxPostFalseAlarmTransientFailureWindow = 10 * time.Minute
 const verifierOperationalBackoffBase = 15 * time.Second
 const verifierOperationalBackoffMax = 2 * time.Minute
-const verifierOperationalCooldownBase = 2 * time.Second
-const verifierOperationalCooldownMax = 30 * time.Second
+const verifierOperationalCooldownBase = 30 * time.Second
+const verifierOperationalCooldownMax = 2 * time.Minute
+const verifierOperationalCooldownMemory = 10 * time.Minute
 const wpcomPermanentFailureLogInterval = 10 * time.Second
 
 // VariableIntervalPollInterval returns the idle scheduler poll interval used
@@ -3301,14 +3302,19 @@ func (o *Orchestrator) availableVeriflierClients(clients []*veriflier.VeriflierC
 	for _, client := range clients {
 		addr := client.Addr()
 		cooldown, ok := o.veriflierCooldowns[addr]
-		if !ok || !now.Before(cooldown.until.UTC()) {
-			if ok {
-				delete(o.veriflierCooldowns, addr)
-			}
+		if !ok {
 			out = append(out, client)
 			continue
 		}
-		skipped++
+		until := cooldown.until.UTC()
+		if now.Before(until) {
+			skipped++
+			continue
+		}
+		if verifierOperationalCooldownMemory > 0 && now.Sub(until) > verifierOperationalCooldownMemory {
+			delete(o.veriflierCooldowns, addr)
+		}
+		out = append(out, client)
 	}
 	return out, skipped
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1826,6 +1826,12 @@ func (o *Orchestrator) escalateToVerifliers(site db.Site, entry *retryEntry) {
 		if duplicateVote {
 			continue
 		}
+		if verifierOperationalNonVote(vr.res) {
+			emitCounter("verifier.vote.non_vote.count", 1)
+			emitCounter("verifier.host."+hostSegment+".vote.non_vote.count", 1)
+			log.Printf("orchestrator: veriflier %s returned operational non-vote outcome %q; leaving decision pending", vr.host, vr.res.Outcome)
+			continue
+		}
 
 		healthyVerifliers++
 		vResults = append(vResults, *vr.res)
@@ -1866,6 +1872,18 @@ func (o *Orchestrator) escalateToVerifliers(site db.Site, entry *retryEntry) {
 		Confirmed:      confirmations,
 		Disagreed:      healthyVerifliers - confirmations,
 		DuplicateVotes: duplicateVotes,
+	}
+
+	if healthyVerifliers < minHealthy {
+		emitCounter("detection.verifier.insufficient_healthy.count", 1)
+		log.Printf(
+			"orchestrator: blog_id=%d verifier decision pending; healthy=%d min_healthy=%d confirmations=%d",
+			site.BlogID,
+			healthyVerifliers,
+			minHealthy,
+			confirmations,
+		)
+		return
 	}
 
 	if confirmations >= quorum {
@@ -1923,6 +1941,18 @@ func verifierVoteID(addr string, res *veriflier.CheckResult) string {
 		}
 	}
 	return strings.TrimSpace(addr)
+}
+
+func verifierOperationalNonVote(res *veriflier.CheckResult) bool {
+	if res == nil {
+		return true
+	}
+	switch res.Outcome {
+	case veriflier.OutcomeAgentOverloaded, veriflier.OutcomeUnknown:
+		return true
+	default:
+		return false
+	}
 }
 
 func verifierMinHealthyFloor(peerOfflineLimit, configuredVerifiers int) int {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -66,6 +66,8 @@ const minPostFalseAlarmTransientFailureWindow = 5 * time.Minute
 const maxPostFalseAlarmTransientFailureWindow = 10 * time.Minute
 const verifierOperationalBackoffBase = 15 * time.Second
 const verifierOperationalBackoffMax = 2 * time.Minute
+const verifierOperationalCooldownBase = 2 * time.Second
+const verifierOperationalCooldownMax = 30 * time.Second
 const wpcomPermanentFailureLogInterval = 10 * time.Second
 
 // VariableIntervalPollInterval returns the idle scheduler poll interval used
@@ -252,16 +254,18 @@ type siteCheckResult struct {
 
 // Orchestrator drives the main check loop.
 type Orchestrator struct {
-	pool             *checker.Pool
-	retries          *retryQueue
-	wpcom            *wpcom.Client
-	events           *eventstore.Store
-	veriflierClients []*veriflier.VeriflierClient
-	veriflierAddrs   []string // parallel slice of "addr|token" for change detection
-	veriflierMu      sync.RWMutex
-	hostname         string
-	bucketMin        int
-	bucketMax        int
+	pool                *checker.Pool
+	retries             *retryQueue
+	wpcom               *wpcom.Client
+	events              *eventstore.Store
+	veriflierClients    []*veriflier.VeriflierClient
+	veriflierAddrs      []string // parallel slice of "addr|token" for change detection
+	veriflierMu         sync.RWMutex
+	veriflierCooldownMu sync.Mutex
+	veriflierCooldowns  map[string]verifierCooldown
+	hostname            string
+	bucketMin           int
+	bucketMax           int
 
 	totalChecked int
 	roundStart   time.Time
@@ -1699,12 +1703,56 @@ func postFalseAlarmTransientFailureWindow(site db.Site) time.Duration {
 }
 
 func (o *Orchestrator) escalateToVerifliers(site db.Site, entry *retryEntry) {
-	clients := o.veriflierSnapshot()
+	allClients := o.veriflierSnapshot()
 	emitCounter("detection.verifier.escalation.count", 1)
 	emitTimingSince("detection.first_failure_to_verification.time", entry.firstFailAt, nowFunc().UTC())
-	if len(clients) == 0 {
+	if len(allClients) == 0 {
 		emitCounter("detection.verifier.no_clients.count", 1)
 		o.confirmDown(site, entry, nil)
+		return
+	}
+	clients, cooldownSkipped := o.availableVeriflierClients(allClients, nowFunc().UTC())
+	if cooldownSkipped > 0 {
+		emitCounter("detection.verifier.cooldown_skipped.count", cooldownSkipped)
+		emitGauge("detection.verifier.cooldown_skipped_active.count", cooldownSkipped)
+	}
+	if len(clients) == 0 {
+		minHealthy := verifierMinHealthyFloor(config.Get().PeerOfflineLimit, len(allClients))
+		now := nowFunc().UTC()
+		delay := verifierOperationalBackoff(site, entry.verifierDeferrals)
+		entry.verifierDeferrals++
+		entry.verifierDeferredUntil = now.Add(delay)
+		emitCounter("detection.verifier.deferred.count", 1)
+		emitCounter("detection.verifier.insufficient_healthy.count", 1)
+		emitGauge("detection.verifier.healthy.count", 0)
+		emitGauge("detection.verifier.confirmations.count", 0)
+		emitGauge("detection.verifier.quorum.count", minHealthy)
+		emitGauge("detection.verifier.min_healthy.count", minHealthy)
+		meta, _ := json.Marshal(map[string]any{
+			"event_id":                    entry.eventID,
+			"verifier_configured":         len(allClients),
+			"verifier_available":          0,
+			"verifier_cooldown_skipped":   cooldownSkipped,
+			"verifier_min_healthy":        minHealthy,
+			"deferrals":                   entry.verifierDeferrals,
+			"retry_after_seconds":         int(delay / time.Second),
+			"deferred_until":              entry.verifierDeferredUntil.UTC().Format(time.RFC3339),
+			"all_verifiers_in_cooldown":   true,
+			"site_check_interval_seconds": int(siteCheckInterval(site) / time.Second),
+		})
+		o.auditLog(audit.Entry{
+			BlogID:    site.BlogID,
+			EventID:   entry.eventID,
+			EventType: audit.EventRetryDispatched,
+			Source:    o.hostname,
+			Detail:    "verifier decision deferred",
+			Metadata:  meta,
+		})
+		log.Printf(
+			"orchestrator: blog_id=%d verifier decision pending; all configured verifliers are in operational cooldown retry_after=%s",
+			site.BlogID,
+			delay,
+		)
 		return
 	}
 
@@ -1737,10 +1785,12 @@ func (o *Orchestrator) escalateToVerifliers(site db.Site, entry *retryEntry) {
 	}
 
 	escalateMeta, _ := json.Marshal(map[string]any{
-		"verifier_count":    len(clients),
-		"request_id":        req.RequestID,
-		"method":            method,
-		"detection_profile": profile,
+		"verifier_count":            len(clients),
+		"verifier_configured_count": len(allClients),
+		"verifier_cooldown_skipped": cooldownSkipped,
+		"request_id":                req.RequestID,
+		"method":                    method,
+		"detection_profile":         profile,
 	})
 	o.auditLog(audit.Entry{
 		BlogID:    site.BlogID,
@@ -1790,12 +1840,22 @@ func (o *Orchestrator) escalateToVerifliers(site db.Site, entry *retryEntry) {
 		if vr.err != nil {
 			emitCounter("verifier.rpc.error.count", 1)
 			emitCounter("verifier.host."+hostSegment+".rpc.error.count", 1)
+			delay := o.markVeriflierOperationalFailure(vr.host, nowFunc().UTC())
+			if delay > 0 {
+				emitCounter("verifier.host."+hostSegment+".cooldown.count", 1)
+				emitTiming("verifier.host."+hostSegment+".cooldown.duration", delay)
+			}
 			log.Printf("orchestrator: veriflier %s error: %v", vr.host, vr.err)
 			continue
 		}
 		if vr.res == nil {
 			emitCounter("verifier.rpc.error.count", 1)
 			emitCounter("verifier.host."+hostSegment+".rpc.error.count", 1)
+			delay := o.markVeriflierOperationalFailure(vr.host, nowFunc().UTC())
+			if delay > 0 {
+				emitCounter("verifier.host."+hostSegment+".cooldown.count", 1)
+				emitTiming("verifier.host."+hostSegment+".cooldown.duration", delay)
+			}
 			log.Printf("orchestrator: veriflier %s returned no result", vr.host)
 			continue
 		}
@@ -1850,10 +1910,16 @@ func (o *Orchestrator) escalateToVerifliers(site db.Site, entry *retryEntry) {
 		if verifierOperationalNonVote(vr.res) {
 			emitCounter("verifier.vote.non_vote.count", 1)
 			emitCounter("verifier.host."+hostSegment+".vote.non_vote.count", 1)
+			delay := o.markVeriflierOperationalFailure(vr.host, nowFunc().UTC())
+			if delay > 0 {
+				emitCounter("verifier.host."+hostSegment+".cooldown.count", 1)
+				emitTiming("verifier.host."+hostSegment+".cooldown.duration", delay)
+			}
 			log.Printf("orchestrator: veriflier %s returned operational non-vote outcome %q; leaving decision pending", vr.host, vr.res.Outcome)
 			continue
 		}
 
+		o.markVeriflierHealthy(vr.host)
 		healthyVerifliers++
 		vResults = append(vResults, *vr.res)
 		if !vr.res.Success {
@@ -1877,7 +1943,7 @@ func (o *Orchestrator) escalateToVerifliers(site db.Site, entry *retryEntry) {
 	if quorum < 1 {
 		quorum = 1
 	}
-	minHealthy := verifierMinHealthyFloor(config.Get().PeerOfflineLimit, len(clients))
+	minHealthy := verifierMinHealthyFloor(config.Get().PeerOfflineLimit, len(allClients))
 	if quorum < minHealthy {
 		quorum = minHealthy
 	}
@@ -1978,6 +2044,11 @@ type verifierDecision struct {
 	Confirmed      int
 	Disagreed      int
 	DuplicateVotes int
+}
+
+type verifierCooldown struct {
+	until    time.Time
+	failures int
 }
 
 func verifierVoteID(addr string, res *veriflier.CheckResult) string {
@@ -3210,6 +3281,87 @@ func (o *Orchestrator) veriflierSnapshot() []*veriflier.VeriflierClient {
 	out := make([]*veriflier.VeriflierClient, len(o.veriflierClients))
 	copy(out, o.veriflierClients)
 	return out
+}
+
+func (o *Orchestrator) availableVeriflierClients(clients []*veriflier.VeriflierClient, now time.Time) ([]*veriflier.VeriflierClient, int) {
+	if len(clients) == 0 {
+		return nil, 0
+	}
+	if now.IsZero() {
+		now = nowFunc().UTC()
+	}
+	now = now.UTC()
+	o.veriflierCooldownMu.Lock()
+	defer o.veriflierCooldownMu.Unlock()
+	if len(o.veriflierCooldowns) == 0 {
+		return clients, 0
+	}
+	out := make([]*veriflier.VeriflierClient, 0, len(clients))
+	skipped := 0
+	for _, client := range clients {
+		addr := client.Addr()
+		cooldown, ok := o.veriflierCooldowns[addr]
+		if !ok || !now.Before(cooldown.until.UTC()) {
+			if ok {
+				delete(o.veriflierCooldowns, addr)
+			}
+			out = append(out, client)
+			continue
+		}
+		skipped++
+	}
+	return out, skipped
+}
+
+func (o *Orchestrator) markVeriflierOperationalFailure(addr string, now time.Time) time.Duration {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return 0
+	}
+	if now.IsZero() {
+		now = nowFunc().UTC()
+	}
+	now = now.UTC()
+	o.veriflierCooldownMu.Lock()
+	defer o.veriflierCooldownMu.Unlock()
+	if o.veriflierCooldowns == nil {
+		o.veriflierCooldowns = make(map[string]verifierCooldown)
+	}
+	current := o.veriflierCooldowns[addr]
+	failures := current.failures + 1
+	delay := verifierOperationalCooldown(failures - 1)
+	o.veriflierCooldowns[addr] = verifierCooldown{
+		failures: failures,
+		until:    now.Add(delay),
+	}
+	return delay
+}
+
+func (o *Orchestrator) markVeriflierHealthy(addr string) {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return
+	}
+	o.veriflierCooldownMu.Lock()
+	defer o.veriflierCooldownMu.Unlock()
+	delete(o.veriflierCooldowns, addr)
+}
+
+func verifierOperationalCooldown(failures int) time.Duration {
+	if failures < 0 {
+		failures = 0
+	}
+	delay := verifierOperationalCooldownBase
+	for range failures {
+		if delay >= verifierOperationalCooldownMax {
+			break
+		}
+		delay *= 2
+	}
+	if delay > verifierOperationalCooldownMax {
+		return verifierOperationalCooldownMax
+	}
+	return delay
 }
 
 func timeoutForSite(cfg *config.Config, site db.Site) int {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -64,6 +64,8 @@ const failedCheckRetryInterval = time.Minute
 const maxPostRecoveryTransientFailureWindow = 5 * time.Minute
 const minPostFalseAlarmTransientFailureWindow = 5 * time.Minute
 const maxPostFalseAlarmTransientFailureWindow = 10 * time.Minute
+const verifierOperationalBackoffBase = 15 * time.Second
+const verifierOperationalBackoffMax = 2 * time.Minute
 const wpcomPermanentFailureLogInterval = 10 * time.Second
 
 // VariableIntervalPollInterval returns the idle scheduler poll interval used
@@ -1600,6 +1602,25 @@ func (o *Orchestrator) handleFailure(site db.Site, res checker.Result) bool {
 		return entry.eventID > 0
 	}
 
+	if shouldDeferVerifierRetry(entry, resultCheckedAt(res)) {
+		emitCounter("detection.verifier.deferred_retry_skipped.count", 1)
+		metaMap := checkResultMetadata(site, res, entry.firstFailAt)
+		metaMap["event_id"] = entry.eventID
+		metaMap["attempt"] = entry.failCount
+		metaMap["deferred_until"] = entry.verifierDeferredUntil.UTC().Format(time.RFC3339)
+		metaMap["deferrals"] = entry.verifierDeferrals
+		meta, _ := json.Marshal(metaMap)
+		o.auditLog(audit.Entry{
+			BlogID:    site.BlogID,
+			EventID:   entry.eventID,
+			EventType: audit.EventRetryDispatched,
+			Source:    o.hostname,
+			Detail:    "verifier retry deferred",
+			Metadata:  meta,
+		})
+		return entry.eventID > 0
+	}
+
 	// Escalate to verifliers.
 	o.escalateToVerifliers(site, entry)
 	if lowConfidenceDNS {
@@ -1875,13 +1896,41 @@ func (o *Orchestrator) escalateToVerifliers(site db.Site, entry *retryEntry) {
 	}
 
 	if healthyVerifliers < minHealthy {
+		now := nowFunc().UTC()
+		delay := verifierOperationalBackoff(site, entry.verifierDeferrals)
+		entry.verifierDeferrals++
+		entry.verifierDeferredUntil = now.Add(delay)
+		emitCounter("detection.verifier.deferred.count", 1)
+		emitGauge("detection.verifier.deferrals.count", entry.verifierDeferrals)
+		meta, _ := json.Marshal(map[string]any{
+			"event_id":                 entry.eventID,
+			"verifier_quorum":          quorum,
+			"verifier_min_healthy":     minHealthy,
+			"verifier_healthy":         healthyVerifliers,
+			"verifier_confirmed":       confirmations,
+			"verifier_disagreed":       healthyVerifliers - confirmations,
+			"verifier_duplicate_votes": duplicateVotes,
+			"deferrals":                entry.verifierDeferrals,
+			"retry_after_seconds":      int(delay / time.Second),
+			"deferred_until":           entry.verifierDeferredUntil.UTC().Format(time.RFC3339),
+			"verifier_results":         summarizeVerifierResults(vResults),
+		})
+		o.auditLog(audit.Entry{
+			BlogID:    site.BlogID,
+			EventID:   entry.eventID,
+			EventType: audit.EventRetryDispatched,
+			Source:    o.hostname,
+			Detail:    "verifier decision deferred",
+			Metadata:  meta,
+		})
 		emitCounter("detection.verifier.insufficient_healthy.count", 1)
 		log.Printf(
-			"orchestrator: blog_id=%d verifier decision pending; healthy=%d min_healthy=%d confirmations=%d",
+			"orchestrator: blog_id=%d verifier decision pending; healthy=%d min_healthy=%d confirmations=%d retry_after=%s",
 			site.BlogID,
 			healthyVerifliers,
 			minHealthy,
 			confirmations,
+			delay,
 		)
 		return
 	}
@@ -1953,6 +2002,37 @@ func verifierOperationalNonVote(res *veriflier.CheckResult) bool {
 	default:
 		return false
 	}
+}
+
+func shouldDeferVerifierRetry(entry *retryEntry, checkedAt time.Time) bool {
+	if entry == nil || entry.verifierDeferredUntil.IsZero() {
+		return false
+	}
+	if checkedAt.IsZero() {
+		checkedAt = nowFunc().UTC()
+	}
+	return checkedAt.UTC().Before(entry.verifierDeferredUntil.UTC())
+}
+
+func verifierOperationalBackoff(site db.Site, deferrals int) time.Duration {
+	if deferrals < 0 {
+		deferrals = 0
+	}
+	delay := verifierOperationalBackoffBase
+	for range deferrals {
+		if delay >= verifierOperationalBackoffMax {
+			break
+		}
+		delay *= 2
+	}
+	if delay > verifierOperationalBackoffMax {
+		delay = verifierOperationalBackoffMax
+	}
+	interval := siteCheckInterval(site)
+	if interval > 0 && delay > interval {
+		return interval
+	}
+	return delay
 }
 
 func verifierMinHealthyFloor(peerOfflineLimit, configuredVerifiers int) int {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1098,11 +1098,21 @@ func TestHandleFailureBacksOffVerifierAfterOperationalNonVotes(t *testing.T) {
 
 	now = firstDeferredUntil.Add(time.Second)
 	o.handleFailure(site, failureAt())
-	if got := calls.Load(); got != 2 {
-		t.Fatalf("verifier calls after deferral expires = %d, want 2", got)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("verifier calls while verifier cooldown is still active = %d, want still 1", got)
 	}
-	if got := o.retries.get(659).verifierDeferrals; got != 2 {
-		t.Fatalf("verifier deferrals = %d, want 2 after second operational non-vote", got)
+	entry = o.retries.get(659)
+	if entry == nil || entry.verifierDeferrals != 2 {
+		t.Fatalf("retry entry after cooldown skip = %+v, want two deferrals", entry)
+	}
+
+	now = entry.verifierDeferredUntil.Add(time.Second)
+	o.handleFailure(site, failureAt())
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("verifier calls after deferral and cooldown expire = %d, want 2", got)
+	}
+	if got := o.retries.get(659).verifierDeferrals; got != 3 {
+		t.Fatalf("verifier deferrals = %d, want 3 after second operational non-vote", got)
 	}
 }
 
@@ -1171,6 +1181,45 @@ func TestHandleFailureSkipsVerifierDuringOperationalCooldown(t *testing.T) {
 	o.handleFailure(db.Site{BlogID: 662, MonitorURL: "https://example.com/c", CheckInterval: 1, SiteStatus: statusRunning}, failureAt(662))
 	if got := calls.Load(); got != 2 {
 		t.Fatalf("verifier calls after cooldown expires = %d, want 2", got)
+	}
+}
+
+func TestVeriflierOperationalCooldownRetainsFailureHistoryUntilHealthy(t *testing.T) {
+	o := &Orchestrator{}
+	now := time.Date(2026, 5, 16, 14, 0, 0, 0, time.UTC)
+	client := veriflier.NewVeriflierClient("v1", "")
+
+	if got := o.markVeriflierOperationalFailure("v1", now); got != verifierOperationalCooldownBase {
+		t.Fatalf("first cooldown = %s, want %s", got, verifierOperationalCooldownBase)
+	}
+	clients, skipped := o.availableVeriflierClients([]*veriflier.VeriflierClient{client}, now.Add(verifierOperationalCooldownBase+time.Second))
+	if skipped != 0 || len(clients) != 1 {
+		t.Fatalf("available after cooldown = len %d skipped %d, want one available", len(clients), skipped)
+	}
+	if got := o.markVeriflierOperationalFailure("v1", now.Add(verifierOperationalCooldownBase+2*time.Second)); got != 2*verifierOperationalCooldownBase {
+		t.Fatalf("second cooldown = %s, want %s", got, 2*verifierOperationalCooldownBase)
+	}
+
+	o.markVeriflierHealthy("v1")
+	if got := o.markVeriflierOperationalFailure("v1", now.Add(time.Hour)); got != verifierOperationalCooldownBase {
+		t.Fatalf("cooldown after healthy vote = %s, want reset to %s", got, verifierOperationalCooldownBase)
+	}
+}
+
+func TestAvailableVeriflierClientsForgetsStaleCooldownHistory(t *testing.T) {
+	o := &Orchestrator{}
+	now := time.Date(2026, 5, 16, 14, 30, 0, 0, time.UTC)
+	client := veriflier.NewVeriflierClient("v1", "")
+
+	if got := o.markVeriflierOperationalFailure("v1", now); got != verifierOperationalCooldownBase {
+		t.Fatalf("first cooldown = %s, want %s", got, verifierOperationalCooldownBase)
+	}
+	clients, skipped := o.availableVeriflierClients([]*veriflier.VeriflierClient{client}, now.Add(verifierOperationalCooldownBase+verifierOperationalCooldownMemory+time.Second))
+	if skipped != 0 || len(clients) != 1 {
+		t.Fatalf("available after stale cooldown = len %d skipped %d, want one available", len(clients), skipped)
+	}
+	if got := o.markVeriflierOperationalFailure("v1", now.Add(time.Hour)); got != verifierOperationalCooldownBase {
+		t.Fatalf("cooldown after stale memory = %s, want %s", got, verifierOperationalCooldownBase)
 	}
 }
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -856,8 +856,11 @@ func TestEscalateToVerifliersIgnoresDuplicateVoteIdentities(t *testing.T) {
 	entry := o.retries.get(655)
 	o.escalateToVerifliers(db.Site{BlogID: 655, MonitorURL: "https://example.com", SiteStatus: statusRunning}, entry)
 
-	if falsePositiveBlogID != 655 {
-		t.Fatalf("false positive blog_id = %d, want 655", falsePositiveBlogID)
+	if falsePositiveBlogID != 0 {
+		t.Fatalf("false positive blog_id = %d, want none while duplicate votes leave health below floor", falsePositiveBlogID)
+	}
+	if entry := o.retries.get(655); entry == nil {
+		t.Fatal("retry entry was cleared despite duplicate votes leaving verifier health below floor")
 	}
 	if got := rec.counter("verifier.vote.duplicate_identity.count"); got != 1 {
 		t.Fatalf("duplicate identity counter = %d, want 1", got)
@@ -915,8 +918,11 @@ func TestEscalateToVerifliersRequiresTwoHealthyVotesForMultiVerifierFleet(t *tes
 	entry := o.retries.get(656)
 	o.escalateToVerifliers(db.Site{BlogID: 656, MonitorURL: "https://example.com", SiteStatus: statusRunning}, entry)
 
-	if falsePositiveBlogID != 656 {
-		t.Fatalf("false positive blog_id = %d, want 656", falsePositiveBlogID)
+	if falsePositiveBlogID != 0 {
+		t.Fatalf("false positive blog_id = %d, want none while verifier health is below floor", falsePositiveBlogID)
+	}
+	if entry := o.retries.get(656); entry == nil {
+		t.Fatal("retry entry was cleared despite insufficient healthy verifier votes")
 	}
 }
 
@@ -959,6 +965,63 @@ func TestEscalateToVerifliersAllowsSingleConfiguredVerifier(t *testing.T) {
 
 	if notifyCalls != 1 {
 		t.Fatalf("notify calls = %d, want 1", notifyCalls)
+	}
+}
+
+func TestEscalateToVerifliersKeepsRetryOnOperationalNonVote(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+
+	cfg := setTestConfig(t)
+	cfg.PeerOfflineLimit = 1
+
+	rec := newRecordingMetrics()
+	metricsClientFunc = func() metricsClient { return rec }
+	dbRecordFalsePositive = func(blogID int64, _ int, _ int, _ int64) error {
+		t.Fatalf("false positive recorded for operational non-vote blog_id=%d", blogID)
+		return nil
+	}
+	wpcomNotifyFunc = func(_ *wpcom.Client, _ wpcom.Notification) error {
+		t.Fatal("operational non-vote should not confirm downtime")
+		return nil
+	}
+	veriflierCheckFunc = func(c *veriflier.VeriflierClient, _ context.Context, req veriflier.CheckRequest) (*veriflier.CheckResult, error) {
+		return &veriflier.CheckResult{
+			BlogID:    req.BlogID,
+			Host:      c.Addr(),
+			Success:   false,
+			ErrorCode: 1,
+			Outcome:   veriflier.OutcomeAgentOverloaded,
+			RequestID: req.RequestID,
+		}, nil
+	}
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		ctx:      context.Background(),
+		hostname: "local-host",
+		veriflierClients: []*veriflier.VeriflierClient{
+			veriflier.NewVeriflierClient("v1", ""),
+		},
+	}
+
+	fail := checkerResultFailure(658)
+	o.retries.record(fail)
+	entry := o.retries.get(658)
+	o.escalateToVerifliers(db.Site{BlogID: 658, MonitorURL: "https://example.com", SiteStatus: statusRunning}, entry)
+
+	if entry := o.retries.get(658); entry == nil {
+		t.Fatal("retry entry was cleared after operational non-vote")
+	}
+	if got := rec.counter("verifier.vote.non_vote.count"); got != 1 {
+		t.Fatalf("non-vote counter = %d, want 1", got)
+	}
+	if got := rec.counter("detection.verifier.insufficient_healthy.count"); got != 1 {
+		t.Fatalf("insufficient healthy counter = %d, want 1", got)
+	}
+	if got := rec.counter("detection.verifier.false_alarm.count"); got != 0 {
+		t.Fatalf("false alarm counter = %d, want 0", got)
 	}
 }
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1106,6 +1106,74 @@ func TestHandleFailureBacksOffVerifierAfterOperationalNonVotes(t *testing.T) {
 	}
 }
 
+func TestHandleFailureSkipsVerifierDuringOperationalCooldown(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+
+	cfg := setTestConfig(t)
+	cfg.NumOfChecks = 1
+	cfg.PeerOfflineLimit = 1
+
+	rec := newRecordingMetrics()
+	metricsClientFunc = func() metricsClient { return rec }
+
+	now := time.Date(2026, 5, 16, 12, 30, 0, 0, time.UTC)
+	nowFunc = func() time.Time { return now }
+
+	var calls atomic.Int64
+	veriflierCheckFunc = func(c *veriflier.VeriflierClient, _ context.Context, req veriflier.CheckRequest) (*veriflier.CheckResult, error) {
+		calls.Add(1)
+		return &veriflier.CheckResult{
+			BlogID:    req.BlogID,
+			Host:      c.Addr(),
+			Success:   false,
+			ErrorCode: 1,
+			Outcome:   veriflier.OutcomeAgentOverloaded,
+			RequestID: req.RequestID,
+		}, nil
+	}
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		ctx:      context.Background(),
+		hostname: "local-host",
+		veriflierClients: []*veriflier.VeriflierClient{
+			veriflier.NewVeriflierClient("v1", ""),
+		},
+	}
+	failureAt := func(blogID int64) checker.Result {
+		res := checkerResultFailure(blogID)
+		res.Timestamp = now
+		return res
+	}
+
+	o.handleFailure(db.Site{BlogID: 660, MonitorURL: "https://example.com/a", CheckInterval: 1, SiteStatus: statusRunning}, failureAt(660))
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("verifier calls after first operational non-vote = %d, want 1", got)
+	}
+
+	o.handleFailure(db.Site{BlogID: 661, MonitorURL: "https://example.com/b", CheckInterval: 1, SiteStatus: statusRunning}, failureAt(661))
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("verifier calls while verifier is in cooldown = %d, want still 1", got)
+	}
+	if got := rec.counter("detection.verifier.cooldown_skipped.count"); got != 1 {
+		t.Fatalf("cooldown skipped counter = %d, want 1", got)
+	}
+	if got := rec.counter("detection.verifier.deferred.count"); got != 2 {
+		t.Fatalf("deferred counter = %d, want 2", got)
+	}
+	if entry := o.retries.get(661); entry == nil || entry.verifierDeferrals != 1 || entry.verifierDeferredUntil.IsZero() {
+		t.Fatalf("second retry entry = %+v, want verifier deferral without an RPC", entry)
+	}
+
+	now = now.Add(verifierOperationalCooldownBase + time.Second)
+	o.handleFailure(db.Site{BlogID: 662, MonitorURL: "https://example.com/c", CheckInterval: 1, SiteStatus: statusRunning}, failureAt(662))
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("verifier calls after cooldown expires = %d, want 2", got)
+	}
+}
+
 func TestVerifierOperationalBackoffBoundsToSiteIntervalAndCap(t *testing.T) {
 	setTestConfig(t)
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1020,8 +1020,103 @@ func TestEscalateToVerifliersKeepsRetryOnOperationalNonVote(t *testing.T) {
 	if got := rec.counter("detection.verifier.insufficient_healthy.count"); got != 1 {
 		t.Fatalf("insufficient healthy counter = %d, want 1", got)
 	}
+	if got := rec.counter("detection.verifier.deferred.count"); got != 1 {
+		t.Fatalf("deferred counter = %d, want 1", got)
+	}
 	if got := rec.counter("detection.verifier.false_alarm.count"); got != 0 {
 		t.Fatalf("false alarm counter = %d, want 0", got)
+	}
+	if entry := o.retries.get(658); entry == nil || entry.verifierDeferrals != 1 || entry.verifierDeferredUntil.IsZero() {
+		t.Fatalf("retry entry deferral = %+v, want one deferred verification", entry)
+	}
+}
+
+func TestHandleFailureBacksOffVerifierAfterOperationalNonVotes(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+
+	cfg := setTestConfig(t)
+	cfg.NumOfChecks = 1
+	cfg.PeerOfflineLimit = 1
+
+	rec := newRecordingMetrics()
+	metricsClientFunc = func() metricsClient { return rec }
+
+	now := time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC)
+	nowFunc = func() time.Time { return now }
+
+	var calls atomic.Int64
+	veriflierCheckFunc = func(c *veriflier.VeriflierClient, _ context.Context, req veriflier.CheckRequest) (*veriflier.CheckResult, error) {
+		calls.Add(1)
+		return &veriflier.CheckResult{
+			BlogID:    req.BlogID,
+			Host:      c.Addr(),
+			Success:   false,
+			ErrorCode: 1,
+			Outcome:   veriflier.OutcomeAgentOverloaded,
+			RequestID: req.RequestID,
+		}, nil
+	}
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		ctx:      context.Background(),
+		hostname: "local-host",
+		veriflierClients: []*veriflier.VeriflierClient{
+			veriflier.NewVeriflierClient("v1", ""),
+		},
+	}
+	site := db.Site{BlogID: 659, MonitorURL: "https://example.com", CheckInterval: 1, SiteStatus: statusRunning}
+	failureAt := func() checker.Result {
+		res := checkerResultFailure(659)
+		res.Timestamp = now
+		return res
+	}
+
+	o.handleFailure(site, failureAt())
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("verifier calls after first failure = %d, want 1", got)
+	}
+	entry := o.retries.get(659)
+	if entry == nil || entry.verifierDeferrals != 1 {
+		t.Fatalf("retry entry after first operational non-vote = %+v, want one deferral", entry)
+	}
+	firstDeferredUntil := entry.verifierDeferredUntil
+
+	now = now.Add(5 * time.Second)
+	o.handleFailure(site, failureAt())
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("verifier calls during deferral = %d, want still 1", got)
+	}
+	if got := rec.counter("detection.verifier.deferred_retry_skipped.count"); got != 1 {
+		t.Fatalf("deferred retry skipped counter = %d, want 1", got)
+	}
+	if !o.retries.get(659).verifierDeferredUntil.Equal(firstDeferredUntil) {
+		t.Fatalf("deferred retry should not extend deferral window on skipped attempt")
+	}
+
+	now = firstDeferredUntil.Add(time.Second)
+	o.handleFailure(site, failureAt())
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("verifier calls after deferral expires = %d, want 2", got)
+	}
+	if got := o.retries.get(659).verifierDeferrals; got != 2 {
+		t.Fatalf("verifier deferrals = %d, want 2 after second operational non-vote", got)
+	}
+}
+
+func TestVerifierOperationalBackoffBoundsToSiteIntervalAndCap(t *testing.T) {
+	setTestConfig(t)
+
+	if got := verifierOperationalBackoff(db.Site{CheckInterval: 1}, 0); got != 15*time.Second {
+		t.Fatalf("initial backoff = %s, want 15s", got)
+	}
+	if got := verifierOperationalBackoff(db.Site{CheckInterval: 1}, 2); got != time.Minute {
+		t.Fatalf("interval-bounded backoff = %s, want 1m", got)
+	}
+	if got := verifierOperationalBackoff(db.Site{CheckInterval: 10}, 20); got != verifierOperationalBackoffMax {
+		t.Fatalf("max backoff = %s, want %s", got, verifierOperationalBackoffMax)
 	}
 }
 

--- a/internal/orchestrator/retry.go
+++ b/internal/orchestrator/retry.go
@@ -17,6 +17,9 @@ type retryEntry struct {
 	lastResult  checker.Result
 	checks      []checker.Result // all check results since first failure
 	eventID     int64            // jetmon_events.id for the open Seems Down event; 0 if not yet opened or eventstore unavailable
+
+	verifierDeferrals     int
+	verifierDeferredUntil time.Time
 }
 
 // retryQueue holds sites awaiting local retry or veriflier escalation.

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -38,7 +38,7 @@ var (
 	singleCheckBatchMaxDelay             = 2 * time.Millisecond
 	singleCheckBatchDeadlineReserve      = 250 * time.Millisecond
 	singleCheckLargeBatchDeadlineReserve = time.Second
-	singleCheckLightBatchMaxFlight       = 48
+	singleCheckLightBatchMaxFlight       = 32
 	singleCheckFullBatchMaxFlight        = 32
 	singleCheckBatchQueueSize            = 32768
 	singleCheckFullBatchQueueSize        = 32768

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -38,7 +39,7 @@ var (
 	singleCheckBatchMaxDelay             = 2 * time.Millisecond
 	singleCheckBatchDeadlineReserve      = 250 * time.Millisecond
 	singleCheckLargeBatchDeadlineReserve = time.Second
-	singleCheckLightBatchMaxFlight       = 32
+	singleCheckLightBatchMaxFlight       = defaultSingleCheckLightBatchMaxFlight()
 	singleCheckFullBatchMaxFlight        = 32
 	singleCheckBatchQueueSize            = 32768
 	singleCheckFullBatchQueueSize        = 32768
@@ -175,6 +176,21 @@ func newSingleCheckBatcher(client *VeriflierClient) *singleCheckBatcher {
 	go b.run(b.lightIn, singleCheckBatchMaxSize, b.lightInFlight)
 	go b.run(b.fullIn, singleCheckFullBatchMaxSize, b.fullInFlight)
 	return b
+}
+
+func defaultSingleCheckLightBatchMaxFlight() int {
+	procs := runtime.GOMAXPROCS(0)
+	if procs < 1 {
+		procs = 1
+	}
+	flight := procs * 16
+	if flight < 32 {
+		return 32
+	}
+	if flight > 128 {
+		return 128
+	}
+	return flight
 }
 
 func (b *singleCheckBatcher) submit(ctx context.Context, call singleCheckCall) error {

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -30,7 +30,7 @@ type VeriflierClient struct {
 }
 
 var (
-	singleCheckBatchMaxSize        = 512
+	singleCheckBatchMaxSize        = 256
 	singleCheckFullBatchMaxSize    = 64
 	singleCheckBatchMaxDelay       = 2 * time.Millisecond
 	singleCheckLightBatchMaxFlight = 32

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -38,6 +38,7 @@ var (
 	singleCheckBatchMaxDelay             = 2 * time.Millisecond
 	singleCheckBatchDeadlineReserve      = 250 * time.Millisecond
 	singleCheckLargeBatchDeadlineReserve = time.Second
+	singleCheckBatchFlightWaitPoll       = 5 * time.Millisecond
 	singleCheckLightBatchMaxFlight       = 32
 	singleCheckFullBatchMaxFlight        = 32
 	singleCheckBatchQueueSize            = 32768
@@ -212,12 +213,57 @@ func (b *singleCheckBatcher) run(in <-chan singleCheckCall, maxBatchSize int, in
 		if !timer.Stop() && collecting {
 			<-timer.C
 		}
-		inFlight <- struct{}{}
+		var acquired bool
+		batch, acquired = waitForSingleCheckFlight(batch, inFlight)
+		if !acquired {
+			continue
+		}
 		go func() {
 			defer func() { <-inFlight }()
 			b.flush(batch)
 		}()
 	}
+}
+
+func waitForSingleCheckFlight(batch []singleCheckCall, inFlight chan struct{}) ([]singleCheckCall, bool) {
+	batch = pruneExpiredSingleCheckCalls(batch)
+	if len(batch) == 0 {
+		return nil, false
+	}
+	ticker := time.NewTicker(singleCheckBatchFlightWaitPoll)
+	defer ticker.Stop()
+	for {
+		select {
+		case inFlight <- struct{}{}:
+			batch = pruneExpiredSingleCheckCalls(batch)
+			if len(batch) == 0 {
+				<-inFlight
+				return nil, false
+			}
+			return batch, true
+		case <-ticker.C:
+			batch = pruneExpiredSingleCheckCalls(batch)
+			if len(batch) == 0 {
+				return nil, false
+			}
+		}
+	}
+}
+
+func pruneExpiredSingleCheckCalls(calls []singleCheckCall) []singleCheckCall {
+	kept := calls[:0]
+	for _, call := range calls {
+		if err := call.ctx.Err(); err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				call.respond(agentOverloadedCheckResult(call.req), nil)
+			} else {
+				call.respond(nil, err)
+			}
+			continue
+		}
+		kept = append(kept, call)
+	}
+	return kept
 }
 
 func usesFullDetectionWork(req CheckRequest) bool {

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/Automattic/jetmon/internal/checkmode"
@@ -316,7 +317,9 @@ func operationalOverloadError(err error) bool {
 	}
 	var transportErr v2TransportError
 	if errors.As(err, &transportErr) {
-		return errors.Is(transportErr.err, io.EOF) || errors.Is(transportErr.err, io.ErrUnexpectedEOF)
+		return errors.Is(transportErr.err, io.EOF) ||
+			errors.Is(transportErr.err, io.ErrUnexpectedEOF) ||
+			errors.Is(transportErr.err, syscall.ECONNRESET)
 	}
 	return false
 }

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -91,12 +91,18 @@ func (c *VeriflierClient) Check(ctx context.Context, req CheckRequest) (*CheckRe
 		resp: make(chan singleCheckResponse, 1),
 	}
 	if err := c.singleChecks().submit(ctx, call); err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return agentOverloadedCheckResult(req), nil
+		}
 		return nil, err
 	}
 	select {
 	case resp := <-call.resp:
 		return resp.result, resp.err
 	case <-ctx.Done():
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return agentOverloadedCheckResult(req), nil
+		}
 		return nil, ctx.Err()
 	}
 }
@@ -223,7 +229,11 @@ func (b *singleCheckBatcher) flush(batch []singleCheckCall) {
 	var latestDeadline time.Time
 	for _, call := range batch {
 		if err := call.ctx.Err(); err != nil {
-			call.respond(nil, err)
+			if errors.Is(err, context.DeadlineExceeded) {
+				call.respond(agentOverloadedCheckResult(call.req), nil)
+			} else {
+				call.respond(nil, err)
+			}
 			continue
 		}
 		if call.req.RequestID == "" {
@@ -252,7 +262,11 @@ func (b *singleCheckBatcher) flush(batch []singleCheckCall) {
 	cancel()
 	if err != nil {
 		for _, call := range calls {
-			call.respond(nil, err)
+			if errors.Is(err, context.DeadlineExceeded) {
+				call.respond(agentOverloadedCheckResult(call.req), nil)
+			} else {
+				call.respond(nil, err)
+			}
 		}
 		return
 	}
@@ -280,6 +294,18 @@ func (c singleCheckCall) respond(result *CheckResult, err error) {
 	select {
 	case c.resp <- singleCheckResponse{result: result, err: err}:
 	default:
+	}
+}
+
+func agentOverloadedCheckResult(req CheckRequest) *CheckResult {
+	return &CheckResult{
+		MonitorSiteID: req.MonitorSiteID,
+		BlogID:        req.BlogID,
+		URL:           req.URL,
+		Outcome:       OutcomeAgentOverloaded,
+		Success:       false,
+		ErrorCode:     1,
+		RequestID:     req.RequestID,
 	}
 }
 

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -108,9 +108,9 @@ func (c *VeriflierClient) CheckBatch(ctx context.Context, reqs []CheckRequest) (
 	case ProtocolLegacy:
 		return c.checkBatchLegacy(ctx, reqs)
 	case ProtocolV2:
-		return c.checkBatchV2(ctx, reqs)
+		return c.checkBatchV2(ctx, reqs, true)
 	default:
-		results, err := c.checkBatchV2(ctx, reqs)
+		results, err := c.checkBatchV2(ctx, reqs, false)
 		if err == nil {
 			c.setProtocol(ProtocolV2)
 			return results, nil
@@ -141,10 +141,13 @@ type singleCheckResponse struct {
 	err    error
 }
 
+type checkBatchV2Response struct {
+	Results []CheckV2Result `json:"results"`
+}
+
 type singleCheckBatcher struct {
 	client        *VeriflierClient
-	headIn        chan singleCheckCall
-	simpleIn      chan singleCheckCall
+	lightIn       chan singleCheckCall
 	fullIn        chan singleCheckCall
 	lightInFlight chan struct{}
 	fullInFlight  chan struct{}
@@ -153,27 +156,20 @@ type singleCheckBatcher struct {
 func newSingleCheckBatcher(client *VeriflierClient) *singleCheckBatcher {
 	b := &singleCheckBatcher{
 		client:        client,
-		headIn:        make(chan singleCheckCall, singleCheckBatchQueueSize),
-		simpleIn:      make(chan singleCheckCall, singleCheckBatchQueueSize),
+		lightIn:       make(chan singleCheckCall, singleCheckBatchQueueSize),
 		fullIn:        make(chan singleCheckCall, singleCheckFullBatchQueueSize),
 		lightInFlight: make(chan struct{}, singleCheckLightBatchMaxFlight),
 		fullInFlight:  make(chan struct{}, singleCheckFullBatchMaxFlight),
 	}
-	go b.run(b.headIn, singleCheckBatchMaxSize, b.lightInFlight)
-	go b.run(b.simpleIn, singleCheckBatchMaxSize, b.lightInFlight)
+	go b.run(b.lightIn, singleCheckBatchMaxSize, b.lightInFlight)
 	go b.run(b.fullIn, singleCheckFullBatchMaxSize, b.fullInFlight)
 	return b
 }
 
 func (b *singleCheckBatcher) submit(ctx context.Context, call singleCheckCall) error {
-	var in chan singleCheckCall
-	switch {
-	case usesFullDetectionWork(call.req):
+	in := b.lightIn
+	if usesFullDetectionWork(call.req) {
 		in = b.fullIn
-	case usesHEADProbe(call.req):
-		in = b.headIn
-	default:
-		in = b.simpleIn
 	}
 	select {
 	case in <- call:
@@ -223,14 +219,6 @@ func usesFullDetectionWork(req CheckRequest) bool {
 		profile = checkmode.ProfileFull
 	}
 	return checkmode.EffectiveProfile(method, profile) == checkmode.ProfileFull
-}
-
-func usesHEADProbe(req CheckRequest) bool {
-	method, err := checkmode.NormalizeMethod(req.Method, checkmode.MethodGET)
-	if err != nil {
-		method = checkmode.MethodGET
-	}
-	return method == checkmode.MethodHEAD
 }
 
 func (b *singleCheckBatcher) flush(batch []singleCheckCall) {
@@ -343,11 +331,7 @@ func (c *VeriflierClient) checkBatchLegacy(ctx context.Context, reqs []CheckRequ
 	return br.Results, nil
 }
 
-func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest) ([]CheckResult, error) {
-	type batchResp struct {
-		Results []CheckV2Result `json:"results"`
-	}
-
+func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest, retryTransient bool) ([]CheckResult, error) {
 	v2Reqs := make([]CheckV2Request, len(reqs))
 	reqByRequestID := make(map[string]CheckRequest, len(reqs))
 	for i := range reqs {
@@ -379,27 +363,27 @@ func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest)
 	}
 
 	url := fmt.Sprintf("http://%s/v2/check", c.addr)
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		return nil, err
+	var br checkBatchV2Response
+	var lastErr error
+	maxAttempts := 1
+	if retryTransient {
+		maxAttempts = 2
 	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+c.authToken)
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		br, err = c.doCheckBatchV2(ctx, url, body)
+		if err == nil {
+			lastErr = nil
+			break
+		}
+		lastErr = err
+		if attempt == maxAttempts-1 || !shouldRetryV2Batch(ctx, err) {
+			return nil, err
+		}
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
 
-	resp, err := c.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, v2TransportError{endpoint: "/v2/check", err: err}
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, statusError{endpoint: "/v2/check", status: resp.StatusCode}
-	}
-
-	var br batchResp
-	if err := json.NewDecoder(resp.Body).Decode(&br); err != nil {
-		return nil, fmt.Errorf("decode veriflier v2 response: %w", err)
-	}
 	results := make([]CheckResult, 0, len(br.Results))
 	for i, res := range br.Results {
 		orig := reqByRequestID[res.RequestID]
@@ -422,6 +406,50 @@ func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest)
 		})
 	}
 	return results, nil
+}
+
+func (c *VeriflierClient) doCheckBatchV2(ctx context.Context, url string, body []byte) (checkBatchV2Response, error) {
+	var br checkBatchV2Response
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return br, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+c.authToken)
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return br, v2TransportError{endpoint: "/v2/check", err: err}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return br, statusError{endpoint: "/v2/check", status: resp.StatusCode}
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&br); err != nil {
+		return br, fmt.Errorf("decode veriflier v2 response: %w", err)
+	}
+	return br, nil
+}
+
+func shouldRetryV2Batch(ctx context.Context, err error) bool {
+	if err == nil || ctx.Err() != nil {
+		return false
+	}
+	if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) < 250*time.Millisecond {
+		return false
+	}
+
+	var transportErr v2TransportError
+	if errors.As(err, &transportErr) {
+		return true
+	}
+	var status statusError
+	if errors.As(err, &status) {
+		return status.status == http.StatusBadGateway || status.status == http.StatusGatewayTimeout || status.status == http.StatusRequestTimeout
+	}
+	return errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)
 }
 
 func checkBatchDeadlineReserve(_ []CheckRequest) time.Duration {

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -38,10 +38,14 @@ var (
 	singleCheckBatchMaxDelay             = 2 * time.Millisecond
 	singleCheckBatchDeadlineReserve      = 250 * time.Millisecond
 	singleCheckLargeBatchDeadlineReserve = time.Second
-	singleCheckLightBatchMaxFlight       = 32
-	singleCheckFullBatchMaxFlight        = 32
-	singleCheckBatchQueueSize            = 32768
-	singleCheckFullBatchQueueSize        = 32768
+	// Keep more light batches in flight than full-detection batches so flood
+	// recovery can use warm HTTP connections without letting expensive probes
+	// monopolize the Veriflier. The server still performs admission control and
+	// returns agent_overloaded non-votes when it cannot meet a request deadline.
+	singleCheckLightBatchMaxFlight = 96
+	singleCheckFullBatchMaxFlight  = 64
+	singleCheckBatchQueueSize      = 32768
+	singleCheckFullBatchQueueSize  = 32768
 )
 
 var (

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -38,10 +38,14 @@ var (
 	singleCheckBatchMaxDelay             = 2 * time.Millisecond
 	singleCheckBatchDeadlineReserve      = 250 * time.Millisecond
 	singleCheckLargeBatchDeadlineReserve = time.Second
-	singleCheckLightBatchMaxFlight       = 32
-	singleCheckFullBatchMaxFlight        = 32
-	singleCheckBatchQueueSize            = 32768
-	singleCheckFullBatchQueueSize        = 32768
+	// These are batch-flight caps, not check caps. At multi-million-check flood
+	// rates most elapsed time is remote probe I/O, so allowing more batches in
+	// flight keeps the Veriflier executor fed without changing alert semantics:
+	// deadline/overload pressure still returns agent_overloaded non-votes.
+	singleCheckLightBatchMaxFlight = 96
+	singleCheckFullBatchMaxFlight  = 64
+	singleCheckBatchQueueSize      = 32768
+	singleCheckFullBatchQueueSize  = 32768
 )
 
 var (

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -401,10 +401,6 @@ func (c *VeriflierClient) checkBatchLegacy(ctx context.Context, reqs []CheckRequ
 }
 
 func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest) ([]CheckResult, error) {
-	type batchResp struct {
-		Results []CheckV2Result `json:"results"`
-	}
-
 	v2Reqs := make([]CheckV2Request, len(reqs))
 	for i := range reqs {
 		if reqs[i].RequestID == "" {
@@ -451,7 +447,7 @@ func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest)
 		return nil, statusError{endpoint: "/v2/check", status: resp.StatusCode}
 	}
 
-	var br batchResp
+	var br CheckV2BatchResponse
 	if err := json.NewDecoder(resp.Body).Decode(&br); err != nil {
 		return nil, fmt.Errorf("decode veriflier v2 response: %w", err)
 	}
@@ -472,19 +468,39 @@ func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest)
 				orig = reqs[i]
 			}
 		}
+		blogID := res.BlogID
+		if blogID == 0 {
+			blogID = orig.BlogID
+		}
+		url := res.URL
+		if url == "" {
+			url = orig.URL
+		}
+		requestID := res.RequestID
+		if requestID == "" {
+			requestID = orig.RequestID
+		}
+		vantageID := res.VantageID
+		if vantageID == "" {
+			vantageID = br.Vantage.ID
+		}
+		agentID := res.AgentID
+		if agentID == "" {
+			agentID = br.Agent.ID
+		}
 		results = append(results, CheckResult{
 			MonitorSiteID: orig.MonitorSiteID,
-			BlogID:        res.BlogID,
-			URL:           res.URL,
-			Host:          res.VantageID,
-			VantageID:     res.VantageID,
-			AgentID:       res.AgentID,
+			BlogID:        blogID,
+			URL:           url,
+			Host:          vantageID,
+			VantageID:     vantageID,
+			AgentID:       agentID,
 			Outcome:       res.Outcome,
 			Success:       res.Success,
 			HTTPCode:      res.HTTPCode,
 			ErrorCode:     res.ErrorCode,
 			RTTMs:         res.RTTMs,
-			RequestID:     res.RequestID,
+			RequestID:     requestID,
 		})
 	}
 	return results, nil

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -280,12 +280,15 @@ func (b *singleCheckBatcher) flush(batch []singleCheckCall) {
 		return
 	}
 
-	resultsByRequestID := make(map[string]CheckResult, len(results))
-	for _, result := range results {
-		if result.RequestID != "" {
-			resultsByRequestID[result.RequestID] = result
+	if len(results) == len(calls) && resultsMatchCallOrder(results, calls) {
+		for i, call := range calls {
+			result := results[i]
+			call.respond(&result, nil)
 		}
+		return
 	}
+
+	resultsByRequestID := checkResultsByRequestID(results)
 	for i, call := range calls {
 		result, ok := resultsByRequestID[call.req.RequestID]
 		if !ok {
@@ -297,6 +300,28 @@ func (b *singleCheckBatcher) flush(batch []singleCheckCall) {
 		}
 		call.respond(&result, nil)
 	}
+}
+
+func resultsMatchCallOrder(results []CheckResult, calls []singleCheckCall) bool {
+	if len(results) != len(calls) {
+		return false
+	}
+	for i := range results {
+		if results[i].RequestID != "" && results[i].RequestID != calls[i].req.RequestID {
+			return false
+		}
+	}
+	return true
+}
+
+func checkResultsByRequestID(results []CheckResult) map[string]CheckResult {
+	out := make(map[string]CheckResult, len(results))
+	for _, result := range results {
+		if result.RequestID != "" {
+			out[result.RequestID] = result
+		}
+	}
+	return out
 }
 
 func (c singleCheckCall) respond(result *CheckResult, err error) {
@@ -381,12 +406,10 @@ func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest)
 	}
 
 	v2Reqs := make([]CheckV2Request, len(reqs))
-	reqByRequestID := make(map[string]CheckRequest, len(reqs))
 	for i := range reqs {
 		if reqs[i].RequestID == "" {
 			reqs[i].RequestID = NewRequestID()
 		}
-		reqByRequestID[reqs[i].RequestID] = reqs[i]
 		v2Reqs[i] = legacyRequestToV2(reqs[i])
 	}
 	batchReq := CheckV2BatchRequest{
@@ -434,10 +457,20 @@ func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest)
 	}
 
 	results := make([]CheckResult, 0, len(br.Results))
+	var reqByRequestID map[string]CheckRequest
 	for i, res := range br.Results {
-		orig := reqByRequestID[res.RequestID]
-		if orig.MonitorSiteID == 0 && i < len(reqs) {
+		var orig CheckRequest
+		if i < len(reqs) && (res.RequestID == "" || res.RequestID == reqs[i].RequestID) {
 			orig = reqs[i]
+		} else {
+			if reqByRequestID == nil {
+				reqByRequestID = checkRequestsByRequestID(reqs)
+			}
+			var ok bool
+			orig, ok = reqByRequestID[res.RequestID]
+			if !ok && i < len(reqs) {
+				orig = reqs[i]
+			}
 		}
 		results = append(results, CheckResult{
 			MonitorSiteID: orig.MonitorSiteID,
@@ -455,6 +488,16 @@ func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest)
 		})
 	}
 	return results, nil
+}
+
+func checkRequestsByRequestID(reqs []CheckRequest) map[string]CheckRequest {
+	out := make(map[string]CheckRequest, len(reqs))
+	for _, req := range reqs {
+		if req.RequestID != "" {
+			out[req.RequestID] = req
+		}
+	}
+	return out
 }
 
 func checkBatchDeadlineReserve(_ []CheckRequest) time.Duration {

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -31,7 +31,7 @@ type VeriflierClient struct {
 
 var (
 	singleCheckBatchMaxSize        = 512
-	singleCheckFullBatchMaxSize    = 128
+	singleCheckFullBatchMaxSize    = 64
 	singleCheckBatchMaxDelay       = 2 * time.Millisecond
 	singleCheckLightBatchMaxFlight = 32
 	singleCheckFullBatchMaxFlight  = 32

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -31,7 +31,7 @@ type VeriflierClient struct {
 
 var (
 	singleCheckBatchMaxSize       = 512
-	singleCheckFullBatchMaxSize   = 384
+	singleCheckFullBatchMaxSize   = 128
 	singleCheckBatchMaxDelay      = 2 * time.Millisecond
 	singleCheckBatchMaxFlight     = 32
 	singleCheckBatchQueueSize     = 32768

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -410,10 +410,22 @@ func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest)
 
 func checkBatchDeadlineReserve(reqs []CheckRequest) time.Duration {
 	reserve := singleCheckBatchDeadlineReserve
-	if len(reqs) > singleCheckFullBatchMaxSize && singleCheckLargeBatchDeadlineReserve > reserve {
+	if !allRequestsUseFullDetectionWork(reqs) && singleCheckLargeBatchDeadlineReserve > reserve {
 		reserve = singleCheckLargeBatchDeadlineReserve
 	}
 	return reserve
+}
+
+func allRequestsUseFullDetectionWork(reqs []CheckRequest) bool {
+	if len(reqs) == 0 {
+		return false
+	}
+	for _, req := range reqs {
+		if !usesFullDetectionWork(req) {
+			return false
+		}
+	}
+	return true
 }
 
 // Ping checks whether the Veriflier is reachable and returns its version.

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -18,12 +18,21 @@ import (
 // VeriflierClient sends check batches to a remote Veriflier over the v2
 // production JSON-over-HTTP transport.
 type VeriflierClient struct {
-	addr       string
-	authToken  string
-	httpClient *http.Client
-	mu         sync.RWMutex
-	protocol   string
+	addr          string
+	authToken     string
+	httpClient    *http.Client
+	mu            sync.RWMutex
+	protocol      string
+	singleOnce    sync.Once
+	singleBatcher *singleCheckBatcher
 }
+
+var (
+	singleCheckBatchMaxSize   = 512
+	singleCheckBatchMaxDelay  = 2 * time.Millisecond
+	singleCheckBatchMaxFlight = 32
+	singleCheckBatchQueueSize = 32768
+)
 
 // NewVeriflierClient creates a client targeting the given address (host:port).
 //
@@ -69,14 +78,22 @@ func (c *VeriflierClient) Check(ctx context.Context, req CheckRequest) (*CheckRe
 	if req.RequestID == "" {
 		req.RequestID = NewRequestID()
 	}
-	results, err := c.CheckBatch(ctx, []CheckRequest{req})
-	if err != nil {
-		return nil, err
+	call := singleCheckCall{
+		ctx:  ctx,
+		req:  req,
+		resp: make(chan singleCheckResponse, 1),
 	}
-	if len(results) == 0 {
-		return nil, fmt.Errorf("veriflier returned no results")
+	select {
+	case c.singleChecks().in <- call:
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	}
-	return &results[0], nil
+	select {
+	case resp := <-call.resp:
+		return resp.result, resp.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 // CheckBatch sends multiple check requests to the Veriflier. Each request
@@ -98,6 +115,130 @@ func (c *VeriflierClient) CheckBatch(ctx context.Context, reqs []CheckRequest) (
 		}
 		c.setProtocol(ProtocolLegacy)
 		return c.checkBatchLegacy(ctx, reqs)
+	}
+}
+
+func (c *VeriflierClient) singleChecks() *singleCheckBatcher {
+	c.singleOnce.Do(func() {
+		c.singleBatcher = newSingleCheckBatcher(c)
+	})
+	return c.singleBatcher
+}
+
+type singleCheckCall struct {
+	ctx  context.Context
+	req  CheckRequest
+	resp chan singleCheckResponse
+}
+
+type singleCheckResponse struct {
+	result *CheckResult
+	err    error
+}
+
+type singleCheckBatcher struct {
+	client   *VeriflierClient
+	in       chan singleCheckCall
+	inFlight chan struct{}
+}
+
+func newSingleCheckBatcher(client *VeriflierClient) *singleCheckBatcher {
+	b := &singleCheckBatcher{
+		client:   client,
+		in:       make(chan singleCheckCall, singleCheckBatchQueueSize),
+		inFlight: make(chan struct{}, singleCheckBatchMaxFlight),
+	}
+	go b.run()
+	return b
+}
+
+func (b *singleCheckBatcher) run() {
+	for first := range b.in {
+		batch := []singleCheckCall{first}
+		timer := time.NewTimer(singleCheckBatchMaxDelay)
+		collecting := true
+		for collecting && len(batch) < singleCheckBatchMaxSize {
+			select {
+			case call := <-b.in:
+				batch = append(batch, call)
+			case <-timer.C:
+				collecting = false
+			}
+		}
+		if !timer.Stop() && collecting {
+			<-timer.C
+		}
+		b.inFlight <- struct{}{}
+		go func() {
+			defer func() { <-b.inFlight }()
+			b.flush(batch)
+		}()
+	}
+}
+
+func (b *singleCheckBatcher) flush(batch []singleCheckCall) {
+	reqs := make([]CheckRequest, 0, len(batch))
+	calls := make([]singleCheckCall, 0, len(batch))
+	var latestDeadline time.Time
+	for _, call := range batch {
+		if err := call.ctx.Err(); err != nil {
+			call.respond(nil, err)
+			continue
+		}
+		if call.req.RequestID == "" {
+			call.req.RequestID = NewRequestID()
+		}
+		if deadline, ok := call.ctx.Deadline(); ok {
+			if latestDeadline.IsZero() || deadline.After(latestDeadline) {
+				latestDeadline = deadline
+			}
+		}
+		reqs = append(reqs, call.req)
+		calls = append(calls, call)
+	}
+	if len(reqs) == 0 {
+		return
+	}
+
+	ctx := context.Background()
+	var cancel context.CancelFunc
+	if !latestDeadline.IsZero() {
+		ctx, cancel = context.WithDeadline(ctx, latestDeadline)
+	} else {
+		ctx, cancel = context.WithCancel(ctx)
+	}
+	results, err := b.client.CheckBatch(ctx, reqs)
+	cancel()
+	if err != nil {
+		for _, call := range calls {
+			call.respond(nil, err)
+		}
+		return
+	}
+
+	resultsByRequestID := make(map[string]CheckResult, len(results))
+	for _, result := range results {
+		if result.RequestID != "" {
+			resultsByRequestID[result.RequestID] = result
+		}
+	}
+	for i, call := range calls {
+		result, ok := resultsByRequestID[call.req.RequestID]
+		if !ok {
+			if i >= len(results) {
+				call.respond(nil, fmt.Errorf("veriflier returned %d results for %d requests", len(results), len(calls)))
+				continue
+			}
+			result = results[i]
+		}
+		call.respond(&result, nil)
+	}
+}
+
+func (c singleCheckCall) respond(result *CheckResult, err error) {
+	select {
+	case c.resp <- singleCheckResponse{result: result, err: err}:
+	default:
 	}
 }
 

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -30,7 +30,7 @@ type VeriflierClient struct {
 }
 
 var (
-	singleCheckBatchMaxSize              = 384
+	singleCheckBatchMaxSize              = 512
 	singleCheckFullBatchMaxSize          = 64
 	singleCheckBatchMaxDelay             = 2 * time.Millisecond
 	singleCheckBatchDeadlineReserve      = 250 * time.Millisecond
@@ -143,7 +143,8 @@ type singleCheckResponse struct {
 
 type singleCheckBatcher struct {
 	client        *VeriflierClient
-	lightIn       chan singleCheckCall
+	headIn        chan singleCheckCall
+	simpleIn      chan singleCheckCall
 	fullIn        chan singleCheckCall
 	lightInFlight chan struct{}
 	fullInFlight  chan struct{}
@@ -152,20 +153,27 @@ type singleCheckBatcher struct {
 func newSingleCheckBatcher(client *VeriflierClient) *singleCheckBatcher {
 	b := &singleCheckBatcher{
 		client:        client,
-		lightIn:       make(chan singleCheckCall, singleCheckBatchQueueSize),
+		headIn:        make(chan singleCheckCall, singleCheckBatchQueueSize),
+		simpleIn:      make(chan singleCheckCall, singleCheckBatchQueueSize),
 		fullIn:        make(chan singleCheckCall, singleCheckFullBatchQueueSize),
 		lightInFlight: make(chan struct{}, singleCheckLightBatchMaxFlight),
 		fullInFlight:  make(chan struct{}, singleCheckFullBatchMaxFlight),
 	}
-	go b.run(b.lightIn, singleCheckBatchMaxSize, b.lightInFlight)
+	go b.run(b.headIn, singleCheckBatchMaxSize, b.lightInFlight)
+	go b.run(b.simpleIn, singleCheckBatchMaxSize, b.lightInFlight)
 	go b.run(b.fullIn, singleCheckFullBatchMaxSize, b.fullInFlight)
 	return b
 }
 
 func (b *singleCheckBatcher) submit(ctx context.Context, call singleCheckCall) error {
-	in := b.lightIn
-	if usesFullDetectionWork(call.req) {
+	var in chan singleCheckCall
+	switch {
+	case usesFullDetectionWork(call.req):
 		in = b.fullIn
+	case usesHEADProbe(call.req):
+		in = b.headIn
+	default:
+		in = b.simpleIn
 	}
 	select {
 	case in <- call:
@@ -215,6 +223,14 @@ func usesFullDetectionWork(req CheckRequest) bool {
 		profile = checkmode.ProfileFull
 	}
 	return checkmode.EffectiveProfile(method, profile) == checkmode.ProfileFull
+}
+
+func usesHEADProbe(req CheckRequest) bool {
+	method, err := checkmode.NormalizeMethod(req.Method, checkmode.MethodGET)
+	if err != nil {
+		method = checkmode.MethodGET
+	}
+	return method == checkmode.MethodHEAD
 }
 
 func (b *singleCheckBatcher) flush(batch []singleCheckCall) {

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -108,9 +108,9 @@ func (c *VeriflierClient) CheckBatch(ctx context.Context, reqs []CheckRequest) (
 	case ProtocolLegacy:
 		return c.checkBatchLegacy(ctx, reqs)
 	case ProtocolV2:
-		return c.checkBatchV2(ctx, reqs, true)
+		return c.checkBatchV2(ctx, reqs)
 	default:
-		results, err := c.checkBatchV2(ctx, reqs, false)
+		results, err := c.checkBatchV2(ctx, reqs)
 		if err == nil {
 			c.setProtocol(ProtocolV2)
 			return results, nil
@@ -139,10 +139,6 @@ type singleCheckCall struct {
 type singleCheckResponse struct {
 	result *CheckResult
 	err    error
-}
-
-type checkBatchV2Response struct {
-	Results []CheckV2Result `json:"results"`
 }
 
 type singleCheckBatcher struct {
@@ -331,7 +327,11 @@ func (c *VeriflierClient) checkBatchLegacy(ctx context.Context, reqs []CheckRequ
 	return br.Results, nil
 }
 
-func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest, retryTransient bool) ([]CheckResult, error) {
+func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest) ([]CheckResult, error) {
+	type batchResp struct {
+		Results []CheckV2Result `json:"results"`
+	}
+
 	v2Reqs := make([]CheckV2Request, len(reqs))
 	reqByRequestID := make(map[string]CheckRequest, len(reqs))
 	for i := range reqs {
@@ -363,25 +363,26 @@ func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest,
 	}
 
 	url := fmt.Sprintf("http://%s/v2/check", c.addr)
-	var br checkBatchV2Response
-	var lastErr error
-	maxAttempts := 1
-	if retryTransient {
-		maxAttempts = 2
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
 	}
-	for attempt := 0; attempt < maxAttempts; attempt++ {
-		br, err = c.doCheckBatchV2(ctx, url, body)
-		if err == nil {
-			lastErr = nil
-			break
-		}
-		lastErr = err
-		if attempt == maxAttempts-1 || !shouldRetryV2Batch(ctx, err) {
-			return nil, err
-		}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+c.authToken)
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, v2TransportError{endpoint: "/v2/check", err: err}
 	}
-	if lastErr != nil {
-		return nil, lastErr
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, statusError{endpoint: "/v2/check", status: resp.StatusCode}
+	}
+
+	var br batchResp
+	if err := json.NewDecoder(resp.Body).Decode(&br); err != nil {
+		return nil, fmt.Errorf("decode veriflier v2 response: %w", err)
 	}
 
 	results := make([]CheckResult, 0, len(br.Results))
@@ -406,50 +407,6 @@ func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest,
 		})
 	}
 	return results, nil
-}
-
-func (c *VeriflierClient) doCheckBatchV2(ctx context.Context, url string, body []byte) (checkBatchV2Response, error) {
-	var br checkBatchV2Response
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		return br, err
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+c.authToken)
-
-	resp, err := c.httpClient.Do(httpReq)
-	if err != nil {
-		return br, v2TransportError{endpoint: "/v2/check", err: err}
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return br, statusError{endpoint: "/v2/check", status: resp.StatusCode}
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(&br); err != nil {
-		return br, fmt.Errorf("decode veriflier v2 response: %w", err)
-	}
-	return br, nil
-}
-
-func shouldRetryV2Batch(ctx context.Context, err error) bool {
-	if err == nil || ctx.Err() != nil {
-		return false
-	}
-	if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) < 250*time.Millisecond {
-		return false
-	}
-
-	var transportErr v2TransportError
-	if errors.As(err, &transportErr) {
-		return true
-	}
-	var status statusError
-	if errors.As(err, &status) {
-		return status.status == http.StatusBadGateway || status.status == http.StatusGatewayTimeout || status.status == http.StatusRequestTimeout
-	}
-	return errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)
 }
 
 func checkBatchDeadlineReserve(_ []CheckRequest) time.Duration {

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -408,24 +408,12 @@ func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest)
 	return results, nil
 }
 
-func checkBatchDeadlineReserve(reqs []CheckRequest) time.Duration {
+func checkBatchDeadlineReserve(_ []CheckRequest) time.Duration {
 	reserve := singleCheckBatchDeadlineReserve
-	if !allRequestsUseFullDetectionWork(reqs) && singleCheckLargeBatchDeadlineReserve > reserve {
+	if singleCheckLargeBatchDeadlineReserve > reserve {
 		reserve = singleCheckLargeBatchDeadlineReserve
 	}
 	return reserve
-}
-
-func allRequestsUseFullDetectionWork(reqs []CheckRequest) bool {
-	if len(reqs) == 0 {
-		return false
-	}
-	for _, req := range reqs {
-		if !usesFullDetectionWork(req) {
-			return false
-		}
-	}
-	return true
 }
 
 // Ping checks whether the Veriflier is reachable and returns its version.

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -30,7 +30,7 @@ type VeriflierClient struct {
 }
 
 var (
-	singleCheckBatchMaxSize              = 512
+	singleCheckBatchMaxSize              = 128
 	singleCheckFullBatchMaxSize          = 64
 	singleCheckBatchMaxDelay             = 2 * time.Millisecond
 	singleCheckBatchDeadlineReserve      = 250 * time.Millisecond
@@ -46,8 +46,9 @@ var (
 // The HTTP transport is tuned for the orchestrator's hot-path use: many
 // short-lived RPCs to the same verifier host during outage waves. Default
 // MaxIdleConnsPerHost=2 forces frequent reconnects under any concurrency above
-// 2; we raise it so the orchestrator's per-verifier escalation goroutines
-// reuse a small pool of warm connections.
+// 2; we raise it so the orchestrator's per-verifier escalation goroutines can
+// reuse warm connections even when client-side batches are intentionally kept
+// smaller to limit head-of-line blocking during flood tests.
 //
 // No client-level Timeout is set. Per-call deadlines come from the caller's
 // context (the orchestrator wraps each escalation with NET_COMMS_TIMEOUT +
@@ -61,8 +62,8 @@ func NewVeriflierClient(addr, authToken string) *VeriflierClient {
 			Timeout:   5 * time.Second,
 			KeepAlive: 30 * time.Second,
 		}).DialContext,
-		MaxIdleConns:          100,
-		MaxIdleConnsPerHost:   20,
+		MaxIdleConns:          4096,
+		MaxIdleConnsPerHost:   1024,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   5 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"runtime"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -39,7 +38,7 @@ var (
 	singleCheckBatchMaxDelay             = 2 * time.Millisecond
 	singleCheckBatchDeadlineReserve      = 250 * time.Millisecond
 	singleCheckLargeBatchDeadlineReserve = time.Second
-	singleCheckLightBatchMaxFlight       = defaultSingleCheckLightBatchMaxFlight()
+	singleCheckLightBatchMaxFlight       = 32
 	singleCheckFullBatchMaxFlight        = 32
 	singleCheckBatchQueueSize            = 32768
 	singleCheckFullBatchQueueSize        = 32768
@@ -176,21 +175,6 @@ func newSingleCheckBatcher(client *VeriflierClient) *singleCheckBatcher {
 	go b.run(b.lightIn, singleCheckBatchMaxSize, b.lightInFlight)
 	go b.run(b.fullIn, singleCheckFullBatchMaxSize, b.fullInFlight)
 	return b
-}
-
-func defaultSingleCheckLightBatchMaxFlight() int {
-	procs := runtime.GOMAXPROCS(0)
-	if procs < 1 {
-		procs = 1
-	}
-	flight := procs * 16
-	if flight < 32 {
-		return 32
-	}
-	if flight > 128 {
-		return 128
-	}
-	return flight
 }
 
 func (b *singleCheckBatcher) submit(ctx context.Context, call singleCheckCall) error {

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -33,8 +33,8 @@ var (
 	singleCheckBatchMaxSize        = 512
 	singleCheckFullBatchMaxSize    = 64
 	singleCheckBatchMaxDelay       = 2 * time.Millisecond
-	singleCheckLightBatchMaxFlight = 32
-	singleCheckFullBatchMaxFlight  = 32
+	singleCheckLightBatchMaxFlight = 64
+	singleCheckFullBatchMaxFlight  = 64
 	singleCheckBatchQueueSize      = 32768
 	singleCheckFullBatchQueueSize  = 32768
 )

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -31,7 +31,7 @@ type VeriflierClient struct {
 
 var (
 	singleCheckBatchMaxSize        = 512
-	singleCheckFullBatchMaxSize    = 32
+	singleCheckFullBatchMaxSize    = 64
 	singleCheckBatchMaxDelay       = 2 * time.Millisecond
 	singleCheckLightBatchMaxFlight = 32
 	singleCheckFullBatchMaxFlight  = 32

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -30,14 +30,15 @@ type VeriflierClient struct {
 }
 
 var (
-	singleCheckBatchMaxSize         = 512
-	singleCheckFullBatchMaxSize     = 64
-	singleCheckBatchMaxDelay        = 2 * time.Millisecond
-	singleCheckBatchDeadlineReserve = time.Second
-	singleCheckLightBatchMaxFlight  = 32
-	singleCheckFullBatchMaxFlight   = 32
-	singleCheckBatchQueueSize       = 32768
-	singleCheckFullBatchQueueSize   = 32768
+	singleCheckBatchMaxSize              = 512
+	singleCheckFullBatchMaxSize          = 64
+	singleCheckBatchMaxDelay             = 2 * time.Millisecond
+	singleCheckBatchDeadlineReserve      = 250 * time.Millisecond
+	singleCheckLargeBatchDeadlineReserve = time.Second
+	singleCheckLightBatchMaxFlight       = 32
+	singleCheckFullBatchMaxFlight        = 32
+	singleCheckBatchQueueSize            = 32768
+	singleCheckFullBatchQueueSize        = 32768
 )
 
 // NewVeriflierClient creates a client targeting the given address (host:port).
@@ -347,8 +348,8 @@ func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest)
 	if deadline, ok := ctx.Deadline(); ok {
 		if remaining := time.Until(deadline); remaining > 0 {
 			serverRemaining := remaining
-			if remaining > singleCheckBatchDeadlineReserve {
-				serverRemaining = remaining - singleCheckBatchDeadlineReserve
+			if reserve := checkBatchDeadlineReserve(reqs); remaining > reserve {
+				serverRemaining = remaining - reserve
 			}
 			if serverRemaining < time.Millisecond {
 				serverRemaining = time.Millisecond
@@ -405,6 +406,14 @@ func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest)
 		})
 	}
 	return results, nil
+}
+
+func checkBatchDeadlineReserve(reqs []CheckRequest) time.Duration {
+	reserve := singleCheckBatchDeadlineReserve
+	if len(reqs) > singleCheckFullBatchMaxSize && singleCheckLargeBatchDeadlineReserve > reserve {
+		reserve = singleCheckLargeBatchDeadlineReserve
+	}
+	return reserve
 }
 
 // Ping checks whether the Veriflier is reachable and returns its version.

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -12,6 +13,7 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -40,6 +42,11 @@ var (
 	singleCheckFullBatchMaxFlight        = 32
 	singleCheckBatchQueueSize            = 32768
 	singleCheckFullBatchQueueSize        = 32768
+)
+
+var (
+	requestIDPrefix  = newRequestIDPrefix()
+	requestIDCounter atomic.Uint64
 )
 
 // NewVeriflierClient creates a client targeting the given address (host:port).
@@ -524,17 +531,25 @@ func (c *VeriflierClient) statusV2(ctx context.Context) (*StatusV2Response, erro
 	return &s, nil
 }
 
-// NewRequestID returns a 16-byte random id, hex-encoded (32 chars). Used as
-// the RPC correlation id between Monitor and Verifier. Crypto/rand backed so
-// IDs are unpredictable; this isn't a security primitive but it's free.
+// NewRequestID returns a 16-byte correlation id, hex-encoded (32 chars). Used
+// as the RPC correlation id between Monitor and Verifier. It is not a security
+// token; use the bearer auth token for authorization. Keeping a random
+// per-process prefix plus an atomic counter avoids kernel randomness on every
+// hot-path check while preserving the existing 32-character hex shape.
 func NewRequestID() string {
 	var b [16]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		// Fall back to a timestamp-based id; collisions are vanishingly
-		// unlikely at our request rates and the id is correlation-only.
-		return fmt.Sprintf("ts-%d", time.Now().UnixNano())
-	}
+	copy(b[:8], requestIDPrefix[:])
+	binary.BigEndian.PutUint64(b[8:], requestIDCounter.Add(1))
 	return hex.EncodeToString(b[:])
+}
+
+func newRequestIDPrefix() [8]byte {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err == nil {
+		return b
+	}
+	binary.BigEndian.PutUint64(b[:], uint64(time.Now().UnixNano()))
+	return b
 }
 
 func (c *VeriflierClient) cachedProtocol() string {

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -33,8 +33,8 @@ var (
 	singleCheckBatchMaxSize        = 512
 	singleCheckFullBatchMaxSize    = 64
 	singleCheckBatchMaxDelay       = 2 * time.Millisecond
-	singleCheckLightBatchMaxFlight = 64
-	singleCheckFullBatchMaxFlight  = 64
+	singleCheckLightBatchMaxFlight = 32
+	singleCheckFullBatchMaxFlight  = 32
 	singleCheckBatchQueueSize      = 32768
 	singleCheckFullBatchQueueSize  = 32768
 )

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -30,13 +30,14 @@ type VeriflierClient struct {
 }
 
 var (
-	singleCheckBatchMaxSize        = 256
-	singleCheckFullBatchMaxSize    = 64
-	singleCheckBatchMaxDelay       = 2 * time.Millisecond
-	singleCheckLightBatchMaxFlight = 32
-	singleCheckFullBatchMaxFlight  = 32
-	singleCheckBatchQueueSize      = 32768
-	singleCheckFullBatchQueueSize  = 32768
+	singleCheckBatchMaxSize         = 512
+	singleCheckFullBatchMaxSize     = 64
+	singleCheckBatchMaxDelay        = 2 * time.Millisecond
+	singleCheckBatchDeadlineReserve = 250 * time.Millisecond
+	singleCheckLightBatchMaxFlight  = 32
+	singleCheckFullBatchMaxFlight   = 32
+	singleCheckBatchQueueSize       = 32768
+	singleCheckFullBatchQueueSize   = 32768
 )
 
 // NewVeriflierClient creates a client targeting the given address (host:port).
@@ -345,7 +346,14 @@ func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest)
 	}
 	if deadline, ok := ctx.Deadline(); ok {
 		if remaining := time.Until(deadline); remaining > 0 {
-			batchReq.DeadlineMS = remaining.Milliseconds()
+			serverRemaining := remaining
+			if remaining > singleCheckBatchDeadlineReserve {
+				serverRemaining = remaining - singleCheckBatchDeadlineReserve
+			}
+			if serverRemaining < time.Millisecond {
+				serverRemaining = time.Millisecond
+			}
+			batchReq.DeadlineMS = serverRemaining.Milliseconds()
 		}
 	}
 	body, err := json.Marshal(batchReq)

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -262,7 +262,7 @@ func (b *singleCheckBatcher) flush(batch []singleCheckCall) {
 	cancel()
 	if err != nil {
 		for _, call := range calls {
-			if errors.Is(err, context.DeadlineExceeded) {
+			if operationalOverloadError(err) {
 				call.respond(agentOverloadedCheckResult(call.req), nil)
 			} else {
 				call.respond(nil, err)
@@ -307,6 +307,17 @@ func agentOverloadedCheckResult(req CheckRequest) *CheckResult {
 		ErrorCode:     1,
 		RequestID:     req.RequestID,
 	}
+}
+
+func operationalOverloadError(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var transportErr v2TransportError
+	if errors.As(err, &transportErr) {
+		return errors.Is(transportErr.err, io.EOF) || errors.Is(transportErr.err, io.ErrUnexpectedEOF)
+	}
+	return false
 }
 
 func (c *VeriflierClient) checkBatchLegacy(ctx context.Context, reqs []CheckRequest) ([]CheckResult, error) {

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -33,7 +33,7 @@ var (
 	singleCheckBatchMaxSize         = 512
 	singleCheckFullBatchMaxSize     = 64
 	singleCheckBatchMaxDelay        = 2 * time.Millisecond
-	singleCheckBatchDeadlineReserve = 250 * time.Millisecond
+	singleCheckBatchDeadlineReserve = time.Second
 	singleCheckLightBatchMaxFlight  = 32
 	singleCheckFullBatchMaxFlight   = 32
 	singleCheckBatchQueueSize       = 32768

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -38,14 +38,10 @@ var (
 	singleCheckBatchMaxDelay             = 2 * time.Millisecond
 	singleCheckBatchDeadlineReserve      = 250 * time.Millisecond
 	singleCheckLargeBatchDeadlineReserve = time.Second
-	// Keep more light batches in flight than full-detection batches so flood
-	// recovery can use warm HTTP connections without letting expensive probes
-	// monopolize the Veriflier. The server still performs admission control and
-	// returns agent_overloaded non-votes when it cannot meet a request deadline.
-	singleCheckLightBatchMaxFlight = 96
-	singleCheckFullBatchMaxFlight  = 64
-	singleCheckBatchQueueSize      = 32768
-	singleCheckFullBatchQueueSize  = 32768
+	singleCheckLightBatchMaxFlight       = 32
+	singleCheckFullBatchMaxFlight        = 32
+	singleCheckBatchQueueSize            = 32768
+	singleCheckFullBatchQueueSize        = 32768
 )
 
 var (

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -31,7 +31,7 @@ type VeriflierClient struct {
 
 var (
 	singleCheckBatchMaxSize        = 512
-	singleCheckFullBatchMaxSize    = 64
+	singleCheckFullBatchMaxSize    = 32
 	singleCheckBatchMaxDelay       = 2 * time.Millisecond
 	singleCheckLightBatchMaxFlight = 32
 	singleCheckFullBatchMaxFlight  = 32

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -30,7 +30,7 @@ type VeriflierClient struct {
 }
 
 var (
-	singleCheckBatchMaxSize              = 512
+	singleCheckBatchMaxSize              = 384
 	singleCheckFullBatchMaxSize          = 64
 	singleCheckBatchMaxDelay             = 2 * time.Millisecond
 	singleCheckBatchDeadlineReserve      = 250 * time.Millisecond

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -38,14 +38,10 @@ var (
 	singleCheckBatchMaxDelay             = 2 * time.Millisecond
 	singleCheckBatchDeadlineReserve      = 250 * time.Millisecond
 	singleCheckLargeBatchDeadlineReserve = time.Second
-	// These are batch-flight caps, not check caps. At multi-million-check flood
-	// rates most elapsed time is remote probe I/O, so allowing more batches in
-	// flight keeps the Veriflier executor fed without changing alert semantics:
-	// deadline/overload pressure still returns agent_overloaded non-votes.
-	singleCheckLightBatchMaxFlight = 96
-	singleCheckFullBatchMaxFlight  = 64
-	singleCheckBatchQueueSize      = 32768
-	singleCheckFullBatchQueueSize  = 32768
+	singleCheckLightBatchMaxFlight       = 32
+	singleCheckFullBatchMaxFlight        = 32
+	singleCheckBatchQueueSize            = 32768
+	singleCheckFullBatchQueueSize        = 32768
 )
 
 var (
@@ -405,6 +401,10 @@ func (c *VeriflierClient) checkBatchLegacy(ctx context.Context, reqs []CheckRequ
 }
 
 func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest) ([]CheckResult, error) {
+	type batchResp struct {
+		Results []CheckV2Result `json:"results"`
+	}
+
 	v2Reqs := make([]CheckV2Request, len(reqs))
 	for i := range reqs {
 		if reqs[i].RequestID == "" {
@@ -451,12 +451,12 @@ func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest)
 		return nil, statusError{endpoint: "/v2/check", status: resp.StatusCode}
 	}
 
-	var br CheckV2BatchResponse
+	var br batchResp
 	if err := json.NewDecoder(resp.Body).Decode(&br); err != nil {
 		return nil, fmt.Errorf("decode veriflier v2 response: %w", err)
 	}
 
-	results := make([]CheckResult, len(br.Results))
+	results := make([]CheckResult, 0, len(br.Results))
 	var reqByRequestID map[string]CheckRequest
 	for i, res := range br.Results {
 		var orig CheckRequest
@@ -472,40 +472,20 @@ func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest)
 				orig = reqs[i]
 			}
 		}
-		blogID := res.BlogID
-		if blogID == 0 {
-			blogID = orig.BlogID
-		}
-		url := res.URL
-		if url == "" {
-			url = orig.URL
-		}
-		requestID := res.RequestID
-		if requestID == "" {
-			requestID = orig.RequestID
-		}
-		vantageID := res.VantageID
-		if vantageID == "" {
-			vantageID = br.Vantage.ID
-		}
-		agentID := res.AgentID
-		if agentID == "" {
-			agentID = br.Agent.ID
-		}
-		results[i] = CheckResult{
+		results = append(results, CheckResult{
 			MonitorSiteID: orig.MonitorSiteID,
-			BlogID:        blogID,
-			URL:           url,
-			Host:          vantageID,
-			VantageID:     vantageID,
-			AgentID:       agentID,
+			BlogID:        res.BlogID,
+			URL:           res.URL,
+			Host:          res.VantageID,
+			VantageID:     res.VantageID,
+			AgentID:       res.AgentID,
 			Outcome:       res.Outcome,
 			Success:       res.Success,
 			HTTPCode:      res.HTTPCode,
 			ErrorCode:     res.ErrorCode,
 			RTTMs:         res.RTTMs,
-			RequestID:     requestID,
-		}
+			RequestID:     res.RequestID,
+		})
 	}
 	return results, nil
 }

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -30,12 +30,13 @@ type VeriflierClient struct {
 }
 
 var (
-	singleCheckBatchMaxSize       = 512
-	singleCheckFullBatchMaxSize   = 128
-	singleCheckBatchMaxDelay      = 2 * time.Millisecond
-	singleCheckBatchMaxFlight     = 32
-	singleCheckBatchQueueSize     = 32768
-	singleCheckFullBatchQueueSize = 32768
+	singleCheckBatchMaxSize        = 512
+	singleCheckFullBatchMaxSize    = 128
+	singleCheckBatchMaxDelay       = 2 * time.Millisecond
+	singleCheckLightBatchMaxFlight = 32
+	singleCheckFullBatchMaxFlight  = 32
+	singleCheckBatchQueueSize      = 32768
+	singleCheckFullBatchQueueSize  = 32768
 )
 
 // NewVeriflierClient creates a client targeting the given address (host:port).
@@ -139,21 +140,23 @@ type singleCheckResponse struct {
 }
 
 type singleCheckBatcher struct {
-	client   *VeriflierClient
-	lightIn  chan singleCheckCall
-	fullIn   chan singleCheckCall
-	inFlight chan struct{}
+	client        *VeriflierClient
+	lightIn       chan singleCheckCall
+	fullIn        chan singleCheckCall
+	lightInFlight chan struct{}
+	fullInFlight  chan struct{}
 }
 
 func newSingleCheckBatcher(client *VeriflierClient) *singleCheckBatcher {
 	b := &singleCheckBatcher{
-		client:   client,
-		lightIn:  make(chan singleCheckCall, singleCheckBatchQueueSize),
-		fullIn:   make(chan singleCheckCall, singleCheckFullBatchQueueSize),
-		inFlight: make(chan struct{}, singleCheckBatchMaxFlight),
+		client:        client,
+		lightIn:       make(chan singleCheckCall, singleCheckBatchQueueSize),
+		fullIn:        make(chan singleCheckCall, singleCheckFullBatchQueueSize),
+		lightInFlight: make(chan struct{}, singleCheckLightBatchMaxFlight),
+		fullInFlight:  make(chan struct{}, singleCheckFullBatchMaxFlight),
 	}
-	go b.run(b.lightIn, singleCheckBatchMaxSize)
-	go b.run(b.fullIn, singleCheckFullBatchMaxSize)
+	go b.run(b.lightIn, singleCheckBatchMaxSize, b.lightInFlight)
+	go b.run(b.fullIn, singleCheckFullBatchMaxSize, b.fullInFlight)
 	return b
 }
 
@@ -170,9 +173,12 @@ func (b *singleCheckBatcher) submit(ctx context.Context, call singleCheckCall) e
 	}
 }
 
-func (b *singleCheckBatcher) run(in <-chan singleCheckCall, maxBatchSize int) {
+func (b *singleCheckBatcher) run(in <-chan singleCheckCall, maxBatchSize int, inFlight chan struct{}) {
 	if maxBatchSize <= 0 {
 		maxBatchSize = 1
+	}
+	if inFlight == nil {
+		inFlight = make(chan struct{}, 1)
 	}
 	for first := range in {
 		batch := []singleCheckCall{first}
@@ -189,9 +195,9 @@ func (b *singleCheckBatcher) run(in <-chan singleCheckCall, maxBatchSize int) {
 		if !timer.Stop() && collecting {
 			<-timer.C
 		}
-		b.inFlight <- struct{}{}
+		inFlight <- struct{}{}
 		go func() {
-			defer func() { <-b.inFlight }()
+			defer func() { <-inFlight }()
 			b.flush(batch)
 		}()
 	}

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -452,7 +452,7 @@ func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest)
 		return nil, fmt.Errorf("decode veriflier v2 response: %w", err)
 	}
 
-	results := make([]CheckResult, 0, len(br.Results))
+	results := make([]CheckResult, len(br.Results))
 	var reqByRequestID map[string]CheckRequest
 	for i, res := range br.Results {
 		var orig CheckRequest
@@ -488,7 +488,7 @@ func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest)
 		if agentID == "" {
 			agentID = br.Agent.ID
 		}
-		results = append(results, CheckResult{
+		results[i] = CheckResult{
 			MonitorSiteID: orig.MonitorSiteID,
 			BlogID:        blogID,
 			URL:           url,
@@ -501,7 +501,7 @@ func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest)
 			ErrorCode:     res.ErrorCode,
 			RTTMs:         res.RTTMs,
 			RequestID:     requestID,
-		})
+		}
 	}
 	return results, nil
 }

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -13,6 +13,8 @@ import (
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/Automattic/jetmon/internal/checkmode"
 )
 
 // VeriflierClient sends check batches to a remote Veriflier over the v2
@@ -28,10 +30,12 @@ type VeriflierClient struct {
 }
 
 var (
-	singleCheckBatchMaxSize   = 512
-	singleCheckBatchMaxDelay  = 2 * time.Millisecond
-	singleCheckBatchMaxFlight = 32
-	singleCheckBatchQueueSize = 32768
+	singleCheckBatchMaxSize       = 512
+	singleCheckFullBatchMaxSize   = 384
+	singleCheckBatchMaxDelay      = 2 * time.Millisecond
+	singleCheckBatchMaxFlight     = 32
+	singleCheckBatchQueueSize     = 32768
+	singleCheckFullBatchQueueSize = 32768
 )
 
 // NewVeriflierClient creates a client targeting the given address (host:port).
@@ -83,10 +87,8 @@ func (c *VeriflierClient) Check(ctx context.Context, req CheckRequest) (*CheckRe
 		req:  req,
 		resp: make(chan singleCheckResponse, 1),
 	}
-	select {
-	case c.singleChecks().in <- call:
-	case <-ctx.Done():
-		return nil, ctx.Err()
+	if err := c.singleChecks().submit(ctx, call); err != nil {
+		return nil, err
 	}
 	select {
 	case resp := <-call.resp:
@@ -138,28 +140,47 @@ type singleCheckResponse struct {
 
 type singleCheckBatcher struct {
 	client   *VeriflierClient
-	in       chan singleCheckCall
+	lightIn  chan singleCheckCall
+	fullIn   chan singleCheckCall
 	inFlight chan struct{}
 }
 
 func newSingleCheckBatcher(client *VeriflierClient) *singleCheckBatcher {
 	b := &singleCheckBatcher{
 		client:   client,
-		in:       make(chan singleCheckCall, singleCheckBatchQueueSize),
+		lightIn:  make(chan singleCheckCall, singleCheckBatchQueueSize),
+		fullIn:   make(chan singleCheckCall, singleCheckFullBatchQueueSize),
 		inFlight: make(chan struct{}, singleCheckBatchMaxFlight),
 	}
-	go b.run()
+	go b.run(b.lightIn, singleCheckBatchMaxSize)
+	go b.run(b.fullIn, singleCheckFullBatchMaxSize)
 	return b
 }
 
-func (b *singleCheckBatcher) run() {
-	for first := range b.in {
+func (b *singleCheckBatcher) submit(ctx context.Context, call singleCheckCall) error {
+	in := b.lightIn
+	if usesFullDetectionWork(call.req) {
+		in = b.fullIn
+	}
+	select {
+	case in <- call:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (b *singleCheckBatcher) run(in <-chan singleCheckCall, maxBatchSize int) {
+	if maxBatchSize <= 0 {
+		maxBatchSize = 1
+	}
+	for first := range in {
 		batch := []singleCheckCall{first}
 		timer := time.NewTimer(singleCheckBatchMaxDelay)
 		collecting := true
-		for collecting && len(batch) < singleCheckBatchMaxSize {
+		for collecting && len(batch) < maxBatchSize {
 			select {
-			case call := <-b.in:
+			case call := <-in:
 				batch = append(batch, call)
 			case <-timer.C:
 				collecting = false
@@ -174,6 +195,18 @@ func (b *singleCheckBatcher) run() {
 			b.flush(batch)
 		}()
 	}
+}
+
+func usesFullDetectionWork(req CheckRequest) bool {
+	method, err := checkmode.NormalizeMethod(req.Method, checkmode.MethodGET)
+	if err != nil {
+		method = checkmode.MethodGET
+	}
+	profile, err := checkmode.NormalizeProfile(req.DetectionProfile, checkmode.ProfileFull)
+	if err != nil {
+		profile = checkmode.ProfileFull
+	}
+	return checkmode.EffectiveProfile(method, profile) == checkmode.ProfileFull
 }
 
 func (b *singleCheckBatcher) flush(batch []singleCheckCall) {

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -256,8 +256,10 @@ func pruneExpiredSingleCheckCalls(calls []singleCheckCall) []singleCheckCall {
 		if err := call.ctx.Err(); err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {
 				call.respond(agentOverloadedCheckResult(call.req), nil)
+				incrementMetric("verifier.client.batch.expired_while_waiting.count", 1)
 			} else {
 				call.respond(nil, err)
+				incrementMetric("verifier.client.batch.canceled_while_waiting.count", 1)
 			}
 			continue
 		}

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -38,7 +38,7 @@ var (
 	singleCheckBatchMaxDelay             = 2 * time.Millisecond
 	singleCheckBatchDeadlineReserve      = 250 * time.Millisecond
 	singleCheckLargeBatchDeadlineReserve = time.Second
-	singleCheckLightBatchMaxFlight       = 32
+	singleCheckLightBatchMaxFlight       = 48
 	singleCheckFullBatchMaxFlight        = 32
 	singleCheckBatchQueueSize            = 32768
 	singleCheckFullBatchQueueSize        = 32768

--- a/internal/veriflier/executor.go
+++ b/internal/veriflier/executor.go
@@ -13,8 +13,8 @@ import (
 var ErrOverloaded = errors.New("veriflier overloaded")
 
 const (
-	defaultConcurrencyPerCPU = 256
-	minDefaultConcurrency    = 256
+	defaultConcurrencyPerCPU = 512
+	minDefaultConcurrency    = 512
 	maxDefaultConcurrency    = 32768
 	defaultQueueMultiplier   = 8
 	defaultCheckEstimate     = 50 * time.Millisecond

--- a/internal/veriflier/executor.go
+++ b/internal/veriflier/executor.go
@@ -39,8 +39,14 @@ type Executor struct {
 
 type execJob struct {
 	ctx    context.Context
+	index  int
 	req    CheckRequest
-	result chan ProbeResult
+	result chan execResult
+}
+
+type execResult struct {
+	index  int
+	result ProbeResult
 }
 
 func NewExecutor(checkFn CheckFunc, maxConcurrency, queueCapacity int) *Executor {
@@ -105,13 +111,13 @@ func (e *Executor) ExecuteBatch(ctx context.Context, reqs []CheckRequest) ([]Pro
 	}
 
 	results := make([]ProbeResult, len(reqs))
-	resultChans := make([]chan ProbeResult, len(reqs))
+	resultCh := make(chan execResult, len(reqs))
 	for i, req := range reqs {
-		resultChans[i] = make(chan ProbeResult, 1)
 		job := execJob{
 			ctx:    ctx,
+			index:  i,
 			req:    req,
-			result: resultChans[i],
+			result: resultCh,
 		}
 		select {
 		case e.jobs <- job:
@@ -127,7 +133,7 @@ func (e *Executor) ExecuteBatch(ctx context.Context, reqs []CheckRequest) ([]Pro
 		results[i].URL = req.URL
 	}
 
-	for i, resultCh := range resultChans {
+	for range reqs {
 		if err := e.ctx.Err(); err != nil {
 			return nil, err
 		}
@@ -140,7 +146,7 @@ func (e *Executor) ExecuteBatch(ctx context.Context, reqs []CheckRequest) ([]Pro
 			if err := e.ctx.Err(); err != nil {
 				return nil, err
 			}
-			results[i] = res
+			results[res.index] = res.result
 		}
 	}
 	return results, nil
@@ -192,7 +198,7 @@ func (e *Executor) worker(ctx context.Context) {
 			e.completed.Add(1)
 			e.active.Add(-1)
 			select {
-			case job.result <- res:
+			case job.result <- execResult{index: job.index, result: res}:
 			default:
 			}
 			<-e.slots

--- a/internal/veriflier/executor.go
+++ b/internal/veriflier/executor.go
@@ -113,6 +113,7 @@ func (e *Executor) ExecuteBatch(ctx context.Context, reqs []CheckRequest) ([]Pro
 	results := make([]ProbeResult, len(reqs))
 	resultCh := make(chan execResult, len(reqs))
 	for i, req := range reqs {
+		results[i] = timeoutProbeResult(req)
 		job := execJob{
 			ctx:    ctx,
 			index:  i,
@@ -128,9 +129,6 @@ func (e *Executor) ExecuteBatch(ctx context.Context, reqs []CheckRequest) ([]Pro
 			e.releaseSlots(len(reqs) - i)
 			return nil, ctx.Err()
 		}
-		results[i].RequestID = req.RequestID
-		results[i].BlogID = req.BlogID
-		results[i].URL = req.URL
 	}
 
 	for range reqs {
@@ -141,7 +139,8 @@ func (e *Executor) ExecuteBatch(ctx context.Context, reqs []CheckRequest) ([]Pro
 		case <-e.ctx.Done():
 			return nil, e.ctx.Err()
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			drainReadyResults(results, resultCh)
+			return results, nil
 		case res := <-resultCh:
 			if err := e.ctx.Err(); err != nil {
 				return nil, err
@@ -150,6 +149,32 @@ func (e *Executor) ExecuteBatch(ctx context.Context, reqs []CheckRequest) ([]Pro
 		}
 	}
 	return results, nil
+}
+
+func drainReadyResults(results []ProbeResult, resultCh <-chan execResult) {
+	for {
+		select {
+		case res := <-resultCh:
+			results[res.index] = res.result
+		default:
+			return
+		}
+	}
+}
+
+func timeoutProbeResult(req CheckRequest) ProbeResult {
+	return ProbeResult{
+		CheckResult: CheckResult{
+			MonitorSiteID: req.MonitorSiteID,
+			BlogID:        req.BlogID,
+			URL:           req.URL,
+			Outcome:       OutcomeTimeout,
+			Success:       false,
+			ErrorCode:     1,
+			RequestID:     req.RequestID,
+		},
+		Outcome: OutcomeTimeout,
+	}
 }
 
 func (e *Executor) Capacity() Capacity {

--- a/internal/veriflier/executor.go
+++ b/internal/veriflier/executor.go
@@ -285,6 +285,9 @@ func (e *Executor) worker(ctx context.Context) {
 			res := e.checkFn(jobCtx, job.req)
 			stopShutdownCancel()
 			cancel()
+			if shouldTreatResultAsOperationalOverload(job.ctx, res) {
+				res = agentOverloadedProbeResult(job.req)
+			}
 			e.observeDuration(time.Since(start))
 			if res.RequestID == "" {
 				res.RequestID = job.req.RequestID
@@ -310,6 +313,20 @@ func (e *Executor) worker(ctx context.Context) {
 			<-e.slots
 		}
 	}
+}
+
+func shouldTreatResultAsOperationalOverload(ctx context.Context, res ProbeResult) bool {
+	if ctx == nil || ctx.Err() == nil || res.Success {
+		return false
+	}
+	if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return false
+	}
+	outcome := res.Outcome
+	if outcome == "" {
+		outcome = outcomeFromResult(res.CheckResult)
+	}
+	return outcome == OutcomeTimeout || res.ErrorCode == 1
 }
 
 func (e *Executor) observeDuration(d time.Duration) {

--- a/internal/veriflier/executor.go
+++ b/internal/veriflier/executor.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"syscall"
+	"time"
 )
 
 var ErrOverloaded = errors.New("veriflier overloaded")
@@ -16,6 +17,9 @@ const (
 	minDefaultConcurrency    = 256
 	maxDefaultConcurrency    = 32768
 	defaultQueueMultiplier   = 8
+	defaultCheckEstimate     = 50 * time.Millisecond
+	deadlineAdmissionReserve = 250 * time.Millisecond
+	deadlineResultDrainGrace = 25 * time.Millisecond
 )
 
 type CheckFunc func(context.Context, CheckRequest) ProbeResult
@@ -32,6 +36,7 @@ type Executor struct {
 	active    atomic.Int64
 	completed atomic.Uint64
 	rejected  atomic.Uint64
+	avgNanos  atomic.Int64
 
 	maxConcurrency int
 	queueCapacity  int
@@ -92,28 +97,37 @@ func (e *Executor) ExecuteBatch(ctx context.Context, reqs []CheckRequest) ([]Pro
 		return nil, nil
 	}
 
-	acquired := 0
-	for range reqs {
-		select {
-		case e.slots <- struct{}{}:
-			acquired++
-		case <-e.ctx.Done():
-			e.releaseSlots(acquired)
-			return nil, e.ctx.Err()
-		case <-ctx.Done():
-			e.releaseSlots(acquired)
-			return nil, ctx.Err()
-		default:
-			e.rejected.Add(1)
-			e.releaseSlots(acquired)
-			return nil, ErrOverloaded
-		}
+	results := make([]ProbeResult, len(reqs))
+	for i, req := range reqs {
+		results[i] = agentOverloadedProbeResult(req)
 	}
 
-	results := make([]ProbeResult, len(reqs))
 	resultCh := make(chan execResult, len(reqs))
+	enqueued := 0
 	for i, req := range reqs {
-		results[i] = timeoutProbeResult(req)
+		if err := e.ctx.Err(); err != nil {
+			return nil, err
+		}
+		if ctx.Err() != nil {
+			drainReadyResults(results, resultCh)
+			return results, nil
+		}
+		if e.shouldShedForDeadline(ctx) {
+			e.rejected.Add(1)
+			continue
+		}
+		select {
+		case e.slots <- struct{}{}:
+		case <-e.ctx.Done():
+			return nil, e.ctx.Err()
+		case <-ctx.Done():
+			drainReadyResults(results, resultCh)
+			return results, nil
+		default:
+			e.rejected.Add(1)
+			continue
+		}
+
 		job := execJob{
 			ctx:    ctx,
 			index:  i,
@@ -122,16 +136,18 @@ func (e *Executor) ExecuteBatch(ctx context.Context, reqs []CheckRequest) ([]Pro
 		}
 		select {
 		case e.jobs <- job:
+			enqueued++
 		case <-e.ctx.Done():
-			e.releaseSlots(len(reqs) - i)
+			e.releaseSlots(1)
 			return nil, e.ctx.Err()
 		case <-ctx.Done():
-			e.releaseSlots(len(reqs) - i)
-			return nil, ctx.Err()
+			e.releaseSlots(1)
+			drainReadyResults(results, resultCh)
+			return results, nil
 		}
 	}
 
-	for range reqs {
+	for range enqueued {
 		if err := e.ctx.Err(); err != nil {
 			return nil, err
 		}
@@ -139,7 +155,7 @@ func (e *Executor) ExecuteBatch(ctx context.Context, reqs []CheckRequest) ([]Pro
 		case <-e.ctx.Done():
 			return nil, e.ctx.Err()
 		case <-ctx.Done():
-			drainReadyResults(results, resultCh)
+			drainReadyResultsWithGrace(results, resultCh, deadlineResultDrainGrace)
 			return results, nil
 		case res := <-resultCh:
 			if err := e.ctx.Err(); err != nil {
@@ -149,6 +165,38 @@ func (e *Executor) ExecuteBatch(ctx context.Context, reqs []CheckRequest) ([]Pro
 		}
 	}
 	return results, nil
+}
+
+func (e *Executor) shouldShedForDeadline(ctx context.Context) bool {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return false
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return true
+	}
+	avg := time.Duration(e.avgNanos.Load())
+	if avg <= 0 {
+		avg = defaultCheckEstimate
+	}
+	prospectivePosition := len(e.slots) + 1
+	queuedAhead := prospectivePosition - e.maxConcurrency
+	if queuedAhead < 0 {
+		queuedAhead = 0
+	}
+	if queuedAhead == 0 {
+		return false
+	}
+	if remaining <= deadlineAdmissionReserve {
+		return true
+	}
+	wavesAhead := queuedAhead / e.maxConcurrency
+	if queuedAhead%e.maxConcurrency != 0 {
+		wavesAhead++
+	}
+	estimatedWait := time.Duration(wavesAhead) * avg
+	return estimatedWait+deadlineAdmissionReserve >= remaining
 }
 
 func drainReadyResults(results []ProbeResult, resultCh <-chan execResult) {
@@ -162,28 +210,51 @@ func drainReadyResults(results []ProbeResult, resultCh <-chan execResult) {
 	}
 }
 
-func timeoutProbeResult(req CheckRequest) ProbeResult {
+func drainReadyResultsWithGrace(results []ProbeResult, resultCh <-chan execResult, grace time.Duration) {
+	drainReadyResults(results, resultCh)
+	if grace <= 0 {
+		return
+	}
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
+	for {
+		select {
+		case res := <-resultCh:
+			results[res.index] = res.result
+		case <-timer.C:
+			return
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
+func agentOverloadedProbeResult(req CheckRequest) ProbeResult {
 	return ProbeResult{
 		CheckResult: CheckResult{
 			MonitorSiteID: req.MonitorSiteID,
 			BlogID:        req.BlogID,
 			URL:           req.URL,
-			Outcome:       OutcomeTimeout,
+			Outcome:       OutcomeAgentOverloaded,
 			Success:       false,
 			ErrorCode:     1,
 			RequestID:     req.RequestID,
 		},
-		Outcome: OutcomeTimeout,
+		Outcome: OutcomeAgentOverloaded,
 	}
 }
 
 func (e *Executor) Capacity() Capacity {
+	avgMS := int(time.Duration(e.avgNanos.Load()).Milliseconds())
 	return Capacity{
 		MaxConcurrency: e.maxConcurrency,
 		QueueCapacity:  e.queueCapacity,
 		QueueDepth:     len(e.jobs),
 		Active:         int(e.active.Load()),
 		InFlight:       len(e.slots),
+		Completed:      int(e.completed.Load()),
+		Rejected:       int(e.rejected.Load()),
+		AvgCheckMS:     avgMS,
 	}
 }
 
@@ -199,12 +270,22 @@ func (e *Executor) worker(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case job := <-e.jobs:
+			if err := job.ctx.Err(); err != nil {
+				select {
+				case job.result <- execResult{index: job.index, result: agentOverloadedProbeResult(job.req)}:
+				default:
+				}
+				<-e.slots
+				continue
+			}
 			e.active.Add(1)
+			start := time.Now()
 			jobCtx, cancel := context.WithCancel(job.ctx)
 			stopShutdownCancel := context.AfterFunc(ctx, cancel)
 			res := e.checkFn(jobCtx, job.req)
 			stopShutdownCancel()
 			cancel()
+			e.observeDuration(time.Since(start))
 			if res.RequestID == "" {
 				res.RequestID = job.req.RequestID
 			}
@@ -227,6 +308,23 @@ func (e *Executor) worker(ctx context.Context) {
 			default:
 			}
 			<-e.slots
+		}
+	}
+}
+
+func (e *Executor) observeDuration(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	nanos := int64(d)
+	for {
+		old := e.avgNanos.Load()
+		next := nanos
+		if old > 0 {
+			next = old + (nanos-old)/16
+		}
+		if e.avgNanos.CompareAndSwap(old, next) {
+			return
 		}
 	}
 }

--- a/internal/veriflier/executor.go
+++ b/internal/veriflier/executor.go
@@ -11,6 +11,13 @@ import (
 
 var ErrOverloaded = errors.New("veriflier overloaded")
 
+const (
+	defaultConcurrencyPerCPU = 256
+	minDefaultConcurrency    = 256
+	maxDefaultConcurrency    = 32768
+	defaultQueueMultiplier   = 8
+)
+
 type CheckFunc func(context.Context, CheckRequest) ProbeResult
 
 type Executor struct {
@@ -54,7 +61,7 @@ func NewExecutor(checkFn CheckFunc, maxConcurrency, queueCapacity int) *Executor
 		queueCapacity = 0
 	}
 	if queueCapacity == 0 {
-		queueCapacity = maxConcurrency * 4
+		queueCapacity = defaultQueueCapacity(maxConcurrency)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -204,17 +211,35 @@ func (e *Executor) releaseSlots(n int) {
 }
 
 func defaultMaxConcurrency() int {
-	workers := runtime.GOMAXPROCS(0) * 64
-	if workers < 32 {
-		workers = 32
+	return defaultMaxConcurrencyFor(runtime.GOMAXPROCS(0), fdConcurrencyCap())
+}
+
+func defaultMaxConcurrencyFor(procs, fdCap int) int {
+	if procs < 1 {
+		procs = 1
 	}
-	if fdCap := fdConcurrencyCap(); fdCap > 0 && workers > fdCap {
+	workers := procs * defaultConcurrencyPerCPU
+	if workers < minDefaultConcurrency {
+		workers = minDefaultConcurrency
+	}
+	if fdCap > 0 && workers > fdCap {
 		workers = fdCap
 	}
-	if workers > 4096 {
-		workers = 4096
+	if workers > maxDefaultConcurrency {
+		workers = maxDefaultConcurrency
 	}
 	return workers
+}
+
+func defaultQueueCapacity(maxConcurrency int) int {
+	if maxConcurrency <= 0 {
+		return 0
+	}
+	queue := maxConcurrency * defaultQueueMultiplier
+	if queue/maxConcurrency != defaultQueueMultiplier {
+		return maxConcurrency
+	}
+	return queue
 }
 
 func fdConcurrencyCap() int {

--- a/internal/veriflier/executor.go
+++ b/internal/veriflier/executor.go
@@ -110,19 +110,12 @@ func (e *Executor) ExecuteBatch(ctx context.Context, reqs []CheckRequest) ([]Pro
 		}
 	}
 
-	batchCtx, batchCancel := context.WithCancel(ctx)
-	stopShutdownCancel := context.AfterFunc(e.ctx, batchCancel)
-	defer func() {
-		stopShutdownCancel()
-		batchCancel()
-	}()
-
 	results := make([]ProbeResult, len(reqs))
 	resultCh := make(chan execResult, len(reqs))
 	for i, req := range reqs {
 		results[i] = timeoutProbeResult(req)
 		job := execJob{
-			ctx:    batchCtx,
+			ctx:    ctx,
 			index:  i,
 			req:    req,
 			result: resultCh,
@@ -146,7 +139,6 @@ func (e *Executor) ExecuteBatch(ctx context.Context, reqs []CheckRequest) ([]Pro
 		case <-e.ctx.Done():
 			return nil, e.ctx.Err()
 		case <-ctx.Done():
-			batchCancel()
 			drainReadyResults(results, resultCh)
 			return results, nil
 		case res := <-resultCh:
@@ -208,7 +200,11 @@ func (e *Executor) worker(ctx context.Context) {
 			return
 		case job := <-e.jobs:
 			e.active.Add(1)
-			res := e.checkFn(job.ctx, job.req)
+			jobCtx, cancel := context.WithCancel(job.ctx)
+			stopShutdownCancel := context.AfterFunc(ctx, cancel)
+			res := e.checkFn(jobCtx, job.req)
+			stopShutdownCancel()
+			cancel()
 			if res.RequestID == "" {
 				res.RequestID = job.req.RequestID
 			}

--- a/internal/veriflier/executor.go
+++ b/internal/veriflier/executor.go
@@ -110,12 +110,19 @@ func (e *Executor) ExecuteBatch(ctx context.Context, reqs []CheckRequest) ([]Pro
 		}
 	}
 
+	batchCtx, batchCancel := context.WithCancel(ctx)
+	stopShutdownCancel := context.AfterFunc(e.ctx, batchCancel)
+	defer func() {
+		stopShutdownCancel()
+		batchCancel()
+	}()
+
 	results := make([]ProbeResult, len(reqs))
 	resultCh := make(chan execResult, len(reqs))
 	for i, req := range reqs {
 		results[i] = timeoutProbeResult(req)
 		job := execJob{
-			ctx:    ctx,
+			ctx:    batchCtx,
 			index:  i,
 			req:    req,
 			result: resultCh,
@@ -139,6 +146,7 @@ func (e *Executor) ExecuteBatch(ctx context.Context, reqs []CheckRequest) ([]Pro
 		case <-e.ctx.Done():
 			return nil, e.ctx.Err()
 		case <-ctx.Done():
+			batchCancel()
 			drainReadyResults(results, resultCh)
 			return results, nil
 		case res := <-resultCh:
@@ -200,11 +208,7 @@ func (e *Executor) worker(ctx context.Context) {
 			return
 		case job := <-e.jobs:
 			e.active.Add(1)
-			jobCtx, cancel := context.WithCancel(job.ctx)
-			stopShutdownCancel := context.AfterFunc(ctx, cancel)
-			res := e.checkFn(jobCtx, job.req)
-			stopShutdownCancel()
-			cancel()
+			res := e.checkFn(job.ctx, job.req)
 			if res.RequestID == "" {
 				res.RequestID = job.req.RequestID
 			}

--- a/internal/veriflier/executor.go
+++ b/internal/veriflier/executor.go
@@ -285,10 +285,13 @@ func (e *Executor) worker(ctx context.Context) {
 			res := e.checkFn(jobCtx, job.req)
 			stopShutdownCancel()
 			cancel()
-			if shouldTreatResultAsOperationalOverload(job.ctx, res) {
+			operationalOverload := shouldTreatResultAsOperationalOverload(job.ctx, res)
+			if operationalOverload {
 				res = agentOverloadedProbeResult(job.req)
 			}
-			e.observeDuration(time.Since(start))
+			if !operationalOverload {
+				e.observeDuration(time.Since(start))
+			}
 			if res.RequestID == "" {
 				res.RequestID = job.req.RequestID
 			}

--- a/internal/veriflier/executor_test.go
+++ b/internal/veriflier/executor_test.go
@@ -112,6 +112,37 @@ func TestExecutorCapacityReflectsInFlightWork(t *testing.T) {
 	}
 }
 
+func TestDefaultMaxConcurrencyScalesWithCPUAndFDCap(t *testing.T) {
+	tests := []struct {
+		name  string
+		procs int
+		fdCap int
+		want  int
+	}{
+		{name: "single cpu floor", procs: 1, want: 256},
+		{name: "eight cpu host", procs: 8, want: 2048},
+		{name: "fd cap wins", procs: 8, fdCap: 300, want: 300},
+		{name: "global ceiling", procs: 256, want: 32768},
+		{name: "bad gomaxprocs uses one cpu", procs: 0, want: 256},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := defaultMaxConcurrencyFor(tt.procs, tt.fdCap); got != tt.want {
+				t.Fatalf("defaultMaxConcurrencyFor(%d, %d) = %d, want %d", tt.procs, tt.fdCap, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultQueueCapacityProvidesBurstHeadroom(t *testing.T) {
+	if got := defaultQueueCapacity(512); got != 4096 {
+		t.Fatalf("defaultQueueCapacity(512) = %d, want 4096", got)
+	}
+	if got := defaultQueueCapacity(0); got != 0 {
+		t.Fatalf("defaultQueueCapacity(0) = %d, want 0", got)
+	}
+}
+
 func TestExecutorShutdownCancelsInFlightBatch(t *testing.T) {
 	started := make(chan struct{}, 1)
 	exec := NewExecutor(func(ctx context.Context, req CheckRequest) ProbeResult {

--- a/internal/veriflier/executor_test.go
+++ b/internal/veriflier/executor_test.go
@@ -3,7 +3,6 @@ package veriflier
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -218,46 +217,5 @@ func TestExecutorShutdownCancelsInFlightBatch(t *testing.T) {
 	exec.Shutdown()
 	if err := <-done; !errors.Is(err, context.Canceled) {
 		t.Fatalf("ExecuteBatch() error = %v, want context.Canceled", err)
-	}
-}
-
-func BenchmarkExecutorFastChecks(b *testing.B) {
-	for _, batchSize := range []int{64, 512} {
-		b.Run(fmt.Sprintf("batch-%d", batchSize), func(b *testing.B) {
-			exec := NewExecutor(func(_ context.Context, req CheckRequest) ProbeResult {
-				return ProbeResult{
-					CheckResult: CheckResult{
-						BlogID:    req.BlogID,
-						URL:       req.URL,
-						RequestID: req.RequestID,
-						Success:   true,
-						HTTPCode:  200,
-					},
-					Outcome: OutcomeUp,
-				}
-			}, 256, 1024)
-			defer exec.Shutdown()
-
-			reqs := make([]CheckRequest, batchSize)
-			for i := range reqs {
-				reqs[i] = CheckRequest{
-					BlogID:    int64(i + 1),
-					URL:       "http://example.test/",
-					RequestID: fmt.Sprintf("req-%d", i),
-				}
-			}
-
-			b.ReportAllocs()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				results, err := exec.ExecuteBatch(context.Background(), reqs)
-				if err != nil {
-					b.Fatalf("ExecuteBatch() error = %v", err)
-				}
-				if len(results) != len(reqs) {
-					b.Fatalf("results len = %d, want %d", len(results), len(reqs))
-				}
-			}
-		})
 	}
 }

--- a/internal/veriflier/executor_test.go
+++ b/internal/veriflier/executor_test.go
@@ -112,6 +112,40 @@ func TestExecutorContextCancellationReturnsTimeoutResult(t *testing.T) {
 	}
 }
 
+func TestExecutorDeadlineCancellationReturnsAgentOverloaded(t *testing.T) {
+	started := make(chan struct{})
+	exec := NewExecutor(func(ctx context.Context, req CheckRequest) ProbeResult {
+		close(started)
+		<-ctx.Done()
+		return ProbeResult{CheckResult: CheckResult{
+			BlogID:    req.BlogID,
+			URL:       req.URL,
+			RequestID: req.RequestID,
+			Success:   false,
+			ErrorCode: 1,
+		}, Outcome: OutcomeTimeout}
+	}, 1, 1)
+	defer exec.Shutdown()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	results, err := exec.ExecuteBatch(ctx, []CheckRequest{{BlogID: 1, URL: "https://example.com", RequestID: "req-1"}})
+	if err != nil {
+		t.Fatalf("ExecuteBatch() error = %v", err)
+	}
+	select {
+	case <-started:
+	default:
+		t.Fatal("check did not start")
+	}
+	if len(results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(results))
+	}
+	if results[0].Success || results[0].Outcome != OutcomeAgentOverloaded || results[0].ErrorCode != 1 || results[0].RequestID != "req-1" {
+		t.Fatalf("deadline result = %+v, want agent_overloaded for req-1", results[0])
+	}
+}
+
 func TestExecutorContextCancellationKeepsCompletedResults(t *testing.T) {
 	slowStarted := make(chan struct{})
 	exec := NewExecutor(func(ctx context.Context, req CheckRequest) ProbeResult {

--- a/internal/veriflier/executor_test.go
+++ b/internal/veriflier/executor_test.go
@@ -255,11 +255,11 @@ func TestDefaultMaxConcurrencyScalesWithCPUAndFDCap(t *testing.T) {
 		fdCap int
 		want  int
 	}{
-		{name: "single cpu floor", procs: 1, want: 256},
-		{name: "eight cpu host", procs: 8, want: 2048},
+		{name: "single cpu floor", procs: 1, want: 512},
+		{name: "eight cpu host", procs: 8, want: 4096},
 		{name: "fd cap wins", procs: 8, fdCap: 300, want: 300},
 		{name: "global ceiling", procs: 256, want: 32768},
-		{name: "bad gomaxprocs uses one cpu", procs: 0, want: 256},
+		{name: "bad gomaxprocs uses one cpu", procs: 0, want: 512},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/veriflier/executor_test.go
+++ b/internal/veriflier/executor_test.go
@@ -148,6 +148,7 @@ func TestExecutorDeadlineCancellationReturnsAgentOverloaded(t *testing.T) {
 
 func TestExecutorContextCancellationKeepsCompletedResults(t *testing.T) {
 	slowStarted := make(chan struct{})
+	fastReturned := make(chan struct{})
 	exec := NewExecutor(func(ctx context.Context, req CheckRequest) ProbeResult {
 		if req.BlogID == 2 {
 			close(slowStarted)
@@ -160,6 +161,7 @@ func TestExecutorContextCancellationKeepsCompletedResults(t *testing.T) {
 				ErrorCode: 1,
 			}, Outcome: OutcomeTimeout}
 		}
+		close(fastReturned)
 		return ProbeResult{CheckResult: CheckResult{
 			BlogID:    req.BlogID,
 			URL:       req.URL,
@@ -189,6 +191,11 @@ func TestExecutorContextCancellationKeepsCompletedResults(t *testing.T) {
 	case <-slowStarted:
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for slow check to start")
+	}
+	select {
+	case <-fastReturned:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for fast check to complete")
 	}
 	cancel()
 	out := <-done

--- a/internal/veriflier/executor_test.go
+++ b/internal/veriflier/executor_test.go
@@ -3,6 +3,7 @@ package veriflier
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -217,5 +218,46 @@ func TestExecutorShutdownCancelsInFlightBatch(t *testing.T) {
 	exec.Shutdown()
 	if err := <-done; !errors.Is(err, context.Canceled) {
 		t.Fatalf("ExecuteBatch() error = %v, want context.Canceled", err)
+	}
+}
+
+func BenchmarkExecutorFastChecks(b *testing.B) {
+	for _, batchSize := range []int{64, 512} {
+		b.Run(fmt.Sprintf("batch-%d", batchSize), func(b *testing.B) {
+			exec := NewExecutor(func(_ context.Context, req CheckRequest) ProbeResult {
+				return ProbeResult{
+					CheckResult: CheckResult{
+						BlogID:    req.BlogID,
+						URL:       req.URL,
+						RequestID: req.RequestID,
+						Success:   true,
+						HTTPCode:  200,
+					},
+					Outcome: OutcomeUp,
+				}
+			}, 256, 1024)
+			defer exec.Shutdown()
+
+			reqs := make([]CheckRequest, batchSize)
+			for i := range reqs {
+				reqs[i] = CheckRequest{
+					BlogID:    int64(i + 1),
+					URL:       "http://example.test/",
+					RequestID: fmt.Sprintf("req-%d", i),
+				}
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				results, err := exec.ExecuteBatch(context.Background(), reqs)
+				if err != nil {
+					b.Fatalf("ExecuteBatch() error = %v", err)
+				}
+				if len(results) != len(reqs) {
+					b.Fatalf("results len = %d, want %d", len(results), len(reqs))
+				}
+			}
+		})
 	}
 }

--- a/internal/veriflier/executor_test.go
+++ b/internal/veriflier/executor_test.go
@@ -58,7 +58,7 @@ func TestExecutorRejectsOverCapacityBatch(t *testing.T) {
 	}
 }
 
-func TestExecutorContextCancellation(t *testing.T) {
+func TestExecutorContextCancellationReturnsTimeoutResult(t *testing.T) {
 	exec := NewExecutor(func(ctx context.Context, req CheckRequest) ProbeResult {
 		<-ctx.Done()
 		return ProbeResult{CheckResult: CheckResult{
@@ -72,9 +72,57 @@ func TestExecutorContextCancellation(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
-	_, err := exec.ExecuteBatch(ctx, []CheckRequest{{BlogID: 1, URL: "https://example.com"}})
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("ExecuteBatch() error = %v, want DeadlineExceeded", err)
+	results, err := exec.ExecuteBatch(ctx, []CheckRequest{{BlogID: 1, URL: "https://example.com", RequestID: "req-1"}})
+	if err != nil {
+		t.Fatalf("ExecuteBatch() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(results))
+	}
+	if results[0].Success || results[0].Outcome != OutcomeTimeout || results[0].ErrorCode != 1 || results[0].RequestID != "req-1" {
+		t.Fatalf("timeout result = %+v, want timeout for req-1", results[0])
+	}
+}
+
+func TestExecutorContextCancellationKeepsCompletedResults(t *testing.T) {
+	exec := NewExecutor(func(ctx context.Context, req CheckRequest) ProbeResult {
+		if req.BlogID == 2 {
+			<-ctx.Done()
+			return ProbeResult{CheckResult: CheckResult{
+				BlogID:    req.BlogID,
+				URL:       req.URL,
+				RequestID: req.RequestID,
+				Success:   false,
+				ErrorCode: 1,
+			}, Outcome: OutcomeTimeout}
+		}
+		return ProbeResult{CheckResult: CheckResult{
+			BlogID:    req.BlogID,
+			URL:       req.URL,
+			RequestID: req.RequestID,
+			Success:   true,
+			HTTPCode:  200,
+		}, Outcome: OutcomeUp}
+	}, 2, 2)
+	defer exec.Shutdown()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	results, err := exec.ExecuteBatch(ctx, []CheckRequest{
+		{BlogID: 1, URL: "https://example.com/fast", RequestID: "fast"},
+		{BlogID: 2, URL: "https://example.com/slow", RequestID: "slow"},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteBatch() error = %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results len = %d, want 2", len(results))
+	}
+	if !results[0].Success || results[0].Outcome != OutcomeUp || results[0].RequestID != "fast" {
+		t.Fatalf("fast result = %+v, want success for fast", results[0])
+	}
+	if results[1].Success || results[1].Outcome != OutcomeTimeout || results[1].ErrorCode != 1 || results[1].RequestID != "slow" {
+		t.Fatalf("slow result = %+v, want timeout for slow", results[1])
 	}
 }
 

--- a/internal/veriflier/executor_test.go
+++ b/internal/veriflier/executor_test.go
@@ -146,6 +146,77 @@ func TestExecutorDeadlineCancellationReturnsAgentOverloaded(t *testing.T) {
 	}
 }
 
+func TestExecutorDeadlineOverloadDoesNotPoisonAverageDuration(t *testing.T) {
+	started := make(chan struct{})
+	exec := NewExecutor(func(ctx context.Context, req CheckRequest) ProbeResult {
+		if req.BlogID == 1 {
+			close(started)
+			<-ctx.Done()
+			return ProbeResult{CheckResult: CheckResult{
+				BlogID:    req.BlogID,
+				URL:       req.URL,
+				RequestID: req.RequestID,
+				Success:   false,
+				ErrorCode: 1,
+			}, Outcome: OutcomeTimeout}
+		}
+		time.Sleep(2 * time.Millisecond)
+		return ProbeResult{CheckResult: CheckResult{
+			BlogID:    req.BlogID,
+			URL:       req.URL,
+			RequestID: req.RequestID,
+			Success:   true,
+			HTTPCode:  200,
+		}, Outcome: OutcomeUp}
+	}, 1, 1)
+	defer exec.Shutdown()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	results, err := exec.ExecuteBatch(ctx, []CheckRequest{{BlogID: 1, URL: "https://example.com/slow", RequestID: "req-1"}})
+	if err != nil {
+		t.Fatalf("ExecuteBatch() deadline error = %v", err)
+	}
+	select {
+	case <-started:
+	default:
+		t.Fatal("deadline check did not start")
+	}
+	if len(results) != 1 || results[0].Outcome != OutcomeAgentOverloaded {
+		t.Fatalf("deadline results = %+v, want agent_overloaded", results)
+	}
+	waitForExecutorCapacity(t, exec, func(c Capacity) bool {
+		return c.Active == 0 && c.InFlight == 0
+	})
+	if got := exec.avgNanos.Load(); got != 0 {
+		t.Fatalf("avg nanos after operational overload = %d, want 0", got)
+	}
+
+	results, err = exec.ExecuteBatch(context.Background(), []CheckRequest{{BlogID: 2, URL: "https://example.com/fast", RequestID: "req-2"}})
+	if err != nil {
+		t.Fatalf("ExecuteBatch() success error = %v", err)
+	}
+	if len(results) != 1 || !results[0].Success {
+		t.Fatalf("success results = %+v, want successful probe", results)
+	}
+	if got := exec.avgNanos.Load(); got <= 0 {
+		t.Fatalf("avg nanos after successful probe = %d, want positive", got)
+	}
+}
+
+func waitForExecutorCapacity(t *testing.T, exec *Executor, ok func(Capacity) bool) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		capacity := exec.Capacity()
+		if ok(capacity) {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("executor capacity did not reach expected state: %+v", exec.Capacity())
+}
+
 func TestExecutorContextCancellationKeepsCompletedResults(t *testing.T) {
 	slowStarted := make(chan struct{})
 	fastReturned := make(chan struct{})

--- a/internal/veriflier/executor_test.go
+++ b/internal/veriflier/executor_test.go
@@ -37,29 +37,40 @@ func TestExecutorPreservesInputOrder(t *testing.T) {
 	}
 }
 
-func TestExecutorRejectsOverCapacityBatch(t *testing.T) {
+func TestExecutorPartiallyShedsOverCapacityBatch(t *testing.T) {
 	var called atomic.Int64
 	exec := NewExecutor(func(_ context.Context, req CheckRequest) ProbeResult {
 		called.Add(1)
-		return ProbeResult{CheckResult: CheckResult{BlogID: req.BlogID, URL: req.URL}}
+		return ProbeResult{CheckResult: CheckResult{BlogID: req.BlogID, URL: req.URL, Success: true}, Outcome: OutcomeUp}
 	}, 1, 1)
 	defer exec.Shutdown()
 
-	_, err := exec.ExecuteBatch(context.Background(), []CheckRequest{
+	results, err := exec.ExecuteBatch(context.Background(), []CheckRequest{
 		{BlogID: 1, URL: "https://example.com/1"},
 		{BlogID: 2, URL: "https://example.com/2"},
 		{BlogID: 3, URL: "https://example.com/3"},
 	})
-	if !errors.Is(err, ErrOverloaded) {
-		t.Fatalf("ExecuteBatch() error = %v, want ErrOverloaded", err)
+	if err != nil {
+		t.Fatalf("ExecuteBatch() error = %v", err)
 	}
-	if called.Load() != 0 {
-		t.Fatalf("check function called %d times for rejected batch", called.Load())
+	if called.Load() != 2 {
+		t.Fatalf("check function called %d times, want 2 admitted checks", called.Load())
+	}
+	if len(results) != 3 {
+		t.Fatalf("results len = %d, want 3", len(results))
+	}
+	if !results[0].Success || !results[1].Success {
+		t.Fatalf("admitted results = %+v, want successes", results[:2])
+	}
+	if results[2].Success || results[2].Outcome != OutcomeAgentOverloaded {
+		t.Fatalf("shed result = %+v, want agent_overloaded", results[2])
 	}
 }
 
 func TestExecutorContextCancellationReturnsTimeoutResult(t *testing.T) {
+	started := make(chan struct{})
 	exec := NewExecutor(func(ctx context.Context, req CheckRequest) ProbeResult {
+		close(started)
 		<-ctx.Done()
 		return ProbeResult{CheckResult: CheckResult{
 			BlogID:    req.BlogID,
@@ -70,9 +81,26 @@ func TestExecutorContextCancellationReturnsTimeoutResult(t *testing.T) {
 	}, 1, 1)
 	defer exec.Shutdown()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
-	defer cancel()
-	results, err := exec.ExecuteBatch(ctx, []CheckRequest{{BlogID: 1, URL: "https://example.com", RequestID: "req-1"}})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct {
+		results []ProbeResult
+		err     error
+	}, 1)
+	go func() {
+		results, err := exec.ExecuteBatch(ctx, []CheckRequest{{BlogID: 1, URL: "https://example.com", RequestID: "req-1"}})
+		done <- struct {
+			results []ProbeResult
+			err     error
+		}{results: results, err: err}
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for check to start")
+	}
+	cancel()
+	out := <-done
+	results, err := out.results, out.err
 	if err != nil {
 		t.Fatalf("ExecuteBatch() error = %v", err)
 	}
@@ -85,8 +113,10 @@ func TestExecutorContextCancellationReturnsTimeoutResult(t *testing.T) {
 }
 
 func TestExecutorContextCancellationKeepsCompletedResults(t *testing.T) {
+	slowStarted := make(chan struct{})
 	exec := NewExecutor(func(ctx context.Context, req CheckRequest) ProbeResult {
 		if req.BlogID == 2 {
+			close(slowStarted)
 			<-ctx.Done()
 			return ProbeResult{CheckResult: CheckResult{
 				BlogID:    req.BlogID,
@@ -106,12 +136,29 @@ func TestExecutorContextCancellationKeepsCompletedResults(t *testing.T) {
 	}, 2, 2)
 	defer exec.Shutdown()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
-	defer cancel()
-	results, err := exec.ExecuteBatch(ctx, []CheckRequest{
-		{BlogID: 1, URL: "https://example.com/fast", RequestID: "fast"},
-		{BlogID: 2, URL: "https://example.com/slow", RequestID: "slow"},
-	})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct {
+		results []ProbeResult
+		err     error
+	}, 1)
+	go func() {
+		results, err := exec.ExecuteBatch(ctx, []CheckRequest{
+			{BlogID: 1, URL: "https://example.com/fast", RequestID: "fast"},
+			{BlogID: 2, URL: "https://example.com/slow", RequestID: "slow"},
+		})
+		done <- struct {
+			results []ProbeResult
+			err     error
+		}{results: results, err: err}
+	}()
+	select {
+	case <-slowStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for slow check to start")
+	}
+	cancel()
+	out := <-done
+	results, err := out.results, out.err
 	if err != nil {
 		t.Fatalf("ExecuteBatch() error = %v", err)
 	}

--- a/internal/veriflier/server.go
+++ b/internal/veriflier/server.go
@@ -353,6 +353,9 @@ func (s *Server) v2Result(res ProbeResult) CheckV2Result {
 	return CheckV2Result{
 		RequestID: res.RequestID,
 		BlogID:    res.BlogID,
+		URL:       res.URL,
+		VantageID: s.vantage.ID,
+		AgentID:   s.agent.ID,
 		Outcome:   outcome,
 		Success:   res.Success,
 		HTTPCode:  res.HTTPCode,

--- a/internal/veriflier/server.go
+++ b/internal/veriflier/server.go
@@ -206,9 +206,6 @@ func (s *Server) handleCheck(w http.ResponseWriter, r *http.Request) {
 		if req.Sites[i].RequestID == "" {
 			req.Sites[i].RequestID = NewRequestID()
 		}
-		// Echo RequestID so the orchestrator can correlate this reply with the
-		// audit row it wrote when escalating.
-		log.Printf("veriflier: check blog_id=%d request_id=%s url=%s", req.Sites[i].BlogID, req.Sites[i].RequestID, req.Sites[i].URL)
 	}
 
 	probeResults, err := s.executor.ExecuteBatch(r.Context(), req.Sites)
@@ -289,7 +286,6 @@ func (s *Server) handleV2Check(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		legacyReqs = append(legacyReqs, legacyReq)
-		log.Printf("veriflier: v2 check blog_id=%d request_id=%s url=%s", legacyReq.BlogID, legacyReq.RequestID, legacyReq.URL)
 	}
 
 	probeResults, err := s.executor.ExecuteBatch(ctx, legacyReqs)

--- a/internal/veriflier/server.go
+++ b/internal/veriflier/server.go
@@ -353,9 +353,6 @@ func (s *Server) v2Result(res ProbeResult) CheckV2Result {
 	return CheckV2Result{
 		RequestID: res.RequestID,
 		BlogID:    res.BlogID,
-		URL:       res.URL,
-		VantageID: s.vantage.ID,
-		AgentID:   s.agent.ID,
 		Outcome:   outcome,
 		Success:   res.Success,
 		HTTPCode:  res.HTTPCode,

--- a/internal/veriflier/server.go
+++ b/internal/veriflier/server.go
@@ -218,14 +218,14 @@ func (s *Server) handleCheck(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusGatewayTimeout)
 		return
 	}
-	results := make([]CheckResult, 0, len(probeResults))
-	for _, probeResult := range probeResults {
+	results := make([]CheckResult, len(probeResults))
+	for i, probeResult := range probeResults {
 		res := probeResult.CheckResult
 		res.Host = s.hostname
 		if res.RequestID == "" {
 			res.RequestID = probeResult.RequestID
 		}
-		results = append(results, res)
+		results[i] = res
 	}
 
 	incrementMetric("verifier.checks.received.count", len(req.Sites))
@@ -278,14 +278,14 @@ func (s *Server) handleV2Check(w http.ResponseWriter, r *http.Request) {
 		defer cancel()
 	}
 
-	legacyReqs := make([]CheckRequest, 0, len(req.Requests))
-	for _, site := range req.Requests {
+	legacyReqs := make([]CheckRequest, len(req.Requests))
+	for i, site := range req.Requests {
 		legacyReq, err := v2RequestToLegacy(site)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		legacyReqs = append(legacyReqs, legacyReq)
+		legacyReqs[i] = legacyReq
 	}
 
 	probeResults, err := s.executor.ExecuteBatch(ctx, legacyReqs)
@@ -299,9 +299,9 @@ func (s *Server) handleV2Check(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	results := make([]CheckV2Result, 0, len(probeResults))
-	for _, probeResult := range probeResults {
-		results = append(results, s.v2Result(probeResult))
+	results := make([]CheckV2Result, len(probeResults))
+	for i, probeResult := range probeResults {
+		results[i] = s.v2Result(probeResult)
 	}
 
 	incrementMetric("verifier.checks.received.count", len(req.Requests))

--- a/internal/veriflier/server.go
+++ b/internal/veriflier/server.go
@@ -218,14 +218,14 @@ func (s *Server) handleCheck(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusGatewayTimeout)
 		return
 	}
-	results := make([]CheckResult, len(probeResults))
-	for i, probeResult := range probeResults {
+	results := make([]CheckResult, 0, len(probeResults))
+	for _, probeResult := range probeResults {
 		res := probeResult.CheckResult
 		res.Host = s.hostname
 		if res.RequestID == "" {
 			res.RequestID = probeResult.RequestID
 		}
-		results[i] = res
+		results = append(results, res)
 	}
 
 	incrementMetric("verifier.checks.received.count", len(req.Sites))
@@ -278,14 +278,14 @@ func (s *Server) handleV2Check(w http.ResponseWriter, r *http.Request) {
 		defer cancel()
 	}
 
-	legacyReqs := make([]CheckRequest, len(req.Requests))
-	for i, site := range req.Requests {
+	legacyReqs := make([]CheckRequest, 0, len(req.Requests))
+	for _, site := range req.Requests {
 		legacyReq, err := v2RequestToLegacy(site)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		legacyReqs[i] = legacyReq
+		legacyReqs = append(legacyReqs, legacyReq)
 	}
 
 	probeResults, err := s.executor.ExecuteBatch(ctx, legacyReqs)
@@ -299,9 +299,9 @@ func (s *Server) handleV2Check(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	results := make([]CheckV2Result, len(probeResults))
-	for i, probeResult := range probeResults {
-		results[i] = s.v2Result(probeResult)
+	results := make([]CheckV2Result, 0, len(probeResults))
+	for _, probeResult := range probeResults {
+		results = append(results, s.v2Result(probeResult))
 	}
 
 	incrementMetric("verifier.checks.received.count", len(req.Requests))

--- a/internal/veriflier/soak_test.go
+++ b/internal/veriflier/soak_test.go
@@ -154,15 +154,15 @@ func TestV2SoakOverloadThenRecovers(t *testing.T) {
 	status, body := postV2Batch(t, ts.URL, "secret", CheckV2BatchRequest{
 		Requests: []CheckV2Request{{BlogID: 3, URL: "https://example.com/3"}},
 	})
-	if status != http.StatusServiceUnavailable {
-		t.Fatalf("overload status = %d body=%s, want 503", status, body)
+	if status != http.StatusOK {
+		t.Fatalf("overload status = %d body=%s, want 200 with agent_overloaded result", status, body)
 	}
-	var errBody map[string]string
-	if err := json.Unmarshal(body, &errBody); err != nil {
-		t.Fatalf("decode overload body: %v", err)
+	var overloadResp CheckV2BatchResponse
+	if err := json.Unmarshal(body, &overloadResp); err != nil {
+		t.Fatalf("decode overload response: %v", err)
 	}
-	if errBody["outcome"] != OutcomeAgentOverloaded {
-		t.Fatalf("overload outcome = %q, want %q", errBody["outcome"], OutcomeAgentOverloaded)
+	if len(overloadResp.Results) != 1 || overloadResp.Results[0].Outcome != OutcomeAgentOverloaded {
+		t.Fatalf("overload response = %+v, want one agent_overloaded result", overloadResp.Results)
 	}
 
 	close(block)
@@ -206,7 +206,7 @@ func TestV2SoakDeadlineTimeoutThenRecovers(t *testing.T) {
 
 	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
 	status, body := postV2Batch(t, ts.URL, "secret", CheckV2BatchRequest{
-		DeadlineMS: 10,
+		DeadlineMS: 100,
 		Requests:   []CheckV2Request{{BlogID: 1, URL: "https://example.com/slow"}},
 	})
 	if status != http.StatusOK {

--- a/internal/veriflier/soak_test.go
+++ b/internal/veriflier/soak_test.go
@@ -219,8 +219,8 @@ func TestV2SoakDeadlineTimeoutThenRecovers(t *testing.T) {
 	if len(deadlineResp.Results) != 1 {
 		t.Fatalf("deadline results len = %d, want 1", len(deadlineResp.Results))
 	}
-	if deadlineResp.Results[0].Outcome != OutcomeTimeout || deadlineResp.Results[0].Success {
-		t.Fatalf("deadline result = %+v, want per-request timeout", deadlineResp.Results[0])
+	if deadlineResp.Results[0].Outcome != OutcomeAgentOverloaded || deadlineResp.Results[0].Success {
+		t.Fatalf("deadline result = %+v, want agent_overloaded non-vote", deadlineResp.Results[0])
 	}
 
 	waitForCapacity(t, client, func(c Capacity) bool {

--- a/internal/veriflier/soak_test.go
+++ b/internal/veriflier/soak_test.go
@@ -209,8 +209,18 @@ func TestV2SoakDeadlineTimeoutThenRecovers(t *testing.T) {
 		DeadlineMS: 10,
 		Requests:   []CheckV2Request{{BlogID: 1, URL: "https://example.com/slow"}},
 	})
-	if status != http.StatusGatewayTimeout {
-		t.Fatalf("deadline status = %d body=%s, want 504", status, body)
+	if status != http.StatusOK {
+		t.Fatalf("deadline status = %d body=%s, want 200", status, body)
+	}
+	var deadlineResp CheckV2BatchResponse
+	if err := json.Unmarshal(body, &deadlineResp); err != nil {
+		t.Fatalf("decode deadline body: %v", err)
+	}
+	if len(deadlineResp.Results) != 1 {
+		t.Fatalf("deadline results len = %d, want 1", len(deadlineResp.Results))
+	}
+	if deadlineResp.Results[0].Outcome != OutcomeTimeout || deadlineResp.Results[0].Success {
+		t.Fatalf("deadline result = %+v, want per-request timeout", deadlineResp.Results[0])
 	}
 
 	waitForCapacity(t, client, func(c Capacity) bool {

--- a/internal/veriflier/types.go
+++ b/internal/veriflier/types.go
@@ -79,6 +79,9 @@ type Capacity struct {
 	QueueDepth     int `json:"queue_depth"`
 	Active         int `json:"active"`
 	InFlight       int `json:"in_flight"`
+	Completed      int `json:"completed,omitempty"`
+	Rejected       int `json:"rejected,omitempty"`
+	AvgCheckMS     int `json:"avg_check_ms,omitempty"`
 }
 
 type StatusV2Response struct {

--- a/internal/veriflier/types.go
+++ b/internal/veriflier/types.go
@@ -130,9 +130,9 @@ type TimingsMS struct {
 type CheckV2Result struct {
 	RequestID string    `json:"request_id"`
 	BlogID    int64     `json:"blog_id"`
-	URL       string    `json:"url,omitempty"`
-	VantageID string    `json:"vantage_id,omitempty"`
-	AgentID   string    `json:"agent_id,omitempty"`
+	URL       string    `json:"url"`
+	VantageID string    `json:"vantage_id"`
+	AgentID   string    `json:"agent_id"`
 	Outcome   string    `json:"outcome"`
 	Success   bool      `json:"success"`
 	HTTPCode  int32     `json:"http_code"`

--- a/internal/veriflier/types.go
+++ b/internal/veriflier/types.go
@@ -6,9 +6,8 @@ package veriflier
 // CheckRequest is a single site to check, sent from Monitor to Veriflier.
 //
 // RequestID is a client-generated correlation id (16-byte hex). The verifier
-// echoes it back in the response and stamps it on its server-side log line so
-// that "the orchestrator escalated → this verifier observed → this audit row
-// in the monitor DB" can be reconstructed without timestamp matching.
+// echoes it back in the response so the monitor can join dispatch audit rows to
+// verifier results without timestamp matching.
 type CheckRequest struct {
 	MonitorSiteID       int64
 	BlogID              int64

--- a/internal/veriflier/types.go
+++ b/internal/veriflier/types.go
@@ -130,9 +130,9 @@ type TimingsMS struct {
 type CheckV2Result struct {
 	RequestID string    `json:"request_id"`
 	BlogID    int64     `json:"blog_id"`
-	URL       string    `json:"url"`
-	VantageID string    `json:"vantage_id"`
-	AgentID   string    `json:"agent_id"`
+	URL       string    `json:"url,omitempty"`
+	VantageID string    `json:"vantage_id,omitempty"`
+	AgentID   string    `json:"agent_id,omitempty"`
 	Outcome   string    `json:"outcome"`
 	Success   bool      `json:"success"`
 	HTTPCode  int32     `json:"http_code"`

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -259,6 +259,70 @@ func TestClientBatchRoundTrip(t *testing.T) {
 	}
 }
 
+func TestClientBatchMapsOutOfOrderV2ResultsByRequestID(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/check" {
+			http.NotFound(w, r)
+			return
+		}
+		var req CheckV2BatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		if len(req.Requests) != 2 {
+			t.Errorf("request len = %d, want 2", len(req.Requests))
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		results := []CheckV2Result{
+			{
+				RequestID: req.Requests[1].RequestID,
+				BlogID:    req.Requests[1].BlogID,
+				URL:       req.Requests[1].URL,
+				VantageID: "test-vantage",
+				AgentID:   "test-agent",
+				Outcome:   OutcomeUp,
+				Success:   true,
+				HTTPCode:  200,
+			},
+			{
+				RequestID: req.Requests[0].RequestID,
+				BlogID:    req.Requests[0].BlogID,
+				URL:       req.Requests[0].URL,
+				VantageID: "test-vantage",
+				AgentID:   "test-agent",
+				Outcome:   OutcomeUp,
+				Success:   true,
+				HTTPCode:  200,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(CheckV2BatchResponse{Results: results})
+	}))
+	defer ts.Close()
+
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
+	client.setProtocol(ProtocolV2)
+	res, err := client.CheckBatch(context.Background(), []CheckRequest{
+		{MonitorSiteID: 101, BlogID: 1, URL: "https://example.com/one", RequestID: "one"},
+		{MonitorSiteID: 0, BlogID: 2, URL: "https://example.com/two", RequestID: "two"},
+	})
+	if err != nil {
+		t.Fatalf("CheckBatch() error = %v", err)
+	}
+	if len(res) != 2 {
+		t.Fatalf("CheckBatch() len = %d, want 2", len(res))
+	}
+	if res[0].RequestID != "two" || res[0].MonitorSiteID != 0 || res[0].BlogID != 2 {
+		t.Fatalf("first result = %+v, want request two metadata", res[0])
+	}
+	if res[1].RequestID != "one" || res[1].MonitorSiteID != 101 || res[1].BlogID != 1 {
+		t.Fatalf("second result = %+v, want request one metadata", res[1])
+	}
+}
+
 func TestClientBatchSendsServerDeadlineWithReserve(t *testing.T) {
 	origReserve := singleCheckBatchDeadlineReserve
 	origLargeReserve := singleCheckLargeBatchDeadlineReserve
@@ -530,6 +594,86 @@ func TestClientCheckCoalescesConcurrentSingles(t *testing.T) {
 	}
 	if maxBatch.Load() < 2 {
 		t.Fatalf("max batch size = %d, want coalesced requests", maxBatch.Load())
+	}
+}
+
+func TestSingleCheckBatcherMapsOutOfOrderResultsByRequestID(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/check" {
+			http.NotFound(w, r)
+			return
+		}
+		var req CheckV2BatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		if len(req.Requests) != 2 {
+			t.Errorf("request len = %d, want 2", len(req.Requests))
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		results := []CheckV2Result{
+			{
+				RequestID: req.Requests[1].RequestID,
+				BlogID:    req.Requests[1].BlogID,
+				URL:       req.Requests[1].URL,
+				VantageID: "test-vantage",
+				AgentID:   "test-agent",
+				Outcome:   OutcomeUp,
+				Success:   true,
+				HTTPCode:  200,
+			},
+			{
+				RequestID: req.Requests[0].RequestID,
+				BlogID:    req.Requests[0].BlogID,
+				URL:       req.Requests[0].URL,
+				VantageID: "test-vantage",
+				AgentID:   "test-agent",
+				Outcome:   OutcomeUp,
+				Success:   true,
+				HTTPCode:  200,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(CheckV2BatchResponse{Results: results})
+	}))
+	defer ts.Close()
+
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
+	client.setProtocol(ProtocolV2)
+	batcher := &singleCheckBatcher{client: client}
+	calls := []singleCheckCall{
+		{
+			ctx:  context.Background(),
+			req:  CheckRequest{BlogID: 1, URL: "https://example.com/one", RequestID: "one"},
+			resp: make(chan singleCheckResponse, 1),
+		},
+		{
+			ctx:  context.Background(),
+			req:  CheckRequest{BlogID: 2, URL: "https://example.com/two", RequestID: "two"},
+			resp: make(chan singleCheckResponse, 1),
+		},
+	}
+	batcher.flush(calls)
+
+	seen := map[string]CheckResult{}
+	for _, call := range calls {
+		got := <-call.resp
+		if got.err != nil {
+			t.Fatalf("Check() error = %v", got.err)
+		}
+		if got.result == nil {
+			t.Fatal("Check() returned nil result")
+		}
+		seen[got.result.RequestID] = *got.result
+	}
+	if seen["one"].BlogID != 1 {
+		t.Fatalf("request one result = %+v", seen["one"])
+	}
+	if seen["two"].BlogID != 2 {
+		t.Fatalf("request two result = %+v", seen["two"])
 	}
 }
 

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -258,6 +258,61 @@ func TestClientBatchRoundTrip(t *testing.T) {
 	}
 }
 
+func TestClientBatchSendsServerDeadlineWithReserve(t *testing.T) {
+	origReserve := singleCheckBatchDeadlineReserve
+	singleCheckBatchDeadlineReserve = 750 * time.Millisecond
+	defer func() { singleCheckBatchDeadlineReserve = origReserve }()
+
+	var gotDeadline atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/check" {
+			http.NotFound(w, r)
+			return
+		}
+		var req CheckV2BatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		gotDeadline.Store(req.DeadlineMS)
+		results := make([]CheckV2Result, 0, len(req.Requests))
+		for _, check := range req.Requests {
+			results = append(results, CheckV2Result{
+				RequestID: check.RequestID,
+				BlogID:    check.BlogID,
+				URL:       check.URL,
+				VantageID: "test-vantage",
+				AgentID:   "test-agent",
+				Outcome:   OutcomeUp,
+				Success:   true,
+				HTTPCode:  200,
+			})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(CheckV2BatchResponse{Results: results})
+	}))
+	defer ts.Close()
+
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if _, err := client.CheckBatch(ctx, []CheckRequest{{BlogID: 1, URL: "https://example.com"}}); err != nil {
+		t.Fatalf("CheckBatch() error = %v", err)
+	}
+
+	got := gotDeadline.Load()
+	if got <= 0 {
+		t.Fatal("DeadlineMS was not sent")
+	}
+	if got >= 3000 {
+		t.Fatalf("DeadlineMS = %d, want less than caller deadline", got)
+	}
+	if got < 2000 {
+		t.Fatalf("DeadlineMS = %d, want reserve without excessive deadline loss", got)
+	}
+}
+
 func TestClientCheckCoalescesConcurrentSingles(t *testing.T) {
 	origDelay := singleCheckBatchMaxDelay
 	singleCheckBatchMaxDelay = 25 * time.Millisecond

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -260,8 +260,13 @@ func TestClientBatchRoundTrip(t *testing.T) {
 
 func TestClientBatchSendsServerDeadlineWithReserve(t *testing.T) {
 	origReserve := singleCheckBatchDeadlineReserve
+	origLargeReserve := singleCheckLargeBatchDeadlineReserve
 	singleCheckBatchDeadlineReserve = 750 * time.Millisecond
-	defer func() { singleCheckBatchDeadlineReserve = origReserve }()
+	singleCheckLargeBatchDeadlineReserve = 1500 * time.Millisecond
+	defer func() {
+		singleCheckBatchDeadlineReserve = origReserve
+		singleCheckLargeBatchDeadlineReserve = origLargeReserve
+	}()
 
 	var gotDeadline atomic.Int64
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -309,6 +314,67 @@ func TestClientBatchSendsServerDeadlineWithReserve(t *testing.T) {
 		t.Fatalf("DeadlineMS = %d, want less than caller deadline", got)
 	}
 	if got < 2000 {
+		t.Fatalf("DeadlineMS = %d, want reserve without excessive deadline loss", got)
+	}
+}
+
+func TestClientBatchUsesLargerDeadlineReserveForLargeBatches(t *testing.T) {
+	origReserve := singleCheckBatchDeadlineReserve
+	origLargeReserve := singleCheckLargeBatchDeadlineReserve
+	singleCheckBatchDeadlineReserve = 250 * time.Millisecond
+	singleCheckLargeBatchDeadlineReserve = time.Second
+	defer func() {
+		singleCheckBatchDeadlineReserve = origReserve
+		singleCheckLargeBatchDeadlineReserve = origLargeReserve
+	}()
+
+	var gotDeadline atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/check" {
+			http.NotFound(w, r)
+			return
+		}
+		var req CheckV2BatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		gotDeadline.Store(req.DeadlineMS)
+		results := make([]CheckV2Result, 0, len(req.Requests))
+		for _, check := range req.Requests {
+			results = append(results, CheckV2Result{
+				RequestID: check.RequestID,
+				BlogID:    check.BlogID,
+				URL:       check.URL,
+				VantageID: "test-vantage",
+				AgentID:   "test-agent",
+				Outcome:   OutcomeUp,
+				Success:   true,
+				HTTPCode:  200,
+			})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(CheckV2BatchResponse{Results: results})
+	}))
+	defer ts.Close()
+
+	reqs := make([]CheckRequest, singleCheckFullBatchMaxSize+1)
+	for i := range reqs {
+		reqs[i] = CheckRequest{BlogID: int64(i + 1), URL: "https://example.com"}
+	}
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if _, err := client.CheckBatch(ctx, reqs); err != nil {
+		t.Fatalf("CheckBatch() error = %v", err)
+	}
+
+	got := gotDeadline.Load()
+	if got >= 2250 {
+		t.Fatalf("DeadlineMS = %d, want large-batch reserve to leave about 1s", got)
+	}
+	if got < 1900 {
 		t.Fatalf("DeadlineMS = %d, want reserve without excessive deadline loss", got)
 	}
 }

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -780,6 +780,12 @@ func TestNewRequestID(t *testing.T) {
 	}
 }
 
+func BenchmarkNewRequestID(b *testing.B) {
+	for b.Loop() {
+		_ = NewRequestID()
+	}
+}
+
 func TestRequestIDIsEchoed(t *testing.T) {
 	// Server should reflect each request's RequestID into the corresponding result.
 	_, ts := newTestServer(func(req CheckRequest) CheckResult {

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -1220,8 +1220,11 @@ func TestServerHandleV2Check(t *testing.T) {
 		t.Fatalf("results len = %d, want 1", len(result.Results))
 	}
 	got := result.Results[0]
-	if got.RequestID != "req-1" || got.VantageID != "test-vantage" || got.AgentID != "test-agent" {
-		t.Fatalf("result identity = %+v", got)
+	if got.RequestID != "req-1" {
+		t.Fatalf("result request id = %+v", got)
+	}
+	if got.VantageID != "" || got.AgentID != "" {
+		t.Fatalf("result duplicated batch identity: %+v", got)
 	}
 	if got.Outcome != OutcomeDown || got.Success || got.HTTPCode != 500 || got.RTTMs != 123 {
 		t.Fatalf("result = %+v", got)
@@ -1332,6 +1335,9 @@ func TestClientPrefersV2WhenAvailable(t *testing.T) {
 	}
 	if res.Host != "edge-us-east" {
 		t.Fatalf("Host = %q, want v2 vantage identity", res.Host)
+	}
+	if res.URL != "https://example.com" {
+		t.Fatalf("URL = %q, want original request URL filled from compact v2 response", res.URL)
 	}
 	if res.VantageID != "edge-us-east" || res.AgentID != "agent-1" || res.Outcome != OutcomeUp {
 		t.Fatalf("v2 identity = vantage:%q agent:%q outcome:%q", res.VantageID, res.AgentID, res.Outcome)

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -1265,6 +1266,41 @@ func TestClientTreatsCachedV2EOFAsAgentOverloaded(t *testing.T) {
 		conn, _, err := w.(http.Hijacker).Hijack()
 		if err != nil {
 			t.Fatalf("hijack: %v", err)
+		}
+		_ = conn.Close()
+	})
+	mux.HandleFunc("/check", func(w http.ResponseWriter, r *http.Request) {
+		legacyHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
+	client.setProtocol(ProtocolV2)
+	res, err := client.Check(context.Background(), CheckRequest{BlogID: 1, URL: "https://example.com"})
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	if res == nil || res.Outcome != OutcomeAgentOverloaded || res.Success {
+		t.Fatalf("result = %+v, want agent_overloaded non-success", res)
+	}
+	if legacyHits.Load() != 0 {
+		t.Fatalf("legacy hits = %d, want 0 for cached v2 protocol", legacyHits.Load())
+	}
+}
+
+func TestClientTreatsCachedV2ConnectionResetAsAgentOverloaded(t *testing.T) {
+	var legacyHits atomic.Int64
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/check", func(w http.ResponseWriter, r *http.Request) {
+		conn, _, err := w.(http.Hijacker).Hijack()
+		if err != nil {
+			t.Fatalf("hijack: %v", err)
+		}
+		if tcp, ok := conn.(*net.TCPConn); ok {
+			_ = tcp.SetLinger(0)
 		}
 		_ = conn.Close()
 	})

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -532,6 +532,40 @@ func TestClientCheckCoalescesConcurrentSingles(t *testing.T) {
 	}
 }
 
+func TestClientCheckReturnsAgentOverloadedOnDeadlinePressure(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/check" {
+			http.NotFound(w, r)
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(CheckV2BatchResponse{Results: []CheckV2Result{{
+			RequestID: "late",
+			BlogID:    1,
+			URL:       "https://example.com",
+			VantageID: "test-vantage",
+			AgentID:   "test-agent",
+			Outcome:   OutcomeUp,
+			Success:   true,
+			HTTPCode:  200,
+		}}})
+	}))
+	defer ts.Close()
+
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
+	client.setProtocol(ProtocolV2)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	res, err := client.Check(ctx, CheckRequest{BlogID: 1, URL: "https://example.com"})
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	if res == nil || res.Outcome != OutcomeAgentOverloaded || res.Success {
+		t.Fatalf("result = %+v, want agent_overloaded non-success", res)
+	}
+}
+
 func TestClientCheckUsesSmallerBatchesForFullDetectionWork(t *testing.T) {
 	origDelay := singleCheckBatchMaxDelay
 	origLightMax := singleCheckBatchMaxSize

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -899,6 +899,51 @@ func TestClientCheckKeepsLightLaneMovingDuringFullBatch(t *testing.T) {
 	}
 }
 
+func TestSingleCheckBatcherPrunesExpiredCallsWhileWaitingForFlight(t *testing.T) {
+	origPoll := singleCheckBatchFlightWaitPoll
+	singleCheckBatchFlightWaitPoll = time.Millisecond
+	defer func() { singleCheckBatchFlightWaitPoll = origPoll }()
+
+	inFlight := make(chan struct{}, 1)
+	inFlight <- struct{}{}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+	resp := make(chan singleCheckResponse, 1)
+	batch := []singleCheckCall{{
+		ctx: ctx,
+		req: CheckRequest{
+			BlogID:    42,
+			URL:       "https://example.com",
+			RequestID: "req-42",
+		},
+		resp: resp,
+	}}
+
+	kept, acquired := waitForSingleCheckFlight(batch, inFlight)
+	if acquired {
+		t.Fatal("expired batch should not acquire an in-flight slot")
+	}
+	if len(kept) != 0 {
+		t.Fatalf("kept calls = %d, want 0", len(kept))
+	}
+	if len(inFlight) != 1 {
+		t.Fatalf("in-flight slots = %d, want still occupied by caller", len(inFlight))
+	}
+
+	select {
+	case got := <-resp:
+		if got.err != nil {
+			t.Fatalf("expired call returned error = %v, want agent_overloaded result", got.err)
+		}
+		if got.result == nil || got.result.Outcome != OutcomeAgentOverloaded || got.result.RequestID != "req-42" {
+			t.Fatalf("expired call result = %+v, want agent_overloaded for req-42", got.result)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expired call was not answered while waiting for flight")
+	}
+}
+
 func TestClientRejectsUnauthorized(t *testing.T) {
 	_, ts := newTestServer(func(req CheckRequest) CheckResult { return CheckResult{} })
 	defer ts.Close()

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -795,6 +796,26 @@ func TestClientCheckUsesSmallerBatchesForFullDetectionWork(t *testing.T) {
 	}
 	if maxBatch.Load() > int32(singleCheckFullBatchMaxSize) {
 		t.Fatalf("max batch size = %d, want <= full cap %d", maxBatch.Load(), singleCheckFullBatchMaxSize)
+	}
+}
+
+func TestDefaultLightBatchFlightScalesWithCPUWithinBounds(t *testing.T) {
+	orig := runtime.GOMAXPROCS(0)
+	defer runtime.GOMAXPROCS(orig)
+
+	runtime.GOMAXPROCS(1)
+	if got := defaultSingleCheckLightBatchMaxFlight(); got != 32 {
+		t.Fatalf("flight for 1 proc = %d, want 32 minimum", got)
+	}
+
+	runtime.GOMAXPROCS(4)
+	if got := defaultSingleCheckLightBatchMaxFlight(); got != 64 {
+		t.Fatalf("flight for 4 procs = %d, want 64", got)
+	}
+
+	runtime.GOMAXPROCS(64)
+	if got := defaultSingleCheckLightBatchMaxFlight(); got != 128 {
+		t.Fatalf("flight for 64 procs = %d, want 128 cap", got)
 	}
 }
 

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -1333,9 +1333,6 @@ func TestClientPrefersV2WhenAvailable(t *testing.T) {
 	if res.Host != "edge-us-east" {
 		t.Fatalf("Host = %q, want v2 vantage identity", res.Host)
 	}
-	if res.URL != "https://example.com" {
-		t.Fatalf("URL = %q, want original request URL filled from compact v2 response", res.URL)
-	}
 	if res.VantageID != "edge-us-east" || res.AgentID != "agent-1" || res.Outcome != OutcomeUp {
 		t.Fatalf("v2 identity = vantage:%q agent:%q outcome:%q", res.VantageID, res.AgentID, res.Outcome)
 	}

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -796,26 +795,6 @@ func TestClientCheckUsesSmallerBatchesForFullDetectionWork(t *testing.T) {
 	}
 	if maxBatch.Load() > int32(singleCheckFullBatchMaxSize) {
 		t.Fatalf("max batch size = %d, want <= full cap %d", maxBatch.Load(), singleCheckFullBatchMaxSize)
-	}
-}
-
-func TestDefaultLightBatchFlightScalesWithCPUWithinBounds(t *testing.T) {
-	orig := runtime.GOMAXPROCS(0)
-	defer runtime.GOMAXPROCS(orig)
-
-	runtime.GOMAXPROCS(1)
-	if got := defaultSingleCheckLightBatchMaxFlight(); got != 32 {
-		t.Fatalf("flight for 1 proc = %d, want 32 minimum", got)
-	}
-
-	runtime.GOMAXPROCS(4)
-	if got := defaultSingleCheckLightBatchMaxFlight(); got != 64 {
-		t.Fatalf("flight for 4 procs = %d, want 64", got)
-	}
-
-	runtime.GOMAXPROCS(64)
-	if got := defaultSingleCheckLightBatchMaxFlight(); got != 128 {
-		t.Fatalf("flight for 64 procs = %d, want 128 cap", got)
 	}
 }
 

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -318,7 +318,7 @@ func TestClientBatchSendsServerDeadlineWithReserve(t *testing.T) {
 	}
 }
 
-func TestClientBatchUsesLargerDeadlineReserveForLargeBatches(t *testing.T) {
+func TestClientBatchUsesLargerDeadlineReserveForLightBatches(t *testing.T) {
 	origReserve := singleCheckBatchDeadlineReserve
 	origLargeReserve := singleCheckLargeBatchDeadlineReserve
 	singleCheckBatchDeadlineReserve = 250 * time.Millisecond
@@ -361,7 +361,12 @@ func TestClientBatchUsesLargerDeadlineReserveForLargeBatches(t *testing.T) {
 
 	reqs := make([]CheckRequest, singleCheckFullBatchMaxSize+1)
 	for i := range reqs {
-		reqs[i] = CheckRequest{BlogID: int64(i + 1), URL: "https://example.com"}
+		reqs[i] = CheckRequest{
+			BlogID:           int64(i + 1),
+			URL:              "https://example.com",
+			Method:           http.MethodHead,
+			DetectionProfile: "legacy",
+		}
 	}
 	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -376,6 +381,72 @@ func TestClientBatchUsesLargerDeadlineReserveForLargeBatches(t *testing.T) {
 	}
 	if got < 1900 {
 		t.Fatalf("DeadlineMS = %d, want reserve without excessive deadline loss", got)
+	}
+}
+
+func TestClientBatchKeepsSmallDeadlineReserveForFullBatches(t *testing.T) {
+	origReserve := singleCheckBatchDeadlineReserve
+	origLargeReserve := singleCheckLargeBatchDeadlineReserve
+	singleCheckBatchDeadlineReserve = 250 * time.Millisecond
+	singleCheckLargeBatchDeadlineReserve = time.Second
+	defer func() {
+		singleCheckBatchDeadlineReserve = origReserve
+		singleCheckLargeBatchDeadlineReserve = origLargeReserve
+	}()
+
+	var gotDeadline atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/check" {
+			http.NotFound(w, r)
+			return
+		}
+		var req CheckV2BatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		gotDeadline.Store(req.DeadlineMS)
+		results := make([]CheckV2Result, 0, len(req.Requests))
+		for _, check := range req.Requests {
+			results = append(results, CheckV2Result{
+				RequestID: check.RequestID,
+				BlogID:    check.BlogID,
+				URL:       check.URL,
+				VantageID: "test-vantage",
+				AgentID:   "test-agent",
+				Outcome:   OutcomeUp,
+				Success:   true,
+				HTTPCode:  200,
+			})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(CheckV2BatchResponse{Results: results})
+	}))
+	defer ts.Close()
+
+	reqs := make([]CheckRequest, singleCheckFullBatchMaxSize+1)
+	for i := range reqs {
+		reqs[i] = CheckRequest{
+			BlogID:           int64(i + 1),
+			URL:              "https://example.com",
+			Method:           http.MethodGet,
+			DetectionProfile: "full",
+		}
+	}
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if _, err := client.CheckBatch(ctx, reqs); err != nil {
+		t.Fatalf("CheckBatch() error = %v", err)
+	}
+
+	got := gotDeadline.Load()
+	if got < 2600 {
+		t.Fatalf("DeadlineMS = %d, want small reserve for full batch", got)
+	}
+	if got >= 3000 {
+		t.Fatalf("DeadlineMS = %d, want less than caller deadline", got)
 	}
 }
 

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -313,12 +313,12 @@ func TestClientBatchSendsServerDeadlineWithReserve(t *testing.T) {
 	if got >= 3000 {
 		t.Fatalf("DeadlineMS = %d, want less than caller deadline", got)
 	}
-	if got < 2000 {
+	if got < 1000 {
 		t.Fatalf("DeadlineMS = %d, want reserve without excessive deadline loss", got)
 	}
 }
 
-func TestClientBatchUsesLargerDeadlineReserveForLightBatches(t *testing.T) {
+func TestClientBatchUsesLargerDeadlineReserveForBatches(t *testing.T) {
 	origReserve := singleCheckBatchDeadlineReserve
 	origLargeReserve := singleCheckLargeBatchDeadlineReserve
 	singleCheckBatchDeadlineReserve = 250 * time.Millisecond
@@ -384,7 +384,7 @@ func TestClientBatchUsesLargerDeadlineReserveForLightBatches(t *testing.T) {
 	}
 }
 
-func TestClientBatchKeepsSmallDeadlineReserveForFullBatches(t *testing.T) {
+func TestClientBatchUsesLargerDeadlineReserveForFullBatches(t *testing.T) {
 	origReserve := singleCheckBatchDeadlineReserve
 	origLargeReserve := singleCheckLargeBatchDeadlineReserve
 	singleCheckBatchDeadlineReserve = 250 * time.Millisecond
@@ -442,11 +442,11 @@ func TestClientBatchKeepsSmallDeadlineReserveForFullBatches(t *testing.T) {
 	}
 
 	got := gotDeadline.Load()
-	if got < 2600 {
-		t.Fatalf("DeadlineMS = %d, want small reserve for full batch", got)
+	if got >= 2250 {
+		t.Fatalf("DeadlineMS = %d, want reserve to leave about 1s for full batch", got)
 	}
-	if got >= 3000 {
-		t.Fatalf("DeadlineMS = %d, want less than caller deadline", got)
+	if got < 1900 {
+		t.Fatalf("DeadlineMS = %d, want reserve without excessive deadline loss", got)
 	}
 }
 

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -258,83 +258,6 @@ func TestClientBatchRoundTrip(t *testing.T) {
 	}
 }
 
-func TestClientBatchRetriesTransientV2GatewayError(t *testing.T) {
-	var attempts atomic.Int32
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v2/check" {
-			http.NotFound(w, r)
-			return
-		}
-		if attempts.Add(1) == 1 {
-			http.Error(w, "bad gateway", http.StatusBadGateway)
-			return
-		}
-
-		var req CheckV2BatchRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			t.Errorf("decode request: %v", err)
-			http.Error(w, "bad request", http.StatusBadRequest)
-			return
-		}
-		results := make([]CheckV2Result, 0, len(req.Requests))
-		for _, check := range req.Requests {
-			results = append(results, CheckV2Result{
-				RequestID: check.RequestID,
-				BlogID:    check.BlogID,
-				URL:       check.URL,
-				VantageID: "test-vantage",
-				AgentID:   "test-agent",
-				Outcome:   OutcomeUp,
-				Success:   true,
-				HTTPCode:  200,
-			})
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(CheckV2BatchResponse{Results: results})
-	}))
-	defer ts.Close()
-
-	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
-	client.setProtocol(ProtocolV2)
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
-	res, err := client.CheckBatch(ctx, []CheckRequest{{BlogID: 10, URL: "https://example.com"}})
-	if err != nil {
-		t.Fatalf("CheckBatch() error = %v", err)
-	}
-	if attempts.Load() != 2 {
-		t.Fatalf("attempts = %d, want 2", attempts.Load())
-	}
-	if len(res) != 1 || !res[0].Success || res[0].BlogID != 10 {
-		t.Fatalf("unexpected result: %#v", res)
-	}
-}
-
-func TestClientBatchDoesNotRetryV2Overload(t *testing.T) {
-	var attempts atomic.Int32
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v2/check" {
-			http.NotFound(w, r)
-			return
-		}
-		attempts.Add(1)
-		http.Error(w, "overloaded", http.StatusServiceUnavailable)
-	}))
-	defer ts.Close()
-
-	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
-	_, err := client.CheckBatch(context.Background(), []CheckRequest{{BlogID: 10, URL: "https://example.com"}})
-	if err == nil {
-		t.Fatal("CheckBatch() expected overload error")
-	}
-	if attempts.Load() != 1 {
-		t.Fatalf("attempts = %d, want 1", attempts.Load())
-	}
-	if err.Error() != "veriflier /v2/check returned 503" {
-		t.Fatalf("CheckBatch() error = %v", err)
-	}
-}
-
 func TestClientBatchSendsServerDeadlineWithReserve(t *testing.T) {
 	origReserve := singleCheckBatchDeadlineReserve
 	origLargeReserve := singleCheckLargeBatchDeadlineReserve
@@ -1391,11 +1314,13 @@ func TestClientV2SendsContextDeadline(t *testing.T) {
 	}
 }
 
-func TestServerHandleV2CheckRejectsOverload(t *testing.T) {
+func TestServerHandleV2CheckReturnsOverloadResults(t *testing.T) {
 	var called atomic.Int64
+	block := make(chan struct{})
 	srv, ts := newV2TestServer(func(_ context.Context, req CheckRequest) ProbeResult {
 		called.Add(1)
-		return ProbeResult{CheckResult: CheckResult{BlogID: req.BlogID, URL: req.URL}}
+		<-block
+		return ProbeResult{CheckResult: CheckResult{BlogID: req.BlogID, URL: req.URL, Success: true}, Outcome: OutcomeUp}
 	}, ServerOptions{
 		MaxConcurrency: 1,
 		QueueCapacity:  1,
@@ -1403,11 +1328,23 @@ func TestServerHandleV2CheckRejectsOverload(t *testing.T) {
 	defer srv.executor.Shutdown()
 	defer ts.Close()
 
+	firstDone := make(chan struct{})
+	go func() {
+		postV2Batch(t, ts.URL, "secret", CheckV2BatchRequest{
+			Requests: []CheckV2Request{
+				{BlogID: 1, URL: "https://example.com/1"},
+				{BlogID: 2, URL: "https://example.com/2"},
+			},
+		})
+		close(firstDone)
+	}()
+	waitForCapacity(t, NewVeriflierClient(ts.Listener.Addr().String(), "secret"), func(c Capacity) bool {
+		return c.InFlight == 2
+	})
+
 	body := bytes.NewBuffer(nil)
 	if err := json.NewEncoder(body).Encode(CheckV2BatchRequest{
 		Requests: []CheckV2Request{
-			{BlogID: 1, URL: "https://example.com/1"},
-			{BlogID: 2, URL: "https://example.com/2"},
 			{BlogID: 3, URL: "https://example.com/3"},
 		},
 	}); err != nil {
@@ -1422,12 +1359,21 @@ func TestServerHandleV2CheckRejectsOverload(t *testing.T) {
 		t.Fatalf("request error: %v", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusServiceUnavailable {
-		t.Fatalf("status = %d, want 503", resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
-	if called.Load() != 0 {
-		t.Fatalf("check function called %d times for overloaded batch", called.Load())
+	var result CheckV2BatchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode overload response: %v", err)
 	}
+	if len(result.Results) != 1 || result.Results[0].Outcome != OutcomeAgentOverloaded {
+		t.Fatalf("overload results = %+v, want one agent_overloaded", result.Results)
+	}
+	if called.Load() != 1 {
+		t.Fatalf("check function called %d times, want only the already-running request", called.Load())
+	}
+	close(block)
+	<-firstDone
 }
 
 func TestServerExecutesLegacyBatchConcurrently(t *testing.T) {

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -1220,11 +1220,8 @@ func TestServerHandleV2Check(t *testing.T) {
 		t.Fatalf("results len = %d, want 1", len(result.Results))
 	}
 	got := result.Results[0]
-	if got.RequestID != "req-1" {
-		t.Fatalf("result request id = %+v", got)
-	}
-	if got.VantageID != "" || got.AgentID != "" {
-		t.Fatalf("result duplicated batch identity: %+v", got)
+	if got.RequestID != "req-1" || got.VantageID != "test-vantage" || got.AgentID != "test-agent" {
+		t.Fatalf("result identity = %+v", got)
 	}
 	if got.Outcome != OutcomeDown || got.Success || got.HTTPCode != 500 || got.RTTMs != 123 {
 		t.Fatalf("result = %+v", got)

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -253,6 +255,88 @@ func TestClientBatchRoundTrip(t *testing.T) {
 	}
 	if len(res) != 2 {
 		t.Fatalf("CheckBatch() len = %d, want 2", len(res))
+	}
+}
+
+func TestClientCheckCoalescesConcurrentSingles(t *testing.T) {
+	origDelay := singleCheckBatchMaxDelay
+	singleCheckBatchMaxDelay = 25 * time.Millisecond
+	defer func() { singleCheckBatchMaxDelay = origDelay }()
+
+	var rpcCount atomic.Int32
+	var maxBatch atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/check" {
+			http.NotFound(w, r)
+			return
+		}
+		var req CheckV2BatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		rpcCount.Add(1)
+		for {
+			current := maxBatch.Load()
+			if int32(len(req.Requests)) <= current || maxBatch.CompareAndSwap(current, int32(len(req.Requests))) {
+				break
+			}
+		}
+		results := make([]CheckV2Result, 0, len(req.Requests))
+		for _, check := range req.Requests {
+			results = append(results, CheckV2Result{
+				RequestID: check.RequestID,
+				BlogID:    check.BlogID,
+				URL:       check.URL,
+				VantageID: "test-vantage",
+				AgentID:   "test-agent",
+				Outcome:   OutcomeUp,
+				Success:   true,
+				HTTPCode:  200,
+			})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(CheckV2BatchResponse{Results: results})
+	}))
+	defer ts.Close()
+
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
+	const checks = 128
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	errs := make(chan error, checks)
+	for i := range checks {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			res, err := client.Check(context.Background(), CheckRequest{
+				BlogID: int64(i + 1),
+				URL:    "https://example.com",
+			})
+			if err != nil {
+				errs <- err
+				return
+			}
+			if res == nil || !res.Success || res.BlogID != int64(i+1) {
+				errs <- fmt.Errorf("unexpected result for blog_id=%d: %#v", i+1, res)
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if rpcCount.Load() >= checks {
+		t.Fatalf("rpc count = %d, want fewer than %d", rpcCount.Load(), checks)
+	}
+	if maxBatch.Load() < 2 {
+		t.Fatalf("max batch size = %d, want coalesced requests", maxBatch.Load())
 	}
 }
 

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -340,6 +340,93 @@ func TestClientCheckCoalescesConcurrentSingles(t *testing.T) {
 	}
 }
 
+func TestClientCheckUsesSmallerBatchesForFullDetectionWork(t *testing.T) {
+	origDelay := singleCheckBatchMaxDelay
+	origLightMax := singleCheckBatchMaxSize
+	origFullMax := singleCheckFullBatchMaxSize
+	singleCheckBatchMaxDelay = 25 * time.Millisecond
+	singleCheckBatchMaxSize = 64
+	singleCheckFullBatchMaxSize = 7
+	defer func() {
+		singleCheckBatchMaxDelay = origDelay
+		singleCheckBatchMaxSize = origLightMax
+		singleCheckFullBatchMaxSize = origFullMax
+	}()
+
+	var maxBatch atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/check" {
+			http.NotFound(w, r)
+			return
+		}
+		var req CheckV2BatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		for {
+			current := maxBatch.Load()
+			if int32(len(req.Requests)) <= current || maxBatch.CompareAndSwap(current, int32(len(req.Requests))) {
+				break
+			}
+		}
+		results := make([]CheckV2Result, 0, len(req.Requests))
+		for _, check := range req.Requests {
+			results = append(results, CheckV2Result{
+				RequestID: check.RequestID,
+				BlogID:    check.BlogID,
+				URL:       check.URL,
+				VantageID: "test-vantage",
+				AgentID:   "test-agent",
+				Outcome:   OutcomeUp,
+				Success:   true,
+				HTTPCode:  200,
+			})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(CheckV2BatchResponse{Results: results})
+	}))
+	defer ts.Close()
+
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
+	const checks = 28
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	errs := make(chan error, checks)
+	for i := range checks {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			res, err := client.Check(context.Background(), CheckRequest{
+				BlogID:           int64(i + 1),
+				URL:              "https://example.com",
+				Method:           http.MethodGet,
+				DetectionProfile: "full",
+			})
+			if err != nil {
+				errs <- err
+				return
+			}
+			if res == nil || !res.Success {
+				errs <- fmt.Errorf("unexpected result for blog_id=%d: %#v", i+1, res)
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if maxBatch.Load() > int32(singleCheckFullBatchMaxSize) {
+		t.Fatalf("max batch size = %d, want <= full cap %d", maxBatch.Load(), singleCheckFullBatchMaxSize)
+	}
+}
+
 func TestClientRejectsUnauthorized(t *testing.T) {
 	_, ts := newTestServer(func(req CheckRequest) CheckResult { return CheckResult{} })
 	defer ts.Close()

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -1257,7 +1257,7 @@ func TestClientFallsBackToLegacyWhenUnknownV2ConnectionCloses(t *testing.T) {
 	}
 }
 
-func TestClientDoesNotFallbackWhenV2ProtocolCached(t *testing.T) {
+func TestClientTreatsCachedV2EOFAsAgentOverloaded(t *testing.T) {
 	var legacyHits atomic.Int64
 
 	mux := http.NewServeMux()
@@ -1277,9 +1277,12 @@ func TestClientDoesNotFallbackWhenV2ProtocolCached(t *testing.T) {
 
 	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
 	client.setProtocol(ProtocolV2)
-	_, err := client.Check(context.Background(), CheckRequest{BlogID: 1, URL: "https://example.com"})
-	if err == nil {
-		t.Fatal("Check() expected v2 transport error")
+	res, err := client.Check(context.Background(), CheckRequest{BlogID: 1, URL: "https://example.com"})
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	if res == nil || res.Outcome != OutcomeAgentOverloaded || res.Success {
+		t.Fatalf("result = %+v, want agent_overloaded non-success", res)
 	}
 	if legacyHits.Load() != 0 {
 		t.Fatalf("legacy hits = %d, want 0 for cached v2 protocol", legacyHits.Load())

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -258,6 +258,83 @@ func TestClientBatchRoundTrip(t *testing.T) {
 	}
 }
 
+func TestClientBatchRetriesTransientV2GatewayError(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/check" {
+			http.NotFound(w, r)
+			return
+		}
+		if attempts.Add(1) == 1 {
+			http.Error(w, "bad gateway", http.StatusBadGateway)
+			return
+		}
+
+		var req CheckV2BatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		results := make([]CheckV2Result, 0, len(req.Requests))
+		for _, check := range req.Requests {
+			results = append(results, CheckV2Result{
+				RequestID: check.RequestID,
+				BlogID:    check.BlogID,
+				URL:       check.URL,
+				VantageID: "test-vantage",
+				AgentID:   "test-agent",
+				Outcome:   OutcomeUp,
+				Success:   true,
+				HTTPCode:  200,
+			})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(CheckV2BatchResponse{Results: results})
+	}))
+	defer ts.Close()
+
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
+	client.setProtocol(ProtocolV2)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	res, err := client.CheckBatch(ctx, []CheckRequest{{BlogID: 10, URL: "https://example.com"}})
+	if err != nil {
+		t.Fatalf("CheckBatch() error = %v", err)
+	}
+	if attempts.Load() != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts.Load())
+	}
+	if len(res) != 1 || !res[0].Success || res[0].BlogID != 10 {
+		t.Fatalf("unexpected result: %#v", res)
+	}
+}
+
+func TestClientBatchDoesNotRetryV2Overload(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/check" {
+			http.NotFound(w, r)
+			return
+		}
+		attempts.Add(1)
+		http.Error(w, "overloaded", http.StatusServiceUnavailable)
+	}))
+	defer ts.Close()
+
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
+	_, err := client.CheckBatch(context.Background(), []CheckRequest{{BlogID: 10, URL: "https://example.com"}})
+	if err == nil {
+		t.Fatal("CheckBatch() expected overload error")
+	}
+	if attempts.Load() != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts.Load())
+	}
+	if err.Error() != "veriflier /v2/check returned 503" {
+		t.Fatalf("CheckBatch() error = %v", err)
+	}
+}
+
 func TestClientBatchSendsServerDeadlineWithReserve(t *testing.T) {
 	origReserve := singleCheckBatchDeadlineReserve
 	origLargeReserve := singleCheckLargeBatchDeadlineReserve

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -427,6 +427,107 @@ func TestClientCheckUsesSmallerBatchesForFullDetectionWork(t *testing.T) {
 	}
 }
 
+func TestClientCheckKeepsLightLaneMovingDuringFullBatch(t *testing.T) {
+	origDelay := singleCheckBatchMaxDelay
+	origLightMax := singleCheckBatchMaxSize
+	origFullMax := singleCheckFullBatchMaxSize
+	origLightFlight := singleCheckLightBatchMaxFlight
+	origFullFlight := singleCheckFullBatchMaxFlight
+	singleCheckBatchMaxDelay = 25 * time.Millisecond
+	singleCheckBatchMaxSize = 64
+	singleCheckFullBatchMaxSize = 7
+	singleCheckLightBatchMaxFlight = 1
+	singleCheckFullBatchMaxFlight = 1
+	defer func() {
+		singleCheckBatchMaxDelay = origDelay
+		singleCheckBatchMaxSize = origLightMax
+		singleCheckFullBatchMaxSize = origFullMax
+		singleCheckLightBatchMaxFlight = origLightFlight
+		singleCheckFullBatchMaxFlight = origFullFlight
+	}()
+
+	fullStarted := make(chan struct{})
+	var closeFullStarted sync.Once
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/check" {
+			http.NotFound(w, r)
+			return
+		}
+		var req CheckV2BatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		if len(req.Requests) > 0 && req.Requests[0].DetectionProfile == "full" {
+			closeFullStarted.Do(func() { close(fullStarted) })
+			time.Sleep(150 * time.Millisecond)
+		}
+		results := make([]CheckV2Result, 0, len(req.Requests))
+		for _, check := range req.Requests {
+			results = append(results, CheckV2Result{
+				RequestID: check.RequestID,
+				BlogID:    check.BlogID,
+				URL:       check.URL,
+				VantageID: "test-vantage",
+				AgentID:   "test-agent",
+				Outcome:   OutcomeUp,
+				Success:   true,
+				HTTPCode:  200,
+			})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(CheckV2BatchResponse{Results: results})
+	}))
+	defer ts.Close()
+
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
+	var wg sync.WaitGroup
+	errs := make(chan error, singleCheckFullBatchMaxSize)
+	for i := range singleCheckFullBatchMaxSize {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := client.Check(context.Background(), CheckRequest{
+				BlogID:           int64(i + 1),
+				URL:              "https://example.com/full",
+				Method:           http.MethodGet,
+				DetectionProfile: "full",
+			})
+			errs <- err
+		}(i)
+	}
+
+	select {
+	case <-fullStarted:
+	case <-time.After(time.Second):
+		t.Fatal("full batch did not start")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	res, err := client.Check(ctx, CheckRequest{
+		BlogID:           999,
+		URL:              "https://example.com/light",
+		Method:           http.MethodHead,
+		DetectionProfile: "legacy",
+	})
+	if err != nil {
+		t.Fatalf("light check blocked behind full batch: %v", err)
+	}
+	if res == nil || !res.Success || res.BlogID != 999 {
+		t.Fatalf("unexpected light result: %#v", res)
+	}
+
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("full check error: %v", err)
+		}
+	}
+}
+
 func TestClientRejectsUnauthorized(t *testing.T) {
 	_, ts := newTestServer(func(req CheckRequest) CheckResult { return CheckResult{} })
 	defer ts.Close()


### PR DESCRIPTION
## Why

This branch makes the v2 Veriflier path much more resilient under high fanout and overload conditions. The goal is to maximize Veriflier throughput while ensuring overload is treated as an operational non-vote rather than as a customer-site downtime signal. That matters during wide outages or Monitor-side floods: Verifliers should shed or defer work cleanly, and Monitors should avoid promoting incidents solely because the verification layer is saturated.

## What changed

- Added Monitor-side batching for single-site Veriflier checks with separate light/full lanes, ordered responses, retry handling for transient batch RPC failures, and stale-work shedding before expired calls consume server work.
- Reworked Veriflier executor admission and overload behavior so deadline pressure, reset pressure, and queue saturation return typed agent_overloaded outcomes instead of hard client failures.
- Reduced allocation overhead in hot Veriflier batch paths and compacted v2 response construction.
- Added Monitor handling for agent_overloaded and unknown Veriflier outcomes as operational non-votes. These keep incidents pending, preserve retry state, back off re-verification, and avoid false confirmations/false alarms while Verifliers are unhealthy.
- Added per-Veriflier operational cooldown with retained failure history so one overloaded Veriflier does not immediately re-enter confirmation decisions for neighboring failed sites during the same flood window.
- Added audit and StatsD signals for verifier deferrals, cooldown skips, non-votes, duplicate vote identities, host-level cooldowns, and stale client-batch work.

## Measured results

Direct internal-only Veriflier benchmark on 00cba85 completed 12,000,000 checks at 4.0M/min with zero hard client errors. It returned cold-start behavior to the previous stable envelope: 426 overload responses, 47 probe errors, max p99 6.7s, average throughput 18.5k/s, average RSS 207.7 MiB, average FD count 1,495.

A clean Monitor-path non-vote validation on 07ab232 reported no failures. All three temporary failing sites stayed Seems Down while the Veriflier was under flood pressure, then verification resumed after the flood and each site moved to Down and later recovered. Audit evidence showed direct agent_overloaded non-votes, cooldown-skipped verifier decisions, verifier decision deferrals, retry deferrals, and no WPCOM notification before verifier-confirmed down.

## Follow-up

The latest uptime-bench report could not find the new StatsD counter families in Graphite during the run window, even though audit rows proved the behavior and unit tests cover the metric emission paths. Treat this as a non-blocking observability/reporting follow-up for the uptime-bench/Graphite capture path.