### PR TITLE
Harden untrusted probe handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,6 +252,7 @@ New tables introduced by Jetmon 2:
 | `jetmon_check_history` | RTT and timing samples for trending |
 | `jetmon_site_check_config` | V2-only per-site check policy/config: HEAD/GET mode, detection profile, keywords, maintenance windows, headers, timeout, redirect policy, cooldown |
 | `jetmon_site_runtime` | V2-only runtime freshness and observation projection: last checked, next check, last alert, SSL expiry |
+| `jetmon_site_safety_flags` | Non-downtime remediation state for unsafe legacy monitor URLs and runtime probe-safety blocks |
 | `jetmon_false_positives` | Veriflier non-confirmation events |
 
 ## Multi-Host Bucket Coordination

--- a/cmd/jetmon2/main.go
+++ b/cmd/jetmon2/main.go
@@ -78,6 +78,8 @@ func main() {
 		cmdAPI(os.Args[2:])
 	case "site-tenants":
 		cmdSiteTenants(os.Args[2:])
+	case "site-safety":
+		cmdSiteSafety(os.Args[2:])
 	case "telemetry":
 		cmdTelemetry(os.Args[2:])
 	case "verifliers":

--- a/cmd/jetmon2/site_safety.go
+++ b/cmd/jetmon2/site_safety.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/Automattic/jetmon/internal/config"
+	"github.com/Automattic/jetmon/internal/db"
+	"github.com/Automattic/jetmon/internal/netguard"
+)
+
+type siteSafetyUnsafeURLOptions struct {
+	BatchSize  int
+	Limit      int64
+	SampleSize int
+	Execute    bool
+}
+
+type siteSafetyUnsafeURLReport struct {
+	ScannedActive int64
+	UnsafeRows    int64
+	Deactivated   int64
+	Samples       []siteSafetyUnsafeURLRow
+}
+
+type siteSafetyUnsafeURLRow struct {
+	SiteID int64
+	BlogID int64
+	URL    string
+	Reason string
+}
+
+func cmdSiteSafety(args []string) {
+	if len(args) < 1 {
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 site-safety <unsafe-urls> [args]")
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "unsafe-urls":
+		cmdSiteSafetyUnsafeURLs(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown site-safety subcommand %q (want: unsafe-urls)\n", args[0])
+		os.Exit(2)
+	}
+}
+
+func cmdSiteSafetyUnsafeURLs(args []string) {
+	fs := flag.NewFlagSet("site-safety unsafe-urls", flag.ExitOnError)
+	opts := siteSafetyUnsafeURLOptions{}
+	fs.IntVar(&opts.BatchSize, "batch-size", 1000, "active site rows to scan per query")
+	fs.Int64Var(&opts.Limit, "limit", 0, "maximum active rows to scan, 0 for all")
+	fs.IntVar(&opts.SampleSize, "sample-size", 50, "maximum unsafe examples to print")
+	fs.BoolVar(&opts.Execute, "execute", false, "deactivate unsafe active rows; default is dry-run")
+	_ = fs.Parse(args)
+	if opts.BatchSize <= 0 {
+		fmt.Fprintln(os.Stderr, "batch-size must be positive")
+		os.Exit(2)
+	}
+	if opts.SampleSize < 0 {
+		fmt.Fprintln(os.Stderr, "sample-size must be >= 0")
+		os.Exit(2)
+	}
+
+	configPath := envOrDefault("JETMON_CONFIG", "config/config.json")
+	if err := config.Load(configPath); err != nil {
+		fmt.Fprintf(os.Stderr, "site-safety unsafe-urls: config parse: %v\n", err)
+		os.Exit(1)
+	}
+	config.LoadDB()
+	if err := db.ConnectWithRetry(3); err != nil {
+		fmt.Fprintf(os.Stderr, "site-safety unsafe-urls: db connect: %v\n", err)
+		os.Exit(1)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+	report, err := runSiteSafetyUnsafeURLs(ctx, os.Stdout, db.DB(), opts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "site-safety unsafe-urls: %v\n", err)
+		os.Exit(1)
+	}
+	if report.UnsafeRows > report.Deactivated && !opts.Execute {
+		fmt.Fprintln(os.Stdout, "INFO dry_run=true pass --execute to deactivate unsafe active rows")
+	}
+}
+
+func runSiteSafetyUnsafeURLs(ctx context.Context, out io.Writer, conn *sql.DB, opts siteSafetyUnsafeURLOptions) (siteSafetyUnsafeURLReport, error) {
+	if out == nil {
+		out = io.Discard
+	}
+	if conn == nil {
+		return siteSafetyUnsafeURLReport{}, fmt.Errorf("db is required")
+	}
+	if opts.BatchSize <= 0 {
+		opts.BatchSize = 1000
+	}
+	if opts.SampleSize < 0 {
+		opts.SampleSize = 0
+	}
+
+	report := siteSafetyUnsafeURLReport{}
+	var lastID int64
+	for opts.Limit == 0 || report.ScannedActive < opts.Limit {
+		remaining := int64(opts.BatchSize)
+		if opts.Limit > 0 && opts.Limit-report.ScannedActive < remaining {
+			remaining = opts.Limit - report.ScannedActive
+		}
+		if remaining <= 0 {
+			break
+		}
+		rows, err := conn.QueryContext(ctx, `
+			SELECT jetpack_monitor_site_id, blog_id, monitor_url
+			  FROM jetpack_monitor_sites
+			 WHERE monitor_active = 1
+			   AND jetpack_monitor_site_id > ?
+			 ORDER BY jetpack_monitor_site_id ASC
+			 LIMIT ?`, lastID, remaining)
+		if err != nil {
+			return report, fmt.Errorf("query active monitor URLs: %w", err)
+		}
+
+		batchRows := 0
+		for rows.Next() {
+			var row siteSafetyUnsafeURLRow
+			if err := rows.Scan(&row.SiteID, &row.BlogID, &row.URL); err != nil {
+				rows.Close()
+				return report, fmt.Errorf("scan monitor URL row: %w", err)
+			}
+			batchRows++
+			report.ScannedActive++
+			lastID = row.SiteID
+			reason := classifyUnsafeMonitorURL(row.URL)
+			if reason == "" {
+				continue
+			}
+			report.UnsafeRows++
+			row.Reason = reason
+			if len(report.Samples) < opts.SampleSize {
+				report.Samples = append(report.Samples, row)
+			}
+			if opts.Execute {
+				n, err := deactivateUnsafeMonitorURL(ctx, conn, row.SiteID)
+				if err != nil {
+					rows.Close()
+					return report, err
+				}
+				report.Deactivated += n
+			}
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return report, fmt.Errorf("iterate monitor URL rows: %w", err)
+		}
+		rows.Close()
+		if batchRows == 0 {
+			break
+		}
+	}
+
+	for _, row := range report.Samples {
+		fmt.Fprintf(out, "WARN unsafe_url site_id=%d blog_id=%d reason=%q url=%q\n", row.SiteID, row.BlogID, row.Reason, row.URL)
+	}
+	fmt.Fprintf(out, "INFO scanned_active=%d unsafe=%d deactivated=%d\n", report.ScannedActive, report.UnsafeRows, report.Deactivated)
+	return report, nil
+}
+
+func classifyUnsafeMonitorURL(rawURL string) string {
+	if _, err := netguard.ParsePublicHTTPURL(rawURL, "monitor_url"); err != nil {
+		return err.Error()
+	}
+	return ""
+}
+
+func deactivateUnsafeMonitorURL(ctx context.Context, conn *sql.DB, siteID int64) (int64, error) {
+	res, err := conn.ExecContext(ctx, `
+		UPDATE jetpack_monitor_sites
+		   SET monitor_active = 0
+		 WHERE jetpack_monitor_site_id = ?
+		   AND monitor_active = 1`, siteID)
+	if err != nil {
+		return 0, fmt.Errorf("deactivate unsafe monitor URL site_id=%d: %w", siteID, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("deactivate unsafe monitor URL site_id=%d rows affected: %w", siteID, err)
+	}
+	return n, nil
+}

--- a/cmd/jetmon2/site_safety.go
+++ b/cmd/jetmon2/site_safety.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/Automattic/jetmon/internal/config"
@@ -125,6 +126,7 @@ func runSiteSafetyUnsafeURLs(ctx context.Context, out io.Writer, conn *sql.DB, o
 		}
 
 		batchRows := 0
+		var unsafeIDs []int64
 		for rows.Next() {
 			var row siteSafetyUnsafeURLRow
 			if err := rows.Scan(&row.SiteID, &row.BlogID, &row.URL); err != nil {
@@ -144,12 +146,7 @@ func runSiteSafetyUnsafeURLs(ctx context.Context, out io.Writer, conn *sql.DB, o
 				report.Samples = append(report.Samples, row)
 			}
 			if opts.Execute {
-				n, err := deactivateUnsafeMonitorURL(ctx, conn, row.SiteID)
-				if err != nil {
-					rows.Close()
-					return report, err
-				}
-				report.Deactivated += n
+				unsafeIDs = append(unsafeIDs, row.SiteID)
 			}
 		}
 		if err := rows.Err(); err != nil {
@@ -157,6 +154,13 @@ func runSiteSafetyUnsafeURLs(ctx context.Context, out io.Writer, conn *sql.DB, o
 			return report, fmt.Errorf("iterate monitor URL rows: %w", err)
 		}
 		rows.Close()
+		if opts.Execute && len(unsafeIDs) > 0 {
+			n, err := deactivateUnsafeMonitorURLs(ctx, conn, unsafeIDs)
+			if err != nil {
+				return report, err
+			}
+			report.Deactivated += n
+		}
 		if batchRows == 0 {
 			break
 		}
@@ -176,18 +180,44 @@ func classifyUnsafeMonitorURL(rawURL string) string {
 	return ""
 }
 
-func deactivateUnsafeMonitorURL(ctx context.Context, conn *sql.DB, siteID int64) (int64, error) {
+func deactivateUnsafeMonitorURLs(ctx context.Context, conn *sql.DB, siteIDs []int64) (int64, error) {
+	const maxDeactivateBatch = 1000
+	var total int64
+	for len(siteIDs) > 0 {
+		chunk := siteIDs
+		if len(chunk) > maxDeactivateBatch {
+			chunk = chunk[:maxDeactivateBatch]
+		}
+		n, err := deactivateUnsafeMonitorURLBatch(ctx, conn, chunk)
+		if err != nil {
+			return total, err
+		}
+		total += n
+		siteIDs = siteIDs[len(chunk):]
+	}
+	return total, nil
+}
+
+func deactivateUnsafeMonitorURLBatch(ctx context.Context, conn *sql.DB, siteIDs []int64) (int64, error) {
+	if len(siteIDs) == 0 {
+		return 0, nil
+	}
+	placeholders := strings.TrimRight(strings.Repeat("?,", len(siteIDs)), ",")
+	args := make([]any, 0, len(siteIDs))
+	for _, siteID := range siteIDs {
+		args = append(args, siteID)
+	}
 	res, err := conn.ExecContext(ctx, `
 		UPDATE jetpack_monitor_sites
 		   SET monitor_active = 0
-		 WHERE jetpack_monitor_site_id = ?
-		   AND monitor_active = 1`, siteID)
+		 WHERE monitor_active = 1
+		   AND jetpack_monitor_site_id IN (`+placeholders+`)`, args...)
 	if err != nil {
-		return 0, fmt.Errorf("deactivate unsafe monitor URL site_id=%d: %w", siteID, err)
+		return 0, fmt.Errorf("deactivate unsafe monitor URLs: %w", err)
 	}
 	n, err := res.RowsAffected()
 	if err != nil {
-		return 0, fmt.Errorf("deactivate unsafe monitor URL site_id=%d rows affected: %w", siteID, err)
+		return 0, fmt.Errorf("deactivate unsafe monitor URLs rows affected: %w", err)
 	}
 	return n, nil
 }

--- a/cmd/jetmon2/site_safety.go
+++ b/cmd/jetmon2/site_safety.go
@@ -25,6 +25,7 @@ type siteSafetyUnsafeURLOptions struct {
 type siteSafetyUnsafeURLReport struct {
 	ScannedActive int64
 	UnsafeRows    int64
+	Flagged       int64
 	Deactivated   int64
 	Samples       []siteSafetyUnsafeURLRow
 }
@@ -126,7 +127,7 @@ func runSiteSafetyUnsafeURLs(ctx context.Context, out io.Writer, conn *sql.DB, o
 		}
 
 		batchRows := 0
-		var unsafeIDs []int64
+		var unsafeRows []siteSafetyUnsafeURLRow
 		for rows.Next() {
 			var row siteSafetyUnsafeURLRow
 			if err := rows.Scan(&row.SiteID, &row.BlogID, &row.URL); err != nil {
@@ -146,7 +147,7 @@ func runSiteSafetyUnsafeURLs(ctx context.Context, out io.Writer, conn *sql.DB, o
 				report.Samples = append(report.Samples, row)
 			}
 			if opts.Execute {
-				unsafeIDs = append(unsafeIDs, row.SiteID)
+				unsafeRows = append(unsafeRows, row)
 			}
 		}
 		if err := rows.Err(); err != nil {
@@ -154,12 +155,13 @@ func runSiteSafetyUnsafeURLs(ctx context.Context, out io.Writer, conn *sql.DB, o
 			return report, fmt.Errorf("iterate monitor URL rows: %w", err)
 		}
 		rows.Close()
-		if opts.Execute && len(unsafeIDs) > 0 {
-			n, err := deactivateUnsafeMonitorURLs(ctx, conn, unsafeIDs)
+		if opts.Execute && len(unsafeRows) > 0 {
+			flagged, deactivated, err := flagAndDeactivateUnsafeMonitorURLs(ctx, conn, unsafeRows)
 			if err != nil {
 				return report, err
 			}
-			report.Deactivated += n
+			report.Flagged += flagged
+			report.Deactivated += deactivated
 		}
 		if batchRows == 0 {
 			break
@@ -169,7 +171,7 @@ func runSiteSafetyUnsafeURLs(ctx context.Context, out io.Writer, conn *sql.DB, o
 	for _, row := range report.Samples {
 		fmt.Fprintf(out, "WARN unsafe_url site_id=%d blog_id=%d reason=%q url=%q\n", row.SiteID, row.BlogID, row.Reason, row.URL)
 	}
-	fmt.Fprintf(out, "INFO scanned_active=%d unsafe=%d deactivated=%d\n", report.ScannedActive, report.UnsafeRows, report.Deactivated)
+	fmt.Fprintf(out, "INFO scanned_active=%d unsafe=%d flagged=%d deactivated=%d\n", report.ScannedActive, report.UnsafeRows, report.Flagged, report.Deactivated)
 	return report, nil
 }
 
@@ -180,44 +182,78 @@ func classifyUnsafeMonitorURL(rawURL string) string {
 	return ""
 }
 
-func deactivateUnsafeMonitorURLs(ctx context.Context, conn *sql.DB, siteIDs []int64) (int64, error) {
+func flagAndDeactivateUnsafeMonitorURLs(ctx context.Context, conn *sql.DB, rows []siteSafetyUnsafeURLRow) (int64, int64, error) {
 	const maxDeactivateBatch = 1000
-	var total int64
-	for len(siteIDs) > 0 {
-		chunk := siteIDs
+	var flaggedTotal int64
+	var deactivatedTotal int64
+	for len(rows) > 0 {
+		chunk := rows
 		if len(chunk) > maxDeactivateBatch {
 			chunk = chunk[:maxDeactivateBatch]
 		}
-		n, err := deactivateUnsafeMonitorURLBatch(ctx, conn, chunk)
+		flagged, deactivated, err := flagAndDeactivateUnsafeMonitorURLBatch(ctx, conn, chunk)
 		if err != nil {
-			return total, err
+			return flaggedTotal, deactivatedTotal, err
 		}
-		total += n
-		siteIDs = siteIDs[len(chunk):]
+		flaggedTotal += flagged
+		deactivatedTotal += deactivated
+		rows = rows[len(chunk):]
 	}
-	return total, nil
+	return flaggedTotal, deactivatedTotal, nil
 }
 
-func deactivateUnsafeMonitorURLBatch(ctx context.Context, conn *sql.DB, siteIDs []int64) (int64, error) {
-	if len(siteIDs) == 0 {
-		return 0, nil
+func flagAndDeactivateUnsafeMonitorURLBatch(ctx context.Context, conn *sql.DB, rows []siteSafetyUnsafeURLRow) (int64, int64, error) {
+	if len(rows) == 0 {
+		return 0, 0, nil
 	}
-	placeholders := strings.TrimRight(strings.Repeat("?,", len(siteIDs)), ",")
-	args := make([]any, 0, len(siteIDs))
-	for _, siteID := range siteIDs {
-		args = append(args, siteID)
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, 0, fmt.Errorf("begin unsafe monitor URL cleanup transaction: %w", err)
 	}
-	res, err := conn.ExecContext(ctx, `
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	deactivatedAt := time.Now().UTC()
+	var flagged int64
+	for _, row := range rows {
+		if err := db.UpsertSiteSafetyFlag(ctx, tx, db.SiteSafetyFlag{
+			BlogID:        row.BlogID,
+			MonitorSiteID: row.SiteID,
+			FlagType:      db.SiteSafetyFlagUnsafeMonitorURL,
+			Reason:        row.Reason,
+			MonitorURL:    row.URL,
+			Status:        db.SiteSafetyStatusDeactivated,
+			DeactivatedAt: &deactivatedAt,
+		}); err != nil {
+			return flagged, 0, err
+		}
+		flagged++
+	}
+
+	placeholders := strings.TrimRight(strings.Repeat("?,", len(rows)), ",")
+	args := make([]any, 0, len(rows))
+	for _, row := range rows {
+		args = append(args, row.SiteID)
+	}
+	res, err := tx.ExecContext(ctx, `
 		UPDATE jetpack_monitor_sites
 		   SET monitor_active = 0
 		 WHERE monitor_active = 1
 		   AND jetpack_monitor_site_id IN (`+placeholders+`)`, args...)
 	if err != nil {
-		return 0, fmt.Errorf("deactivate unsafe monitor URLs: %w", err)
+		return flagged, 0, fmt.Errorf("deactivate unsafe monitor URLs: %w", err)
 	}
 	n, err := res.RowsAffected()
 	if err != nil {
-		return 0, fmt.Errorf("deactivate unsafe monitor URLs rows affected: %w", err)
+		return flagged, 0, fmt.Errorf("deactivate unsafe monitor URLs rows affected: %w", err)
 	}
-	return n, nil
+	if err := tx.Commit(); err != nil {
+		return flagged, 0, fmt.Errorf("commit unsafe monitor URL cleanup transaction: %w", err)
+	}
+	committed = true
+	return flagged, n, nil
 }

--- a/cmd/jetmon2/site_safety_test.go
+++ b/cmd/jetmon2/site_safety_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestClassifyUnsafeMonitorURL(t *testing.T) {
+	if got := classifyUnsafeMonitorURL("https://example.com"); got != "" {
+		t.Fatalf("safe URL classified unsafe: %q", got)
+	}
+	for _, raw := range []string{
+		"example.com",
+		"http://127.0.0.1",
+		"http://0177.0.0.1",
+		"http://user@example.com",
+	} {
+		if got := classifyUnsafeMonitorURL(raw); got == "" {
+			t.Fatalf("classifyUnsafeMonitorURL(%q) = empty, want reason", raw)
+		}
+	}
+}
+
+func TestRunSiteSafetyUnsafeURLsDryRun(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+
+	mock.ExpectQuery("SELECT jetpack_monitor_site_id, blog_id, monitor_url").
+		WithArgs(int64(0), int64(10)).
+		WillReturnRows(sqlmock.NewRows([]string{"jetpack_monitor_site_id", "blog_id", "monitor_url"}).
+			AddRow(int64(1), int64(101), "https://example.com").
+			AddRow(int64(2), int64(102), "http://127.0.0.1"))
+	mock.ExpectQuery("SELECT jetpack_monitor_site_id, blog_id, monitor_url").
+		WithArgs(int64(2), int64(10)).
+		WillReturnRows(sqlmock.NewRows([]string{"jetpack_monitor_site_id", "blog_id", "monitor_url"}))
+
+	var out bytes.Buffer
+	report, err := runSiteSafetyUnsafeURLs(context.Background(), &out, conn, siteSafetyUnsafeURLOptions{
+		BatchSize:  10,
+		SampleSize: 5,
+	})
+	if err != nil {
+		t.Fatalf("runSiteSafetyUnsafeURLs: %v", err)
+	}
+	if report.ScannedActive != 2 || report.UnsafeRows != 1 || report.Deactivated != 0 {
+		t.Fatalf("report = %+v", report)
+	}
+	if !strings.Contains(out.String(), "WARN unsafe_url") || !strings.Contains(out.String(), "INFO scanned_active=2 unsafe=1 deactivated=0") {
+		t.Fatalf("unexpected output: %s", out.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestRunSiteSafetyUnsafeURLsExecuteDeactivates(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+
+	mock.ExpectQuery("SELECT jetpack_monitor_site_id, blog_id, monitor_url").
+		WithArgs(int64(0), int64(10)).
+		WillReturnRows(sqlmock.NewRows([]string{"jetpack_monitor_site_id", "blog_id", "monitor_url"}).
+			AddRow(int64(2), int64(102), "http://127.0.0.1"))
+	mock.ExpectExec("UPDATE jetpack_monitor_sites").
+		WithArgs(int64(2)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("SELECT jetpack_monitor_site_id, blog_id, monitor_url").
+		WithArgs(int64(2), int64(10)).
+		WillReturnRows(sqlmock.NewRows([]string{"jetpack_monitor_site_id", "blog_id", "monitor_url"}))
+
+	report, err := runSiteSafetyUnsafeURLs(context.Background(), nil, conn, siteSafetyUnsafeURLOptions{
+		BatchSize: 10,
+		Execute:   true,
+	})
+	if err != nil {
+		t.Fatalf("runSiteSafetyUnsafeURLs: %v", err)
+	}
+	if report.UnsafeRows != 1 || report.Deactivated != 1 {
+		t.Fatalf("report = %+v", report)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}

--- a/cmd/jetmon2/site_safety_test.go
+++ b/cmd/jetmon2/site_safety_test.go
@@ -70,12 +70,13 @@ func TestRunSiteSafetyUnsafeURLsExecuteDeactivates(t *testing.T) {
 	mock.ExpectQuery("SELECT jetpack_monitor_site_id, blog_id, monitor_url").
 		WithArgs(int64(0), int64(10)).
 		WillReturnRows(sqlmock.NewRows([]string{"jetpack_monitor_site_id", "blog_id", "monitor_url"}).
-			AddRow(int64(2), int64(102), "http://127.0.0.1"))
+			AddRow(int64(2), int64(102), "http://127.0.0.1").
+			AddRow(int64(3), int64(103), "http://2130706433"))
 	mock.ExpectExec("UPDATE jetpack_monitor_sites").
-		WithArgs(int64(2)).
-		WillReturnResult(sqlmock.NewResult(0, 1))
+		WithArgs(int64(2), int64(3)).
+		WillReturnResult(sqlmock.NewResult(0, 2))
 	mock.ExpectQuery("SELECT jetpack_monitor_site_id, blog_id, monitor_url").
-		WithArgs(int64(2), int64(10)).
+		WithArgs(int64(3), int64(10)).
 		WillReturnRows(sqlmock.NewRows([]string{"jetpack_monitor_site_id", "blog_id", "monitor_url"}))
 
 	report, err := runSiteSafetyUnsafeURLs(context.Background(), nil, conn, siteSafetyUnsafeURLOptions{
@@ -85,7 +86,7 @@ func TestRunSiteSafetyUnsafeURLsExecuteDeactivates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runSiteSafetyUnsafeURLs: %v", err)
 	}
-	if report.UnsafeRows != 1 || report.Deactivated != 1 {
+	if report.UnsafeRows != 2 || report.Deactivated != 2 {
 		t.Fatalf("report = %+v", report)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/cmd/jetmon2/site_safety_test.go
+++ b/cmd/jetmon2/site_safety_test.go
@@ -93,3 +93,31 @@ func TestRunSiteSafetyUnsafeURLsExecuteDeactivates(t *testing.T) {
 		t.Fatalf("unmet expectations: %v", err)
 	}
 }
+
+func TestDeactivateUnsafeMonitorURLsChunksLargeBatches(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+
+	ids := make([]int64, 1001)
+	for i := range ids {
+		ids[i] = int64(i + 1)
+	}
+	mock.ExpectExec("UPDATE jetpack_monitor_sites").
+		WillReturnResult(sqlmock.NewResult(0, 1000))
+	mock.ExpectExec("UPDATE jetpack_monitor_sites").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	deactivated, err := deactivateUnsafeMonitorURLs(context.Background(), conn, ids)
+	if err != nil {
+		t.Fatalf("deactivateUnsafeMonitorURLs: %v", err)
+	}
+	if deactivated != 1001 {
+		t.Fatalf("deactivated = %d, want 1001", deactivated)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}

--- a/cmd/jetmon2/site_safety_test.go
+++ b/cmd/jetmon2/site_safety_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Automattic/jetmon/internal/db"
 	"github.com/DATA-DOG/go-sqlmock"
 )
 
@@ -52,7 +53,7 @@ func TestRunSiteSafetyUnsafeURLsDryRun(t *testing.T) {
 	if report.ScannedActive != 2 || report.UnsafeRows != 1 || report.Deactivated != 0 {
 		t.Fatalf("report = %+v", report)
 	}
-	if !strings.Contains(out.String(), "WARN unsafe_url") || !strings.Contains(out.String(), "INFO scanned_active=2 unsafe=1 deactivated=0") {
+	if !strings.Contains(out.String(), "WARN unsafe_url") || !strings.Contains(out.String(), "INFO scanned_active=2 unsafe=1 flagged=0 deactivated=0") {
 		t.Fatalf("unexpected output: %s", out.String())
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -72,9 +73,17 @@ func TestRunSiteSafetyUnsafeURLsExecuteDeactivates(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"jetpack_monitor_site_id", "blog_id", "monitor_url"}).
 			AddRow(int64(2), int64(102), "http://127.0.0.1").
 			AddRow(int64(3), int64(103), "http://2130706433"))
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO jetmon_site_safety_flags").
+		WithArgs(int64(102), int64(2), db.SiteSafetyFlagUnsafeMonitorURL, sqlmock.AnyArg(), "http://127.0.0.1", db.SiteSafetyStatusDeactivated, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO jetmon_site_safety_flags").
+		WithArgs(int64(103), int64(3), db.SiteSafetyFlagUnsafeMonitorURL, sqlmock.AnyArg(), "http://2130706433", db.SiteSafetyStatusDeactivated, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(2, 1))
 	mock.ExpectExec("UPDATE jetpack_monitor_sites").
 		WithArgs(int64(2), int64(3)).
 		WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectCommit()
 	mock.ExpectQuery("SELECT jetpack_monitor_site_id, blog_id, monitor_url").
 		WithArgs(int64(3), int64(10)).
 		WillReturnRows(sqlmock.NewRows([]string{"jetpack_monitor_site_id", "blog_id", "monitor_url"}))
@@ -86,7 +95,7 @@ func TestRunSiteSafetyUnsafeURLsExecuteDeactivates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runSiteSafetyUnsafeURLs: %v", err)
 	}
-	if report.UnsafeRows != 2 || report.Deactivated != 2 {
+	if report.UnsafeRows != 2 || report.Flagged != 2 || report.Deactivated != 2 {
 		t.Fatalf("report = %+v", report)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -101,18 +110,36 @@ func TestDeactivateUnsafeMonitorURLsChunksLargeBatches(t *testing.T) {
 	}
 	defer conn.Close()
 
-	ids := make([]int64, 1001)
-	for i := range ids {
-		ids[i] = int64(i + 1)
+	rows := make([]siteSafetyUnsafeURLRow, 1001)
+	for i := range rows {
+		rows[i] = siteSafetyUnsafeURLRow{
+			SiteID: int64(i + 1),
+			BlogID: int64(100000 + i),
+			URL:    "http://127.0.0.1",
+			Reason: "monitor_url host \"127.0.0.1\" is not public",
+		}
+	}
+	mock.ExpectBegin()
+	for i := 0; i < 1000; i++ {
+		mock.ExpectExec("INSERT INTO jetmon_site_safety_flags").
+			WillReturnResult(sqlmock.NewResult(int64(i+1), 1))
 	}
 	mock.ExpectExec("UPDATE jetpack_monitor_sites").
 		WillReturnResult(sqlmock.NewResult(0, 1000))
+	mock.ExpectCommit()
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO jetmon_site_safety_flags").
+		WillReturnResult(sqlmock.NewResult(1001, 1))
 	mock.ExpectExec("UPDATE jetpack_monitor_sites").
 		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
 
-	deactivated, err := deactivateUnsafeMonitorURLs(context.Background(), conn, ids)
+	flagged, deactivated, err := flagAndDeactivateUnsafeMonitorURLs(context.Background(), conn, rows)
 	if err != nil {
-		t.Fatalf("deactivateUnsafeMonitorURLs: %v", err)
+		t.Fatalf("flagAndDeactivateUnsafeMonitorURLs: %v", err)
+	}
+	if flagged != 1001 {
+		t.Fatalf("flagged = %d, want 1001", flagged)
 	}
 	if deactivated != 1001 {
 		t.Fatalf("deactivated = %d, want 1001", deactivated)

--- a/cmd/security-lab-client/README.md
+++ b/cmd/security-lab-client/README.md
@@ -1,0 +1,10 @@
+# Security Lab Client
+
+`security-lab-client` is a lab-only helper used to exercise a temporary
+Veriflier against adversarial HTTP responses. It is not a production binary and
+is not built by `make all`.
+
+The client posts fixed `/v2/check` scenarios to a Veriflier and fails if any
+expected safety behavior regresses. It is intended to run against
+`cmd/security-lab-responder` on isolated high ports, usually from one of the
+approved Jetmon test hosts.

--- a/cmd/security-lab-client/main.go
+++ b/cmd/security-lab-client/main.go
@@ -1,0 +1,301 @@
+// security-lab-client is a lab-only helper for repeatable adversarial
+// Veriflier checks. It is intentionally outside the production build targets.
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Automattic/jetmon/internal/checker"
+	"github.com/Automattic/jetmon/internal/veriflier"
+)
+
+type scenario struct {
+	name           string
+	url            string
+	timeoutMS      int64
+	bodyReadBytes  int64
+	bodyReadMS     int32
+	wantHTTPStatus int
+	wantSuccess    *bool
+	wantOutcome    string
+	wantErrorCode  *int32
+}
+
+type scenarioResult struct {
+	Name       string `json:"name"`
+	Pass       bool   `json:"pass"`
+	DurationMS int64  `json:"duration_ms"`
+	HTTPStatus int    `json:"http_status"`
+	Outcome    string `json:"outcome,omitempty"`
+	Success    *bool  `json:"success,omitempty"`
+	ErrorCode  *int32 `json:"error_code,omitempty"`
+	Error      string `json:"error,omitempty"`
+}
+
+func main() {
+	addr := flag.String("addr", "127.0.0.1:7803", "Veriflier host:port")
+	token := flag.String("token", "", "Veriflier bearer token")
+	targetBase := flag.String("target-base", "", "public HTTP responder base URL")
+	tlsBase := flag.String("tls-base", "", "public HTTPS responder base URL")
+	flag.Parse()
+
+	if *token == "" || *targetBase == "" {
+		fmt.Fprintln(os.Stderr, "-token and -target-base are required")
+		os.Exit(2)
+	}
+
+	scenarios := buildScenarios(*targetBase, *tlsBase)
+	client := &http.Client{Timeout: 10 * time.Second}
+	var failed bool
+	results := make([]scenarioResult, 0, len(scenarios))
+	for _, sc := range scenarios {
+		result := runScenario(client, *addr, *token, sc)
+		results = append(results, result)
+		status := "PASS"
+		if !result.Pass {
+			status = "FAIL"
+			failed = true
+		}
+		fmt.Printf("%-18s %-4s http=%d duration_ms=%d outcome=%s success=%s error_code=%s error=%s\n",
+			sc.name,
+			status,
+			result.HTTPStatus,
+			result.DurationMS,
+			result.Outcome,
+			boolLabel(result.Success),
+			int32Label(result.ErrorCode),
+			result.Error,
+		)
+	}
+
+	encoded, _ := json.MarshalIndent(results, "", "  ")
+	fmt.Println(string(encoded))
+	if failed {
+		os.Exit(1)
+	}
+}
+
+func buildScenarios(targetBase, tlsBase string) []scenario {
+	base := strings.TrimRight(targetBase, "/")
+	boolTrue := true
+	boolFalse := false
+	errNone := int32(checker.ErrorNone)
+	errProbeSafety := int32(checker.ErrorProbeSafety)
+	errBodyRead := int32(checker.ErrorBodyRead)
+	errRedirect := int32(checker.ErrorRedirect)
+	errConnect := int32(checker.ErrorConnect)
+	errSSL := int32(checker.ErrorSSL)
+
+	scenarios := []scenario{
+		{
+			name:           "unsafe-loopback",
+			url:            "http://127.0.0.1/private",
+			timeoutMS:      1000,
+			wantHTTPStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "ok-public",
+			url:            base + "/ok",
+			timeoutMS:      3000,
+			wantHTTPStatus: http.StatusOK,
+			wantSuccess:    &boolTrue,
+			wantOutcome:    veriflier.OutcomeUp,
+			wantErrorCode:  &errNone,
+		},
+		{
+			name:           "redirect-local",
+			url:            base + "/redirect-local",
+			timeoutMS:      3000,
+			wantHTTPStatus: http.StatusOK,
+			wantSuccess:    &boolFalse,
+			wantOutcome:    veriflier.OutcomeUnknown,
+			wantErrorCode:  &errProbeSafety,
+		},
+		{
+			name:           "redirect-metadata",
+			url:            base + "/redirect-metadata",
+			timeoutMS:      3000,
+			wantHTTPStatus: http.StatusOK,
+			wantSuccess:    &boolFalse,
+			wantOutcome:    veriflier.OutcomeUnknown,
+			wantErrorCode:  &errProbeSafety,
+		},
+		{
+			name:           "redirect-loop",
+			url:            base + "/redirect-loop",
+			timeoutMS:      3000,
+			wantHTTPStatus: http.StatusOK,
+			wantSuccess:    &boolFalse,
+			wantOutcome:    veriflier.OutcomeProbeError,
+			wantErrorCode:  &errRedirect,
+		},
+		{
+			name:           "infinite-body",
+			url:            base + "/infinite",
+			timeoutMS:      3000,
+			bodyReadBytes:  1024,
+			bodyReadMS:     1000,
+			wantHTTPStatus: http.StatusOK,
+			wantSuccess:    &boolTrue,
+			wantOutcome:    veriflier.OutcomeUp,
+			wantErrorCode:  &errNone,
+		},
+		{
+			name:           "slow-body",
+			url:            base + "/slow-body",
+			timeoutMS:      5000,
+			bodyReadBytes:  1024,
+			bodyReadMS:     50,
+			wantHTTPStatus: http.StatusOK,
+			wantSuccess:    &boolFalse,
+			wantOutcome:    veriflier.OutcomeProbeError,
+			wantErrorCode:  &errBodyRead,
+		},
+		{
+			name:           "huge-header",
+			url:            base + "/huge-header",
+			timeoutMS:      3000,
+			wantHTTPStatus: http.StatusOK,
+			wantSuccess:    &boolFalse,
+			wantOutcome:    veriflier.OutcomeProbeError,
+			wantErrorCode:  &errConnect,
+		},
+		{
+			name:           "gzip-bomb",
+			url:            base + "/gzip-bomb",
+			timeoutMS:      3000,
+			bodyReadBytes:  1024,
+			bodyReadMS:     1000,
+			wantHTTPStatus: http.StatusOK,
+			wantSuccess:    &boolTrue,
+			wantOutcome:    veriflier.OutcomeUp,
+			wantErrorCode:  &errNone,
+		},
+	}
+
+	if tlsBase != "" {
+		scenarios = append(scenarios, scenario{
+			name:           "tls-self-signed",
+			url:            strings.TrimRight(tlsBase, "/") + "/ok",
+			timeoutMS:      3000,
+			wantHTTPStatus: http.StatusOK,
+			wantSuccess:    &boolFalse,
+			wantOutcome:    veriflier.OutcomeProbeError,
+			wantErrorCode:  &errSSL,
+		})
+	}
+	return scenarios
+}
+
+func runScenario(client *http.Client, addr, token string, sc scenario) scenarioResult {
+	start := time.Now()
+	status, result, err := postCheck(client, addr, token, sc)
+	out := scenarioResult{
+		Name:       sc.name,
+		DurationMS: time.Since(start).Milliseconds(),
+		HTTPStatus: status,
+	}
+	if result != nil {
+		out.Outcome = result.Outcome
+		out.Success = &result.Success
+		out.ErrorCode = &result.ErrorCode
+	}
+	if err != nil {
+		out.Error = err.Error()
+	}
+	out.Pass = scenarioPassed(sc, status, result, err)
+	return out
+}
+
+func postCheck(client *http.Client, addr, token string, sc scenario) (int, *veriflier.CheckV2Result, error) {
+	reqBody := veriflier.CheckV2BatchRequest{
+		BatchID:    sc.name,
+		DeadlineMS: sc.timeoutMS + 500,
+		Requests: []veriflier.CheckV2Request{{
+			RequestID:        sc.name,
+			BlogID:           1001,
+			URL:              sc.url,
+			TimeoutMS:        sc.timeoutMS,
+			BodyReadMaxBytes: sc.bodyReadBytes,
+			BodyReadMaxMS:    sc.bodyReadMS,
+		}},
+	}
+	payload, err := json.Marshal(reqBody)
+	if err != nil {
+		return 0, nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://"+addr+"/v2/check", bytes.NewReader(payload))
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return resp.StatusCode, nil, errors.New(strings.TrimSpace(string(body)))
+	}
+	var decoded veriflier.CheckV2BatchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		return resp.StatusCode, nil, err
+	}
+	if len(decoded.Results) != 1 {
+		return resp.StatusCode, nil, fmt.Errorf("got %d results, want 1", len(decoded.Results))
+	}
+	return resp.StatusCode, &decoded.Results[0], nil
+}
+
+func scenarioPassed(sc scenario, status int, result *veriflier.CheckV2Result, err error) bool {
+	if status != sc.wantHTTPStatus {
+		return false
+	}
+	if sc.wantHTTPStatus != http.StatusOK {
+		return status == sc.wantHTTPStatus
+	}
+	if err != nil || result == nil {
+		return false
+	}
+	if sc.wantSuccess != nil && result.Success != *sc.wantSuccess {
+		return false
+	}
+	if sc.wantOutcome != "" && result.Outcome != sc.wantOutcome {
+		return false
+	}
+	if sc.wantErrorCode != nil && result.ErrorCode != *sc.wantErrorCode {
+		return false
+	}
+	return true
+}
+
+func boolLabel(v *bool) string {
+	if v == nil {
+		return "-"
+	}
+	if *v {
+		return "true"
+	}
+	return "false"
+}
+
+func int32Label(v *int32) string {
+	if v == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%d", *v)
+}

--- a/cmd/security-lab-responder/README.md
+++ b/cmd/security-lab-responder/README.md
@@ -1,0 +1,10 @@
+# Security Lab Responder
+
+`security-lab-responder` is a lab-only helper that serves adversarial HTTP and
+HTTPS responses for Monitor / Veriflier safety validation. It is not a
+production binary and is not built by `make all`.
+
+The responder includes endpoints for unsafe redirects, redirect loops,
+infinite and slow response bodies, oversized response headers, gzip-expanded
+bodies, and self-signed TLS. Run it only on isolated high ports on approved
+test hosts.

--- a/cmd/security-lab-responder/main.go
+++ b/cmd/security-lab-responder/main.go
@@ -1,0 +1,214 @@
+// security-lab-responder is a lab-only helper for repeatable adversarial HTTP
+// response checks. It is intentionally outside the production build targets.
+package main
+
+import (
+	"compress/gzip"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+)
+
+func main() {
+	addr := flag.String("addr", ":18080", "HTTP listen address")
+	tlsAddr := flag.String("tls-addr", ":18443", "HTTPS listen address; empty disables TLS")
+	largeBytes := flag.Int64("large-bytes", 4<<20, "bytes returned by /large and compressed by /gzip-bomb")
+	slowDelay := flag.Duration("slow-delay", 250*time.Millisecond, "delay between /slow-body chunks")
+	flag.Parse()
+
+	handler := newHandler(*largeBytes, *slowDelay)
+	httpSrv := &http.Server{
+		Addr:              *addr,
+		Handler:           handler,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	errCh := make(chan error, 2)
+	go func() {
+		log.Printf("security-lab-responder: http listening on %s", *addr)
+		errCh <- httpSrv.ListenAndServe()
+	}()
+
+	var tlsSrv *http.Server
+	if *tlsAddr != "" {
+		cfg, err := selfSignedTLSConfig()
+		if err != nil {
+			log.Fatalf("tls config: %v", err)
+		}
+		ln, err := net.Listen("tcp", *tlsAddr)
+		if err != nil {
+			log.Fatalf("tls listen: %v", err)
+		}
+		tlsSrv = &http.Server{
+			Addr:              *tlsAddr,
+			Handler:           handler,
+			ReadHeaderTimeout: 5 * time.Second,
+		}
+		go func() {
+			log.Printf("security-lab-responder: https listening on %s", *tlsAddr)
+			errCh <- tlsSrv.Serve(tls.NewListener(ln, cfg))
+		}()
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	select {
+	case sig := <-sigCh:
+		log.Printf("security-lab-responder: %s received, shutting down", sig)
+	case err := <-errCh:
+		if err != nil && err != http.ErrServerClosed {
+			log.Printf("security-lab-responder: server error: %v", err)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = httpSrv.Shutdown(ctx)
+	if tlsSrv != nil {
+		_ = tlsSrv.Shutdown(ctx)
+	}
+}
+
+func newHandler(largeBytes int64, slowDelay time.Duration) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("%s %s", r.Method, r.URL.Path)
+		switch r.URL.Path {
+		case "/ok":
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = io.WriteString(w, "ok\n")
+		case "/large":
+			writeLarge(w, largeBytes)
+		case "/infinite":
+			writeInfinite(r.Context(), w, 0)
+		case "/slow-body":
+			writeInfinite(r.Context(), w, slowDelay)
+		case "/redirect-local":
+			http.Redirect(w, r, "http://127.0.0.1:1/private", http.StatusFound)
+		case "/redirect-metadata":
+			http.Redirect(w, r, "http://169.254.169.254/latest/meta-data/", http.StatusFound)
+		case "/redirect-loop":
+			http.Redirect(w, r, "http://"+r.Host+"/redirect-loop", http.StatusFound)
+		case "/huge-header":
+			writeHugeHeader(w)
+		case "/gzip-bomb":
+			writeGzipBomb(w, largeBytes)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	return mux
+}
+
+func writeLarge(w http.ResponseWriter, bytes int64) {
+	if bytes < 0 {
+		bytes = 0
+	}
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Length", strconv.FormatInt(bytes, 10))
+	w.WriteHeader(http.StatusOK)
+	writeBytes(w, bytes)
+}
+
+func writeInfinite(ctx context.Context, w http.ResponseWriter, delay time.Duration) {
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.WriteHeader(http.StatusOK)
+	flusher, _ := w.(http.Flusher)
+	chunk := make([]byte, 1024)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		if _, err := w.Write(chunk); err != nil {
+			return
+		}
+		if flusher != nil {
+			flusher.Flush()
+		}
+		if delay > 0 {
+			timer := time.NewTimer(delay)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
+		}
+	}
+}
+
+func writeHugeHeader(w http.ResponseWriter) {
+	w.Header().Set("X-Jetmon-Lab-Large", string(make([]byte, 80<<10)))
+	w.WriteHeader(http.StatusOK)
+	_, _ = io.WriteString(w, "large header\n")
+}
+
+func writeGzipBomb(w http.ResponseWriter, bytes int64) {
+	w.Header().Set("Content-Encoding", "gzip")
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.WriteHeader(http.StatusOK)
+	zw := gzip.NewWriter(w)
+	writeBytes(zw, bytes)
+	_ = zw.Close()
+}
+
+func writeBytes(w io.Writer, bytes int64) {
+	const chunkSize = 32 << 10
+	chunk := make([]byte, chunkSize)
+	for bytes > 0 {
+		n := int64(len(chunk))
+		if bytes < n {
+			n = bytes
+		}
+		if _, err := w.Write(chunk[:n]); err != nil {
+			return
+		}
+		bytes -= n
+	}
+}
+
+func selfSignedTLSConfig() (*tls.Config, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, err
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("parse generated key pair: %w", err)
+	}
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}, nil
+}

--- a/docker/.env-sample
+++ b/docker/.env-sample
@@ -8,10 +8,12 @@ BIND_ADDR=127.0.0.1
 # set to 127.0.0.1 when you only want local API access.
 API_BIND_ADDR=0.0.0.0
 
-# MySQL container bootstrap plus Jetmon's app-level DB connection.
-# MYSQL_ROOT_PASSWORD is only used by the local MySQL container and the
+# Local database image plus bootstrap and Jetmon's app-level DB connection.
+# Defaults to MariaDB 11.4, matching the current production database family.
+# MYSQL_ROOT_PASSWORD is only used by the local database container and the
 # one-shot mysql-user setup service. Jetmon connects with MYSQL_USER and
 # MYSQL_PASSWORD instead of root.
+JETMON_DB_IMAGE=mariadb:11.4
 MYSQL_USER=jetmon
 MYSQL_PASSWORD=jetmon_dev_password
 MYSQL_ROOT_PASSWORD=123456

--- a/docker/Dockerfile_api_fixture
+++ b/docker/Dockerfile_api_fixture
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.26.3 AS builder
 
 WORKDIR /src
 

--- a/docker/Dockerfile_jetmon
+++ b/docker/Dockerfile_jetmon
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.26.3 AS builder
 
 WORKDIR /src
 

--- a/docker/Dockerfile_veriflier
+++ b/docker/Dockerfile_veriflier
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.26.3 AS builder
 
 WORKDIR /src
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,25 +1,29 @@
 services:
   mysqldb:
-    image: mysql:8.0
+    image: ${JETMON_DB_IMAGE:-mariadb:11.4}
     restart: unless-stopped
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-123456}
       MYSQL_DATABASE: ${MYSQL_DATABASE:-jetmon_db}
       MYSQL_USER: ${MYSQL_USER:-jetmon}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD:-jetmon_dev_password}
+      MARIADB_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-123456}
+      MARIADB_DATABASE: ${MYSQL_DATABASE:-jetmon_db}
+      MARIADB_USER: ${MYSQL_USER:-jetmon}
+      MARIADB_PASSWORD: ${MYSQL_PASSWORD:-jetmon_dev_password}
     ports:
       - "${BIND_ADDR:-127.0.0.1}:${MYSQL_HOST_PORT:-3307}:3306"
     volumes:
       - db:/var/lib/mysql
     healthcheck:
-      test: ["CMD-SHELL", "MYSQL_PWD=$$MYSQL_ROOT_PASSWORD mysqladmin ping --protocol=tcp -h 127.0.0.1 -u root --silent"]
+      test: ["CMD-SHELL", "if command -v healthcheck.sh >/dev/null 2>&1; then healthcheck.sh --connect --innodb_initialized; else MYSQL_PWD=$$MYSQL_ROOT_PASSWORD mysqladmin ping --protocol=tcp -h 127.0.0.1 -u root --silent; fi"]
       interval: 5s
       timeout: 5s
       retries: 10
       start_period: 10s
 
   mysql-user:
-    image: mysql:8.0
+    image: ${JETMON_DB_IMAGE:-mariadb:11.4}
     restart: "no"
     depends_on:
       mysqldb:

--- a/docker/init-mysql-user.sh
+++ b/docker/init-mysql-user.sh
@@ -29,7 +29,11 @@ app_user=$(sql_string "${MYSQL_USER}")
 app_password=$(sql_string "${MYSQL_PASSWORD}")
 
 mysql_root() {
-	MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql \
+	local client=mysql
+	if command -v mariadb >/dev/null 2>&1; then
+		client=mariadb
+	fi
+	MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" "${client}" \
 		--protocol=tcp \
 		--host=mysqldb \
 		--user=root \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -546,6 +546,12 @@ Database Tables
     ssl_expiry_date       Updated after HTTPS checks
     last_alert_sent_at    Tracks cooldown window
 
+  jetmon_site_safety_flags Non-downtime remediation state
+    monitor_site_id/blog_id Source monitor row and site identifiers
+    flag_type/status       unsafe_monitor_url / probe_safety_block lifecycle
+    reason/monitor_url     Bounded explanation and target URL snapshot
+    first_seen/last_seen   Finding timestamps for operator cleanup
+
   jetmon_hosts            Active monitor instances and bucket leases
     host_id               System hostname (PRIMARY KEY)
     bucket_min/max        Owned bucket range

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -646,11 +646,14 @@ Error Codes (checker.ErrorCode)
   ErrorTLSExpired    6   Certificate has passed NotAfter date
   ErrorTLSDeprecated 7   TLS 1.0 or 1.1 detected (advisory only, not a failure)
   ErrorBodyRead      8   GET response body closed early or could not be read
+  ErrorProbeSafety   9   Probe skipped because the target is unsafe for an untrusted check
 ```
 
-`IsFailure()` returns true for all codes except `ErrorNone` and
-`ErrorTLSDeprecated`. `StatusType()` maps codes to the string values
-expected by the WPCOM API (e.g. "https", "intermittent", "redirect").
+`IsFailure()` returns true for all codes except `ErrorNone`,
+`ErrorTLSDeprecated`, and `ErrorProbeSafety`. `ErrorProbeSafety` is audited
+as a probe-safety block and must not open or close customer-site downtime.
+`StatusType()` maps codes to the string values expected by the WPCOM API
+(e.g. "https", "intermittent", "redirect").
 Body integrity reads are capped to a bounded prefix so Jetmon can catch
 truncated successful GET responses without buffering unbounded response
 bodies. Keyword checks retain their larger bounded body window.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -56,6 +56,7 @@ writes only the v1 compatibility projection fields `site_status` and
 | `jetmon_check_targets` | V2-native scheduling target state for the streaming monitor engine |
 | `jetmon_site_check_config` | Per-site v2 check config: rollout method/profile, body rules, maintenance windows, custom headers, timeout, redirect policy, and cooldown overrides |
 | `jetmon_site_runtime` | V2 runtime freshness and derived observation state such as last checked time, next due time, last alert time, and SSL expiry |
+| `jetmon_site_safety_flags` | Non-downtime remediation state for unsafe legacy monitor URLs and runtime probe-safety blocks |
 | `jetmon_rollout_sessions` | API-driven container rollout sessions bound to bucket ranges and operator/change metadata |
 | `jetmon_rollout_range_locks` | Durable activation/release history for API-controlled bucket ranges |
 | `jetmon_rollout_bucket_locks` | One active lock row per bucket, used to prevent overlapping v2 range activation |
@@ -98,6 +99,20 @@ and forbidden-content checks require `GET`.
 The API can expose a derived `cli_batch` field for local API CLI test data when
 `include_cli_metadata=true` is requested and `custom_headers` contains
 `X-Jetmon-CLI-Batch`; it is not a dedicated database column.
+
+## Site Safety Flags
+
+`jetmon_site_safety_flags` tracks unsafe targets separately from customer
+downtime events. Runtime probe-safety blocks are inserted as open flags with
+`flag_type='probe_safety_block'`; `jetmon2 site-safety unsafe-urls --execute`
+inserts `flag_type='unsafe_monitor_url'` rows with `status='deactivated'`
+before it sets the legacy row's `monitor_active` value to false.
+
+The table preserves the monitor row id, blog id, URL, reason, first/last seen
+timestamps, and remediation status. It intentionally does not replace the
+legacy site table or event tables: `monitor_active` still controls whether a
+site is checked, and probe-safety blocks remain excluded from SLA downtime,
+WPCOM down/recovery notifications, webhooks, and alert-contact delivery.
 
 ## Site Runtime
 

--- a/docs/docker-images.md
+++ b/docs/docker-images.md
@@ -64,9 +64,9 @@ Required env vars:
 
 ## Run Jetmon
 
-Jetmon needs MySQL connectivity and (in production) at least one reachable
-Veriflier. The simplest invocation against an already-running MySQL and
-Veriflier:
+Jetmon needs MySQL-compatible database connectivity and (in production) at
+least one reachable Veriflier. The simplest invocation against an
+already-running database and Veriflier:
 
 ```bash
 docker pull ghcr.io/automattic/jetmon:latest
@@ -105,7 +105,7 @@ Required env vars:
 
 | Var | Notes |
 |---|---|
-| `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, `DB_NAME` | MySQL connection. |
+| `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, `DB_NAME` | MySQL-compatible database connection. |
 | `VERIFLIER_AUTH_TOKEN`, `VERIFLIER_PORT` | Shared with each Veriflier. |
 | `WPCOM_AUTH_TOKEN` | Set to `change_me` for non-WPCOM environments. |
 | `EMAIL_TRANSPORT` | `stub` for dev; `smtp` plus `SMTP_*` vars for real delivery. |
@@ -155,9 +155,10 @@ services:
       - ./jetmon-stats:/jetmon/stats
 ```
 
-MySQL is intentionally not in this snippet — pre-built images are for talking
-to an existing database. For the full local stack including MySQL, Mailpit, and
-StatsD, keep using the build-from-source compose file under `docker/`.
+The database is intentionally not in this snippet; pre-built images are for
+talking to an existing database. For the full local stack including the
+database, Mailpit, and StatsD, keep using the build-from-source compose file
+under `docker/`.
 
 ## Validate Config Inside The Container
 
@@ -170,7 +171,7 @@ docker run --rm \
 ```
 
 The entrypoint renders a config first, then `validate-config` checks shape,
-MySQL connectivity, email transport mode, and Veriflier reachability.
+database connectivity, email transport mode, and Veriflier reachability.
 
 ## Reload And Drain
 
@@ -199,7 +200,7 @@ before the workflow runs.
 | Symptom | Check |
 |---|---|
 | `denied: requested access to the resource is denied` on pull | The package is still private — authenticate with `docker login ghcr.io` using a PAT with `read:packages`, or have a maintainer flip the package visibility. |
-| Container starts but Jetmon exits with a MySQL error | `DB_HOST` is reachable from inside the container — remember `localhost` inside the container is not the host. Use the host IP, a docker network, or `host.docker.internal`. |
+| Container starts but Jetmon exits with a database error | `DB_HOST` is reachable from inside the container — remember `localhost` inside the container is not the host. Use the host IP, a docker network, or `host.docker.internal`. |
 | `reload` / `drain` reports "no PID file" | Mount a writable volume at `/jetmon/stats`. The PID file lives at `/jetmon/stats/jetmon2.pid`. |
 | Config changes do not persist across container restarts | Either mount `/jetmon/config` and edit the file directly, or rely on env vars — the rendered `config.json` is rebuilt from env vars on every fresh start. |
 | Jetmon cannot reach Veriflier | `VERIFLIER_AUTH_TOKEN` must match on both sides, and `VERIFLIER_PORT` (default `7803`) must be reachable from the Jetmon container. |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,12 +5,17 @@ live in [operations-guide.md](operations-guide.md).
 
 ## Requirements
 
-- Go 1.22 or newer
+- Go 1.26.3 or newer
 - Docker and Docker Compose
 - `make`
 
-The Docker environment provides MySQL, StatsD/Graphite, Mailpit, the monitor,
-the Go Veriflier, and the API failure fixture.
+The Docker environment provides a local database, StatsD/Graphite, Mailpit, the
+monitor, the Go Veriflier, and the API failure fixture. `docker/.env-sample`
+defaults to `JETMON_DB_IMAGE=mariadb:11.4`, matching the current production
+database family. If you change this value for compatibility testing, recreate
+the database volume before comparing behavior across engines. Existing local
+volumes created with the old `mysql:8.0` default should be recreated with
+`docker compose down -v` before first starting the MariaDB default.
 
 ## Start Docker
 
@@ -61,7 +66,7 @@ when present. Override with `make GO=/path/to/go ...` for other layouts.
 ./bin/jetmon2 validate-config
 ```
 
-Validation checks required keys, value ranges, MySQL connectivity, legacy
+Validation checks required keys, value ranges, database connectivity, legacy
 projection mode, email transport mode, and configured Verifliers. Veriflier
 reachability is reported as operational context rather than a hard validation
 failure.

--- a/docs/jetmon-v2-prelaunch-readiness.md
+++ b/docs/jetmon-v2-prelaunch-readiness.md
@@ -99,6 +99,13 @@ clear stop/go threshold.
   API unavailable, Veriflier degraded, WPCOM unavailable, MySQL errors,
   delivery backlog, stale heartbeat, bad deploy rollback, WAF false positive,
   and monitor-side `Unknown`.
+- [ ] MariaDB 11.4 runtime validation completed against the production patch
+  range, not just migration smoke. Cover bucket claiming, runtime freshness
+  writes, SSL expiry batches, `ON DUPLICATE KEY UPDATE ... VALUES(...)`, and
+  webhook / alert delivery claims.
+- [ ] Probe-safety follow-up work is tracked before rollout: scheduled
+  `jetmon_site_safety_flags` reporting, authoritative DNS rebinding tests,
+  deeper TLS pathology tests, and optional streaming keyword short-circuiting.
 
 The API rollout smoke gate is necessary but not sufficient for launch. Until
 synthetic canary execution is built into the API rollout gates, run the approved
@@ -381,6 +388,36 @@ Evidence:
 
 - Drill notes with command sequence, expected behavior, observed behavior, and
   follow-up items.
+
+### 8. Probe Safety And Database Runtime Validation
+
+- [ ] Owner: `Jetmon`, `Systems` - Run an end-to-end MariaDB 11.4 runtime
+  exercise against versions matching the production patch range. Migration
+  smoke on `mariadb:11.4.8` and `mariadb:11.4.10` is useful evidence, but the
+  rollout gate must also exercise runtime write paths.
+- [ ] Owner: `Jetmon`, `Systems` - Include bucket claiming, runtime freshness
+  writes, SSL expiry updates, `ON DUPLICATE KEY UPDATE ... VALUES(...)`, and
+  webhook / alert delivery row claims in the MariaDB runtime exercise.
+- [ ] Owner: `Jetmon` - Add or open follow-up tracking for scheduled
+  `jetmon_site_safety_flags` reporting so unsafe legacy row counts and runtime
+  probe-safety blocks are visible before and after API rejection rolls out.
+- [ ] Owner: `Jetmon` - Add or open follow-up tracking for authoritative DNS
+  rebinding coverage: public address on first lookup, then private/reserved
+  address on redirect or later check.
+- [ ] Owner: `Jetmon` - Add or open follow-up tracking for deeper TLS pathology
+  coverage: TLS 1.0/1.1, no common cipher, handshake close/alert, large
+  certificate chains, expired/self-signed certificates, and hostname mismatch.
+- [ ] Owner: `Jetmon` - Decide whether streaming keyword matching should
+  short-circuit when a required-only keyword is found. This is an optimization
+  follow-up, not a production rollout blocker unless body-read cost becomes a
+  measured canary issue.
+
+Evidence:
+
+- MariaDB runtime exercise transcript, including server versions and pass/fail
+  output for each covered write path.
+- Links to follow-up issues or roadmap entries for safety-flag reporting, DNS
+  rebinding tests, TLS pathology tests, and keyword short-circuiting.
 
 ## Early Canary Gates
 

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -120,6 +120,22 @@ keeps legacy `failure_class` for WPCOM-compatible status types and adds
 operator-facing `detector_class` plus `body_read` evidence for partial/truncated
 responses.
 
+## Probe Safety Cleanup
+
+Use `./jetmon2 site-safety unsafe-urls` to scan active legacy
+`jetpack_monitor_sites.monitor_url` values with the same public-target guard
+used by API admission and runtime probe execution. The default mode is a
+dry-run: it prints bounded examples plus `scanned_active`, `unsafe`, `flagged`,
+and `deactivated` counts without changing rows.
+
+Run with `--execute` only after reviewing the dry-run output. Execution records
+one `jetmon_site_safety_flags` row for each unsafe active monitor URL, then sets
+that legacy row's `monitor_active` value to false. It does not delete site
+rows, does not create downtime events, and does not send WPCOM down/recovery,
+webhook, or alert-contact notifications. Runtime probe-safety blocks also write
+open `jetmon_site_safety_flags` rows when the monitor row is known, so
+operators can query one table for cleanup and recurring unsafe-target findings.
+
 ## Production Host Setup
 
 1. Install `bin/jetmon2` as `/opt/jetmon2/jetmon2`, or update the service unit

--- a/docs/project.md
+++ b/docs/project.md
@@ -167,7 +167,7 @@ Store `redirect_policy` in `jetmon_site_check_config` with three options: `follo
 ## Tooling and Developer Experience
 
 **Docker Compose Environment**
-The existing Docker Compose setup is updated for the Go binary. A single `docker compose up` starts MySQL, the Jetmon 2 binary, one or more Veriflier instances, Mailpit for local email capture, StatsD + Graphite, the operator dashboard, and the deterministic API fixture. No npm, no node-gyp, no manual build steps. `docker compose up --build` rebuilds the Go binaries in a reproducible multi-stage Docker build.
+The existing Docker Compose setup is updated for the Go binary. A single `docker compose up` starts a local MySQL-compatible database, the Jetmon 2 binary, one or more Veriflier instances, Mailpit for local email capture, StatsD + Graphite, the operator dashboard, and the deterministic API fixture. No npm, no node-gyp, no manual build steps. `docker compose up --build` rebuilds the Go binaries in a reproducible multi-stage Docker build.
 
 **Docker-Local API Fixture**
 The Docker Compose environment includes an `api-fixture` service for deterministic local API CLI and event-flow rehearsals without depending on public endpoint timing. It exposes:

--- a/docs/security-adversarial-probe-analysis.md
+++ b/docs/security-adversarial-probe-analysis.md
@@ -160,6 +160,7 @@ Tests added:
 - `TestProcessResultsProbeSafetyBlockAuditsWithoutStateChange`
 - `TestServerHandleCheckRejectsUnsafeURL`
 - `TestServerHandleV2CheckRejectsUnsafeURL`
+- `TestServerHandleV2CheckRejectsOversizedBody`
 - `TestCheckerProbeSafetyErrorCodeContract`
 - `TestTransportSafetyBlocksUnsafeIPBeforeDial`
 
@@ -196,6 +197,7 @@ Tests added:
 - `TestValidateDestinationRejectsUnsafeWebhookURLs`
 - `TestProtectedDialContextRejectsUnsafeLiteral`
 - `TestProtectedHTTPClientRejectsUnsafeRedirectURL`
+- `TestProtectedHTTPClientDoesNotUseAmbientProxy`
 
 ### Legacy Cleanup Path
 
@@ -206,6 +208,7 @@ Tests added:
 - `TestClassifyUnsafeMonitorURL`
 - `TestRunSiteSafetyUnsafeURLsDryRun`
 - `TestRunSiteSafetyUnsafeURLsExecuteDeactivates`
+- `TestDeactivateUnsafeMonitorURLsChunksLargeBatches`
 
 ### Custom Header Safety
 
@@ -298,6 +301,19 @@ Benchmarks were refreshed locally from clean `v2` and this branch. CPU: `13th Ge
 
 The large-body benchmarks are intentionally conservative and noisy: they include `httptest`, large response-body reads, and do not enable the target-safety flag. The direct safety benchmark is the better estimate for the added per-check validation cost after DNS cache warmup: about 0.34 microseconds and 64 bytes per check. A previous draft created a fresh resolver during validation and measured around 23 microseconds / 4.8 KiB per cached check; this branch now reuses the checker resolver and transport cache.
 
+## Dependency And Toolchain Audit
+
+`govulncheck` was initially run with the local Go toolchain (`go1.26.2`) against `./...`. It reported two reachable standard-library vulnerabilities, both fixed in Go `1.26.3`:
+
+- `GO-2026-4971`: `net` panic in `Dial` and `LookupPort` with NUL byte input. Example reachable traces include StatsD `net.Dial`, database dial paths, checker DNS lookup, and protected delivery DNS lookup.
+- `GO-2026-4918`: HTTP/2 transport infinite loop on a bad `SETTINGS_MAX_FRAME_SIZE`. Example reachable traces include checker `http.Client.Do` and other HTTP client paths.
+
+It also reported additional package/module-level standard-library findings in the local toolchain that do not appear reachable from this code. The repo-level floor is now explicit: `go.mod` requires Go `1.26.3`, and Docker builder images use `golang:1.26.3`. A refreshed `govulncheck ./...` pass under Go `1.26.3` reported no vulnerabilities.
+
+Production database compatibility should be validated against MariaDB 11.4, not just MySQL 8.0. Current production database servers are MariaDB 11.4.8 through 11.4.10; MariaDB lists 11.4 as an LTS series with Community maintenance through May 29, 2029, and MariaDB announced 11.4.10 as a February 6, 2026 maintenance release. The local Docker Compose file now defaults `JETMON_DB_IMAGE` to `mariadb:11.4` while still allowing explicit database-image overrides for compatibility checks.
+
+`github.com/go-sql-driver/mysql` remains the right driver family: its current README says maintainers support MariaDB 10.5+ as well as MySQL 5.7+. The project now uses `v1.10.0`. Before production rollout, run MariaDB 11.4 integration tests that cover migrations, JSON columns, generated columns, `ON DUPLICATE KEY UPDATE ... VALUES(...)`, bucket claiming, and runtime write batching.
+
 ## Probe-Safety Event Options
 
 Current branch behavior is intentionally conservative:
@@ -327,6 +343,6 @@ If more checker result fields become shared protocol semantics, move the stable 
 1. Decide whether to implement `Probe Safety Blocked` as a non-downtime event state before rollout, or keep the current audit/metrics-only behavior for this branch.
 2. If cleanup will be run on production data, decide whether deactivation alone is acceptable or whether an additive reason table is needed first.
 3. Add a scheduled or operator-invoked cleanup dry-run report so the unsafe legacy row count can be watched before and after API rejection rolls out.
-3. Exercise DNS rebinding with an authoritative test DNS responder: public address on first lookup, private address on a redirect hop or later check.
-4. Exercise TLS pathology with uptime-bench responders: TLS 1.0/1.1, no common cipher, handshake close/alert, large certificate chains, expired/self-signed/hostname mismatch certificates.
-5. Consider streaming keyword matching that can stop as soon as a required-only keyword is found instead of reading until EOF/limit/budget.
+4. Exercise DNS rebinding with an authoritative test DNS responder: public address on first lookup, private address on a redirect hop or later check.
+5. Exercise TLS pathology with uptime-bench responders: TLS 1.0/1.1, no common cipher, handshake close/alert, large certificate chains, expired/self-signed/hostname mismatch certificates.
+6. Consider streaming keyword matching that can stop as soon as a required-only keyword is found instead of reading until EOF/limit/budget.

--- a/docs/security-adversarial-probe-analysis.md
+++ b/docs/security-adversarial-probe-analysis.md
@@ -1,0 +1,322 @@
+# Jetmon Adversarial Probe Security Analysis
+
+Date: 2026-05-17
+Branch: `security-adversarial-probes`
+Scope: Monitor and Veriflier handling of remote, untrusted HTTP(S), DNS, redirect, TLS, headers, and body-response behavior.
+
+## Executive Summary
+
+This pass focused on attacker-controlled site responses that can consume Monitor or Veriflier resources, amplify stored metadata, or make Jetmon probe unintended destinations.
+
+Fixes landed in this branch:
+
+- Enforce `BODY_READ_MAX_MS` and `KEYWORD_READ_MAX_MS` during response-body reads.
+- Cap redirect diagnostic metadata before storing it in `Result.RedirectChain` and `Result.FinalURL`.
+- Set `MaxResponseHeaderBytes` on checker transports.
+- Block cross-host redirects to localhost, private, link-local, multicast, CGNAT, documentation, benchmark, and reserved address ranges.
+- Reject same-host redirects that introduce URL userinfo, and reject obfuscated IPv4 host forms such as octal, hex, and single-integer loopback encodings.
+- Validate and bound custom headers at API write time, and defensively filter stored custom headers before outbound checks.
+- Reject unsafe literal target URLs at the site API and both Veriflier protocols.
+- Add last-mile transport safety checks so target-safety-enabled checks validate resolved addresses immediately before dialing, not only before request construction.
+- Add per-entry DNS cache expiry jitter so lookups created during one check wave do not all refresh on the same later wave.
+- Cap authenticated API JSON request bodies at 1 MiB, including idempotency-key hashing and replay caching.
+- Apply public-target validation and guarded HTTP clients to outbound webhook and Slack / Teams alert delivery URLs.
+- Add `jetmon2 site-safety unsafe-urls`, a dry-run-first cleanup tool that scans active legacy rows with the same URL guard and can deactivate unsafe rows when run with `--execute`.
+- Block already-stored unsafe or malformed direct targets in the checker hot path with a non-downtime `ErrorProbeSafety` result. The orchestrator audits these as `probe_safety_blocked` and does not open or close downtime incidents.
+- Classify unsafe redirect targets as `ErrorProbeSafety` rather than generic redirect failures, so redirect SSRF blocks are not counted as customer-site downtime.
+- Add regression coverage for gzip expansion, slow/infinite body streaming, oversized response headers, unsafe redirects, unsafe Veriflier URLs, and custom header injection/framing attempts.
+
+The remaining product/design question is whether these probe-safety blocks should also be visible as first-class event/degradation states. This branch records them in the audit log and metrics, but intentionally does not create customer-site downtime events.
+
+## Evidence Reviewed
+
+- Checker transport, redirect, body, DNS, TLS, and metadata paths: `internal/checker/checker.go`
+- Checker adversarial and regression tests: `internal/checker/checker_test.go`
+- Shared unsafe-target guard: `internal/netguard/`
+- Site API URL and custom check config writes: `internal/api/handlers_sites_write.go`
+- Veriflier HTTP server request-size, auth, URL validation, and timeout controls: `internal/veriflier/server.go`
+- Veriflier client batch/deadline behavior: `internal/veriflier/client.go`
+- Monitor escalation request propagation to Verifliers: `internal/orchestrator/orchestrator.go`
+- Uptime-bench scenario and target/DNS/TLS responder capabilities, read-only: `../uptime-bench/internal/scenario`, `../uptime-bench/internal/targetserver`, `../uptime-bench/internal/dnsserver`
+- Live v1 table backup, read-only and parsed on `jetmon-service-host-5`: `../jetpack_monitor_sites-2026-05-13-225300.sql.gz`
+
+## Backup Data Review
+
+I parsed the May 13, 2026 v1 `jetpack_monitor_sites` backup on `jetmon-service-host-5` to avoid heavier work on the local machine, then restored it into an isolated loopback-only MariaDB container on host 5 to exercise the cleanup command against a realistic copy.
+
+Totals:
+
+- Rows: 3,557,537
+- Active rows: 594,377
+- Maximum stored `monitor_url` length: 300 bytes
+- Schemes: 2,081,334 `http`, 1,475,834 `https`, 366 missing scheme, 3 malformed/bad scheme.
+
+Initial rough categories found:
+
+- 30 active unsafe IP literal URLs.
+- 6 active localhost-name URLs.
+- 12 active `.local` / local-internal hostname URLs.
+- 4 active missing-scheme URLs.
+- 1 active URL with userinfo.
+
+The first full cleanup pass surfaced a false-positive risk: ordinary DNS names with numeric labels, such as `02.example.com`, were being treated like octal IPv4 fragments. I narrowed that guard so non-canonical IPv4 detection only applies when the whole hostname is numeric/IPv4-like, then reran the backup exercise. The corrected `site-safety unsafe-urls` pass found 61 unsafe active rows.
+
+Representative active examples:
+
+- `www.nichederich.com`
+- `www.umunion.org`
+- `naphtaliassociates.org.uk`
+- `trulyteachmetarot.com`
+- `http://192.168.1.213/dtcpl`
+- `https://127.0.0.1:80`
+- `http://10.4.5.238:8080`
+- `https://10.0.20.176/blog`
+- `http://172.31.26.160`
+- `https://0.0.0.0`
+- `http://localhost/lightupwear.com`
+- `http://localhost:8000`
+- `https://app.localhost/buddygodutch`
+- `https://localhost:3000`
+- `https://adonislounge.local/nyc`
+- `http://jucosol.local`
+- `https://rtcamp.local`
+- `http://host.docker.internal:99`
+- `https://safemed.siteqa.uthsc.local`
+- `http://mjrodero@50.87.195.157`
+- `http://102`
+- `http://1717657663`
+- `http://6`
+
+Cleanup command exercise against the temporary database copy:
+
+```text
+dry-run:        scanned_active=594377 unsafe=61 deactivated=0
+execute:        scanned_active=594377 unsafe=61 deactivated=61
+follow-up dry:  scanned_active=594316 unsafe=0 deactivated=0
+```
+
+The command only changed the temporary restored copy. The container was stopped after validation.
+
+## Fixes Added
+
+### Body-Read Time Budgets
+
+`readResponseBody` now starts a post-header read budget when:
+
+- response integrity mode is budgeted, not strict finite, and `BodyReadMaxMS > 0`;
+- keyword/body-rule mode is active and `KeywordReadMaxMS > 0`.
+
+Budget exhaustion closes the response body to unblock the reader. Non-keyword budget exhaustion remains `ErrorBodyRead`; keyword budget exhaustion is classified as `ErrorTimeout`.
+
+Tests added:
+
+- `TestCheckBodyReadMaxMSTimesOutBudgetedRead`
+- `TestCheckBodyReadMaxMSDoesNotFailStrictFiniteBody`
+- `TestCheckKeywordReadMaxMSTimesOutAsTimeout`
+
+### Response Size And Metadata Bounds
+
+Checker transports now set a 64 KiB `MaxResponseHeaderBytes` cap. Redirect chain entries and final URL diagnostics are capped at 2048 bytes plus ellipsis. This prevents hostile targets from producing oversized headers or multi-megabyte event metadata.
+
+Tests added:
+
+- `TestCheckRejectsOversizedResponseHeaders`
+- `TestCheckRedirectMetadataBoundsLargeLocation`
+
+### Body Expansion
+
+Gzip responses are bounded after decompression by the existing body-read byte cap. This was added as explicit regression coverage because compressed expansion is a common way to bypass wire-size assumptions.
+
+Test added:
+
+- `TestCheckCompressedLargeBodyIsCappedAfterDecompression`
+
+### Redirect SSRF Guard
+
+Cross-host redirects now run through a target safety check before the checker follows them. The guard rejects localhost, private, link-local, multicast, CGNAT, documentation, benchmark, and reserved address ranges, including hostnames that resolve into those ranges. Unsafe redirect blocks are classified as `ErrorProbeSafety` and are not downtime failures.
+
+Same-host redirects are also rejected if they introduce URL userinfo.
+
+Tests covered/added:
+
+- `TestCheckRejectsCrossHostRedirectToUnsafeAddress`
+- `TestCheckRejectsSameHostRedirectWithUserinfo`
+
+### Unsafe Direct Target Rejection
+
+The site API and both Veriflier protocol handlers now reject unsafe direct target URLs before storage or execution. The checker also enforces the same protection for already-stored rows when called by the Monitor, trigger-now, rollout checks, or Veriflier runtime.
+
+Blocked targets include missing schemes, non-HTTP schemes, userinfo, localhost, loopback, RFC1918, `.local` / internal-style names, IPv6 loopback, cloud metadata-style link-local targets, CGNAT, documentation, benchmark, reserved ranges, and non-canonical IPv4 encodings. When the checker blocks a stored direct target, it returns `ErrorProbeSafety`; the orchestrator records an audit row and intentionally skips downtime state transitions.
+
+Target-safety-enabled checks also carry a context flag into the checker transports. The HTTP pooled transport and HTTPS dial path validate every selected address immediately before dialing so a future call path cannot validate one resolution and accidentally dial another unsafe address.
+
+Tests added:
+
+- `TestValidateMonitorURL`
+- `TestUnsafeHost`
+- `TestParsePublicHTTPURL`
+- `TestCheckBlocksUnsafeDirectTargetWhenSafetyEnforced`
+- `TestProcessResultsProbeSafetyBlockAuditsWithoutStateChange`
+- `TestServerHandleCheckRejectsUnsafeURL`
+- `TestServerHandleV2CheckRejectsUnsafeURL`
+- `TestTransportSafetyBlocksUnsafeIPBeforeDial`
+
+### DNS Cache Burst Smoothing
+
+The checker DNS cache is lazy rather than prewarmed. Entries are created when checks first resolve a host. This branch changes cache expiration from a fixed `lookup time + 15m` to a per-entry expiration spread across the last three minutes of the TTL, salted per process. That means a batch of hostnames resolved during one scheduler wave should refresh over a window instead of expiring together.
+
+Tests added:
+
+- `TestCheckDNSCacheExpiryUsesJitter`
+- `TestValidateResolvedTargetRejectsMixedPublicPrivateDNSAnswers`
+- `TestValidateResolvedTargetRejectsDNSRebindAfterCacheExpiry`
+
+### TLS Pathology Coverage
+
+The checker keeps TLS 1.0/1.1 handshakes enabled so deprecated TLS can be recorded as an advisory rather than an outage. This branch also keeps certificate trust failures classified as SSL failures.
+
+Tests added:
+
+- `TestCheckTLS11IsAdvisoryNotOutage`
+- `TestCheckSelfSignedTLSFailsAsSSL`
+
+### API And Delivery URL Hardening
+
+API JSON routes now wrap request bodies with a 1 MiB `MaxBytesReader`, and idempotency-key hashing applies the same cap before `io.ReadAll`. Outbound webhook registrations are validated in the webhooks package as well as the API handler. Slack and Teams alert-contact destinations are validated on create/update, and default alert delivery uses a protected HTTP client that rejects unsafe redirects and non-public resolved dial addresses.
+
+Tests added:
+
+- `TestIdempotencyMiddlewareRejectsOversizedJSONBody`
+- `TestCreateWebhookRejectsBadURL`
+- `TestUpdateWebhookRejectsUnsafeURLBeforeDB`
+- `TestValidateDestinationRejectsUnsafeWebhookURLs`
+- `TestProtectedDialContextRejectsUnsafeLiteral`
+- `TestProtectedHTTPClientRejectsUnsafeRedirectURL`
+
+### Legacy Cleanup Path
+
+`jetmon2 site-safety unsafe-urls` scans active `jetpack_monitor_sites` rows and classifies `monitor_url` with the same admission-time shape/literal guard, `netguard.ParsePublicHTTPURL`. By default it is a dry run and prints counts plus bounded examples. Passing `--execute` deactivates matching active rows by setting `monitor_active = 0`; it does not delete rows. Runtime DNS safety checks still remain necessary for hostnames whose resolution changes later.
+
+Tests added:
+
+- `TestClassifyUnsafeMonitorURL`
+- `TestRunSiteSafetyUnsafeURLsDryRun`
+- `TestRunSiteSafetyUnsafeURLsExecuteDeactivates`
+
+### Custom Header Safety
+
+API writes now reject custom header maps with too many entries, oversized names/values, invalid token characters, control characters, or hop-by-hop/request-framing headers. The checker also filters stored headers defensively before sending outbound requests.
+
+Tests added:
+
+- `TestEncodeCustomHeadersRejectsUnsafeNamesAndValues`
+- `TestEncodeCustomHeadersRejectsLargeInput`
+- `TestParseCustomHeaders`
+
+## External Vulnerability Notes Checked
+
+After the initial fixes, I searched public advisory/release notes for uptime-monitor style failures that could suggest new test cases. Relevant patterns:
+
+- Uptime Kuma had a monitor URL handling advisory for local-file access through `file:///`-style targets: <https://github.com/louislam/uptime-kuma/security/advisories/GHSA-2qgm-m29m-cj2h>. Jetmon already required `http`/`https`; this branch adds unsafe literal target rejection at API and Veriflier boundaries.
+- Uptime Kuma had an SSRF-style metadata exposure advisory through keyword monitors and cloud metadata endpoints: <https://github.com/louislam/uptime-kuma/security/advisories/GHSA-qjxc-h5jf-c7rj>. This branch blocks metadata link-local IPs, internal metadata hostnames, and custom metadata headers that would require unsafe target URLs to be useful.
+- Uptime Kuma had a notification-template SSTI advisory: <https://github.com/louislam/uptime-kuma/security/advisories/GHSA-vffh-c9pq-4crh>. I searched Jetmon for user-provided template execution and found no equivalent template engine path in webhook or alert rendering.
+- Uptime Kuma had a notification URL ReDoS advisory: <https://github.com/louislam/uptime-kuma/security/advisories/GHSA-hx7h-9vf7-5xhg>. Jetmon uses Go's RE2 engine for regexes and this branch caps untrusted URL length at admission.
+- Uptime Kuma had command injection in a monitor type that shell-executed host input: <https://github.com/louislam/uptime-kuma/security/advisories/GHSA-hfxh-rjv7-2369>. Jetmon's HTTP Monitor / Veriflier paths do not shell out for target checks.
+- Uptime Kuma had a missing-authorization monitor-data leak: <https://github.com/louislam/uptime-kuma/security/advisories/GHSA-c7hf-c5p5-5g6h>. Jetmon's internal API routes are scope-gated; the analogous risk remains future public/gateway routes exposing monitor timing data without tenant checks.
+
+## Host Status
+
+- `jetmon-service-host-3`: reachable as `jetmon`; passwordless sudo works; no active `jetmon*` or `uptime-bench*` units observed.
+- `jetmon-service-host-4`: reachable as `jetmon`; passwordless sudo works; currently running uptime-bench target/DNS units.
+- `jetmon-service-host-5`: reachable as `jetmon`; passwordless sudo works; no active `jetmon*` or `uptime-bench*` units observed. Used for remote checker and Veriflier test-binary execution.
+- `jetmon-service-host-6`: reachable as `jetmon`, but `sudo -n` fails with password required. Provisioning this host still needs a bootstrap credential or approved out-of-band admin path.
+
+## End-to-End Lab
+
+On `jetmon-service-host-5`, I ran temporary high-port binaries only:
+
+- `/tmp/jetmon-security-lab-responder`: hostile HTTP/TLS responder on `:18080` and `:18443`.
+- `/tmp/jetmon-veriflier2-security`: Veriflier on `:17803`, target safety enabled.
+- `/tmp/jetmon-security-lab-client`: scenario runner posting to `/v2/check`.
+
+The responder was accessed through host 5's public IPv6 address, so the Veriflier exercised the real target-safety path instead of bypassing it with loopback. Temporary listeners were stopped after the run.
+
+Passing scenarios:
+
+| Scenario | Result |
+|---|---|
+| Direct `127.0.0.1` target | Veriflier rejected with HTTP 400 before execution. |
+| Public `/ok` target | `outcome=up`, `success=true`, `error_code=0`. |
+| Public target redirecting to `127.0.0.1` | `outcome=unknown`, `success=false`, `error_code=9` (`ErrorProbeSafety`). |
+| Public target redirecting to `169.254.169.254` | `outcome=unknown`, `success=false`, `error_code=9`. |
+| Redirect loop | `outcome=probe_error`, `error_code=4` (`ErrorRedirect`) after redirect cap. |
+| Infinite body stream with 1 KiB body cap | Completed immediately as `up`, proving the checker stops reading after the cap. |
+| Slow body stream with 50 ms body-read budget | Completed in 51 ms as `ErrorBodyRead`, no hang. |
+| 80 KiB response header | Blocked as `probe_error`, `ErrorConnect`, no unbounded header read. |
+| Gzip-expanded body with 1 KiB cap | Completed as `up`, proving cap applies after decompression. |
+| Self-signed TLS endpoint | `probe_error`, `ErrorSSL`, no crash or hang. |
+
+## Verification Run
+
+Local targeted tests:
+
+```bash
+go test -count=1 ./internal/netguard ./internal/checker ./internal/api ./internal/veriflier ./veriflier2/cmd ./internal/orchestrator ./internal/webhooks ./internal/alerting ./internal/deliverer ./cmd/jetmon2 ./cmd/security-lab-client ./cmd/security-lab-responder
+git diff --check
+```
+
+Remote targeted tests on `jetmon-service-host-5`:
+
+```bash
+/tmp/jetmon-checker-security.test -test.run "Test(ParseCustomHeaders|Check(BlocksUnsafeDirectTargetWhenSafetyEnforced|BodyReadMaxMS|KeywordReadMaxMS|RedirectMetadataBoundsLargeLocation|RejectsCrossHostRedirectToUnsafeAddress|RejectsOversizedResponseHeaders|CompressedLargeBody|TruncatedBody|RedirectFail|Timeout))" -test.v
+/tmp/jetmon-veriflier-security.test -test.run "Test(ServerHandleCheckRejectsUnsafeURL|ServerHandleV2CheckRejectsUnsafeURL|ServerHandleCheckRequestBodyLimit|ServerRejectsEmptyAuthToken|ServerHandleCheckUnauthorized|ServerHandleV2Check)" -test.v
+/tmp/jetmon-api-security.test -test.run "Test(ValidateMonitorURL|TriggerNowUnsafeStoredURLIsProbeSafetyBlock|EncodeCustomHeadersRejects)" -test.v
+/tmp/jetmon-orchestrator-security.test -test.run "TestProcessResultsProbeSafetyBlockAuditsWithoutStateChange" -test.v
+```
+
+All targeted tests passed.
+
+## Performance Notes
+
+Most checks added here are constant-time string or URL-shape checks. The meaningful added work is target-safety DNS validation for production Monitor / Veriflier checks. That validation runs at check time for already-stored legacy rows, not once at write time, because the v1 table does not have a persisted safety-vetted projection. It uses the existing 15-minute checker DNS cache, so repeated checks of the same hostname on a five-minute cadence should normally reuse cached resolution.
+
+The response-header cap has no steady-state cost. Body-read timing adds a timer only for budgeted response-body reads. Custom-header validation happens at write time, and checker-side header filtering is proportional to the small configured header map size.
+
+Benchmarks were run on `jetmon-service-host-5` with prebuilt Linux test binaries from clean `v2` and this branch. CPU: `Intel(R) Core(TM) i5-6500T CPU @ 2.50GHz`. A default-benchtime pass was noisy, so the comparable table below uses `-test.benchtime=3s -test.count=3 -test.cpu=1`; values are medians.
+
+| Benchmark | v2 | this branch | delta |
+|---|---:|---:|---:|
+| `BenchmarkCheckNoKeywordLargeBody` | 1,502,320 ns/op, 1,078,222 B/op, 180 allocs/op | 1,384,076 ns/op, 1,078,339 B/op, 181 allocs/op | -7.9% time, +117 B, +1 alloc |
+| `BenchmarkCheckKeywordLargeBody` | 2,882,773 ns/op, 4,371,827 B/op, 225 allocs/op | 2,576,229 ns/op, 4,371,812 B/op, 225 allocs/op | -10.6% time, -15 B, no alloc change |
+| `BenchmarkProbeTargetSafetyCached` | n/a | 596 ns/op, 96 B/op, 3 allocs/op | added hot-path target guard |
+| `BenchmarkParsePublicHTTPURL` | n/a | 547 ns/op, 224 B/op, 3 allocs/op | API / Veriflier admission guard |
+| `BenchmarkProbeTargetSafetyBlockedLiteral` | n/a | 895 ns/op, 272 B/op, 5 allocs/op | unsafe literal rejection |
+
+The large-body benchmarks are intentionally conservative and noisy: they include `httptest`, large response-body reads, and do not enable the target-safety flag. The direct safety benchmark is the better estimate for the added per-check validation cost after DNS cache warmup: about 0.6 microseconds and 96 bytes per check. A previous draft created a fresh resolver during validation and measured around 23 microseconds / 4.8 KiB per cached check; this branch now reuses the checker resolver and transport cache.
+
+## Probe-Safety Event Options
+
+Current branch behavior is intentionally conservative:
+
+- Unsafe direct targets and unsafe redirects return `ErrorProbeSafety`.
+- The checker marks them non-failures for downtime purposes.
+- The orchestrator writes `probe_safety_blocked` audit rows and metrics.
+- No customer downtime event is opened, promoted, or closed.
+
+Product options:
+
+1. Keep audit + metrics only. This is lowest risk for rollout and avoids confusing unsafe URL cleanup with customer downtime. It is weaker operationally because dashboards and event consumers must know to inspect audit rows.
+2. Add a first-class non-downtime event state, for example `Probe Blocked` or `Probe Safety Blocked`, with severity 2 and `check_type=probe_safety`. It should be excluded from SLA downtime and WPCOM down/recovery notifications. This is my recommendation if operators need persistent visibility into unsafe legacy rows without paging customers.
+3. Add a separate stored label/deactivation reason for cleanup. The current cleanup command can deactivate unsafe rows but the v1 table has no explicit reason column. An additive v2-side table such as `jetmon_site_safety_flags` could preserve `site_id`, reason, first_seen, last_seen, and remediation status without mutating v1 semantics beyond `monitor_active=0`.
+4. Treat public-host hostile responses as degraded states only after repeat evidence. Oversized headers, body-read budget exhaustion, and TLS pathology can be real site problems or adversarial behavior. If represented as events, they should use thresholds and cooldowns to avoid opening transient one-probe noise.
+
+API behavior should remain strict regardless of which product option is chosen: new or updated monitor URLs should be rejected at write time when they are shape-unsafe, and runtime target-safety should remain in place for already-stored rows and DNS changes.
+
+## Remaining High-Value Scenarios
+
+1. Decide whether to implement `Probe Safety Blocked` as a non-downtime event state before rollout, or keep the current audit/metrics-only behavior for this branch.
+2. If cleanup will be run on production data, decide whether deactivation alone is acceptable or whether an additive reason table is needed first.
+3. Add a scheduled or operator-invoked cleanup dry-run report so the unsafe legacy row count can be watched before and after API rejection rolls out.
+3. Exercise DNS rebinding with an authoritative test DNS responder: public address on first lookup, private address on a redirect hop or later check.
+4. Exercise TLS pathology with uptime-bench responders: TLS 1.0/1.1, no common cipher, handshake close/alert, large certificate chains, expired/self-signed/hostname mismatch certificates.
+5. Consider streaming keyword matching that can stop as soon as a required-only keyword is found instead of reading until EOF/limit/budget.

--- a/docs/security-adversarial-probe-analysis.md
+++ b/docs/security-adversarial-probe-analysis.md
@@ -22,11 +22,12 @@ Fixes landed in this branch:
 - Cap authenticated API JSON request bodies at 1 MiB, including idempotency-key hashing and replay caching.
 - Apply public-target validation and guarded HTTP clients to outbound webhook and Slack / Teams alert delivery URLs.
 - Add `jetmon2 site-safety unsafe-urls`, a dry-run-first cleanup tool that scans active legacy rows with the same URL guard and can deactivate unsafe rows when run with `--execute`.
-- Block already-stored unsafe or malformed direct targets in the checker hot path with a non-downtime `ErrorProbeSafety` result. The orchestrator audits these as `probe_safety_blocked` and does not open or close downtime incidents.
+- Add `jetmon_site_safety_flags`, a durable non-downtime remediation table for unsafe legacy URLs and runtime probe-safety blocks.
+- Block already-stored unsafe or malformed direct targets in the checker hot path with a non-downtime `ErrorProbeSafety` result. The orchestrator audits these as `probe_safety_blocked`, records an open safety flag, and does not open or close downtime incidents.
 - Classify unsafe redirect targets as `ErrorProbeSafety` rather than generic redirect failures, so redirect SSRF blocks are not counted as customer-site downtime.
 - Add regression coverage for gzip expansion, slow/infinite body streaming, oversized response headers, unsafe redirects, unsafe Veriflier URLs, and custom header injection/framing attempts.
 
-The remaining product/design question is whether these probe-safety blocks should also be visible as first-class event/degradation states. This branch records them in the audit log and metrics, but intentionally does not create customer-site downtime events.
+This branch intentionally does not create customer-site downtime events for probe-safety blocks. Durable safety flags are the operator remediation trail; a first-class non-downtime event state remains optional future product work if dashboard/API event visibility needs to be richer than flags plus audit rows.
 
 ## Evidence Reviewed
 
@@ -90,9 +91,9 @@ Representative active examples:
 Cleanup command exercise against the temporary database copy:
 
 ```text
-dry-run:        scanned_active=594377 unsafe=61 deactivated=0
-execute:        scanned_active=594377 unsafe=61 deactivated=61
-follow-up dry:  scanned_active=594316 unsafe=0 deactivated=0
+dry-run:        scanned_active=594377 unsafe=61 flagged=0  deactivated=0
+execute:        scanned_active=594377 unsafe=61 flagged=61 deactivated=61
+follow-up dry:  scanned_active=594316 unsafe=0  flagged=0  deactivated=0
 ```
 
 The command only changed the temporary restored copy. The container was stopped after validation.
@@ -201,7 +202,7 @@ Tests added:
 
 ### Legacy Cleanup Path
 
-`jetmon2 site-safety unsafe-urls` scans active `jetpack_monitor_sites` rows and classifies `monitor_url` with the same admission-time shape/literal guard, `netguard.ParsePublicHTTPURL`. By default it is a dry run and prints counts plus bounded examples. Passing `--execute` deactivates matching active rows by setting `monitor_active = 0`; it does not delete rows. Runtime DNS safety checks still remain necessary for hostnames whose resolution changes later.
+`jetmon2 site-safety unsafe-urls` scans active `jetpack_monitor_sites` rows and classifies `monitor_url` with the same admission-time shape/literal guard, `netguard.ParsePublicHTTPURL`. By default it is a dry run and prints counts plus bounded examples. Passing `--execute` records a `jetmon_site_safety_flags` row for each unsafe active row, then deactivates that monitor row by setting `monitor_active = 0`; it does not delete rows. The flag preserves `blog_id`, `monitor_site_id`, `flag_type`, reason, URL, first/last seen timestamps, and deactivation time. Runtime DNS safety checks still remain necessary for hostnames whose resolution changes later.
 
 Tests added:
 
@@ -209,6 +210,8 @@ Tests added:
 - `TestRunSiteSafetyUnsafeURLsDryRun`
 - `TestRunSiteSafetyUnsafeURLsExecuteDeactivates`
 - `TestDeactivateUnsafeMonitorURLsChunksLargeBatches`
+- `TestUpsertSiteSafetyFlag`
+- `TestProcessResultsProbeSafetyBlockAuditsWithoutStateChange`
 
 ### Custom Header Safety
 
@@ -298,7 +301,7 @@ go mod verify
 
 Docker image builds were also refreshed for `Dockerfile_jetmon`, `Dockerfile_veriflier`, and `Dockerfile_api_fixture` using the updated `golang:1.26.3` builder image.
 
-MariaDB migration smoke tests were run against isolated local Docker Compose stacks for `mariadb:11.4.8` and `mariadb:11.4.10`. In both cases app-user setup succeeded, `./bin/jetmon2 migrate` applied all migrations, an immediate second migrate was idempotent, and `jetmon_schema_migrations` reported `COUNT(*)=48` and `MAX(id)=48`.
+MariaDB migration smoke tests were run against isolated local Docker Compose stacks for `mariadb:11.4.8` and `mariadb:11.4.10`. In both cases app-user setup succeeded, `./bin/jetmon2 migrate` applied all migrations, an immediate second migrate was idempotent, `jetmon_schema_migrations` reported `COUNT(*)=49` and `MAX(id)=49`, and `jetmon_site_safety_flags` existed.
 
 ## Performance Notes
 
@@ -331,21 +334,24 @@ Production database compatibility should be validated against MariaDB 11.4, not 
 
 `github.com/go-sql-driver/mysql` remains the right driver family: its current README says maintainers support MariaDB 10.5+ as well as MySQL 5.7+. The project now uses `v1.10.0`. The migration smoke coverage above verifies schema compatibility across the production MariaDB patch range. Before production rollout, still run an end-to-end MariaDB 11.4 exercise that covers runtime write paths such as bucket claiming, runtime freshness writes, SSL expiry batches, `ON DUPLICATE KEY UPDATE ... VALUES(...)`, and webhook / alert delivery claims.
 
-## Probe-Safety Event Options
+## Probe-Safety Visibility Decision
 
 Current branch behavior is intentionally conservative:
 
 - Unsafe direct targets and unsafe redirects return `ErrorProbeSafety`.
 - The checker marks them non-failures for downtime purposes.
 - The orchestrator writes `probe_safety_blocked` audit rows and metrics.
+- The orchestrator upserts an open `jetmon_site_safety_flags` row for runtime probe-safety blocks when the source monitor row is known.
+- `site-safety unsafe-urls --execute` records `unsafe_monitor_url` flags with `status='deactivated'` before setting `monitor_active = 0`.
 - No customer downtime event is opened, promoted, or closed.
 
-Product options:
+The branch implements the stored remediation-label option instead of a first-class event state. That keeps SLA, WPCOM down/recovery, webhook, and alert-contact behavior unchanged while giving operators a durable reason table for cleanup and runtime blocks.
 
-1. Keep audit + metrics only. This is lowest risk for rollout and avoids confusing unsafe URL cleanup with customer downtime. It is weaker operationally because dashboards and event consumers must know to inspect audit rows.
-2. Add a first-class non-downtime event state, for example `Probe Blocked` or `Probe Safety Blocked`, with severity 2 and `check_type=probe_safety`. It should be excluded from SLA downtime and WPCOM down/recovery notifications. This is my recommendation if operators need persistent visibility into unsafe legacy rows without paging customers.
-3. Add a separate stored label/deactivation reason for cleanup. The current cleanup command can deactivate unsafe rows but the v1 table has no explicit reason column. An additive v2-side table such as `jetmon_site_safety_flags` could preserve `site_id`, reason, first_seen, last_seen, and remediation status without mutating v1 semantics beyond `monitor_active=0`.
-4. Treat public-host hostile responses as degraded states only after repeat evidence. Oversized headers, body-read budget exhaustion, and TLS pathology can be real site problems or adversarial behavior. If represented as events, they should use thresholds and cooldowns to avoid opening transient one-probe noise.
+Deferred product options:
+
+1. Add a first-class non-downtime event state, for example `Probe Blocked` or `Probe Safety Blocked`, with severity 2 and `check_type=probe_safety`. Do this if dashboards or API consumers need probe-safety findings in the normal event feed. It must be excluded from SLA downtime and WPCOM down/recovery notifications.
+2. Treat public-host hostile responses as degraded states only after repeat evidence. Oversized headers, body-read budget exhaustion, and TLS pathology can be real site problems or adversarial behavior. If represented as events, they should use thresholds and cooldowns to avoid opening transient one-probe noise.
+3. Add scheduled reporting over `jetmon_site_safety_flags` and dry-run scans so operators can watch unsafe legacy row counts before and after API rejection rolls out.
 
 API behavior should remain strict regardless of which product option is chosen: new or updated monitor URLs should be rejected at write time when they are shape-unsafe, and runtime target-safety should remain in place for already-stored rows and DNS changes.
 
@@ -357,9 +363,8 @@ If more checker result fields become shared protocol semantics, move the stable 
 
 ## Remaining High-Value Scenarios
 
-1. Decide whether to implement `Probe Safety Blocked` as a non-downtime event state before rollout, or keep the current audit/metrics-only behavior for this branch.
-2. If cleanup will be run on production data, decide whether deactivation alone is acceptable or whether an additive reason table is needed first.
-3. Add a scheduled or operator-invoked cleanup dry-run report so the unsafe legacy row count can be watched before and after API rejection rolls out.
-4. Exercise DNS rebinding with an authoritative test DNS responder: public address on first lookup, private address on a redirect hop or later check.
-5. Exercise TLS pathology with uptime-bench responders: TLS 1.0/1.1, no common cipher, handshake close/alert, large certificate chains, expired/self-signed/hostname mismatch certificates.
-6. Consider streaming keyword matching that can stop as soon as a required-only keyword is found instead of reading until EOF/limit/budget.
+1. Run an end-to-end MariaDB 11.4 runtime exercise before production rollout, covering bucket claiming, runtime freshness writes, SSL expiry batches, `ON DUPLICATE KEY UPDATE ... VALUES(...)`, and webhook / alert delivery claims.
+2. Add scheduled reporting over `jetmon_site_safety_flags` and dry-run scans so the unsafe legacy row count can be watched before and after API rejection rolls out.
+3. Exercise DNS rebinding with an authoritative test DNS responder: public address on first lookup, private address on a redirect hop or later check.
+4. Exercise TLS pathology with uptime-bench responders: TLS 1.0/1.1, no common cipher, handshake close/alert, large certificate chains, expired/self-signed/hostname mismatch certificates.
+5. Consider streaming keyword matching that can stop as soon as a required-only keyword is found instead of reading until EOF/limit/budget.

--- a/docs/security-adversarial-probe-analysis.md
+++ b/docs/security-adversarial-probe-analysis.md
@@ -156,9 +156,11 @@ Tests added:
 - `TestUnsafeHost`
 - `TestParsePublicHTTPURL`
 - `TestCheckBlocksUnsafeDirectTargetWhenSafetyEnforced`
+- `TestCheckTargetSafetyDNSFailureIsConnectFailure`
 - `TestProcessResultsProbeSafetyBlockAuditsWithoutStateChange`
 - `TestServerHandleCheckRejectsUnsafeURL`
 - `TestServerHandleV2CheckRejectsUnsafeURL`
+- `TestCheckerProbeSafetyErrorCodeContract`
 - `TestTransportSafetyBlocksUnsafeIPBeforeDial`
 
 ### DNS Cache Burst Smoothing
@@ -183,6 +185,8 @@ Tests added:
 ### API And Delivery URL Hardening
 
 API JSON routes now wrap request bodies with a 1 MiB `MaxBytesReader`, and idempotency-key hashing applies the same cap before `io.ReadAll`. Outbound webhook registrations are validated in the webhooks package as well as the API handler. Slack and Teams alert-contact destinations are validated on create/update, and default alert delivery uses a protected HTTP client that rejects unsafe redirects and non-public resolved dial addresses.
+
+Protected delivery clients intentionally do not use `http.ProxyFromEnvironment`. A proxy would make the Jetmon process dial the proxy rather than the final consumer URL, so this process could no longer prove that the final resolved target is public. If production egress requires proxy support for webhook or alert delivery, add an explicit trusted-proxy mode with documented proxy-side SSRF controls rather than honoring ambient proxy environment variables by default.
 
 Tests added:
 
@@ -282,17 +286,17 @@ Most checks added here are constant-time string or URL-shape checks. The meaning
 
 The response-header cap has no steady-state cost. Body-read timing adds a timer only for budgeted response-body reads. Custom-header validation happens at write time, and checker-side header filtering is proportional to the small configured header map size.
 
-Benchmarks were run on `jetmon-service-host-5` with prebuilt Linux test binaries from clean `v2` and this branch. CPU: `Intel(R) Core(TM) i5-6500T CPU @ 2.50GHz`. A default-benchtime pass was noisy, so the comparable table below uses `-test.benchtime=3s -test.count=3 -test.cpu=1`; values are medians.
+Benchmarks were refreshed locally from clean `v2` and this branch. CPU: `13th Gen Intel(R) Core(TM) i5-1340P`. A default-benchtime pass was noisy, so the comparable table below uses `-test.benchtime=3s -test.count=3 -test.cpu=1`; values are medians.
 
 | Benchmark | v2 | this branch | delta |
 |---|---:|---:|---:|
-| `BenchmarkCheckNoKeywordLargeBody` | 1,502,320 ns/op, 1,078,222 B/op, 180 allocs/op | 1,384,076 ns/op, 1,078,339 B/op, 181 allocs/op | -7.9% time, +117 B, +1 alloc |
-| `BenchmarkCheckKeywordLargeBody` | 2,882,773 ns/op, 4,371,827 B/op, 225 allocs/op | 2,576,229 ns/op, 4,371,812 B/op, 225 allocs/op | -10.6% time, -15 B, no alloc change |
-| `BenchmarkProbeTargetSafetyCached` | n/a | 596 ns/op, 96 B/op, 3 allocs/op | added hot-path target guard |
-| `BenchmarkParsePublicHTTPURL` | n/a | 547 ns/op, 224 B/op, 3 allocs/op | API / Veriflier admission guard |
-| `BenchmarkProbeTargetSafetyBlockedLiteral` | n/a | 895 ns/op, 272 B/op, 5 allocs/op | unsafe literal rejection |
+| `BenchmarkCheckNoKeywordLargeBody` | 901,947 ns/op, 1,078,171 B/op, 180 allocs/op | 857,896 ns/op, 1,078,201 B/op, 181 allocs/op | -4.9% time, +30 B, +1 alloc |
+| `BenchmarkCheckKeywordLargeBody` | 2,339,498 ns/op, 4,372,204 B/op, 225 allocs/op | 2,153,608 ns/op, 4,372,397 B/op, 226 allocs/op | -7.9% time, +193 B, +1 alloc |
+| `BenchmarkProbeTargetSafetyCached` | n/a | 341.8 ns/op, 64 B/op, 2 allocs/op | added hot-path target guard |
+| `BenchmarkParsePublicHTTPURL` | n/a | 327.6 ns/op, 192 B/op, 2 allocs/op | API / Veriflier admission guard |
+| `BenchmarkProbeTargetSafetyBlockedLiteral` | n/a | 578.9 ns/op, 272 B/op, 5 allocs/op | unsafe literal rejection |
 
-The large-body benchmarks are intentionally conservative and noisy: they include `httptest`, large response-body reads, and do not enable the target-safety flag. The direct safety benchmark is the better estimate for the added per-check validation cost after DNS cache warmup: about 0.6 microseconds and 96 bytes per check. A previous draft created a fresh resolver during validation and measured around 23 microseconds / 4.8 KiB per cached check; this branch now reuses the checker resolver and transport cache.
+The large-body benchmarks are intentionally conservative and noisy: they include `httptest`, large response-body reads, and do not enable the target-safety flag. The direct safety benchmark is the better estimate for the added per-check validation cost after DNS cache warmup: about 0.34 microseconds and 64 bytes per check. A previous draft created a fresh resolver during validation and measured around 23 microseconds / 4.8 KiB per cached check; this branch now reuses the checker resolver and transport cache.
 
 ## Probe-Safety Event Options
 
@@ -311,6 +315,12 @@ Product options:
 4. Treat public-host hostile responses as degraded states only after repeat evidence. Oversized headers, body-read budget exhaustion, and TLS pathology can be real site problems or adversarial behavior. If represented as events, they should use thresholds and cooldowns to avoid opening transient one-probe noise.
 
 API behavior should remain strict regardless of which product option is chosen: new or updated monitor URLs should be rejected at write time when they are shape-unsafe, and runtime target-safety should remain in place for already-stored rows and DNS changes.
+
+## Probe Error-Code Contract
+
+The Veriflier maps checker probe-safety blocks to `OutcomeUnknown` so unsafe targets are not treated as regional proof of customer-site downtime. Today that mapping uses a private wire-compatible copy of the checker error code and a test asserts it stays equal to `checker.ErrorProbeSafety`. This avoids adding a production dependency from `internal/veriflier` back to `internal/checker` for one constant.
+
+If more checker result fields become shared protocol semantics, move the stable error-code constants into a neutral contract package used by both checker and Veriflier. That change is worth doing when there are multiple duplicated result constants, when a non-Go transport starts consuming the same codes, or when the result schema needs versioning. Until then, the test guard is lower risk than a broader package split.
 
 ## Remaining High-Value Scenarios
 

--- a/docs/security-adversarial-probe-analysis.md
+++ b/docs/security-adversarial-probe-analysis.md
@@ -283,6 +283,23 @@ Remote targeted tests on `jetmon-service-host-5`:
 
 All targeted tests passed.
 
+Final branch readiness checks:
+
+```bash
+make test
+make lint
+make all
+make test-race
+make test-veriflier-soak
+make rollout-docs-verify
+go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+go mod verify
+```
+
+Docker image builds were also refreshed for `Dockerfile_jetmon`, `Dockerfile_veriflier`, and `Dockerfile_api_fixture` using the updated `golang:1.26.3` builder image.
+
+MariaDB migration smoke tests were run against isolated local Docker Compose stacks for `mariadb:11.4.8` and `mariadb:11.4.10`. In both cases app-user setup succeeded, `./bin/jetmon2 migrate` applied all migrations, an immediate second migrate was idempotent, and `jetmon_schema_migrations` reported `COUNT(*)=48` and `MAX(id)=48`.
+
 ## Performance Notes
 
 Most checks added here are constant-time string or URL-shape checks. The meaningful added work is target-safety DNS validation for production Monitor / Veriflier checks. That validation runs at check time for already-stored legacy rows, not once at write time, because the v1 table does not have a persisted safety-vetted projection. It uses the existing 15-minute checker DNS cache, so repeated checks of the same hostname on a five-minute cadence should normally reuse cached resolution.
@@ -312,7 +329,7 @@ It also reported additional package/module-level standard-library findings in th
 
 Production database compatibility should be validated against MariaDB 11.4, not just MySQL 8.0. Current production database servers are MariaDB 11.4.8 through 11.4.10; MariaDB lists 11.4 as an LTS series with Community maintenance through May 29, 2029, and MariaDB announced 11.4.10 as a February 6, 2026 maintenance release. The local Docker Compose file now defaults `JETMON_DB_IMAGE` to `mariadb:11.4` while still allowing explicit database-image overrides for compatibility checks.
 
-`github.com/go-sql-driver/mysql` remains the right driver family: its current README says maintainers support MariaDB 10.5+ as well as MySQL 5.7+. The project now uses `v1.10.0`. Before production rollout, run MariaDB 11.4 integration tests that cover migrations, JSON columns, generated columns, `ON DUPLICATE KEY UPDATE ... VALUES(...)`, bucket claiming, and runtime write batching.
+`github.com/go-sql-driver/mysql` remains the right driver family: its current README says maintainers support MariaDB 10.5+ as well as MySQL 5.7+. The project now uses `v1.10.0`. The migration smoke coverage above verifies schema compatibility across the production MariaDB patch range. Before production rollout, still run an end-to-end MariaDB 11.4 exercise that covers runtime write paths such as bucket claiming, runtime freshness writes, SSL expiry batches, `ON DUPLICATE KEY UPDATE ... VALUES(...)`, and webhook / alert delivery claims.
 
 ## Probe-Safety Event Options
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,9 @@
 module github.com/Automattic/jetmon
 
-go 1.22
+go 1.26.3
 
-require github.com/go-sql-driver/mysql v1.7.1
+require github.com/go-sql-driver/mysql v1.10.0
 
 require github.com/DATA-DOG/go-sqlmock v1.5.2
+
+require filippo.io/edwards25519 v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
+filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
+filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
-github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrtU8EI=
-github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
+github.com/go-sql-driver/mysql v1.10.0 h1:Q+1LV8DkHJvSYAdR83XzuhDaTykuDx0l6fkXxoWCWfw=
+github.com/go-sql-driver/mysql v1.10.0/go.mod h1:M+cqaI7+xxXGG9swrdeUIoPG3Y3KCkF0pZej+SK+nWk=
 github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=

--- a/internal/alerting/contacts.go
+++ b/internal/alerting/contacts.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/Automattic/jetmon/internal/netguard"
 )
 
 // Create inserts a new alert contact and returns the persisted record.
@@ -354,6 +356,9 @@ func validateDestination(t Transport, dest json.RawMessage) error {
 		if d.WebhookURL == "" {
 			return errors.New("alerting: slack destination requires a webhook_url")
 		}
+		if _, err := netguard.ParsePublicHTTPURL(d.WebhookURL, "slack webhook_url"); err != nil {
+			return fmt.Errorf("alerting: %w", err)
+		}
 	case TransportTeams:
 		var d teamsDestination
 		if err := json.Unmarshal(dest, &d); err != nil {
@@ -361,6 +366,9 @@ func validateDestination(t Transport, dest json.RawMessage) error {
 		}
 		if d.WebhookURL == "" {
 			return errors.New("alerting: teams destination requires a webhook_url")
+		}
+		if _, err := netguard.ParsePublicHTTPURL(d.WebhookURL, "teams webhook_url"); err != nil {
+			return fmt.Errorf("alerting: %w", err)
 		}
 	default:
 		return fmt.Errorf("%w: %q", ErrInvalidTransport, t)

--- a/internal/alerting/repository_coverage_test.go
+++ b/internal/alerting/repository_coverage_test.go
@@ -119,6 +119,21 @@ func TestDestinationPreviewByTransport(t *testing.T) {
 	}
 }
 
+func TestValidateDestinationRejectsUnsafeWebhookURLs(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		transport Transport
+		dest      json.RawMessage
+	}{
+		{"slack localhost", TransportSlack, json.RawMessage(`{"webhook_url":"http://localhost/hook"}`)},
+		{"teams private", TransportTeams, json.RawMessage(`{"webhook_url":"http://10.0.0.1/hook"}`)},
+	} {
+		if err := validateDestination(tc.transport, tc.dest); err == nil {
+			t.Fatalf("%s: validateDestination accepted unsafe URL", tc.name)
+		}
+	}
+}
+
 func TestGetContactNotFound(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/alerting/transports.go
+++ b/internal/alerting/transports.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Automattic/jetmon/internal/eventstore"
+	"github.com/Automattic/jetmon/internal/netguard"
 )
 
 // defaultTransportTimeout bounds every outbound HTTP transport call.
@@ -26,7 +27,7 @@ func httpClientOrDefault(c *http.Client) *http.Client {
 	if c != nil {
 		return c
 	}
-	return &http.Client{Timeout: defaultTransportTimeout}
+	return netguard.NewProtectedHTTPClient(defaultTransportTimeout)
 }
 
 // truncateResponseBody caps a transport response at the
@@ -202,6 +203,11 @@ func (d *SlackDispatcher) Send(ctx context.Context, destination json.RawMessage,
 	if dest.WebhookURL == "" {
 		return 0, "destination missing webhook_url", errors.New("alerting/slack: destination missing webhook_url")
 	}
+	if d.HTTPClient == nil {
+		if _, err := netguard.ParsePublicHTTPURL(dest.WebhookURL, "slack webhook_url"); err != nil {
+			return 0, "unsafe webhook_url", fmt.Errorf("alerting/slack: %w", err)
+		}
+	}
 
 	body := slackMessage{
 		Text:   slackFallbackText(n),
@@ -297,6 +303,11 @@ func (d *TeamsDispatcher) Send(ctx context.Context, destination json.RawMessage,
 	}
 	if dest.WebhookURL == "" {
 		return 0, "destination missing webhook_url", errors.New("alerting/teams: destination missing webhook_url")
+	}
+	if d.HTTPClient == nil {
+		if _, err := netguard.ParsePublicHTTPURL(dest.WebhookURL, "teams webhook_url"); err != nil {
+			return 0, "unsafe webhook_url", fmt.Errorf("alerting/teams: %w", err)
+		}
 	}
 
 	header := fmt.Sprintf("**%s** — %s", n.SeverityName, n.SiteURL)

--- a/internal/alerting/transports_test.go
+++ b/internal/alerting/transports_test.go
@@ -40,6 +40,9 @@ func newCaptureServer() *captureServer {
 
 func (c *captureServer) URL() string { return c.srv.URL }
 func (c *captureServer) Close()      { c.srv.Close() }
+func (c *captureServer) Client() *http.Client {
+	return c.srv.Client()
+}
 
 // ─── PagerDuty ────────────────────────────────────────────────────────
 
@@ -47,7 +50,7 @@ func TestPagerDutyTriggerHappyPath(t *testing.T) {
 	cap := newCaptureServer()
 	defer cap.Close()
 
-	d := &PagerDutyDispatcher{Endpoint: cap.URL()}
+	d := &PagerDutyDispatcher{Endpoint: cap.URL(), HTTPClient: cap.Client()}
 	dest := json.RawMessage(`{"integration_key":"PDKEY"}`)
 	n := makeTestNotification()
 
@@ -84,7 +87,7 @@ func TestPagerDutyResolveOnRecovery(t *testing.T) {
 	cap := newCaptureServer()
 	defer cap.Close()
 
-	d := &PagerDutyDispatcher{Endpoint: cap.URL()}
+	d := &PagerDutyDispatcher{Endpoint: cap.URL(), HTTPClient: cap.Client()}
 	n := makeTestNotification()
 	n.Recovery = true
 	n.Severity = eventstore.SeverityUp
@@ -108,7 +111,7 @@ func TestPagerDutyTestUsesDistinctDedupKey(t *testing.T) {
 	cap := newCaptureServer()
 	defer cap.Close()
 
-	d := &PagerDutyDispatcher{Endpoint: cap.URL()}
+	d := &PagerDutyDispatcher{Endpoint: cap.URL(), HTTPClient: cap.Client()}
 	n := makeTestNotification()
 	n.IsTest = true
 
@@ -157,7 +160,7 @@ func TestPagerDutySurfacesUpstreamError(t *testing.T) {
 	cap.respBody = `{"error":"missing routing_key"}`
 	defer cap.Close()
 
-	d := &PagerDutyDispatcher{Endpoint: cap.URL()}
+	d := &PagerDutyDispatcher{Endpoint: cap.URL(), HTTPClient: cap.Client()}
 	status, body, err := d.Send(context.Background(), json.RawMessage(`{"integration_key":"K"}`), makeTestNotification())
 	if err == nil {
 		t.Fatal("expected error on 400")
@@ -176,7 +179,7 @@ func TestSlackHappyPath(t *testing.T) {
 	cap := newCaptureServer()
 	defer cap.Close()
 
-	d := &SlackDispatcher{}
+	d := &SlackDispatcher{HTTPClient: cap.Client()}
 	dest, _ := json.Marshal(slackDestination{WebhookURL: cap.URL()})
 
 	status, _, err := d.Send(context.Background(), dest, makeTestNotification())
@@ -210,7 +213,7 @@ func TestSlackRecoveryHeader(t *testing.T) {
 	cap := newCaptureServer()
 	defer cap.Close()
 
-	d := &SlackDispatcher{}
+	d := &SlackDispatcher{HTTPClient: cap.Client()}
 	dest, _ := json.Marshal(slackDestination{WebhookURL: cap.URL()})
 	n := makeTestNotification()
 	n.Recovery = true
@@ -229,7 +232,7 @@ func TestSlackTestHeader(t *testing.T) {
 	cap := newCaptureServer()
 	defer cap.Close()
 
-	d := &SlackDispatcher{}
+	d := &SlackDispatcher{HTTPClient: cap.Client()}
 	dest, _ := json.Marshal(slackDestination{WebhookURL: cap.URL()})
 	n := makeTestNotification()
 	n.IsTest = true
@@ -249,6 +252,7 @@ func TestSlackRejectsBadDestination(t *testing.T) {
 	for _, dest := range []json.RawMessage{
 		json.RawMessage(`{}`),
 		json.RawMessage(`{"webhook_url":""}`),
+		json.RawMessage(`{"webhook_url":"http://127.0.0.1/hook"}`),
 		json.RawMessage(`not json`),
 	} {
 		if _, _, err := d.Send(context.Background(), dest, makeTestNotification()); err == nil {
@@ -263,7 +267,7 @@ func TestTeamsHappyPath(t *testing.T) {
 	cap := newCaptureServer()
 	defer cap.Close()
 
-	d := &TeamsDispatcher{}
+	d := &TeamsDispatcher{HTTPClient: cap.Client()}
 	dest, _ := json.Marshal(teamsDestination{WebhookURL: cap.URL()})
 
 	status, _, err := d.Send(context.Background(), dest, makeTestNotification())
@@ -306,7 +310,7 @@ func TestTeamsRecoveryHeader(t *testing.T) {
 	cap := newCaptureServer()
 	defer cap.Close()
 
-	d := &TeamsDispatcher{}
+	d := &TeamsDispatcher{HTTPClient: cap.Client()}
 	dest, _ := json.Marshal(teamsDestination{WebhookURL: cap.URL()})
 	n := makeTestNotification()
 	n.Recovery = true
@@ -324,6 +328,7 @@ func TestTeamsRejectsBadDestination(t *testing.T) {
 	for _, dest := range []json.RawMessage{
 		json.RawMessage(`{}`),
 		json.RawMessage(`{"webhook_url":""}`),
+		json.RawMessage(`{"webhook_url":"http://127.0.0.1/hook"}`),
 		json.RawMessage(`not json`),
 	} {
 		if _, _, err := d.Send(context.Background(), dest, makeTestNotification()); err == nil {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -25,10 +25,11 @@ import (
 // the verifier's defaults because some endpoints (uptime stats over long
 // windows, full transition lists) legitimately do more work.
 const (
-	readHeaderTimeout = 5 * time.Second
-	readTimeout       = 60 * time.Second
-	writeTimeout      = 65 * time.Second
-	idleTimeout       = 120 * time.Second
+	readHeaderTimeout   = 5 * time.Second
+	readTimeout         = 60 * time.Second
+	writeTimeout        = 65 * time.Second
+	idleTimeout         = 120 * time.Second
+	maxAPIJSONBodyBytes = 1 << 20
 )
 
 // Server hosts the API on a single addr. Lifecycle mirrors the verifier:

--- a/internal/api/handlers_alerts.go
+++ b/internal/api/handlers_alerts.go
@@ -85,9 +85,7 @@ type alertContactTestResponse struct {
 // handleCreateAlertContact implements POST /api/v1/alert-contacts.
 func (s *Server) handleCreateAlertContact(w http.ResponseWriter, r *http.Request) {
 	var body createAlertContactRequest
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, r, http.StatusBadRequest, "invalid_body",
-			"request body must be valid JSON: "+err.Error())
+	if !decodeJSONBody(w, r, &body) {
 		return
 	}
 	if !alerting.IsValidTransport(body.Transport) {
@@ -181,9 +179,7 @@ func (s *Server) handleUpdateAlertContact(w http.ResponseWriter, r *http.Request
 		return
 	}
 	var body updateAlertContactRequest
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, r, http.StatusBadRequest, "invalid_body",
-			"request body must be valid JSON: "+err.Error())
+	if !decodeJSONBody(w, r, &body) {
 		return
 	}
 

--- a/internal/api/handlers_alerts_test.go
+++ b/internal/api/handlers_alerts_test.go
@@ -158,6 +158,7 @@ func TestCreateAlertContactRejectsMissingDestinationFields(t *testing.T) {
 	}{
 		{`{"label":"x","transport":"email","destination":{}}`, "invalid_alert_contact"},
 		{`{"label":"x","transport":"slack","destination":{"webhook_url":""}}`, "invalid_alert_contact"},
+		{`{"label":"x","transport":"slack","destination":{"webhook_url":"http://127.0.0.1/hook"}}`, "invalid_alert_contact"},
 		{`{"label":"","transport":"slack","destination":{"webhook_url":"https://x"}}`, "invalid_alert_contact"},
 	}
 	for _, c := range cases {

--- a/internal/api/handlers_events_write.go
+++ b/internal/api/handlers_events_write.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -54,14 +53,8 @@ func (s *Server) handleCloseEvent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body closeEventRequest
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		// Empty body is OK — defaults below kick in. json.NewDecoder
-		// surfaces io.EOF for an empty/missing body.
-		if !errors.Is(err, io.EOF) {
-			writeError(w, r, http.StatusBadRequest, "invalid_body",
-				"request body must be valid JSON: "+err.Error())
-			return
-		}
+	if !decodeOptionalJSONBody(w, r, &body) {
+		return
 	}
 	reason := body.Reason
 	if reason == "" {

--- a/internal/api/handlers_events_write.go
+++ b/internal/api/handlers_events_write.go
@@ -171,6 +171,8 @@ type checkResultPayload struct {
 // a hung target site doesn't pin a connection forever.
 const triggerNowTimeout = 30 * time.Second
 
+var triggerNowEnforceTargetSafety = true
+
 // handleTriggerNow implements POST /api/v1/sites/{id}/trigger-now.
 //
 // Runs a single HTTP check inline using the checker package, returns the
@@ -224,13 +226,14 @@ func (s *Server) handleTriggerNow(w http.ResponseWriter, r *http.Request) {
 	profile := site.effectiveDetectionProfile(method)
 
 	req := checker.Request{
-		BlogID:           siteID,
-		URL:              site.monitorURL,
-		Method:           method,
-		DetectionProfile: profile,
-		TimeoutSeconds:   timeoutSec,
-		CustomHeaders:    headers,
-		RedirectPolicy:   checker.RedirectFollow,
+		BlogID:              siteID,
+		URL:                 site.monitorURL,
+		Method:              method,
+		DetectionProfile:    profile,
+		TimeoutSeconds:      timeoutSec,
+		CustomHeaders:       headers,
+		RedirectPolicy:      checker.RedirectFollow,
+		EnforceTargetSafety: triggerNowEnforceTargetSafety,
 	}
 	if profile == checkmode.ProfileFull {
 		req.Keyword = site.checkKeywordPtr()

--- a/internal/api/handlers_rollout.go
+++ b/internal/api/handlers_rollout.go
@@ -1369,6 +1369,7 @@ func rolloutCheckRequest(cfg *config.Config, site jetdb.Site, mode rolloutModeSp
 		BodyReadMaxBytes:    1048576,
 		BodyReadMaxMS:       250,
 		KeywordReadMaxBytes: 1048576,
+		EnforceTargetSafety: true,
 	}
 	if cfg != nil {
 		req.BodyReadMaxBytes = cfg.BodyReadMaxBytes

--- a/internal/api/handlers_rollout.go
+++ b/internal/api/handlers_rollout.go
@@ -40,6 +40,8 @@ const (
 	rolloutDefaultProbeSample     = 100
 	rolloutMaxSynchronousSample   = 1000
 	rolloutDefaultProbeConcurrent = 16
+
+	requiredRolloutSchemaMigration = 49
 )
 
 type rolloutCapabilitiesResponse struct {
@@ -336,8 +338,8 @@ func (s *Server) handleRolloutPreflight(w http.ResponseWriter, r *http.Request) 
 	maxMigration, err := s.maxSchemaMigration(r.Context())
 	if err != nil {
 		blockers = append(blockers, "schema migration lookup failed: "+err.Error())
-	} else if maxMigration < 48 {
-		blockers = append(blockers, fmt.Sprintf("schema migration %d is older than required rollout migration 48", maxMigration))
+	} else if maxMigration < requiredRolloutSchemaMigration {
+		blockers = append(blockers, fmt.Sprintf("schema migration %d is older than required rollout migration %d", maxMigration, requiredRolloutSchemaMigration))
 	}
 	summary := "preflight passed"
 	status := "ok"

--- a/internal/api/handlers_rollout.go
+++ b/internal/api/handlers_rollout.go
@@ -246,8 +246,7 @@ func (s *Server) handleRolloutCapabilities(w http.ResponseWriter, r *http.Reques
 
 func (s *Server) handleCreateRolloutSession(w http.ResponseWriter, r *http.Request) {
 	var body rolloutSessionRequest
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, r, http.StatusBadRequest, "invalid_body", "request body must be valid JSON: "+err.Error())
+	if !decodeJSONBody(w, r, &body) {
 		return
 	}
 	if err := validateRolloutRange(body.BucketMin, body.BucketMax); err != nil {
@@ -855,8 +854,7 @@ func (s *Server) updateRolloutJobResult(ctx context.Context, jobID string, resul
 
 func (s *Server) decodeRolloutRangeBody(w http.ResponseWriter, r *http.Request) (rolloutRangeRequest, bool) {
 	var body rolloutRangeRequest
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, r, http.StatusBadRequest, "invalid_body", "request body must be valid JSON: "+err.Error())
+	if !decodeJSONBody(w, r, &body) {
 		return body, false
 	}
 	if err := validateRolloutRange(body.BucketMin, body.BucketMax); err != nil {

--- a/internal/api/handlers_sites_write.go
+++ b/internal/api/handlers_sites_write.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -15,6 +14,7 @@ import (
 	"github.com/Automattic/jetmon/internal/checkmode"
 	"github.com/Automattic/jetmon/internal/config"
 	jetdb "github.com/Automattic/jetmon/internal/db"
+	"github.com/Automattic/jetmon/internal/netguard"
 )
 
 // validRedirectPolicies bounds the redirect_policy field. Matches the ENUM in
@@ -26,8 +26,11 @@ var validRedirectPolicies = map[string]struct{}{
 }
 
 const (
-	maxForbiddenKeywords     = 20
-	maxForbiddenKeywordBytes = 500
+	maxForbiddenKeywords      = 20
+	maxForbiddenKeywordBytes  = 500
+	maxCustomHeaders          = 32
+	maxCustomHeaderNameBytes  = 128
+	maxCustomHeaderValueBytes = 4096
 )
 
 // createSiteRequest is the body shape for POST /api/v1/sites.
@@ -591,20 +594,8 @@ func (s *Server) readSite(ctx context.Context, blogID int64) (siteResponse, erro
 
 // validateMonitorURL accepts only http and https URLs with a non-empty host.
 func validateMonitorURL(s string) error {
-	if s == "" {
-		return errors.New("monitor_url is required")
-	}
-	u, err := url.Parse(s)
-	if err != nil {
-		return fmt.Errorf("monitor_url is not a valid URL: %v", err)
-	}
-	if u.Scheme != "http" && u.Scheme != "https" {
-		return errors.New("monitor_url must use http or https")
-	}
-	if u.Host == "" {
-		return errors.New("monitor_url must include a host")
-	}
-	return nil
+	_, err := netguard.ParsePublicHTTPURL(s, "monitor_url")
+	return err
 }
 
 // encodeCustomHeaders marshals a map[string]string into the JSON shape the
@@ -613,9 +604,12 @@ func encodeCustomHeaders(h *map[string]string) (any, error) {
 	if h == nil || len(*h) == 0 {
 		return nil, nil
 	}
-	for k := range *h {
-		if k == "" {
-			return nil, errors.New("custom_headers must not contain empty header names")
+	if len(*h) > maxCustomHeaders {
+		return nil, fmt.Errorf("custom_headers supports at most %d entries", maxCustomHeaders)
+	}
+	for k, v := range *h {
+		if err := validateCustomHeader(k, v); err != nil {
+			return nil, err
 		}
 	}
 	b, err := json.Marshal(*h)
@@ -623,6 +617,80 @@ func encodeCustomHeaders(h *map[string]string) (any, error) {
 		return nil, fmt.Errorf("encode custom_headers: %v", err)
 	}
 	return string(b), nil
+}
+
+func validateCustomHeader(name, value string) error {
+	if name == "" {
+		return errors.New("custom_headers must not contain empty header names")
+	}
+	if len([]byte(name)) > maxCustomHeaderNameBytes {
+		return fmt.Errorf("custom_headers names must be %d bytes or fewer", maxCustomHeaderNameBytes)
+	}
+	if len([]byte(value)) > maxCustomHeaderValueBytes {
+		return fmt.Errorf("custom_headers values must be %d bytes or fewer", maxCustomHeaderValueBytes)
+	}
+	if !validHTTPHeaderName(name) {
+		return fmt.Errorf("custom_headers contains invalid header name %q", name)
+	}
+	if forbiddenCustomHeaderName(name) {
+		return fmt.Errorf("custom_headers may not set hop-by-hop or request-framing header %q", name)
+	}
+	if !validHTTPHeaderValue(value) {
+		return fmt.Errorf("custom_headers contains invalid value for %q", name)
+	}
+	return nil
+}
+
+func validHTTPHeaderName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		if !isHTTPTokenChar(name[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func isHTTPTokenChar(c byte) bool {
+	switch {
+	case c >= 'a' && c <= 'z':
+		return true
+	case c >= 'A' && c <= 'Z':
+		return true
+	case c >= '0' && c <= '9':
+		return true
+	}
+	switch c {
+	case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~':
+		return true
+	default:
+		return false
+	}
+}
+
+func forbiddenCustomHeaderName(name string) bool {
+	switch strings.ToLower(name) {
+	case "connection", "content-length", "host", "keep-alive", "proxy-authenticate",
+		"proxy-authorization", "te", "trailer", "transfer-encoding", "upgrade":
+		return true
+	default:
+		return false
+	}
+}
+
+func validHTTPHeaderValue(value string) bool {
+	for i := 0; i < len(value); i++ {
+		c := value[i]
+		if c == '\t' {
+			continue
+		}
+		if c < 0x20 || c == 0x7f {
+			return false
+		}
+	}
+	return true
 }
 
 // encodeForbiddenKeywords marshals explicit bad-content body strings into the

--- a/internal/api/handlers_sites_write.go
+++ b/internal/api/handlers_sites_write.go
@@ -64,9 +64,7 @@ type createSiteRequest struct {
 // returns 201 with the full site object.
 func (s *Server) handleCreateSite(w http.ResponseWriter, r *http.Request) {
 	var body createSiteRequest
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, r, http.StatusBadRequest, "invalid_body",
-			"request body must be valid JSON: "+err.Error())
+	if !decodeJSONBody(w, r, &body) {
 		return
 	}
 
@@ -241,9 +239,7 @@ func (s *Server) handleUpdateSite(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body updateSiteRequest
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, r, http.StatusBadRequest, "invalid_body",
-			"request body must be valid JSON: "+err.Error())
+	if !decodeJSONBody(w, r, &body) {
 		return
 	}
 
@@ -623,74 +619,22 @@ func validateCustomHeader(name, value string) error {
 	if name == "" {
 		return errors.New("custom_headers must not contain empty header names")
 	}
-	if len([]byte(name)) > maxCustomHeaderNameBytes {
+	if len(name) > maxCustomHeaderNameBytes {
 		return fmt.Errorf("custom_headers names must be %d bytes or fewer", maxCustomHeaderNameBytes)
 	}
-	if len([]byte(value)) > maxCustomHeaderValueBytes {
+	if len(value) > maxCustomHeaderValueBytes {
 		return fmt.Errorf("custom_headers values must be %d bytes or fewer", maxCustomHeaderValueBytes)
 	}
-	if !validHTTPHeaderName(name) {
+	if !netguard.ValidHTTPHeaderName(name) {
 		return fmt.Errorf("custom_headers contains invalid header name %q", name)
 	}
-	if forbiddenCustomHeaderName(name) {
+	if netguard.ForbiddenOutboundHeaderName(name) {
 		return fmt.Errorf("custom_headers may not set hop-by-hop or request-framing header %q", name)
 	}
-	if !validHTTPHeaderValue(value) {
+	if !netguard.ValidHTTPHeaderValue(value) {
 		return fmt.Errorf("custom_headers contains invalid value for %q", name)
 	}
 	return nil
-}
-
-func validHTTPHeaderName(name string) bool {
-	if name == "" {
-		return false
-	}
-	for i := 0; i < len(name); i++ {
-		if !isHTTPTokenChar(name[i]) {
-			return false
-		}
-	}
-	return true
-}
-
-func isHTTPTokenChar(c byte) bool {
-	switch {
-	case c >= 'a' && c <= 'z':
-		return true
-	case c >= 'A' && c <= 'Z':
-		return true
-	case c >= '0' && c <= '9':
-		return true
-	}
-	switch c {
-	case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~':
-		return true
-	default:
-		return false
-	}
-}
-
-func forbiddenCustomHeaderName(name string) bool {
-	switch strings.ToLower(name) {
-	case "connection", "content-length", "host", "keep-alive", "proxy-authenticate",
-		"proxy-authorization", "te", "trailer", "transfer-encoding", "upgrade":
-		return true
-	default:
-		return false
-	}
-}
-
-func validHTTPHeaderValue(value string) bool {
-	for i := 0; i < len(value); i++ {
-		c := value[i]
-		if c == '\t' {
-			continue
-		}
-		if c < 0x20 || c == 0x7f {
-			return false
-		}
-	}
-	return true
 }
 
 // encodeForbiddenKeywords marshals explicit bad-content body strings into the

--- a/internal/api/handlers_sites_write_test.go
+++ b/internal/api/handlers_sites_write_test.go
@@ -2,8 +2,10 @@ package api
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -404,6 +406,14 @@ func TestValidateMonitorURL(t *testing.T) {
 		{"ftp://example.com", false},
 		{"http://", false}, // empty host
 		{"https:///path", false},
+		{"http://localhost", false},
+		{"http://127.0.0.1", false},
+		{"http://[::1]/", false},
+		{"http://169.254.169.254/latest/meta-data/", false},
+		{"http://10.0.0.1", false},
+		{"https://adonislounge.local/nyc", false},
+		{"http://host.docker.internal:99", false},
+		{"http://user@example.com", false},
 	}
 	for _, c := range cases {
 		err := validateMonitorURL(c.in)
@@ -435,6 +445,37 @@ func TestEncodeCustomHeaders(t *testing.T) {
 	bad := map[string]string{"": "bad"}
 	if _, err := encodeCustomHeaders(&bad); err == nil {
 		t.Error("empty header name should error")
+	}
+}
+
+func TestEncodeCustomHeadersRejectsUnsafeNamesAndValues(t *testing.T) {
+	cases := []map[string]string{
+		{"X-Bad\r\nInjected": "1"},
+		{"Connection": "close"},
+		{"Transfer-Encoding": "chunked"},
+		{"Host": "other.example"},
+		{"X-Value": "ok\r\nX-Injected: yes"},
+		{"X-Null": "ok\x00bad"},
+	}
+	for _, headers := range cases {
+		if _, err := encodeCustomHeaders(&headers); err == nil {
+			t.Fatalf("encodeCustomHeaders(%#v) error = nil, want rejection", headers)
+		}
+	}
+}
+
+func TestEncodeCustomHeadersRejectsLargeInput(t *testing.T) {
+	tooMany := make(map[string]string, maxCustomHeaders+1)
+	for i := 0; i < maxCustomHeaders+1; i++ {
+		tooMany[fmt.Sprintf("X-Test-%d", i)] = "ok"
+	}
+	if _, err := encodeCustomHeaders(&tooMany); err == nil {
+		t.Fatal("encodeCustomHeaders() error = nil for too many headers")
+	}
+
+	largeValue := map[string]string{"X-Large": strings.Repeat("a", maxCustomHeaderValueBytes+1)}
+	if _, err := encodeCustomHeaders(&largeValue); err == nil {
+		t.Fatal("encodeCustomHeaders() error = nil for oversized value")
 	}
 }
 

--- a/internal/api/handlers_trigger_test.go
+++ b/internal/api/handlers_trigger_test.go
@@ -13,6 +13,13 @@ const readSiteForCheckSQL = ` SELECT s.monitor_url, c.timeout_seconds, c.check_k
 
 var columnsSiteForCheck = []string{"monitor_url", "timeout_seconds", "check_keyword", "forbidden_keyword", "forbidden_keywords", "custom_headers", "redirect_policy", "request_method", "detection_profile", "site_status"}
 
+func allowUnsafeTriggerTargetsForTest(t *testing.T) {
+	t.Helper()
+	old := triggerNowEnforceTargetSafety
+	triggerNowEnforceTargetSafety = false
+	t.Cleanup(func() { triggerNowEnforceTargetSafety = old })
+}
+
 func TestTriggerNowSiteNotFound(t *testing.T) {
 	s, mock, key, cleanup := newTestServer(t)
 	defer cleanup()
@@ -35,6 +42,8 @@ func TestTriggerNowSiteNotFound(t *testing.T) {
 }
 
 func TestTriggerNowSuccessNoActiveEvents(t *testing.T) {
+	allowUnsafeTriggerTargetsForTest(t)
+
 	// Spin up a fake target that returns 200 OK so checker.Check returns success.
 	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -74,6 +83,8 @@ func TestTriggerNowSuccessNoActiveEvents(t *testing.T) {
 }
 
 func TestTriggerNowForbiddenKeywordFailsCheck(t *testing.T) {
+	allowUnsafeTriggerTargetsForTest(t)
+
 	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("OK FORBIDDEN OK"))
@@ -109,6 +120,8 @@ func TestTriggerNowForbiddenKeywordFailsCheck(t *testing.T) {
 }
 
 func TestTriggerNowWithGatewayTenantAllowsMappedSite(t *testing.T) {
+	allowUnsafeTriggerTargetsForTest(t)
+
 	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -146,6 +159,8 @@ func TestTriggerNowWithGatewayTenantAllowsMappedSite(t *testing.T) {
 }
 
 func TestTriggerNowSuccessClosesActiveEvent(t *testing.T) {
+	allowUnsafeTriggerTargetsForTest(t)
+
 	// Same as above but with one active event that should be closed
 	// with reason=probe_cleared on success.
 	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -180,6 +195,38 @@ func TestTriggerNowSuccessClosesActiveEvent(t *testing.T) {
 	}
 	if resp.CurrentState != "Up" {
 		t.Errorf("current_state = %q, want Up after close-on-success", resp.CurrentState)
+	}
+}
+
+func TestTriggerNowUnsafeStoredURLIsProbeSafetyBlock(t *testing.T) {
+	s, mock, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	mock.ExpectQuery(readSiteForCheckSQL).WithArgs(int64(42)).
+		WillReturnRows(sqlmock.NewRows(columnsSiteForCheck).
+			AddRow("http://127.0.0.1/admin", nil, nil, nil, nil, nil, "follow", nil, nil, 2))
+
+	req := httptest.NewRequest("POST", "/api/v1/sites/42/trigger-now", nil)
+	req.SetPathValue("id", "42")
+	req = setAuthCtx(req, key)
+	rec := invokeAuthed(s, req, s.handleTriggerNow)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp triggerNowResponse
+	readJSON(t, rec.Body, &resp)
+	if resp.Result.ErrorCode != checker.ErrorProbeSafety {
+		t.Fatalf("error_code = %d, want %d", resp.Result.ErrorCode, checker.ErrorProbeSafety)
+	}
+	if resp.Result.Success {
+		t.Fatalf("success = true, want false for probe safety block")
+	}
+	if len(resp.ActiveEventsClosed) != 0 {
+		t.Fatalf("active_events_closed = %v, want empty", resp.ActiveEventsClosed)
+	}
+	if resp.CurrentState != "Down" {
+		t.Fatalf("current_state = %q, want unchanged Down", resp.CurrentState)
 	}
 }
 

--- a/internal/api/handlers_webhooks.go
+++ b/internal/api/handlers_webhooks.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -79,9 +78,7 @@ type updateWebhookRequest struct {
 // after this response, only secret_preview is returned.
 func (s *Server) handleCreateWebhook(w http.ResponseWriter, r *http.Request) {
 	var body createWebhookRequest
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, r, http.StatusBadRequest, "invalid_body",
-			"request body must be valid JSON: "+err.Error())
+	if !decodeJSONBody(w, r, &body) {
 		return
 	}
 	if err := validateMonitorURL(body.URL); err != nil {
@@ -183,9 +180,7 @@ func (s *Server) handleUpdateWebhook(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body updateWebhookRequest
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, r, http.StatusBadRequest, "invalid_body",
-			"request body must be valid JSON: "+err.Error())
+	if !decodeJSONBody(w, r, &body) {
 		return
 	}
 	if body.URL != nil {

--- a/internal/api/handlers_webhooks_test.go
+++ b/internal/api/handlers_webhooks_test.go
@@ -101,6 +101,7 @@ func TestCreateWebhookRejectsBadURL(t *testing.T) {
 		[]byte(`{"url":""}`),
 		[]byte(`{"url":"not-a-url"}`),
 		[]byte(`{"url":"ftp://example.com"}`),
+		[]byte(`{"url":"http://127.0.0.1/hook"}`),
 	}
 	for _, body := range cases {
 		req := newPOSTWithBody("/api/v1/webhooks", body)

--- a/internal/api/idempotency.go
+++ b/internal/api/idempotency.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"io"
 	"net/http"
 	"sync"
@@ -153,9 +154,17 @@ func (s *Server) withIdempotency(h http.HandlerFunc) http.HandlerFunc {
 
 		// Read the body so we can both hash it (for conflict detection) and
 		// re-supply it to the handler. Body size is bounded by the server's
-		// ReadTimeout; a future MaxBytesReader would tighten this.
+		// JSON body cap so authenticated retries cannot force unbounded
+		// idempotency hashing or response caching work.
+		r.Body = http.MaxBytesReader(w, r.Body, maxAPIJSONBodyBytes)
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
+			var maxBytesErr *http.MaxBytesError
+			if errors.As(err, &maxBytesErr) {
+				writeError(w, r, http.StatusRequestEntityTooLarge, "request_body_too_large",
+					"request body exceeds the maximum supported JSON payload size")
+				return
+			}
 			writeError(w, r, http.StatusBadRequest, "invalid_body",
 				"failed to read request body: "+err.Error())
 			return

--- a/internal/api/idempotency_test.go
+++ b/internal/api/idempotency_test.go
@@ -188,6 +188,34 @@ func TestIdempotencyMiddlewareConflictOnDifferentBody(t *testing.T) {
 	}
 }
 
+func TestIdempotencyMiddlewareRejectsOversizedJSONBody(t *testing.T) {
+	s, _, key, cleanup := newTestServer(t)
+	defer cleanup()
+
+	called := 0
+	wrapped := s.withJSONBodyLimit(s.withIdempotency(func(w http.ResponseWriter, r *http.Request) {
+		called++
+		w.WriteHeader(http.StatusCreated)
+	}))
+
+	req := requestWithKey("POST", "/", key)
+	req.Header.Set(idempotencyHeader, "too-large")
+	req.Body = bodyReader(bytes.Repeat([]byte("a"), maxAPIJSONBodyBytes+1))
+	rec := httptest.NewRecorder()
+	wrapped(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413; body=%s", rec.Code, rec.Body.String())
+	}
+	if called != 0 {
+		t.Fatalf("handler called %d times, want 0", called)
+	}
+	body := readErrorBody(t, rec.Body)
+	if body.Code != "request_body_too_large" {
+		t.Fatalf("error code = %q, want request_body_too_large", body.Code)
+	}
+}
+
 func TestIdempotencyMiddlewareIsolatesByKeyID(t *testing.T) {
 	// Two different API keys with the same idempotency string don't share
 	// cached entries — the cache key includes the API key id.

--- a/internal/api/json_body.go
+++ b/internal/api/json_body.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+)
+
+func decodeJSONBody(w http.ResponseWriter, r *http.Request, dst any) bool {
+	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+		writeJSONBodyDecodeError(w, r, err)
+		return false
+	}
+	return true
+}
+
+func decodeOptionalJSONBody(w http.ResponseWriter, r *http.Request, dst any) bool {
+	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+		if errors.Is(err, io.EOF) {
+			return true
+		}
+		writeJSONBodyDecodeError(w, r, err)
+		return false
+	}
+	return true
+}
+
+func writeJSONBodyDecodeError(w http.ResponseWriter, r *http.Request, err error) {
+	var maxBytesErr *http.MaxBytesError
+	if errors.As(err, &maxBytesErr) {
+		writeError(w, r, http.StatusRequestEntityTooLarge, "request_body_too_large",
+			"request body exceeds the maximum supported JSON payload size")
+		return
+	}
+	writeError(w, r, http.StatusBadRequest, "invalid_body",
+		"request body must be valid JSON: "+err.Error())
+}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -160,6 +160,13 @@ func (s *Server) requireScope(required apikeys.Scope, h http.HandlerFunc) http.H
 	}
 }
 
+func (s *Server) withJSONBodyLimit(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, maxAPIJSONBodyBytes)
+		h(w, r)
+	}
+}
+
 func parseGatewayContext(r *http.Request, key *apikeys.Key) (*gatewayContext, int, string, string) {
 	hasContext := false
 	for _, h := range []string{

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -43,6 +43,9 @@ func (r routeDef) register(s *Server, mux *http.ServeMux) {
 	if r.Idempotency {
 		handler = s.withIdempotency(handler)
 	}
+	if r.JSONBody {
+		handler = s.withJSONBodyLimit(handler)
+	}
 	if r.authenticated() {
 		handler = s.requireScope(r.Scope, handler)
 	}

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -29,6 +29,7 @@ const (
 	EventAlertSuppressed   = "alert_suppressed"
 	EventConfigChange      = "config_change"
 	EventAPIAccess         = "api_access"
+	EventProbeSafetyBlock  = "probe_safety_blocked"
 )
 
 var db *sql.DB

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -3,13 +3,16 @@ package checker
 import (
 	"context"
 	"crypto/tls"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptrace"
+	"net/url"
 	"os"
 	"runtime"
 	"strconv"
@@ -19,6 +22,7 @@ import (
 	"time"
 
 	"github.com/Automattic/jetmon/internal/checkmode"
+	"github.com/Automattic/jetmon/internal/netguard"
 )
 
 // ErrorCode mirrors the status change email types from the original Jetmon.
@@ -32,16 +36,23 @@ const (
 	ErrorTLSExpired    = 6
 	ErrorTLSDeprecated = 7
 	ErrorBodyRead      = 8
+	ErrorProbeSafety   = 9
 	ErrorBodyTruncated = ErrorBodyRead
 )
 
 const (
 	maxBodyIntegrityBytes      int64 = 64 << 10
 	maxKeywordBodyBytes        int64 = 1 << 20
+	maxResultURLDetailBytes          = 2048
+	maxResponseHeaderBytes     int64 = 64 << 10
 	checkDNSCacheTTL                 = 15 * time.Minute
+	checkDNSCacheTTLJitter           = 3 * time.Minute
 	checkDNSCacheMaxEntries          = 2000000
 	checkDNSCachePurgeInterval       = 10000
 )
+
+var errBodyReadBudgetExceeded = errors.New("response body read budget exceeded")
+var errProbeSafetyBlock = errors.New("probe safety block")
 
 // RedirectPolicy controls how redirect responses are handled.
 type RedirectPolicy string
@@ -57,12 +68,26 @@ const (
 // redirect policy remains isolated to that site check. Timeouts are carried by
 // the request context instead of http.Client.Timeout so each probe does not pay
 // for a second timer on the hot path.
-var defaultTransport = newCheckTransport()
-var defaultHTTPIPTransport = newHTTPIPPoolTransport()
+var defaultResolver = newCheckResolver()
+var defaultTransport = newCheckTransportWithResolver(defaultResolver)
+var defaultHTTPIPTransport = newHTTPIPPoolTransportWithFallbackAndResolver(defaultTransport, defaultResolver)
 var defaultDNSCache = newCheckDNSCache(checkDNSCacheTTL, checkDNSCacheMaxEntries)
 var defaultDNSLookupLimiter = newCheckDNSLookupLimiter()
 var configuredResolverMu sync.RWMutex
 var configuredResolverServers []string
+
+type checkContextKey int
+
+const checkContextKeyTargetSafety checkContextKey = iota
+
+func withTargetSafety(ctx context.Context) context.Context {
+	return context.WithValue(ctx, checkContextKeyTargetSafety, true)
+}
+
+func targetSafetyEnabled(ctx context.Context) bool {
+	enabled, _ := ctx.Value(checkContextKeyTargetSafety).(bool)
+	return enabled
+}
 
 type checkDNSLookupLimiter struct {
 	slots chan struct{}
@@ -105,12 +130,14 @@ func ConfigureResolverServers(rawServers []string) error {
 	configuredResolverServers = servers
 	configuredResolverMu.Unlock()
 
-	newTransport := newCheckTransport()
-	newHTTPIPTransport := newHTTPIPPoolTransportWithFallback(newTransport)
+	newResolver := newCheckResolver()
+	newTransport := newCheckTransportWithResolver(newResolver)
+	newHTTPIPTransport := newHTTPIPPoolTransportWithFallbackAndResolver(newTransport, newResolver)
 
 	configuredResolverMu.Lock()
 	oldTransport := defaultTransport
 	oldHTTPIPTransport := defaultHTTPIPTransport
+	defaultResolver = newResolver
 	defaultTransport = newTransport
 	defaultHTTPIPTransport = newHTTPIPTransport
 	defaultDNSCache = newCheckDNSCache(checkDNSCacheTTL, checkDNSCacheMaxEntries)
@@ -137,6 +164,8 @@ func ConfiguredResolverServers() []string {
 type checkDNSCache struct {
 	mu         sync.RWMutex
 	ttl        time.Duration
+	jitter     time.Duration
+	salt       uint64
 	maxEntries int
 	writes     int
 	entries    map[string]checkDNSCacheEntry
@@ -150,6 +179,8 @@ type checkDNSCacheEntry struct {
 func newCheckDNSCache(ttl time.Duration, maxEntries int) *checkDNSCache {
 	return &checkDNSCache{
 		ttl:        ttl,
+		jitter:     checkDNSCacheTTLJitter,
+		salt:       newDNSCacheSalt(),
 		maxEntries: maxEntries,
 		entries:    make(map[string]checkDNSCacheEntry),
 	}
@@ -199,8 +230,36 @@ func (c *checkDNSCache) lookup(ctx context.Context, resolver *net.Resolver, host
 	if err != nil || len(addrs) == 0 {
 		return addrs, err
 	}
-	c.store(key, addrs, now.Add(c.ttl))
+	c.store(key, addrs, c.expiresAt(key, now))
 	return addrs, nil
+}
+
+func (c *checkDNSCache) expiresAt(key string, now time.Time) time.Time {
+	if c == nil || c.ttl <= 0 {
+		return now
+	}
+	jitter := c.jitter
+	if jitter <= 0 || jitter >= c.ttl {
+		return now.Add(c.ttl)
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(key))
+	var salt [8]byte
+	binary.LittleEndian.PutUint64(salt[:], c.salt)
+	_, _ = h.Write(salt[:])
+	offset := time.Duration(h.Sum64() % uint64(jitter))
+	return now.Add(c.ttl - jitter + offset)
+}
+
+func newDNSCacheSalt() uint64 {
+	h := fnv.New64a()
+	if hostname, err := os.Hostname(); err == nil {
+		_, _ = h.Write([]byte(hostname))
+	}
+	var now [8]byte
+	binary.LittleEndian.PutUint64(now[:], uint64(time.Now().UnixNano()))
+	_, _ = h.Write(now[:])
+	return h.Sum64()
 }
 
 func (c *checkDNSCache) store(key string, addrs []net.IPAddr, expires time.Time) {
@@ -291,8 +350,12 @@ func cloneIPAddrs(addrs []net.IPAddr) []net.IPAddr {
 }
 
 func newCheckTransport() *http.Transport {
+	return newCheckTransportWithResolver(newCheckResolver())
+}
+
+func newCheckTransportWithResolver(resolver *net.Resolver) *http.Transport {
 	return &http.Transport{
-		DialContext: newCheckDialContext(newCheckResolver()),
+		DialContext: newCheckDialContext(resolver),
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: false,
 			// Deprecated TLS versions are still site-reachability signals.
@@ -300,7 +363,8 @@ func newCheckTransport() *http.Transport {
 			// tls_deprecated event instead of reporting customer downtime.
 			MinVersion: tls.VersionTLS10,
 		},
-		TLSHandshakeTimeout: 10 * time.Second,
+		TLSHandshakeTimeout:    10 * time.Second,
+		MaxResponseHeaderBytes: maxResponseHeaderBytes,
 		// Jetmon checks huge fleets of mostly-unique hostnames on minute-scale
 		// cadences. Connections would usually expire before reuse, while the
 		// shared idle pool becomes a global lock and goroutine-pressure point at
@@ -320,7 +384,11 @@ func newHTTPIPPoolTransport() *httpIPPoolTransport {
 }
 
 func newHTTPIPPoolTransportWithFallback(fallback *http.Transport) *httpIPPoolTransport {
-	inner := newCheckTransport()
+	return newHTTPIPPoolTransportWithFallbackAndResolver(fallback, newCheckResolver())
+}
+
+func newHTTPIPPoolTransportWithFallbackAndResolver(fallback *http.Transport, resolver *net.Resolver) *httpIPPoolTransport {
+	inner := newCheckTransportWithResolver(resolver)
 	inner.DisableKeepAlives = false
 	inner.MaxIdleConns = 8192
 	inner.MaxIdleConnsPerHost = 2048
@@ -328,7 +396,7 @@ func newHTTPIPPoolTransportWithFallback(fallback *http.Transport) *httpIPPoolTra
 	return &httpIPPoolTransport{
 		inner:    inner,
 		fallback: fallback,
-		resolver: newCheckResolver(),
+		resolver: resolver,
 	}
 }
 
@@ -366,6 +434,13 @@ func (t *httpIPPoolTransport) RoundTrip(req *http.Request) (*http.Response, erro
 
 	var firstErr error
 	for _, addr := range ordered {
+		if targetSafetyEnabled(req.Context()) && netguard.UnsafeIP(addr.IP) {
+			err := fmt.Errorf("%w: target %q resolves to non-public address %s", errProbeSafetyBlock, host, addr.IP)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
 		resp, err := t.roundTripResolvedIP(req, addr, port)
 		if err == nil || resp != nil {
 			return resp, err
@@ -433,6 +508,9 @@ func newCheckDialContext(resolver *net.Resolver) func(context.Context, string, s
 			return nil, err
 		}
 		if ip := net.ParseIP(host); ip != nil {
+			if targetSafetyEnabled(ctx) && netguard.UnsafeIP(ip) {
+				return nil, fmt.Errorf("%w: target address %s is not public", errProbeSafetyBlock, ip)
+			}
 			return dialer.DialContext(ctx, network, address)
 		}
 
@@ -450,6 +528,13 @@ func newCheckDialContext(resolver *net.Resolver) func(context.Context, string, s
 
 		var firstErr error
 		for _, addr := range orderedResolverAddrs(addrs, network) {
+			if targetSafetyEnabled(ctx) && netguard.UnsafeIP(addr.IP) {
+				err := fmt.Errorf("%w: target %q resolves to non-public address %s", errProbeSafetyBlock, host, addr.IP)
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
+			}
 			target := net.JoinHostPort(addr.IP.String(), port)
 			conn, err := dialer.DialContext(ctx, network, target)
 			if err == nil {
@@ -636,6 +721,7 @@ type Request struct {
 	ForbiddenKeywords   []string
 	CustomHeaders       map[string]string
 	RedirectPolicy      RedirectPolicy
+	EnforceTargetSafety bool
 }
 
 // Result holds the outcome of a single HTTP check.
@@ -683,6 +769,8 @@ func (r *Result) StatusType() string {
 	switch {
 	case r.Success:
 		return "success"
+	case r.ErrorCode == ErrorProbeSafety:
+		return "probe_safety"
 	case r.ErrorCode == ErrorSSL || r.ErrorCode == ErrorTLSExpired:
 		return "https"
 	case r.ErrorCode == ErrorTimeout || r.ErrorCode == ErrorBodyRead:
@@ -702,6 +790,9 @@ func (r *Result) StatusType() string {
 
 // IsFailure reports whether the result should enter the downtime pipeline.
 func (r *Result) IsFailure() bool {
+	if r.ErrorCode == ErrorProbeSafety {
+		return false
+	}
 	if !r.Success {
 		return true
 	}
@@ -711,6 +802,12 @@ func (r *Result) IsFailure() bool {
 	default:
 		return true
 	}
+}
+
+// IsProbeSafetyBlock reports that Jetmon intentionally skipped the outbound
+// probe because the target would be unsafe for an untrusted remote site check.
+func (r *Result) IsProbeSafetyBlock() bool {
+	return r != nil && r.ErrorCode == ErrorProbeSafety
 }
 
 // Check performs an HTTP check and returns the result.
@@ -741,6 +838,9 @@ func Check(ctx context.Context, req Request) Result {
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
+	if req.EnforceTargetSafety {
+		ctx = withTargetSafety(ctx)
+	}
 
 	var (
 		dnsStart, tcpStart, tlsStart, reqStart time.Time
@@ -762,6 +862,7 @@ func Check(ctx context.Context, req Request) Result {
 	headers := req.CustomHeaders
 
 	var redirectChain []string
+	var initialRedirectHost string
 	redirectPolicyStr := string(req.RedirectPolicy)
 	if redirectPolicyStr == "" {
 		redirectPolicyStr = string(RedirectFollow)
@@ -773,12 +874,15 @@ func Check(ctx context.Context, req Request) Result {
 	client := &http.Client{
 		Transport: transportForRequestURL(req.URL),
 		CheckRedirect: func(r *http.Request, via []*http.Request) error {
-			redirectChain = append(redirectChain, r.URL.String())
+			redirectChain = append(redirectChain, boundedURLDetail(r.URL.String()))
 			if redirectPolicyStr == string(RedirectFail) {
 				return fmt.Errorf("redirect policy: fail")
 			}
 			if len(redirectChain) > 10 {
 				return fmt.Errorf("too many redirects")
+			}
+			if err := validateRedirectTarget(r.Context(), initialRedirectHost, r.URL); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -786,13 +890,28 @@ func Check(ctx context.Context, req Request) Result {
 
 	httpReq, err := http.NewRequestWithContext(ctx, method, req.URL, nil)
 	if err != nil {
-		res.ErrorCode = ErrorConnect
+		if req.EnforceTargetSafety {
+			res.ErrorCode = ErrorProbeSafety
+		} else {
+			res.ErrorCode = ErrorConnect
+		}
 		res.ErrorDetail = boundedErrorDetail(err)
 		return res
+	}
+	initialRedirectHost = normalizedURLHost(httpReq.URL)
+	if req.EnforceTargetSafety {
+		if err := validateInitialTarget(ctx, httpReq.URL); err != nil {
+			res.ErrorCode = ErrorProbeSafety
+			res.ErrorDetail = boundedErrorDetail(err)
+			return res
+		}
 	}
 
 	httpReq.Header.Set("User-Agent", "jetmon/2.0 (Jetpack Site Uptime Monitor by WordPress.com)")
 	for k, v := range headers {
+		if !validOutboundCustomHeader(k, v) {
+			continue
+		}
 		httpReq.Header.Set(k, v)
 	}
 
@@ -804,7 +923,7 @@ func Check(ctx context.Context, req Request) Result {
 		res.RedirectChain = append([]string(nil), redirectChain...)
 	}
 	if resp != nil && resp.Request != nil && resp.Request.URL != nil {
-		res.FinalURL = resp.Request.URL.String()
+		res.FinalURL = boundedURLDetail(resp.Request.URL.String())
 	}
 
 	// Only record a phase duration when BOTH start and end fired. If a
@@ -830,6 +949,8 @@ func Check(ctx context.Context, req Request) Result {
 		res.DNSFailureKind, res.DNSFailureName, res.DNSFailureServer = classifyDNSError(err)
 		if ctx.Err() != nil {
 			res.ErrorCode = ErrorTimeout
+		} else if errors.Is(err, errProbeSafetyBlock) {
+			res.ErrorCode = ErrorProbeSafety
 		} else if strings.Contains(err.Error(), "redirect") {
 			res.ErrorCode = ErrorRedirect
 		} else if strings.Contains(err.Error(), "tls") || strings.Contains(err.Error(), "certificate") {
@@ -883,7 +1004,11 @@ func Check(ctx context.Context, req Request) Result {
 			res.BodyReadError = boundedErrorDetail(bodyRead.Err)
 		}
 		if bodyRead.Err != nil && res.HTTPCode < http.StatusBadRequest {
-			res.ErrorCode = ErrorBodyRead
+			if needsBody && errors.Is(bodyRead.Err, errBodyReadBudgetExceeded) {
+				res.ErrorCode = ErrorTimeout
+			} else {
+				res.ErrorCode = ErrorBodyRead
+			}
 			res.ErrorDetail = res.BodyReadError
 			return res
 		}
@@ -922,6 +1047,74 @@ func boundedErrorDetail(err error) string {
 		return detail
 	}
 	return detail[:maxErrorDetail] + "..."
+}
+
+func boundedURLDetail(rawURL string) string {
+	if len(rawURL) <= maxResultURLDetailBytes {
+		return rawURL
+	}
+	return rawURL[:maxResultURLDetailBytes] + "..."
+}
+
+func normalizedURLHost(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	return strings.TrimSuffix(strings.ToLower(u.Hostname()), ".")
+}
+
+func validateRedirectTarget(ctx context.Context, initialHost string, target *url.URL) error {
+	if target != nil && target.Scheme != "" && target.Scheme != "http" && target.Scheme != "https" {
+		return fmt.Errorf("%w: redirect safety check: target must use http or https", errProbeSafetyBlock)
+	}
+	if target != nil && target.User != nil {
+		return fmt.Errorf("%w: redirect safety check: target must not include userinfo", errProbeSafetyBlock)
+	}
+	targetHost := normalizedURLHost(target)
+	if targetHost == "" || targetHost == initialHost {
+		return nil
+	}
+	if netguard.UnsafeHost(targetHost) {
+		return fmt.Errorf("%w: redirect safety check: target host %q is not public", errProbeSafetyBlock, targetHost)
+	}
+	return validateResolvedTarget(ctx, "redirect safety check", targetHost)
+}
+
+func validateInitialTarget(ctx context.Context, target *url.URL) error {
+	if target == nil {
+		return fmt.Errorf("probe safety check: target URL is required")
+	}
+	if target.Scheme != "http" && target.Scheme != "https" {
+		return fmt.Errorf("probe safety check: target URL must use http or https")
+	}
+	targetHost := normalizedURLHost(target)
+	if targetHost == "" {
+		return fmt.Errorf("probe safety check: target URL must include a host")
+	}
+	if target.User != nil {
+		return fmt.Errorf("probe safety check: target URL must not include userinfo")
+	}
+	if netguard.UnsafeHost(targetHost) {
+		return fmt.Errorf("probe safety check: target host %q is not public", targetHost)
+	}
+	return validateResolvedTarget(ctx, "probe safety check", targetHost)
+}
+
+func validateResolvedTarget(ctx context.Context, detailPrefix, targetHost string) error {
+	resolver := defaultResolver
+	if resolver == nil {
+		resolver = net.DefaultResolver
+	}
+	addrs, err := defaultDNSCache.lookup(ctx, resolver, targetHost, "tcp")
+	if err != nil {
+		return fmt.Errorf("%w: %s: resolve target %q: %w", errProbeSafetyBlock, detailPrefix, targetHost, err)
+	}
+	for _, addr := range addrs {
+		if netguard.UnsafeIP(addr.IP) {
+			return fmt.Errorf("%w: %s: target %q resolves to non-public address %s", errProbeSafetyBlock, detailPrefix, targetHost, addr.IP)
+		}
+	}
+	return nil
 }
 
 func classifyDNSError(err error) (kind, name, server string) {
@@ -972,8 +1165,16 @@ func readResponseBody(resp *http.Response, needKeyword bool, req Request) bodyRe
 		mode = "strict_finite"
 	}
 
+	stopBudget := startBodyReadBudget(resp.Body, responseBodyReadBudget(mode, needKeyword, req))
+	defer func() {
+		_ = stopBudget()
+	}()
+
 	if !needKeyword {
 		n, err := io.Copy(io.Discard, io.LimitReader(resp.Body, limit+1))
+		if stopBudget() {
+			err = bodyReadBudgetError(err)
+		}
 		result := bodyReadResult{
 			Err:           err,
 			Mode:          mode,
@@ -992,6 +1193,9 @@ func readResponseBody(resp *http.Response, needKeyword bool, req Request) bodyRe
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	if stopBudget() {
+		err = bodyReadBudgetError(err)
+	}
 	result := bodyReadResult{
 		Body:          body,
 		Err:           err,
@@ -1015,6 +1219,97 @@ func readResponseBody(resp *http.Response, needKeyword bool, req Request) bodyRe
 	return result
 }
 
+func responseBodyReadBudget(mode string, needKeyword bool, req Request) time.Duration {
+	if needKeyword {
+		if req.KeywordReadMaxMS <= 0 {
+			return 0
+		}
+		return time.Duration(req.KeywordReadMaxMS) * time.Millisecond
+	}
+	if mode == "strict_finite" || req.BodyReadMaxMS <= 0 {
+		return 0
+	}
+	return time.Duration(req.BodyReadMaxMS) * time.Millisecond
+}
+
+func startBodyReadBudget(body io.Closer, budget time.Duration) func() bool {
+	if body == nil || budget <= 0 {
+		return func() bool { return false }
+	}
+	var timedOut atomic.Bool
+	timer := time.AfterFunc(budget, func() {
+		timedOut.Store(true)
+		_ = body.Close()
+	})
+	return func() bool {
+		timer.Stop()
+		return timedOut.Load()
+	}
+}
+
+func bodyReadBudgetError(err error) error {
+	if err == nil {
+		return errBodyReadBudgetExceeded
+	}
+	return fmt.Errorf("%w: %v", errBodyReadBudgetExceeded, err)
+}
+
+func validOutboundCustomHeader(name, value string) bool {
+	return validHTTPHeaderName(name) && !forbiddenOutboundCustomHeader(name) && validHTTPHeaderValue(value)
+}
+
+func validHTTPHeaderName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		if !isHTTPTokenChar(name[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func isHTTPTokenChar(c byte) bool {
+	switch {
+	case c >= 'a' && c <= 'z':
+		return true
+	case c >= 'A' && c <= 'Z':
+		return true
+	case c >= '0' && c <= '9':
+		return true
+	}
+	switch c {
+	case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~':
+		return true
+	default:
+		return false
+	}
+}
+
+func forbiddenOutboundCustomHeader(name string) bool {
+	switch strings.ToLower(name) {
+	case "connection", "content-length", "host", "keep-alive", "proxy-authenticate",
+		"proxy-authorization", "te", "trailer", "transfer-encoding", "upgrade":
+		return true
+	default:
+		return false
+	}
+}
+
+func validHTTPHeaderValue(value string) bool {
+	for i := 0; i < len(value); i++ {
+		c := value[i]
+		if c == '\t' {
+			continue
+		}
+		if c < 0x20 || c == 0x7f {
+			return false
+		}
+	}
+	return true
+}
+
 func collectForbiddenKeywords(single *string, many []string) []string {
 	out := make([]string, 0, 1+len(many))
 	if single != nil && *single != "" {
@@ -1035,7 +1330,19 @@ func ParseCustomHeaders(raw *string) map[string]string {
 	}
 	var m map[string]string
 	_ = json.Unmarshal([]byte(*raw), &m)
-	return m
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		if validOutboundCustomHeader(k, v) {
+			out[k] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // ParseForbiddenKeywords deserialises a JSON array of body strings that must

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -901,7 +901,12 @@ func Check(ctx context.Context, req Request) Result {
 	initialRedirectHost = normalizedURLHost(httpReq.URL)
 	if req.EnforceTargetSafety {
 		if err := validateInitialTarget(ctx, httpReq.URL); err != nil {
-			res.ErrorCode = ErrorProbeSafety
+			if errors.Is(err, errProbeSafetyBlock) {
+				res.ErrorCode = ErrorProbeSafety
+			} else {
+				res.ErrorCode = ErrorConnect
+				res.DNSFailureKind, res.DNSFailureName, res.DNSFailureServer = classifyDNSError(err)
+			}
 			res.ErrorDetail = boundedErrorDetail(err)
 			return res
 		}
@@ -909,7 +914,7 @@ func Check(ctx context.Context, req Request) Result {
 
 	httpReq.Header.Set("User-Agent", "jetmon/2.0 (Jetpack Site Uptime Monitor by WordPress.com)")
 	for k, v := range headers {
-		if !validOutboundCustomHeader(k, v) {
+		if !netguard.ValidOutboundHeader(k, v) {
 			continue
 		}
 		httpReq.Header.Set(k, v)
@@ -1060,7 +1065,7 @@ func normalizedURLHost(u *url.URL) string {
 	if u == nil {
 		return ""
 	}
-	return strings.TrimSuffix(strings.ToLower(u.Hostname()), ".")
+	return netguard.NormalizeHost(u.Hostname())
 }
 
 func validateRedirectTarget(ctx context.Context, initialHost string, target *url.URL) error {
@@ -1082,20 +1087,20 @@ func validateRedirectTarget(ctx context.Context, initialHost string, target *url
 
 func validateInitialTarget(ctx context.Context, target *url.URL) error {
 	if target == nil {
-		return fmt.Errorf("probe safety check: target URL is required")
+		return fmt.Errorf("%w: probe safety check: target URL is required", errProbeSafetyBlock)
 	}
 	if target.Scheme != "http" && target.Scheme != "https" {
-		return fmt.Errorf("probe safety check: target URL must use http or https")
+		return fmt.Errorf("%w: probe safety check: target URL must use http or https", errProbeSafetyBlock)
 	}
 	targetHost := normalizedURLHost(target)
 	if targetHost == "" {
-		return fmt.Errorf("probe safety check: target URL must include a host")
+		return fmt.Errorf("%w: probe safety check: target URL must include a host", errProbeSafetyBlock)
 	}
 	if target.User != nil {
-		return fmt.Errorf("probe safety check: target URL must not include userinfo")
+		return fmt.Errorf("%w: probe safety check: target URL must not include userinfo", errProbeSafetyBlock)
 	}
 	if netguard.UnsafeHost(targetHost) {
-		return fmt.Errorf("probe safety check: target host %q is not public", targetHost)
+		return fmt.Errorf("%w: probe safety check: target host %q is not public", errProbeSafetyBlock, targetHost)
 	}
 	return validateResolvedTarget(ctx, "probe safety check", targetHost)
 }
@@ -1107,7 +1112,7 @@ func validateResolvedTarget(ctx context.Context, detailPrefix, targetHost string
 	}
 	addrs, err := defaultDNSCache.lookup(ctx, resolver, targetHost, "tcp")
 	if err != nil {
-		return fmt.Errorf("%w: %s: resolve target %q: %w", errProbeSafetyBlock, detailPrefix, targetHost, err)
+		return fmt.Errorf("%s: resolve target %q: %w", detailPrefix, targetHost, err)
 	}
 	for _, addr := range addrs {
 		if netguard.UnsafeIP(addr.IP) {
@@ -1166,13 +1171,10 @@ func readResponseBody(resp *http.Response, needKeyword bool, req Request) bodyRe
 	}
 
 	stopBudget := startBodyReadBudget(resp.Body, responseBodyReadBudget(mode, needKeyword, req))
-	defer func() {
-		_ = stopBudget()
-	}()
 
 	if !needKeyword {
 		n, err := io.Copy(io.Discard, io.LimitReader(resp.Body, limit+1))
-		if stopBudget() {
+		if stopBodyReadBudget(stopBudget) {
 			err = bodyReadBudgetError(err)
 		}
 		result := bodyReadResult{
@@ -1193,7 +1195,7 @@ func readResponseBody(resp *http.Response, needKeyword bool, req Request) bodyRe
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
-	if stopBudget() {
+	if stopBodyReadBudget(stopBudget) {
 		err = bodyReadBudgetError(err)
 	}
 	result := bodyReadResult{
@@ -1234,7 +1236,7 @@ func responseBodyReadBudget(mode string, needKeyword bool, req Request) time.Dur
 
 func startBodyReadBudget(body io.Closer, budget time.Duration) func() bool {
 	if body == nil || budget <= 0 {
-		return func() bool { return false }
+		return nil
 	}
 	var timedOut atomic.Bool
 	timer := time.AfterFunc(budget, func() {
@@ -1247,67 +1249,18 @@ func startBodyReadBudget(body io.Closer, budget time.Duration) func() bool {
 	}
 }
 
+func stopBodyReadBudget(stop func() bool) bool {
+	if stop == nil {
+		return false
+	}
+	return stop()
+}
+
 func bodyReadBudgetError(err error) error {
 	if err == nil {
 		return errBodyReadBudgetExceeded
 	}
 	return fmt.Errorf("%w: %v", errBodyReadBudgetExceeded, err)
-}
-
-func validOutboundCustomHeader(name, value string) bool {
-	return validHTTPHeaderName(name) && !forbiddenOutboundCustomHeader(name) && validHTTPHeaderValue(value)
-}
-
-func validHTTPHeaderName(name string) bool {
-	if name == "" {
-		return false
-	}
-	for i := 0; i < len(name); i++ {
-		if !isHTTPTokenChar(name[i]) {
-			return false
-		}
-	}
-	return true
-}
-
-func isHTTPTokenChar(c byte) bool {
-	switch {
-	case c >= 'a' && c <= 'z':
-		return true
-	case c >= 'A' && c <= 'Z':
-		return true
-	case c >= '0' && c <= '9':
-		return true
-	}
-	switch c {
-	case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~':
-		return true
-	default:
-		return false
-	}
-}
-
-func forbiddenOutboundCustomHeader(name string) bool {
-	switch strings.ToLower(name) {
-	case "connection", "content-length", "host", "keep-alive", "proxy-authenticate",
-		"proxy-authorization", "te", "trailer", "transfer-encoding", "upgrade":
-		return true
-	default:
-		return false
-	}
-}
-
-func validHTTPHeaderValue(value string) bool {
-	for i := 0; i < len(value); i++ {
-		c := value[i]
-		if c == '\t' {
-			continue
-		}
-		if c < 0x20 || c == 0x7f {
-			return false
-		}
-	}
-	return true
 }
 
 func collectForbiddenKeywords(single *string, many []string) []string {
@@ -1335,7 +1288,7 @@ func ParseCustomHeaders(raw *string) map[string]string {
 	}
 	out := make(map[string]string, len(m))
 	for k, v := range m {
-		if validOutboundCustomHeader(k, v) {
+		if netguard.ValidOutboundHeader(k, v) {
 			out[k] = v
 		}
 	}

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -1,6 +1,8 @@
 package checker
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -8,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -28,6 +31,7 @@ func TestResultStatusType(t *testing.T) {
 		{name: "timeout", res: Result{ErrorCode: ErrorTimeout}, want: "intermittent"},
 		{name: "body read", res: Result{ErrorCode: ErrorBodyRead}, want: "intermittent"},
 		{name: "redirect", res: Result{ErrorCode: ErrorRedirect}, want: "redirect"},
+		{name: "probe safety", res: Result{ErrorCode: ErrorProbeSafety}, want: "probe_safety"},
 		{name: "403 blocked", res: Result{HTTPCode: 403}, want: "blocked"},
 		{name: "500 server error", res: Result{HTTPCode: 500}, want: "server"},
 		{name: "503 server error", res: Result{HTTPCode: 503}, want: "server"},
@@ -68,6 +72,12 @@ func TestParseCustomHeaders(t *testing.T) {
 	if got["X-Foo"] != "bar" {
 		t.Fatalf("ParseCustomHeaders()[\"X-Foo\"] = %q, want %q", got["X-Foo"], "bar")
 	}
+
+	mixed := `{"X-Good":"ok","Connection":"close","Bad\r\nName":"x","X-Bad":"ok\r\nInjected: yes"}`
+	got = ParseCustomHeaders(&mixed)
+	if len(got) != 1 || got["X-Good"] != "ok" {
+		t.Fatalf("ParseCustomHeaders(mixed) = %#v, want only X-Good", got)
+	}
 }
 
 func TestResultIsFailure(t *testing.T) {
@@ -100,6 +110,11 @@ func TestResultIsFailure(t *testing.T) {
 			name: "transport failure is hard failure",
 			res:  Result{Success: false, ErrorCode: ErrorConnect},
 			want: true,
+		},
+		{
+			name: "probe safety block is non-downtime",
+			res:  Result{Success: false, ErrorCode: ErrorProbeSafety},
+			want: false,
 		},
 	}
 
@@ -682,6 +697,125 @@ func TestCheckBodyReadMaxBytesUnknownLengthOverLimitSucceeds(t *testing.T) {
 	}
 }
 
+func TestCheckCompressedLargeBodyIsCappedAfterDecompression(t *testing.T) {
+	const bodyReadLimit = int64(1024)
+
+	var compressed bytes.Buffer
+	zw := gzip.NewWriter(&compressed)
+	_, _ = zw.Write([]byte(strings.Repeat("a", int(bodyReadLimit)*128)))
+	if err := zw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Content-Length", strconv.Itoa(compressed.Len()))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(compressed.Bytes())
+	}))
+	defer srv.Close()
+
+	res := Check(context.Background(), Request{
+		BlogID:           1,
+		URL:              srv.URL,
+		TimeoutSeconds:   5,
+		BodyReadMaxBytes: bodyReadLimit,
+	})
+	if !res.Success {
+		t.Fatalf("Success = false for compressed body over read cap, want true; result=%+v", res)
+	}
+	if res.ErrorCode != ErrorNone {
+		t.Fatalf("ErrorCode = %d, want ErrorNone", res.ErrorCode)
+	}
+	if res.BodyBytesRead != bodyReadLimit {
+		t.Fatalf("BodyBytesRead = %d, want cap %d", res.BodyBytesRead, bodyReadLimit)
+	}
+}
+
+func TestCheckBodyReadMaxMSTimesOutBudgetedRead(t *testing.T) {
+	srv := slowStreamingBodyServer(t, "x", 200*time.Millisecond)
+	defer srv.Close()
+
+	start := time.Now()
+	res := Check(context.Background(), Request{
+		BlogID:           1,
+		URL:              srv.URL,
+		TimeoutSeconds:   5,
+		BodyReadMaxBytes: 1024,
+		BodyReadMaxMS:    50,
+	})
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("Check() took %s, want body-read budget to stop promptly", elapsed)
+	}
+	if res.Success {
+		t.Fatalf("Success = true for body-read budget exhaustion, want false; result=%+v", res)
+	}
+	if res.ErrorCode != ErrorBodyRead {
+		t.Fatalf("ErrorCode = %d, want ErrorBodyRead", res.ErrorCode)
+	}
+	if !strings.Contains(res.BodyReadError, "response body read budget exceeded") {
+		t.Fatalf("BodyReadError = %q, want budget diagnostic", res.BodyReadError)
+	}
+}
+
+func TestCheckBodyReadMaxMSDoesNotFailStrictFiniteBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", "2")
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		time.Sleep(75 * time.Millisecond)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	res := Check(context.Background(), Request{
+		BlogID:           1,
+		URL:              srv.URL,
+		TimeoutSeconds:   5,
+		BodyReadMaxBytes: 1024,
+		BodyReadMaxMS:    10,
+	})
+	if !res.Success {
+		t.Fatalf("Success = false for slow strict finite body, want true; result=%+v", res)
+	}
+	if res.ErrorCode != ErrorNone {
+		t.Fatalf("ErrorCode = %d, want ErrorNone", res.ErrorCode)
+	}
+	if res.BodyReadMode != "strict_finite" {
+		t.Fatalf("BodyReadMode = %q, want strict_finite", res.BodyReadMode)
+	}
+}
+
+func TestCheckKeywordReadMaxMSTimesOutAsTimeout(t *testing.T) {
+	srv := slowStreamingBodyServer(t, "x", 200*time.Millisecond)
+	defer srv.Close()
+
+	kw := "needle"
+	start := time.Now()
+	res := Check(context.Background(), Request{
+		BlogID:              1,
+		URL:                 srv.URL,
+		TimeoutSeconds:      5,
+		Keyword:             &kw,
+		KeywordReadMaxBytes: 1024,
+		KeywordReadMaxMS:    50,
+	})
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("Check() took %s, want keyword-read budget to stop promptly", elapsed)
+	}
+	if res.Success {
+		t.Fatalf("Success = true for keyword-read budget exhaustion, want false; result=%+v", res)
+	}
+	if res.ErrorCode != ErrorTimeout {
+		t.Fatalf("ErrorCode = %d, want ErrorTimeout", res.ErrorCode)
+	}
+	if !strings.Contains(res.BodyReadError, "response body read budget exceeded") {
+		t.Fatalf("BodyReadError = %q, want budget diagnostic", res.BodyReadError)
+	}
+}
+
 func TestCheckRedirectFail(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/" {
@@ -704,6 +838,138 @@ func TestCheckRedirectFail(t *testing.T) {
 	}
 	if res.ErrorDetail == "" {
 		t.Fatal("ErrorDetail is empty, want redirect diagnostic context")
+	}
+}
+
+func TestCheckRedirectMetadataBoundsLargeLocation(t *testing.T) {
+	longQuery := strings.Repeat("a", maxResultURLDetailBytes*2)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			http.Redirect(w, r, "/final?x="+longQuery, http.StatusFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	res := Check(context.Background(), Request{BlogID: 1, URL: srv.URL, TimeoutSeconds: 5, RedirectPolicy: RedirectAlert})
+	if !res.Success {
+		t.Fatalf("Success = false after long redirect, want true; result=%+v", res)
+	}
+	if len(res.RedirectChain) != 1 {
+		t.Fatalf("RedirectChain len = %d, want 1", len(res.RedirectChain))
+	}
+	if len(res.RedirectChain[0]) != maxResultURLDetailBytes+3 || !strings.HasSuffix(res.RedirectChain[0], "...") {
+		t.Fatalf("RedirectChain[0] length/suffix = %d/%q, want bounded ellipsis", len(res.RedirectChain[0]), res.RedirectChain[0][len(res.RedirectChain[0])-3:])
+	}
+	if len(res.FinalURL) != maxResultURLDetailBytes+3 || !strings.HasSuffix(res.FinalURL, "...") {
+		t.Fatalf("FinalURL length/suffix = %d/%q, want bounded ellipsis", len(res.FinalURL), res.FinalURL[len(res.FinalURL)-3:])
+	}
+}
+
+func TestCheckRejectsCrossHostRedirectToUnsafeAddress(t *testing.T) {
+	privateTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer privateTarget.Close()
+	privateURL := strings.Replace(privateTarget.URL, "127.0.0.1", "localhost", 1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, privateURL, http.StatusFound)
+	}))
+	defer srv.Close()
+
+	res := Check(context.Background(), Request{BlogID: 1, URL: srv.URL, TimeoutSeconds: 5, RedirectPolicy: RedirectFollow})
+	if res.Success {
+		t.Fatalf("Success = true for unsafe cross-host redirect, want false; result=%+v", res)
+	}
+	if res.ErrorCode != ErrorProbeSafety {
+		t.Fatalf("ErrorCode = %d, want ErrorProbeSafety", res.ErrorCode)
+	}
+	if res.IsFailure() {
+		t.Fatal("IsFailure = true for unsafe redirect, want false")
+	}
+	if !strings.Contains(res.ErrorDetail, "redirect safety check") {
+		t.Fatalf("ErrorDetail = %q, want redirect safety diagnostic", res.ErrorDetail)
+	}
+	if res.RedirectCount != 1 {
+		t.Fatalf("RedirectCount = %d, want 1", res.RedirectCount)
+	}
+}
+
+func TestCheckRejectsSameHostRedirectWithUserinfo(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			u := *r.URL
+			u.Scheme = "http"
+			u.Host = r.Host
+			u.Path = "/final"
+			u.User = url.User("user")
+			http.Redirect(w, r, u.String(), http.StatusFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	res := Check(context.Background(), Request{BlogID: 1, URL: srv.URL, TimeoutSeconds: 5, RedirectPolicy: RedirectFollow})
+	if res.Success {
+		t.Fatalf("Success = true for userinfo redirect, want false; result=%+v", res)
+	}
+	if res.ErrorCode != ErrorProbeSafety {
+		t.Fatalf("ErrorCode = %d, want ErrorProbeSafety", res.ErrorCode)
+	}
+	if res.IsFailure() {
+		t.Fatal("IsFailure = true for unsafe userinfo redirect, want false")
+	}
+	if !strings.Contains(res.ErrorDetail, "userinfo") {
+		t.Fatalf("ErrorDetail = %q, want userinfo diagnostic", res.ErrorDetail)
+	}
+}
+
+func TestTransportSafetyBlocksUnsafeIPBeforeDial(t *testing.T) {
+	ctx := withTargetSafety(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://127.0.0.1/", nil)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext: %v", err)
+	}
+
+	_, err = defaultHTTPIPTransport.RoundTrip(req)
+	if !errors.Is(err, errProbeSafetyBlock) {
+		t.Fatalf("RoundTrip err = %v, want errProbeSafetyBlock", err)
+	}
+}
+
+func TestCheckDNSCacheExpiryUsesJitter(t *testing.T) {
+	cache := newCheckDNSCache(15*time.Minute, 10)
+	cache.jitter = 3 * time.Minute
+	cache.salt = 1
+	now := time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC)
+
+	expires := cache.expiresAt("example.com|ip4", now)
+	min := now.Add(12 * time.Minute)
+	max := now.Add(15 * time.Minute)
+	if expires.Before(min) || !expires.Before(max) {
+		t.Fatalf("expiresAt = %s, want in [%s, %s)", expires, min, max)
+	}
+}
+
+func TestCheckRejectsOversizedResponseHeaders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Large-Header", strings.Repeat("a", int(maxResponseHeaderBytes)+1024))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	res := Check(context.Background(), Request{BlogID: 1, URL: srv.URL, TimeoutSeconds: 5})
+	if res.Success {
+		t.Fatalf("Success = true for oversized response headers, want false; result=%+v", res)
+	}
+	if res.ErrorCode != ErrorConnect {
+		t.Fatalf("ErrorCode = %d, want ErrorConnect", res.ErrorCode)
+	}
+	if !strings.Contains(res.ErrorDetail, "server response headers exceeded") {
+		t.Fatalf("ErrorDetail = %q, want oversized-header diagnostic", res.ErrorDetail)
 	}
 }
 
@@ -982,6 +1248,43 @@ func TestCheckDNSCacheReturnsCachedAddresses(t *testing.T) {
 	}
 }
 
+func TestValidateResolvedTargetRejectsMixedPublicPrivateDNSAnswers(t *testing.T) {
+	dnsAddr := startTestDNSServer(t, [][]net.IP{{
+		net.ParseIP("93.184.216.34"),
+		net.ParseIP("127.0.0.1"),
+	}})
+	withTestResolver(t, dnsAddr, 15*time.Minute)
+
+	err := validateResolvedTarget(context.Background(), "probe safety check", "mixed.test")
+	if err == nil {
+		t.Fatal("validateResolvedTarget accepted mixed public/private DNS answers")
+	}
+	if !strings.Contains(err.Error(), "non-public address") {
+		t.Fatalf("err = %v, want non-public address diagnostic", err)
+	}
+}
+
+func TestValidateResolvedTargetRejectsDNSRebindAfterCacheExpiry(t *testing.T) {
+	dnsAddr := startTestDNSServer(t, [][]net.IP{
+		{net.ParseIP("93.184.216.34")},
+		{net.ParseIP("127.0.0.1")},
+	})
+	withTestResolver(t, dnsAddr, time.Millisecond)
+
+	if err := validateResolvedTarget(context.Background(), "probe safety check", "rebind.test"); err != nil {
+		t.Fatalf("first validateResolvedTarget() error = %v, want nil", err)
+	}
+	time.Sleep(5 * time.Millisecond)
+
+	err := validateResolvedTarget(context.Background(), "probe safety check", "rebind.test")
+	if err == nil {
+		t.Fatal("validateResolvedTarget accepted rebound private DNS answer")
+	}
+	if !strings.Contains(err.Error(), "non-public address") {
+		t.Fatalf("err = %v, want non-public address diagnostic", err)
+	}
+}
+
 func TestPreferredLookupFamily(t *testing.T) {
 	if got := preferredLookupFamily("tcp"); got != "ip4" {
 		t.Fatalf("preferredLookupFamily(tcp) = %q, want ip4", got)
@@ -1058,6 +1361,21 @@ func TestCheckTLS11IsAdvisoryNotOutage(t *testing.T) {
 	}
 }
 
+func TestCheckSelfSignedTLSFailsAsSSL(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	res := Check(context.Background(), Request{BlogID: 1, URL: srv.URL, TimeoutSeconds: 5})
+	if res.Success {
+		t.Fatalf("Success = true for untrusted TLS cert, want false; result=%+v", res)
+	}
+	if res.ErrorCode != ErrorSSL {
+		t.Fatalf("ErrorCode = %d, want ErrorSSL; detail=%q", res.ErrorCode, res.ErrorDetail)
+	}
+}
+
 func TestCheckInvalidURL(t *testing.T) {
 	res := Check(context.Background(), Request{BlogID: 1, URL: "://invalid-url", TimeoutSeconds: 5})
 	if res.ErrorCode != ErrorConnect {
@@ -1065,6 +1383,36 @@ func TestCheckInvalidURL(t *testing.T) {
 	}
 	if res.ErrorDetail == "" {
 		t.Fatal("ErrorDetail is empty, want invalid-url diagnostic context")
+	}
+}
+
+func TestCheckBlocksUnsafeDirectTargetWhenSafetyEnforced(t *testing.T) {
+	for _, rawURL := range []string{
+		"http://127.0.0.1/admin",
+		"www.example.com",
+		"file:///etc/passwd",
+		"http://user@example.com",
+	} {
+		t.Run(rawURL, func(t *testing.T) {
+			res := Check(context.Background(), Request{
+				BlogID:              1,
+				URL:                 rawURL,
+				TimeoutSeconds:      5,
+				EnforceTargetSafety: true,
+			})
+			if res.ErrorCode != ErrorProbeSafety {
+				t.Fatalf("ErrorCode = %d, want ErrorProbeSafety; result=%+v", res.ErrorCode, res)
+			}
+			if !res.IsProbeSafetyBlock() {
+				t.Fatal("IsProbeSafetyBlock = false, want true")
+			}
+			if res.IsFailure() {
+				t.Fatal("IsFailure = true for probe safety block, want non-downtime result")
+			}
+			if !strings.Contains(res.ErrorDetail, "probe safety check") {
+				t.Fatalf("ErrorDetail = %q, want probe safety diagnostic", res.ErrorDetail)
+			}
+		})
 	}
 }
 
@@ -1170,6 +1518,119 @@ func truncatedBodyServerWithContentLength(t *testing.T, contentLength int64, bod
 			return
 		}
 		_ = conn.Close()
+	}))
+}
+
+func withTestResolver(t *testing.T, dnsAddr string, ttl time.Duration) {
+	t.Helper()
+	oldResolver := defaultResolver
+	oldCache := defaultDNSCache
+	defaultResolver = &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			d := net.Dialer{Timeout: time.Second}
+			return d.DialContext(ctx, network, dnsAddr)
+		},
+	}
+	defaultDNSCache = newCheckDNSCache(ttl, 100)
+	defaultDNSCache.jitter = 0
+	t.Cleanup(func() {
+		defaultResolver = oldResolver
+		defaultDNSCache = oldCache
+	})
+}
+
+func startTestDNSServer(t *testing.T, answerBatches [][]net.IP) string {
+	t.Helper()
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("ListenPacket: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	var queryCount atomic.Uint64
+	go func() {
+		buf := make([]byte, 1500)
+		for {
+			n, addr, err := pc.ReadFrom(buf)
+			if err != nil {
+				return
+			}
+			query := append([]byte(nil), buf[:n]...)
+			idx := int(queryCount.Add(1)) - 1
+			if idx >= len(answerBatches) {
+				idx = len(answerBatches) - 1
+			}
+			resp := buildTestDNSAResponse(query, answerBatches[idx])
+			if len(resp) > 0 {
+				_, _ = pc.WriteTo(resp, addr)
+			}
+		}
+	}()
+	return pc.LocalAddr().String()
+}
+
+func buildTestDNSAResponse(query []byte, ips []net.IP) []byte {
+	if len(query) < 12 {
+		return nil
+	}
+	qEnd := 12
+	for qEnd < len(query) && query[qEnd] != 0 {
+		qEnd += int(query[qEnd]) + 1
+	}
+	if qEnd+5 > len(query) {
+		return nil
+	}
+	question := query[12 : qEnd+5]
+	answers := make([]net.IP, 0, len(ips))
+	for _, ip := range ips {
+		if ip4 := ip.To4(); ip4 != nil {
+			answers = append(answers, ip4)
+		}
+	}
+
+	resp := make([]byte, 0, 12+len(question)+len(answers)*16)
+	resp = append(resp, query[0], query[1], 0x81, 0x80)
+	resp = append(resp, 0x00, 0x01)
+	resp = append(resp, byte(len(answers)>>8), byte(len(answers)))
+	resp = append(resp, 0x00, 0x00, 0x00, 0x00)
+	resp = append(resp, question...)
+	for _, ip := range answers {
+		resp = append(resp,
+			0xc0, 0x0c,
+			0x00, 0x01,
+			0x00, 0x01,
+			0x00, 0x00, 0x00, 0x01,
+			0x00, 0x04,
+			ip[0], ip[1], ip[2], ip[3],
+		)
+	}
+	return resp
+}
+
+func slowStreamingBodyServer(t *testing.T, chunk string, delay time.Duration) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		ticker := time.NewTicker(delay)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-r.Context().Done():
+				return
+			case <-ticker.C:
+				if _, err := w.Write([]byte(chunk)); err != nil {
+					return
+				}
+				if flusher, ok := w.(http.Flusher); ok {
+					flusher.Flush()
+				}
+			}
+		}
 	}))
 }
 

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -1416,6 +1416,27 @@ func TestCheckBlocksUnsafeDirectTargetWhenSafetyEnforced(t *testing.T) {
 	}
 }
 
+func TestCheckTargetSafetyDNSFailureIsConnectFailure(t *testing.T) {
+	dnsAddr := startTestNXDomainDNSServer(t)
+	withTestResolver(t, dnsAddr, time.Millisecond)
+
+	res := Check(context.Background(), Request{
+		BlogID:              1,
+		URL:                 "http://missing.example/security-check",
+		TimeoutSeconds:      2,
+		EnforceTargetSafety: true,
+	})
+	if res.ErrorCode != ErrorConnect {
+		t.Fatalf("ErrorCode = %d, want ErrorConnect; result=%+v", res.ErrorCode, res)
+	}
+	if res.IsProbeSafetyBlock() {
+		t.Fatal("IsProbeSafetyBlock = true for DNS failure, want false")
+	}
+	if res.DNSFailureKind != "nxdomain" {
+		t.Fatalf("DNSFailureKind = %q, want nxdomain; detail=%q", res.DNSFailureKind, res.ErrorDetail)
+	}
+}
+
 func TestCheckConnectionRefused(t *testing.T) {
 	// Start a server to get a free port, then stop it so connections are refused.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
@@ -1570,6 +1591,30 @@ func startTestDNSServer(t *testing.T, answerBatches [][]net.IP) string {
 	return pc.LocalAddr().String()
 }
 
+func startTestNXDomainDNSServer(t *testing.T) string {
+	t.Helper()
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("ListenPacket: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	go func() {
+		buf := make([]byte, 1500)
+		for {
+			n, addr, err := pc.ReadFrom(buf)
+			if err != nil {
+				return
+			}
+			resp := buildTestDNSNXDomainResponse(buf[:n])
+			if len(resp) > 0 {
+				_, _ = pc.WriteTo(resp, addr)
+			}
+		}
+	}()
+	return pc.LocalAddr().String()
+}
+
 func buildTestDNSAResponse(query []byte, ips []net.IP) []byte {
 	if len(query) < 12 {
 		return nil
@@ -1605,6 +1650,27 @@ func buildTestDNSAResponse(query []byte, ips []net.IP) []byte {
 			ip[0], ip[1], ip[2], ip[3],
 		)
 	}
+	return resp
+}
+
+func buildTestDNSNXDomainResponse(query []byte) []byte {
+	if len(query) < 12 {
+		return nil
+	}
+	qEnd := 12
+	for qEnd < len(query) && query[qEnd] != 0 {
+		qEnd += int(query[qEnd]) + 1
+	}
+	if qEnd+5 > len(query) {
+		return nil
+	}
+	question := query[12 : qEnd+5]
+	resp := make([]byte, 0, 12+len(question))
+	resp = append(resp, query[0], query[1], 0x81, 0x83)
+	resp = append(resp, 0x00, 0x01)
+	resp = append(resp, 0x00, 0x00)
+	resp = append(resp, 0x00, 0x00, 0x00, 0x00)
+	resp = append(resp, question...)
 	return resp
 }
 

--- a/internal/checker/security_benchmark_test.go
+++ b/internal/checker/security_benchmark_test.go
@@ -1,0 +1,61 @@
+package checker
+
+import (
+	"context"
+	"net"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/Automattic/jetmon/internal/netguard"
+)
+
+func BenchmarkProbeTargetSafetyCached(b *testing.B) {
+	oldCache := defaultDNSCache
+	defaultDNSCache = newCheckDNSCache(time.Hour, 16)
+	defaultDNSCache.store(
+		normalizeDNSCacheKey("example.com", "ip4"),
+		[]net.IPAddr{{IP: net.ParseIP("93.184.216.34")}},
+		time.Now().Add(time.Hour),
+	)
+	b.Cleanup(func() { defaultDNSCache = oldCache })
+
+	target, err := url.Parse("https://example.com/path")
+	if err != nil {
+		b.Fatalf("parse target: %v", err)
+	}
+	const rawURL = "https://example.com/path"
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := validateInitialTarget(ctx, target); err != nil {
+			b.Fatalf("validateInitialTarget: %v", err)
+		}
+	}
+}
+
+func BenchmarkParsePublicHTTPURL(b *testing.B) {
+	const rawURL = "https://example.com/path"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := netguard.ParsePublicHTTPURL(rawURL, "monitor_url"); err != nil {
+			b.Fatalf("ParsePublicHTTPURL: %v", err)
+		}
+	}
+}
+
+func BenchmarkProbeTargetSafetyBlockedLiteral(b *testing.B) {
+	const rawURL = "http://127.0.0.1/admin"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := netguard.ParsePublicHTTPURL(rawURL, "probe safety check: target URL"); err == nil {
+			b.Fatal("ParsePublicHTTPURL accepted unsafe target")
+		}
+	}
+}

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -742,6 +742,29 @@ var migrations = []migration{
 		INDEX idx_rollback (run_id, rolled_back_at, created_at),
 		INDEX idx_blog (blog_id)
 	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
+
+	// Migration 49 records non-downtime probe safety findings separately from
+	// customer incident events. This gives operators a durable remediation
+	// trail for unsafe legacy monitor URLs without mutating v1 site-table
+	// semantics beyond an explicit deactivation when requested.
+	{49, `CREATE TABLE IF NOT EXISTS jetmon_site_safety_flags (
+		id              BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		blog_id         BIGINT UNSIGNED NOT NULL,
+		monitor_site_id BIGINT UNSIGNED NOT NULL,
+		flag_type       ENUM('unsafe_monitor_url','probe_safety_block') NOT NULL,
+		reason          VARCHAR(1024) NOT NULL,
+		monitor_url     VARCHAR(2083) NOT NULL,
+		status          ENUM('open','deactivated','ignored','resolved') NOT NULL DEFAULT 'open',
+		first_seen_at   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+		last_seen_at    TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+		deactivated_at  TIMESTAMP(3) NULL,
+		created_at      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+		updated_at      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+		UNIQUE KEY uniq_site_flag (monitor_site_id, flag_type),
+		INDEX idx_blog_status (blog_id, status),
+		INDEX idx_status_seen (status, last_seen_at),
+		INDEX idx_type_status (flag_type, status)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`},
 }
 
 // Migrate applies all pending migrations idempotently.

--- a/internal/db/site_safety.go
+++ b/internal/db/site_safety.go
@@ -1,0 +1,98 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	SiteSafetyFlagUnsafeMonitorURL = "unsafe_monitor_url"
+	SiteSafetyFlagProbeSafetyBlock = "probe_safety_block"
+
+	SiteSafetyStatusOpen        = "open"
+	SiteSafetyStatusDeactivated = "deactivated"
+	SiteSafetyStatusIgnored     = "ignored"
+	SiteSafetyStatusResolved    = "resolved"
+
+	siteSafetyReasonMaxRunes = 1024
+	siteSafetyURLMaxRunes    = 2083
+)
+
+type SiteSafetyFlagExecer interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}
+
+// SiteSafetyFlag is a durable non-downtime remediation marker for unsafe
+// monitor targets or runtime probe-safety blocks.
+type SiteSafetyFlag struct {
+	BlogID        int64
+	MonitorSiteID int64
+	FlagType      string
+	Reason        string
+	MonitorURL    string
+	Status        string
+	DeactivatedAt *time.Time
+}
+
+// UpsertSiteSafetyFlag records the latest safety finding for a monitor row
+// while preserving first_seen_at. It accepts *sql.DB and *sql.Tx so cleanup
+// commands can group flag writes with deactivation in one transaction.
+func UpsertSiteSafetyFlag(ctx context.Context, execer SiteSafetyFlagExecer, flag SiteSafetyFlag) error {
+	if execer == nil {
+		return fmt.Errorf("db execer is required")
+	}
+	if flag.BlogID <= 0 {
+		return fmt.Errorf("blog_id is required")
+	}
+	if flag.MonitorSiteID <= 0 {
+		return fmt.Errorf("monitor_site_id is required")
+	}
+	if flag.FlagType == "" {
+		return fmt.Errorf("flag_type is required")
+	}
+	if flag.Status == "" {
+		flag.Status = SiteSafetyStatusOpen
+	}
+	if flag.Reason == "" {
+		flag.Reason = "probe safety block"
+	}
+
+	_, err := execer.ExecContext(ctx, `
+		INSERT INTO jetmon_site_safety_flags
+			(blog_id, monitor_site_id, flag_type, reason, monitor_url, status, first_seen_at, last_seen_at, deactivated_at)
+		VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP(3), CURRENT_TIMESTAMP(3), ?)
+		ON DUPLICATE KEY UPDATE
+			blog_id = VALUES(blog_id),
+			reason = VALUES(reason),
+			monitor_url = VALUES(monitor_url),
+			status = VALUES(status),
+			last_seen_at = VALUES(last_seen_at),
+			deactivated_at = CASE
+				WHEN VALUES(deactivated_at) IS NOT NULL THEN VALUES(deactivated_at)
+				ELSE deactivated_at
+			END,
+			updated_at = CURRENT_TIMESTAMP(3)`,
+		flag.BlogID,
+		flag.MonitorSiteID,
+		flag.FlagType,
+		truncateRunes(flag.Reason, siteSafetyReasonMaxRunes),
+		truncateRunes(flag.MonitorURL, siteSafetyURLMaxRunes),
+		flag.Status,
+		flag.DeactivatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert site safety flag: %w", err)
+	}
+	return nil
+}
+
+func truncateRunes(s string, maxRunes int) string {
+	if maxRunes <= 0 || utf8.RuneCountInString(s) <= maxRunes {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:maxRunes])
+}

--- a/internal/db/site_safety_test.go
+++ b/internal/db/site_safety_test.go
@@ -1,0 +1,88 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestUpsertSiteSafetyFlag(t *testing.T) {
+	mock, cleanup := withMockDB(t)
+	defer cleanup()
+
+	mock.ExpectExec("INSERT INTO jetmon_site_safety_flags").
+		WithArgs(int64(42), int64(123), SiteSafetyFlagUnsafeMonitorURL, "blocked", "http://127.0.0.1", SiteSafetyStatusDeactivated, nil).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	if err := UpsertSiteSafetyFlag(context.Background(), DB(), SiteSafetyFlag{
+		BlogID:        42,
+		MonitorSiteID: 123,
+		FlagType:      SiteSafetyFlagUnsafeMonitorURL,
+		Reason:        "blocked",
+		MonitorURL:    "http://127.0.0.1",
+		Status:        SiteSafetyStatusDeactivated,
+	}); err != nil {
+		t.Fatalf("UpsertSiteSafetyFlag: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestUpsertSiteSafetyFlagTruncatesLongValues(t *testing.T) {
+	mock, cleanup := withMockDB(t)
+	defer cleanup()
+
+	var gotReason string
+	var gotURL string
+	mock.ExpectExec("INSERT INTO jetmon_site_safety_flags").
+		WithArgs(int64(42), int64(123), SiteSafetyFlagProbeSafetyBlock, sqlmock.AnyArg(), sqlmock.AnyArg(), SiteSafetyStatusOpen, nil).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	if err := UpsertSiteSafetyFlag(context.Background(), captureSiteSafetyFlagExecer{
+		t:         t,
+		mock:      DB(),
+		gotReason: &gotReason,
+		gotURL:    &gotURL,
+	}, SiteSafetyFlag{
+		BlogID:        42,
+		MonitorSiteID: 123,
+		FlagType:      SiteSafetyFlagProbeSafetyBlock,
+		Reason:        strings.Repeat("x", siteSafetyReasonMaxRunes+1),
+		MonitorURL:    "https://" + strings.Repeat("a", siteSafetyURLMaxRunes) + ".example",
+	}); err != nil {
+		t.Fatalf("UpsertSiteSafetyFlag: %v", err)
+	}
+	if len([]rune(gotReason)) != siteSafetyReasonMaxRunes {
+		t.Fatalf("reason runes = %d, want %d", len([]rune(gotReason)), siteSafetyReasonMaxRunes)
+	}
+	if len([]rune(gotURL)) != siteSafetyURLMaxRunes {
+		t.Fatalf("url runes = %d, want %d", len([]rune(gotURL)), siteSafetyURLMaxRunes)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+type captureSiteSafetyFlagExecer struct {
+	t         *testing.T
+	mock      SiteSafetyFlagExecer
+	gotReason *string
+	gotURL    *string
+}
+
+func (c captureSiteSafetyFlagExecer) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	c.t.Helper()
+	if len(args) >= 5 {
+		if reason, ok := args[3].(string); ok {
+			*c.gotReason = reason
+		}
+		if url, ok := args[4].(string); ok {
+			*c.gotURL = url
+		}
+	}
+	return c.mock.ExecContext(ctx, query, args...)
+}

--- a/internal/netguard/http.go
+++ b/internal/netguard/http.go
@@ -40,6 +40,10 @@ func NewProtectedHTTPTransport(resolver *net.Resolver) *http.Transport {
 		TLSHandshakeTimeout:    5 * time.Second,
 		ExpectContinueTimeout:  1 * time.Second,
 		ForceAttemptHTTP2:      true,
+		// Intentionally omit Proxy / ProxyFromEnvironment. If a proxy resolves
+		// the final URL, this process can no longer prove the dialed target is
+		// public. Add an explicit trusted-proxy mode if production egress ever
+		// requires proxy support for untrusted destinations.
 	}
 }
 

--- a/internal/netguard/http.go
+++ b/internal/netguard/http.go
@@ -1,0 +1,134 @@
+package netguard
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+)
+
+const ProtectedMaxResponseHeaderBytes int64 = 64 << 10
+
+var ErrUnsafeTarget = errors.New("unsafe outbound target")
+
+// NewProtectedHTTPClient returns an HTTP client for untrusted, user-supplied
+// destinations. It validates redirect targets and refuses to dial non-public
+// resolved addresses.
+func NewProtectedHTTPClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Transport: NewProtectedHTTPTransport(nil),
+		Timeout:   timeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return errors.New("stopped after 10 redirects")
+			}
+			if req == nil || req.URL == nil {
+				return fmt.Errorf("%w: redirect target URL is required", ErrUnsafeTarget)
+			}
+			_, err := ParsePublicHTTPURL(req.URL.String(), "redirect url")
+			return err
+		},
+	}
+}
+
+func NewProtectedHTTPTransport(resolver *net.Resolver) *http.Transport {
+	return &http.Transport{
+		DialContext:            ProtectedDialContext(resolver),
+		MaxResponseHeaderBytes: ProtectedMaxResponseHeaderBytes,
+		TLSHandshakeTimeout:    5 * time.Second,
+		ExpectContinueTimeout:  1 * time.Second,
+		ForceAttemptHTTP2:      true,
+	}
+}
+
+func ProtectedDialContext(resolver *net.Resolver) func(context.Context, string, string) (net.Conn, error) {
+	if resolver == nil {
+		resolver = net.DefaultResolver
+	}
+	dialer := &net.Dialer{
+		Timeout:   5 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, err
+		}
+		addrs, err := resolvePublicIPAddrs(ctx, resolver, host, "target")
+		if err != nil {
+			return nil, err
+		}
+		var firstErr error
+		for _, addr := range addrs {
+			if !networkAllowsIP(network, addr.IP) {
+				continue
+			}
+			conn, err := dialer.DialContext(ctx, network, net.JoinHostPort(addr.IP.String(), port))
+			if err == nil {
+				return conn, nil
+			}
+			if firstErr == nil {
+				firstErr = err
+			}
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+		}
+		if firstErr != nil {
+			return nil, firstErr
+		}
+		return nil, fmt.Errorf("target %q has no addresses usable on %s", host, network)
+	}
+}
+
+func ValidateResolvedHost(ctx context.Context, resolver *net.Resolver, host, field string) error {
+	_, err := resolvePublicIPAddrs(ctx, resolver, host, field)
+	return err
+}
+
+func resolvePublicIPAddrs(ctx context.Context, resolver *net.Resolver, host, field string) ([]net.IPAddr, error) {
+	if field == "" {
+		field = "target"
+	}
+	if resolver == nil {
+		resolver = net.DefaultResolver
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if UnsafeIP(ip) {
+			return nil, fmt.Errorf("%w: %s address %s is not public", ErrUnsafeTarget, field, ip)
+		}
+		return []net.IPAddr{{IP: ip}}, nil
+	}
+	if UnsafeHost(host) {
+		return nil, fmt.Errorf("%w: %s host %q is not public", ErrUnsafeTarget, field, host)
+	}
+	addrs, err := resolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, fmt.Errorf("%s resolve %q: %w", field, host, err)
+	}
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("%s resolve %q: no addresses", field, host)
+	}
+	for _, addr := range addrs {
+		if UnsafeIP(addr.IP) {
+			return nil, fmt.Errorf("%w: %s host %q resolves to non-public address %s", ErrUnsafeTarget, field, host, addr.IP)
+		}
+	}
+	return addrs, nil
+}
+
+func networkAllowsIP(network string, ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	switch network {
+	case "tcp4":
+		return ip.To4() != nil
+	case "tcp6":
+		return ip.To4() == nil
+	default:
+		return true
+	}
+}

--- a/internal/netguard/http_test.go
+++ b/internal/netguard/http_test.go
@@ -1,0 +1,28 @@
+package netguard
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestProtectedDialContextRejectsUnsafeLiteral(t *testing.T) {
+	dial := ProtectedDialContext(nil)
+	_, err := dial(context.Background(), "tcp", "127.0.0.1:80")
+	if !errors.Is(err, ErrUnsafeTarget) {
+		t.Fatalf("dial err = %v, want ErrUnsafeTarget", err)
+	}
+}
+
+func TestProtectedHTTPClientRejectsUnsafeRedirectURL(t *testing.T) {
+	client := NewProtectedHTTPClient(time.Second)
+	req, err := http.NewRequest(http.MethodGet, "http://user@example.com/path", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	if err := client.CheckRedirect(req, nil); err == nil {
+		t.Fatal("CheckRedirect accepted userinfo URL")
+	}
+}

--- a/internal/netguard/http_test.go
+++ b/internal/netguard/http_test.go
@@ -3,6 +3,7 @@ package netguard
 import (
 	"context"
 	"errors"
+	"net"
 	"net/http"
 	"testing"
 	"time"
@@ -24,5 +25,32 @@ func TestProtectedHTTPClientRejectsUnsafeRedirectURL(t *testing.T) {
 	}
 	if err := client.CheckRedirect(req, nil); err == nil {
 		t.Fatal("CheckRedirect accepted userinfo URL")
+	}
+}
+
+func TestProtectedHTTPClientDoesNotUseAmbientProxy(t *testing.T) {
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:9")
+	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:9")
+	t.Setenv("NO_PROXY", "")
+
+	client := NewProtectedHTTPClient(time.Second)
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("Transport = %T, want *http.Transport", client.Transport)
+	}
+	if transport.Proxy != nil {
+		req, err := http.NewRequest(http.MethodGet, "https://example.com/", nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		proxyURL, err := transport.Proxy(req)
+		if err != nil {
+			t.Fatalf("Proxy returned error: %v", err)
+		}
+		t.Fatalf("protected transport uses proxy %v, want direct dial", proxyURL)
+	}
+
+	if _, err := ProtectedDialContext(nil)(context.Background(), "tcp", net.JoinHostPort("127.0.0.1", "80")); !errors.Is(err, ErrUnsafeTarget) {
+		t.Fatalf("protected dial err = %v, want ErrUnsafeTarget", err)
 	}
 }

--- a/internal/netguard/netguard.go
+++ b/internal/netguard/netguard.go
@@ -1,0 +1,170 @@
+// Package netguard contains small SSRF guard helpers for outbound probes.
+package netguard
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+var unsafeCIDRs = mustParseCIDRs([]string{
+	"100.64.0.0/10",   // carrier-grade NAT
+	"192.0.0.0/24",    // IETF protocol assignments
+	"192.0.2.0/24",    // TEST-NET-1 documentation network
+	"198.51.100.0/24", // TEST-NET-2 documentation network
+	"198.18.0.0/15",   // benchmarking networks
+	"203.0.113.0/24",  // TEST-NET-3 documentation network
+	"240.0.0.0/4",     // reserved IPv4
+	"2001:db8::/32",   // documentation IPv6
+	"2001:2::/48",     // benchmarking IPv6
+	"2001:10::/28",    // deprecated ORCHID
+	"2002::/16",       // 6to4
+	"3fff::/20",       // documentation IPv6
+})
+
+const MaxPublicHTTPURLBytes = 2083
+
+var unsafeHostSuffixes = []string{
+	".localhost",
+	".local",
+	".lan",
+	".internal",
+	".intranet",
+	".home",
+	".corp",
+}
+
+func mustParseCIDRs(rawCIDRs []string) []*net.IPNet {
+	out := make([]*net.IPNet, 0, len(rawCIDRs))
+	for _, raw := range rawCIDRs {
+		_, network, err := net.ParseCIDR(raw)
+		if err != nil {
+			panic(err)
+		}
+		out = append(out, network)
+	}
+	return out
+}
+
+// UnsafeHost reports whether host is an obvious non-public probe target.
+//
+// Hostnames are treated as safe unless they are localhost aliases. Callers
+// that resolve arbitrary hostnames should also apply UnsafeIP to every
+// resolved address before connecting.
+func UnsafeHost(host string) bool {
+	host = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+	if host == "" || host == "localhost" || host == "local" {
+		return true
+	}
+	for _, suffix := range unsafeHostSuffixes {
+		if strings.HasSuffix(host, suffix) {
+			return true
+		}
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return UnsafeIP(ip)
+	}
+	if looksLikeNonCanonicalIPv4(host) {
+		return true
+	}
+	return false
+}
+
+func looksLikeNonCanonicalIPv4(host string) bool {
+	if host == "" || strings.Contains(host, ":") {
+		return false
+	}
+	for _, label := range strings.Split(host, ".") {
+		if label == "" {
+			return false
+		}
+		if allDigits(label) {
+			continue
+		}
+		if len(label) > 2 && label[0] == '0' && (label[1] == 'x' || label[1] == 'X') && allHexDigits(label[2:]) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func allDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func allHexDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F') {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// ParsePublicHTTPURL parses rawURL and rejects obvious unsafe untrusted probe
+// targets. It intentionally does not resolve DNS; callers that will connect to
+// the URL should also validate resolved addresses with UnsafeIP.
+func ParsePublicHTTPURL(rawURL, field string) (*url.URL, error) {
+	if field == "" {
+		field = "url"
+	}
+	if rawURL == "" {
+		return nil, fmt.Errorf("%s is required", field)
+	}
+	if len([]byte(rawURL)) > MaxPublicHTTPURLBytes {
+		return nil, fmt.Errorf("%s must be %d bytes or fewer", field, MaxPublicHTTPURLBytes)
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("%s is not a valid URL: %v", field, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("%s must use http or https", field)
+	}
+	if u.Host == "" || u.Hostname() == "" {
+		return nil, fmt.Errorf("%s must include a host", field)
+	}
+	if u.User != nil {
+		return nil, fmt.Errorf("%s must not include userinfo", field)
+	}
+	host := strings.TrimSuffix(strings.ToLower(u.Hostname()), ".")
+	if UnsafeHost(host) {
+		return nil, fmt.Errorf("%s host %q is not a public target", field, host)
+	}
+	return u, nil
+}
+
+// UnsafeIP reports whether ip is unsuitable for an untrusted outbound probe.
+func UnsafeIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	if ip4 := ip.To4(); ip4 != nil {
+		ip = ip4
+	}
+	if ip.IsUnspecified() || ip.IsLoopback() || ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsMulticast() {
+		return true
+	}
+	for _, network := range unsafeCIDRs {
+		if network.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/netguard/netguard.go
+++ b/internal/netguard/netguard.go
@@ -53,7 +53,7 @@ func mustParseCIDRs(rawCIDRs []string) []*net.IPNet {
 // that resolve arbitrary hostnames should also apply UnsafeIP to every
 // resolved address before connecting.
 func UnsafeHost(host string) bool {
-	host = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+	host = NormalizeHost(host)
 	if host == "" || host == "localhost" || host == "local" {
 		return true
 	}
@@ -71,23 +71,37 @@ func UnsafeHost(host string) bool {
 	return false
 }
 
+func NormalizeHost(host string) string {
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+}
+
 func looksLikeNonCanonicalIPv4(host string) bool {
 	if host == "" || strings.Contains(host, ":") {
 		return false
 	}
-	for _, label := range strings.Split(host, ".") {
-		if label == "" {
+	labelStart := 0
+	for i := 0; i <= len(host); i++ {
+		if i < len(host) && host[i] != '.' {
+			continue
+		}
+		if !looksLikeNumericIPv4Label(host[labelStart:i]) {
 			return false
 		}
-		if allDigits(label) {
-			continue
-		}
-		if len(label) > 2 && label[0] == '0' && (label[1] == 'x' || label[1] == 'X') && allHexDigits(label[2:]) {
-			continue
-		}
-		return false
+		labelStart = i + 1
 	}
 	return true
+}
+
+func looksLikeNumericIPv4Label(label string) bool {
+	if label == "" {
+		return false
+	}
+	if allDigits(label) {
+		return true
+	}
+	return len(label) > 2 && label[0] == '0' &&
+		(label[1] == 'x' || label[1] == 'X') &&
+		allHexDigits(label[2:])
 }
 
 func allDigits(s string) bool {
@@ -96,6 +110,62 @@ func allDigits(s string) bool {
 	}
 	for i := 0; i < len(s); i++ {
 		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func ValidOutboundHeader(name, value string) bool {
+	return ValidHTTPHeaderName(name) && !ForbiddenOutboundHeaderName(name) && ValidHTTPHeaderValue(value)
+}
+
+func ValidHTTPHeaderName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		if !isHTTPTokenChar(name[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func isHTTPTokenChar(c byte) bool {
+	switch {
+	case c >= 'a' && c <= 'z':
+		return true
+	case c >= 'A' && c <= 'Z':
+		return true
+	case c >= '0' && c <= '9':
+		return true
+	}
+	switch c {
+	case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~':
+		return true
+	default:
+		return false
+	}
+}
+
+func ForbiddenOutboundHeaderName(name string) bool {
+	switch strings.ToLower(name) {
+	case "connection", "content-length", "host", "keep-alive", "proxy-authenticate",
+		"proxy-authorization", "te", "trailer", "transfer-encoding", "upgrade":
+		return true
+	default:
+		return false
+	}
+}
+
+func ValidHTTPHeaderValue(value string) bool {
+	for i := 0; i < len(value); i++ {
+		c := value[i]
+		if c == '\t' {
+			continue
+		}
+		if c < 0x20 || c == 0x7f {
 			return false
 		}
 	}
@@ -126,7 +196,7 @@ func ParsePublicHTTPURL(rawURL, field string) (*url.URL, error) {
 	if rawURL == "" {
 		return nil, fmt.Errorf("%s is required", field)
 	}
-	if len([]byte(rawURL)) > MaxPublicHTTPURLBytes {
+	if len(rawURL) > MaxPublicHTTPURLBytes {
 		return nil, fmt.Errorf("%s must be %d bytes or fewer", field, MaxPublicHTTPURLBytes)
 	}
 	u, err := url.Parse(rawURL)
@@ -142,7 +212,7 @@ func ParsePublicHTTPURL(rawURL, field string) (*url.URL, error) {
 	if u.User != nil {
 		return nil, fmt.Errorf("%s must not include userinfo", field)
 	}
-	host := strings.TrimSuffix(strings.ToLower(u.Hostname()), ".")
+	host := NormalizeHost(u.Hostname())
 	if UnsafeHost(host) {
 		return nil, fmt.Errorf("%s host %q is not a public target", field, host)
 	}

--- a/internal/netguard/netguard_test.go
+++ b/internal/netguard/netguard_test.go
@@ -72,6 +72,28 @@ func TestParsePublicHTTPURL(t *testing.T) {
 	}
 }
 
+func TestOutboundHeaderValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		headerName  string
+		headerValue string
+		want        bool
+	}{
+		{"valid", "X-Test", "ok\tvalue", true},
+		{"empty name", "", "ok", false},
+		{"bad name", "Bad\r\nName", "ok", false},
+		{"forbidden name", "Connection", "close", false},
+		{"bad value", "X-Bad", "ok\r\nInjected: yes", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ValidOutboundHeader(tt.headerName, tt.headerValue); got != tt.want {
+				t.Fatalf("ValidOutboundHeader(%q, %q) = %v, want %v", tt.headerName, tt.headerValue, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestUnsafeIP(t *testing.T) {
 	if !UnsafeIP(net.ParseIP("0.0.0.0")) {
 		t.Fatal("UnsafeIP(0.0.0.0) = false, want true")

--- a/internal/netguard/netguard_test.go
+++ b/internal/netguard/netguard_test.go
@@ -1,0 +1,82 @@
+package netguard
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestUnsafeHost(t *testing.T) {
+	tests := []struct {
+		host string
+		want bool
+	}{
+		{"localhost", true},
+		{"app.localhost", true},
+		{"example.local", true},
+		{"host.docker.internal", true},
+		{"metadata.google.internal", true},
+		{"router.lan", true},
+		{"127.0.0.1", true},
+		{"::1", true},
+		{"10.0.0.1", true},
+		{"0177.0.0.1", true},
+		{"0x7f.0.0.1", true},
+		{"2130706433", true},
+		{"127.1", true},
+		{"169.254.169.254", true},
+		{"100.64.0.1", true},
+		{"192.0.2.1", true},
+		{"198.18.0.1", true},
+		{"198.51.100.1", true},
+		{"203.0.113.1", true},
+		{"example.com", false},
+		{"02.example.com", false},
+		{"0x0fff.com", false},
+		{"03062013.jackchan.hk", false},
+		{"93.184.216.34", false},
+		{"2606:2800:220:1:248:1893:25c8:1946", false},
+	}
+	for _, tt := range tests {
+		if got := UnsafeHost(tt.host); got != tt.want {
+			t.Fatalf("UnsafeHost(%q) = %v, want %v", tt.host, got, tt.want)
+		}
+	}
+}
+
+func TestParsePublicHTTPURL(t *testing.T) {
+	valid, err := ParsePublicHTTPURL("https://example.com/path", "monitor_url")
+	if err != nil {
+		t.Fatalf("ParsePublicHTTPURL(valid) err = %v", err)
+	}
+	if valid.Hostname() != "example.com" {
+		t.Fatalf("hostname = %q, want example.com", valid.Hostname())
+	}
+
+	for _, raw := range []string{
+		"",
+		"example.com",
+		"file:///etc/passwd",
+		"http://localhost",
+		"http://127.0.0.1",
+		"http://0177.0.0.1",
+		"http://2130706433",
+		"http://metadata.google.internal/computeMetadata/v1/",
+		"http://host.docker.internal:99",
+		"http://user@example.com",
+		"https://example.com/" + strings.Repeat("a", MaxPublicHTTPURLBytes),
+	} {
+		if _, err := ParsePublicHTTPURL(raw, "monitor_url"); err == nil {
+			t.Fatalf("ParsePublicHTTPURL(%q) err = nil, want rejection", raw)
+		}
+	}
+}
+
+func TestUnsafeIP(t *testing.T) {
+	if !UnsafeIP(net.ParseIP("0.0.0.0")) {
+		t.Fatal("UnsafeIP(0.0.0.0) = false, want true")
+	}
+	if UnsafeIP(net.ParseIP("8.8.8.8")) {
+		t.Fatal("UnsafeIP(8.8.8.8) = true, want false")
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -748,6 +748,7 @@ func checkRequestForSite(cfg *config.Config, site db.Site) checker.Request {
 		KeywordReadMaxMS:    cfg.KeywordReadMaxMS,
 		CustomHeaders:       checker.ParseCustomHeaders(site.CustomHeaders),
 		RedirectPolicy:      checker.RedirectFollow,
+		EnforceTargetSafety: true,
 	}
 	if profile == checkmode.ProfileFull {
 		req.Keyword = site.CheckKeyword
@@ -1031,7 +1032,9 @@ func (o *Orchestrator) processResults(results map[int64]checker.Result, sites ma
 	for _, record := range records {
 		// Per-check data is recorded in jetmon_check_history (above); duplicating
 		// it in jetmon_audit_log was retired with the operational/site-state split.
-		if !record.res.IsFailure() {
+		if record.res.IsProbeSafetyBlock() {
+			o.handleProbeSafetyBlock(record.site, record.res)
+		} else if !record.res.IsFailure() {
 			o.handleRecovery(record.site, record.res)
 		} else {
 			o.handleFailure(record.site, record.res)
@@ -1448,6 +1451,8 @@ func detectorClass(res checker.Result) string {
 		return "timeout"
 	case res.ErrorCode == checker.ErrorRedirect:
 		return "redirect"
+	case res.ErrorCode == checker.ErrorProbeSafety:
+		return "probe_safety"
 	case res.ErrorCode == checker.ErrorSSL || res.ErrorCode == checker.ErrorTLSExpired:
 		return "tls_failure"
 	case res.ErrorCode == checker.ErrorTLSDeprecated:
@@ -1632,6 +1637,20 @@ func (o *Orchestrator) handleFailure(site db.Site, res checker.Result) bool {
 		return entry.eventID > 0
 	}
 	return true
+}
+
+func (o *Orchestrator) handleProbeSafetyBlock(site db.Site, res checker.Result) {
+	emitCounter("detection.probe_safety_blocked.count", 1)
+	metaMap := checkResultMetadata(site, res, resultCheckedAt(res))
+	metaMap["probe_safety_blocked"] = true
+	meta, _ := json.Marshal(metaMap)
+	o.auditLog(audit.Entry{
+		BlogID:    site.BlogID,
+		EventType: audit.EventProbeSafetyBlock,
+		Source:    o.hostname,
+		Detail:    "probe safety blocked outbound check",
+		Metadata:  meta,
+	})
 }
 
 func (o *Orchestrator) shouldSuppressPostRecoveryTransientFailure(site db.Site, res checker.Result) bool {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -101,6 +101,7 @@ var (
 	dbCountProjectionDrift  = db.CountLegacyProjectionDrift
 	dbListVeriflierVantages = db.ListEnabledVeriflierVantages
 	dbUpsertVeriflierAgent  = db.UpsertVeriflierAgent
+	dbUpsertSiteSafetyFlag  = db.UpsertSiteSafetyFlag
 	dbGetActiveRolloutRange = db.GetActiveRolloutRange
 	veriflierStatusFunc     = func(c *veriflier.VeriflierClient, ctx stdctx.Context) (*veriflier.StatusV2Response, error) {
 		return c.Status(ctx)
@@ -1641,6 +1642,22 @@ func (o *Orchestrator) handleFailure(site db.Site, res checker.Result) bool {
 
 func (o *Orchestrator) handleProbeSafetyBlock(site db.Site, res checker.Result) {
 	emitCounter("detection.probe_safety_blocked.count", 1)
+	if site.ID > 0 {
+		ctx := o.ctx
+		if ctx == nil {
+			ctx = stdctx.Background()
+		}
+		if err := dbUpsertSiteSafetyFlag(ctx, db.DB(), db.SiteSafetyFlag{
+			BlogID:        site.BlogID,
+			MonitorSiteID: site.ID,
+			FlagType:      db.SiteSafetyFlagProbeSafetyBlock,
+			Reason:        res.ErrorDetail,
+			MonitorURL:    site.MonitorURL,
+			Status:        db.SiteSafetyStatusOpen,
+		}); err != nil {
+			log.Printf("orchestrator: record probe safety flag blog_id=%d site_id=%d: %v", site.BlogID, site.ID, err)
+		}
+	}
 	metaMap := checkResultMetadata(site, res, resultCheckedAt(res))
 	metaMap["probe_safety_blocked"] = true
 	meta, _ := json.Marshal(metaMap)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1348,6 +1348,7 @@ func stubOrchestratorDeps() func() {
 	origDBCountProjectionDrift := dbCountProjectionDrift
 	origDBListVeriflierVantages := dbListVeriflierVantages
 	origDBUpsertVeriflierAgent := dbUpsertVeriflierAgent
+	origDBUpsertSiteSafetyFlag := dbUpsertSiteSafetyFlag
 	origNotify := wpcomNotifyFunc
 	origVeriflierStatus := veriflierStatusFunc
 	origVeriflierCheck := veriflierCheckFunc
@@ -1373,6 +1374,9 @@ func stubOrchestratorDeps() func() {
 	dbCountProjectionDrift = func(context.Context, int, int) (int, error) { return 0, nil }
 	dbListVeriflierVantages = func(context.Context, time.Duration) ([]db.VeriflierVantage, error) { return nil, nil }
 	dbUpsertVeriflierAgent = func(context.Context, db.VeriflierAgentHeartbeat) error { return nil }
+	dbUpsertSiteSafetyFlag = func(context.Context, db.SiteSafetyFlagExecer, db.SiteSafetyFlag) error {
+		return nil
+	}
 	wpcomNotifyFunc = func(_ *wpcom.Client, _ wpcom.Notification) error { return nil }
 	veriflierStatusFunc = func(c *veriflier.VeriflierClient, ctx context.Context) (*veriflier.StatusV2Response, error) {
 		return c.Status(ctx)
@@ -1402,6 +1406,7 @@ func stubOrchestratorDeps() func() {
 		dbCountProjectionDrift = origDBCountProjectionDrift
 		dbListVeriflierVantages = origDBListVeriflierVantages
 		dbUpsertVeriflierAgent = origDBUpsertVeriflierAgent
+		dbUpsertSiteSafetyFlag = origDBUpsertSiteSafetyFlag
 		wpcomNotifyFunc = origNotify
 		veriflierStatusFunc = origVeriflierStatus
 		veriflierCheckFunc = origVeriflierCheck
@@ -2089,6 +2094,11 @@ func TestProcessResultsProbeSafetyBlockAuditsWithoutStateChange(t *testing.T) {
 		t.Fatal("probe safety block must not send notifications")
 		return nil
 	}
+	var safetyFlag db.SiteSafetyFlag
+	dbUpsertSiteSafetyFlag = func(_ context.Context, _ db.SiteSafetyFlagExecer, flag db.SiteSafetyFlag) error {
+		safetyFlag = flag
+		return nil
+	}
 
 	mock.ExpectExec(`INSERT INTO jetmon_audit_log`).
 		WithArgs(int64(42), nil, audit.EventProbeSafetyBlock, "local", "probe safety blocked outbound check", sqlmock.AnyArg()).
@@ -2109,11 +2119,14 @@ func TestProcessResultsProbeSafetyBlockAuditsWithoutStateChange(t *testing.T) {
 		ErrorDetail: "probe safety check: target host \"127.0.0.1\" is not public",
 		Timestamp:   time.Now().UTC(),
 	}
-	sites := map[int64]db.Site{42: {BlogID: 42, MonitorURL: "http://127.0.0.1", SiteStatus: statusRunning, CheckInterval: 5}}
+	sites := map[int64]db.Site{42: {ID: 123, BlogID: 42, MonitorURL: "http://127.0.0.1", SiteStatus: statusRunning, CheckInterval: 5}}
 	o.processResults(map[int64]checker.Result{42: res}, sites)
 
 	if retry := o.retries.get(42); retry != nil {
 		t.Fatalf("retry entry = %+v, want nil for probe safety block", retry)
+	}
+	if safetyFlag.BlogID != 42 || safetyFlag.MonitorSiteID != 123 || safetyFlag.FlagType != db.SiteSafetyFlagProbeSafetyBlock || safetyFlag.Status != db.SiteSafetyStatusOpen {
+		t.Fatalf("safety flag = %+v", safetyFlag)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("audit expectations: %v", err)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2068,6 +2068,58 @@ func TestProcessResultsMarksChecked(t *testing.T) {
 	}
 }
 
+func TestProcessResultsProbeSafetyBlockAuditsWithoutStateChange(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	setTestConfig(t)
+
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqlDB.Close()
+	audit.Init(sqlDB)
+	t.Cleanup(func() { audit.Init(nil) })
+
+	dbUpdateSiteStatus = func(context.Context, int64, int, time.Time) error {
+		t.Fatal("probe safety block must not update site status")
+		return nil
+	}
+	wpcomNotifyFunc = func(_ *wpcom.Client, _ wpcom.Notification) error {
+		t.Fatal("probe safety block must not send notifications")
+		return nil
+	}
+
+	mock.ExpectExec(`INSERT INTO jetmon_audit_log`).
+		WithArgs(int64(42), nil, audit.EventProbeSafetyBlock, "local", "probe safety blocked outbound check", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		hostname: "local",
+		ctx:      context.Background(),
+	}
+
+	res := checker.Result{
+		BlogID:      42,
+		URL:         "http://127.0.0.1",
+		Success:     false,
+		ErrorCode:   checker.ErrorProbeSafety,
+		ErrorDetail: "probe safety check: target host \"127.0.0.1\" is not public",
+		Timestamp:   time.Now().UTC(),
+	}
+	sites := map[int64]db.Site{42: {BlogID: 42, MonitorURL: "http://127.0.0.1", SiteStatus: statusRunning, CheckInterval: 5}}
+	o.processResults(map[int64]checker.Result{42: res}, sites)
+
+	if retry := o.retries.get(42); retry != nil {
+		t.Fatalf("retry entry = %+v, want nil for probe safety block", retry)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("audit expectations: %v", err)
+	}
+}
+
 func TestProcessResultsSchedulesFailedChecksSoonerThanNormalInterval(t *testing.T) {
 	restore := stubOrchestratorDeps()
 	defer restore()

--- a/internal/orchestrator/streaming.go
+++ b/internal/orchestrator/streaming.go
@@ -1160,7 +1160,9 @@ func (o *Orchestrator) processStreamingSideEffects(site db.Site, res checker.Res
 	summary.sslDuration += time.Since(sslStart)
 
 	eventStart := time.Now()
-	if !res.IsFailure() {
+	if res.IsProbeSafetyBlock() {
+		o.handleProbeSafetyBlock(site, res)
+	} else if !res.IsFailure() {
 		o.handleRecovery(site, res)
 		site.SiteStatus = statusRunning
 	} else {

--- a/internal/veriflier/executor.go
+++ b/internal/veriflier/executor.go
@@ -20,7 +20,10 @@ const (
 	defaultCheckEstimate     = 50 * time.Millisecond
 	deadlineAdmissionReserve = 250 * time.Millisecond
 	deadlineResultDrainGrace = 25 * time.Millisecond
-	checkerErrorProbeSafety  = 9
+	// Wire-compatible checker error code for probe safety blocks. Keep this
+	// private to avoid a production dependency from veriflier back to checker;
+	// executor tests assert it stays in sync with checker.ErrorProbeSafety.
+	checkerErrorProbeSafety = 9
 )
 
 type CheckFunc func(context.Context, CheckRequest) ProbeResult

--- a/internal/veriflier/executor.go
+++ b/internal/veriflier/executor.go
@@ -20,6 +20,7 @@ const (
 	defaultCheckEstimate     = 50 * time.Millisecond
 	deadlineAdmissionReserve = 250 * time.Millisecond
 	deadlineResultDrainGrace = 25 * time.Millisecond
+	checkerErrorProbeSafety  = 9
 )
 
 type CheckFunc func(context.Context, CheckRequest) ProbeResult
@@ -408,6 +409,9 @@ func fdConcurrencyCap() int {
 func outcomeFromResult(res CheckResult) string {
 	if res.Success {
 		return OutcomeUp
+	}
+	if res.ErrorCode == checkerErrorProbeSafety {
+		return OutcomeUnknown
 	}
 	if res.ErrorCode == 1 {
 		return OutcomeTimeout

--- a/internal/veriflier/executor_test.go
+++ b/internal/veriflier/executor_test.go
@@ -6,7 +6,19 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/Automattic/jetmon/internal/checker"
 )
+
+func TestCheckerProbeSafetyErrorCodeContract(t *testing.T) {
+	if checkerErrorProbeSafety != checker.ErrorProbeSafety {
+		t.Fatalf("checkerErrorProbeSafety = %d, want checker.ErrorProbeSafety %d", checkerErrorProbeSafety, checker.ErrorProbeSafety)
+	}
+	got := outcomeFromResult(CheckResult{Success: false, ErrorCode: int32(checkerErrorProbeSafety)})
+	if got != OutcomeUnknown {
+		t.Fatalf("outcomeFromResult(probe safety) = %q, want %q", got, OutcomeUnknown)
+	}
+}
 
 func TestExecutorPreservesInputOrder(t *testing.T) {
 	exec := NewExecutor(func(_ context.Context, req CheckRequest) ProbeResult {

--- a/internal/veriflier/server.go
+++ b/internal/veriflier/server.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Automattic/jetmon/internal/checkmode"
 	"github.com/Automattic/jetmon/internal/metrics"
+	"github.com/Automattic/jetmon/internal/netguard"
 )
 
 // Server listens for inbound connections from the Monitor and dispatches
@@ -201,6 +202,12 @@ func (s *Server) handleCheck(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("decode: %v", err), http.StatusBadRequest)
 		return
 	}
+	for i := range req.Sites {
+		if err := validateCheckURL(req.Sites[i].URL); err != nil {
+			http.Error(w, fmt.Sprintf("site %d: %v", i, err), http.StatusBadRequest)
+			return
+		}
+	}
 
 	for i := range req.Sites {
 		if req.Sites[i].RequestID == "" {
@@ -366,8 +373,8 @@ func (s *Server) v2Result(res ProbeResult) CheckV2Result {
 }
 
 func v2RequestToLegacy(req CheckV2Request) (CheckRequest, error) {
-	if req.URL == "" {
-		return CheckRequest{}, fmt.Errorf("url is required")
+	if err := validateCheckURL(req.URL); err != nil {
+		return CheckRequest{}, err
 	}
 	method, err := checkmode.NormalizeMethod(req.Method, checkmode.MethodGET)
 	if err != nil {
@@ -410,6 +417,11 @@ func v2RequestToLegacy(req CheckV2Request) (CheckRequest, error) {
 		legacyReq.ForbiddenKeywords = append([]string(nil), req.BodyRules.Forbidden...)
 	}
 	return legacyReq, nil
+}
+
+func validateCheckURL(rawURL string) error {
+	_, err := netguard.ParsePublicHTTPURL(rawURL, "url")
+	return err
 }
 
 func legacyRequestToV2(req CheckRequest) CheckV2Request {

--- a/internal/veriflier/server.go
+++ b/internal/veriflier/server.go
@@ -185,21 +185,8 @@ func (s *Server) handleCheck(w http.ResponseWriter, r *http.Request) {
 		Results []CheckResult `json:"results"`
 	}
 
-	// Cap the body before decoding. An overlong body produces a clear 413
-	// rather than streaming through the JSON decoder until something else
-	// times out.
-	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
-
 	var req batchReq
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		// MaxBytesReader's "http: request body too large" error is the
-		// signal we want to surface as 413; everything else is a malformed
-		// JSON payload (400).
-		if err.Error() == "http: request body too large" {
-			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
-			return
-		}
-		http.Error(w, fmt.Sprintf("decode: %v", err), http.StatusBadRequest)
+	if !decodeLimitedJSON(w, r, &req) {
 		return
 	}
 	for i := range req.Sites {
@@ -263,14 +250,8 @@ func (s *Server) handleV2Check(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	var req CheckV2BatchRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		if err.Error() == "http: request body too large" {
-			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
-			return
-		}
-		http.Error(w, fmt.Sprintf("decode: %v", err), http.StatusBadRequest)
+	if !decodeLimitedJSON(w, r, &req) {
 		return
 	}
 	if len(req.Requests) == 0 {
@@ -326,6 +307,20 @@ func (s *Server) handleV2Check(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleV2Status(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(s.Status())
+}
+
+func decodeLimitedJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return false
+		}
+		http.Error(w, fmt.Sprintf("decode: %v", err), http.StatusBadRequest)
+		return false
+	}
+	return true
 }
 
 func (s *Server) Status() StatusV2Response {

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -1054,18 +1054,10 @@ func TestServerRejectsOversizedBody(t *testing.T) {
 	})
 	defer ts.Close()
 
-	// Build a body just over the 10MB cap. Padding lives in a custom_headers
-	// value so the JSON shape is still valid (we want to confirm the cap
-	// fires, not that the JSON is malformed).
-	pad := make([]byte, 11*1024*1024)
-	for i := range pad {
-		pad[i] = 'x'
-	}
-	body := bytes.NewBuffer(nil)
-	body.WriteString(`{"sites":[{"BlogID":1,"URL":"https://example.com","CustomHeaders":{"X-Pad":"`)
-	body.Write(pad)
-	body.WriteString(`"}}]}`)
-
+	body := oversizedJSONBody(
+		`{"sites":[{"BlogID":1,"URL":"https://example.com","CustomHeaders":{"X-Pad":"`,
+		`"}}]}`,
+	)
 	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/check", body)
 	req.Header.Set("Authorization", "Bearer secret")
 	req.Header.Set("Content-Type", "application/json")
@@ -1079,6 +1071,44 @@ func TestServerRejectsOversizedBody(t *testing.T) {
 	if resp.StatusCode != http.StatusRequestEntityTooLarge {
 		t.Fatalf("status = %d, want 413", resp.StatusCode)
 	}
+}
+
+func TestServerHandleV2CheckRejectsOversizedBody(t *testing.T) {
+	var called atomic.Bool
+	_, ts := newV2TestServer(func(_ context.Context, req CheckRequest) ProbeResult {
+		called.Store(true)
+		return ProbeResult{CheckResult: CheckResult{BlogID: req.BlogID, URL: req.URL, Success: true}, Outcome: OutcomeUp}
+	})
+	defer ts.Close()
+
+	body := oversizedJSONBody(
+		`{"requests":[{"blog_id":1,"url":"https://example.com","headers":{"X-Pad":"`,
+		`"}}]}`,
+	)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v2/check", body)
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413", resp.StatusCode)
+	}
+	if called.Load() {
+		t.Fatal("checkFn should not be called for oversized v2 body")
+	}
+}
+
+func oversizedJSONBody(prefix, suffix string) *bytes.Buffer {
+	pad := bytes.Repeat([]byte("x"), maxRequestBodyBytes+1)
+	body := bytes.NewBuffer(nil)
+	body.WriteString(prefix)
+	body.Write(pad)
+	body.WriteString(suffix)
+	return body
 }
 
 func TestServerShutdownDrains(t *testing.T) {

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -152,6 +152,33 @@ func TestServerHandleCheckMethodNotAllowed(t *testing.T) {
 	}
 }
 
+func TestServerHandleCheckRejectsUnsafeURL(t *testing.T) {
+	var called atomic.Bool
+	_, ts := newTestServer(func(req CheckRequest) CheckResult {
+		called.Store(true)
+		return CheckResult{Success: true}
+	})
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/check", checkReqBody(t, []CheckRequest{
+		{BlogID: 1, URL: "http://127.0.0.1/admin"},
+	}))
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+	if called.Load() {
+		t.Fatal("check function was called for unsafe URL")
+	}
+}
+
 func TestServerHandleStatus(t *testing.T) {
 	_, ts := newTestServer(func(req CheckRequest) CheckResult { return CheckResult{} })
 	defer ts.Close()
@@ -970,7 +997,7 @@ func TestNewRequestID(t *testing.T) {
 }
 
 func BenchmarkNewRequestID(b *testing.B) {
-	for b.Loop() {
+	for i := 0; i < b.N; i++ {
 		_ = NewRequestID()
 	}
 }
@@ -1273,6 +1300,42 @@ func TestServerHandleV2Check(t *testing.T) {
 	}
 	if got.TimingsMS.DNS != 1 || got.TimingsMS.TTFB != 4 {
 		t.Fatalf("timings = %+v", got.TimingsMS)
+	}
+}
+
+func TestServerHandleV2CheckRejectsUnsafeURL(t *testing.T) {
+	var called atomic.Bool
+	srv, ts := newV2TestServer(func(_ context.Context, req CheckRequest) ProbeResult {
+		called.Store(true)
+		return ProbeResult{CheckResult: CheckResult{Success: true}, Outcome: OutcomeUp}
+	})
+	defer srv.executor.Shutdown()
+	defer ts.Close()
+
+	body := bytes.NewBuffer(nil)
+	if err := json.NewEncoder(body).Encode(CheckV2BatchRequest{
+		Requests: []CheckV2Request{{
+			RequestID: "req-unsafe",
+			BlogID:    42,
+			URL:       "http://169.254.169.254/latest/meta-data/",
+		}},
+	}); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v2/check", body)
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+	if called.Load() {
+		t.Fatal("check function was called for unsafe URL")
 	}
 }
 

--- a/internal/webhooks/repository_coverage_test.go
+++ b/internal/webhooks/repository_coverage_test.go
@@ -86,6 +86,9 @@ func TestCreateWebhookRejectsInvalidInputBeforeDB(t *testing.T) {
 	if _, _, err := Create(context.Background(), db, CreateInput{}); err == nil {
 		t.Fatal("Create accepted an empty URL")
 	}
+	if _, _, err := Create(context.Background(), db, CreateInput{URL: "http://127.0.0.1/hook"}); err == nil {
+		t.Fatal("Create accepted an unsafe URL")
+	}
 	if _, _, err := Create(context.Background(), db, CreateInput{
 		URL:    "https://consumer.example/hook",
 		Events: []string{"event.bogus"},
@@ -262,6 +265,22 @@ func TestUpdateWebhookAppliesPatchAndFetchesRecord(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestUpdateWebhookRejectsUnsafeURLBeforeDB(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	url := "http://127.0.0.1/hook"
+	if _, err := Update(context.Background(), db, 5, UpdateInput{URL: &url}); err == nil {
+		t.Fatal("Update accepted an unsafe URL")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unexpected sql calls: %v", err)
 	}
 }
 

--- a/internal/webhooks/webhooks.go
+++ b/internal/webhooks/webhooks.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"strconv"
 	"time"
+
+	"github.com/Automattic/jetmon/internal/netguard"
 )
 
 // Storage note: the raw secret is stored in plaintext in jetmon_webhooks.
@@ -155,6 +157,9 @@ type UpdateInput struct {
 func Create(ctx context.Context, db *sql.DB, in CreateInput) (rawSecret string, w *Webhook, err error) {
 	if in.URL == "" {
 		return "", nil, errors.New("webhooks: URL is required")
+	}
+	if _, err := netguard.ParsePublicHTTPURL(in.URL, "webhook url"); err != nil {
+		return "", nil, fmt.Errorf("webhooks: %w", err)
 	}
 	if err := validateEvents(in.Events); err != nil {
 		return "", nil, err
@@ -304,6 +309,11 @@ func UpdateForTenant(ctx context.Context, db *sql.DB, id int64, ownerTenantID st
 }
 
 func update(ctx context.Context, db *sql.DB, id int64, ownerTenantID string, in UpdateInput) (*Webhook, error) {
+	if in.URL != nil {
+		if _, err := netguard.ParsePublicHTTPURL(*in.URL, "webhook url"); err != nil {
+			return nil, fmt.Errorf("webhooks: %w", err)
+		}
+	}
 	if in.Events != nil {
 		if err := validateEvents(*in.Events); err != nil {
 			return nil, err

--- a/internal/webhooks/worker.go
+++ b/internal/webhooks/worker.go
@@ -9,11 +9,12 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net"
 	"net/http"
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/Automattic/jetmon/internal/netguard"
 )
 
 // retrySchedule maps the *next* attempt number to its delay from the
@@ -59,6 +60,7 @@ type WorkerConfig struct {
 	PerWebhookCap int           // per-webhook in-flight cap; default 3
 	HTTPTimeout   time.Duration // per-delivery HTTP timeout; default 30s
 	BatchSize     int           // dispatcher's transition fetch + deliverer's claim batch; default 200
+	HTTPClient    *http.Client  // optional test/client override; nil uses SSRF-guarded client
 }
 
 func (c *WorkerConfig) applyDefaults() {
@@ -108,26 +110,20 @@ type Worker struct {
 // NewWorker constructs a Worker. Call Start to launch the goroutines.
 func NewWorker(cfg WorkerConfig) *Worker {
 	cfg.applyDefaults()
-	transport := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   5 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
-		MaxIdleConns:          100,
-		MaxIdleConnsPerHost:   10,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   5 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-		ForceAttemptHTTP2:     true,
-	}
 	return &Worker{
 		cfg:        cfg,
-		httpClient: &http.Client{Transport: transport, Timeout: cfg.HTTPTimeout},
+		httpClient: httpClientOrProtected(cfg.HTTPClient, cfg.HTTPTimeout),
 		inFlight:   make(map[int64]int),
 		stop:       make(chan struct{}),
 		done:       make(chan struct{}),
 	}
+}
+
+func httpClientOrProtected(client *http.Client, timeout time.Duration) *http.Client {
+	if client != nil {
+		return client
+	}
+	return netguard.NewProtectedHTTPClient(timeout)
 }
 
 // Start launches the dispatcher and deliverer goroutines. Call Stop to
@@ -400,6 +396,10 @@ func (w *Worker) deliver(d Delivery) {
 		// Webhook was paused between dispatch and deliver. Abandon: the
 		// caller doesn't want this delivery anymore.
 		w.handleResult(ctx, d, 0, "webhook is inactive", true)
+		return
+	}
+	if _, err := netguard.ParsePublicHTTPURL(hook.URL, "webhook url"); err != nil {
+		w.handleResult(ctx, d, 0, fmt.Sprintf("webhook url rejected: %v", err), true)
 		return
 	}
 

--- a/migrations/001_jetmon2.sql
+++ b/migrations/001_jetmon2.sql
@@ -101,6 +101,28 @@ CREATE TABLE IF NOT EXISTS jetmon_site_runtime (
     INDEX idx_last_checked (last_checked_at, blog_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+-- Durable, non-downtime safety findings for unsafe legacy monitor URLs and
+-- runtime probe-safety blocks. These rows let operators remediate or ignore
+-- unsafe targets without representing them as customer-site downtime events.
+CREATE TABLE IF NOT EXISTS jetmon_site_safety_flags (
+    id              BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    blog_id         BIGINT UNSIGNED NOT NULL,
+    monitor_site_id BIGINT UNSIGNED NOT NULL,
+    flag_type       ENUM('unsafe_monitor_url','probe_safety_block') NOT NULL,
+    reason          VARCHAR(1024) NOT NULL,
+    monitor_url     VARCHAR(2083) NOT NULL,
+    status          ENUM('open','deactivated','ignored','resolved') NOT NULL DEFAULT 'open',
+    first_seen_at   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    last_seen_at    TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    deactivated_at  TIMESTAMP(3) NULL,
+    created_at      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    updated_at      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+    UNIQUE KEY uniq_site_flag (monitor_site_id, flag_type),
+    INDEX idx_blog_status (blog_id, status),
+    INDEX idx_status_seen (status, last_seen_at),
+    INDEX idx_type_status (flag_type, status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 -- Trusted Veriflier vantage registry for monitor-side discovery.
 CREATE TABLE IF NOT EXISTS jetmon_veriflier_vantages (
     vantage_id    VARCHAR(128) NOT NULL PRIMARY KEY,

--- a/veriflier2/cmd/main.go
+++ b/veriflier2/cmd/main.go
@@ -19,6 +19,7 @@ import (
 )
 
 var version = "dev"
+var enforceOutboundTargetSafety = true
 
 const shutdownGracePeriod = 30 * time.Second
 
@@ -158,6 +159,7 @@ func performCheckContext(ctx context.Context, req veriflier.CheckRequest) verifl
 		ForbiddenKeywords:   req.ForbiddenKeywords,
 		CustomHeaders:       req.CustomHeaders,
 		RedirectPolicy:      checker.RedirectPolicy(req.RedirectPolicy),
+		EnforceTargetSafety: enforceOutboundTargetSafety,
 	})
 
 	checkResult := veriflier.CheckResult{
@@ -216,6 +218,9 @@ func (c veriflierConfig) TransportPort() string {
 func outcomeFromCheckerResult(res checker.Result) string {
 	if res.Success {
 		return veriflier.OutcomeUp
+	}
+	if res.ErrorCode == checker.ErrorProbeSafety {
+		return veriflier.OutcomeUnknown
 	}
 	if res.ErrorCode == checker.ErrorTimeout {
 		return veriflier.OutcomeTimeout

--- a/veriflier2/cmd/main_test.go
+++ b/veriflier2/cmd/main_test.go
@@ -12,6 +12,13 @@ import (
 	"github.com/Automattic/jetmon/internal/veriflier"
 )
 
+func allowUnsafeOutboundTargetsForTest(t *testing.T) {
+	t.Helper()
+	old := enforceOutboundTargetSafety
+	enforceOutboundTargetSafety = false
+	t.Cleanup(func() { enforceOutboundTargetSafety = old })
+}
+
 func TestEnvOrDefault(t *testing.T) {
 	const key = "VERIFLIER_TEST_ENV_OR_DEFAULT"
 	t.Setenv(key, "")
@@ -136,6 +143,8 @@ func TestVeriflierAgentIDIncludesPort(t *testing.T) {
 }
 
 func TestPerformCheckSuccess(t *testing.T) {
+	allowUnsafeOutboundTargetsForTest(t)
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("X-Test"); got != "present" {
 			t.Fatalf("X-Test header = %q, want present", got)
@@ -161,6 +170,8 @@ func TestPerformCheckSuccess(t *testing.T) {
 }
 
 func TestPerformCheckContextOutcomeAndTimings(t *testing.T) {
+	allowUnsafeOutboundTargetsForTest(t)
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("ok"))
 	}))
@@ -184,6 +195,8 @@ func TestPerformCheckContextOutcomeAndTimings(t *testing.T) {
 }
 
 func TestPerformCheckKeywordFailure(t *testing.T) {
+	allowUnsafeOutboundTargetsForTest(t)
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("different"))
 	}))
@@ -205,6 +218,8 @@ func TestPerformCheckKeywordFailure(t *testing.T) {
 }
 
 func TestPerformCheckTruncatedBodyFailure(t *testing.T) {
+	allowUnsafeOutboundTargetsForTest(t)
+
 	srv := truncatedBodyServer(t, "needle but incomplete")
 	defer srv.Close()
 
@@ -223,6 +238,21 @@ func TestPerformCheckTruncatedBodyFailure(t *testing.T) {
 	}
 	if res.ErrorCode != int32(checker.ErrorBodyRead) {
 		t.Fatalf("error code = %d, want %d", res.ErrorCode, checker.ErrorBodyRead)
+	}
+}
+
+func TestPerformCheckProbeSafetyOutcomeUnknown(t *testing.T) {
+	res := performCheckContext(context.Background(), veriflier.CheckRequest{
+		BlogID:         46,
+		URL:            "http://127.0.0.1/admin",
+		TimeoutSeconds: 2,
+		RedirectPolicy: string(checker.RedirectFollow),
+	})
+	if res.Outcome != veriflier.OutcomeUnknown {
+		t.Fatalf("outcome = %q, want unknown; result=%+v", res.Outcome, res)
+	}
+	if res.ErrorCode != int32(checker.ErrorProbeSafety) {
+		t.Fatalf("error code = %d, want %d", res.ErrorCode, checker.ErrorProbeSafety)
 	}
 }
 


### PR DESCRIPTION
## Summary

- harden Monitor and Veriflier handling for hostile targets, redirects, response headers, body streaming, gzip expansion, DNS rebinding, and unsafe direct URLs
- add API, webhook, Slack, and Teams destination validation plus guarded delivery clients for public-target enforcement
- add legacy unsafe URL cleanup support and `jetmon_site_safety_flags` so cleanup and runtime probe-safety blocks have durable non-downtime remediation state
- keep probe-safety blocks out of customer downtime events, SLA downtime, WPCOM down/recovery notifications, webhooks, and alert-contact delivery
- raise the Go floor to 1.26.3, update go-sql-driver/mysql to v1.10.0, and default local Docker database images to MariaDB 11.4

## Validation

- make test
- make lint
- make all
- make test-race
- make test-veriflier-soak
- make rollout-docs-verify
- go run golang.org/x/vuln/cmd/govulncheck@latest ./...
- go mod verify
- Docker image builds for Jetmon, Veriflier, and API fixture using golang:1.26.3
- isolated MariaDB migration smoke on mariadb:11.4.8 and mariadb:11.4.10, including idempotent second migrate, migration count/max 49, and `jetmon_site_safety_flags` existence

## Notes

- Probe-safety blocks are intentionally audit, metrics, and site-safety flag signals in this branch, not customer downtime events.
- Before production rollout, still run an end-to-end MariaDB 11.4 exercise that covers runtime write paths such as bucket claiming, runtime freshness writes, SSL expiry batches, and delivery claims.
- Deferred follow-ups: scheduled safety-flag reporting, authoritative DNS rebinding tests, deeper TLS pathology tests, and optional streaming keyword short-circuiting.