### PR TITLE
Add rollout rehearsal Docker lab

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ BUILD_FLAGS := -ldflags "-X main.version=$(shell git describe --tags --always --
                          -X main.buildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ) \
                          -X main.goVersion=$(shell $(GO) version | awk '{print $$3}')"
 
-.PHONY: all build build-deliverer build-veriflier generate test test-race test-veriflier-soak lint vet migration-smoke delivery-claim-smoke rollout-docs-verify rollout-rehearsal-verify rollout-vm-lab-sync rollout-vm-lab-sync-artifacts rollout-vm-lab-stage-v2 rollout-vm-lab-doctor rollout-vm-lab-prepare rollout-vm-lab-smoke rollout-vm-lab-execute-smoke rollout-vm-lab-failure-smoke rollout-vm-lab-resume-smoke rollout-vm-lab-post-start-rollback-smoke rollout-vm-lab-bad-ssh-smoke rollout-vm-lab-v2-start-failure-smoke rollout-vm-lab-runtime-guard-smoke rollout-vm-lab-real-activity-smoke rollout-vm-lab-snapshot-execute-smoke rollout-vm-lab-snapshot-all-smoke api-cli-smoke api-cli-validate api-cli-token-create api-cli-token-list api-cli-token-revoke clean
+.PHONY: all build build-deliverer build-veriflier generate test test-race test-veriflier-soak lint vet migration-smoke delivery-claim-smoke rollout-docs-verify rollout-rehearsal-verify rollout-docker-lab rollout-docker-lab-clean rollout-vm-lab-sync rollout-vm-lab-sync-artifacts rollout-vm-lab-stage-v2 rollout-vm-lab-doctor rollout-vm-lab-prepare rollout-vm-lab-smoke rollout-vm-lab-execute-smoke rollout-vm-lab-failure-smoke rollout-vm-lab-resume-smoke rollout-vm-lab-post-start-rollback-smoke rollout-vm-lab-bad-ssh-smoke rollout-vm-lab-v2-start-failure-smoke rollout-vm-lab-runtime-guard-smoke rollout-vm-lab-real-activity-smoke rollout-vm-lab-snapshot-execute-smoke rollout-vm-lab-snapshot-all-smoke api-cli-smoke api-cli-validate api-cli-token-create api-cli-token-list api-cli-token-revoke clean
 
 all: build build-deliverer build-veriflier
 
@@ -74,6 +74,12 @@ rollout-docs-verify: all test lint
 
 rollout-rehearsal-verify: build
 	scripts/rollout-rehearsal-verify.sh
+
+rollout-docker-lab:
+	scripts/rollout-docker-lab.sh run
+
+rollout-docker-lab-clean:
+	scripts/rollout-docker-lab.sh cleanup
 
 rollout-vm-lab-sync:
 	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'mkdir -p ~/jetmon-rollout-tools/scripts ~/jetmon-rollout-tools/docs'

--- a/cmd/jetmon2/main.go
+++ b/cmd/jetmon2/main.go
@@ -801,7 +801,12 @@ func monitorProcessHealthSnapshot(hostname string, startedAt time.Time, state st
 	if st.UpdatedAt.IsZero() {
 		st.UpdatedAt = time.Now().UTC()
 	}
-	bucketMin, bucketMax := st.BucketMin, st.BucketMax
+	var bucketMinPtr, bucketMaxPtr *int
+	if st.BucketMin >= 0 && st.BucketMax >= st.BucketMin {
+		bucketMin, bucketMax := st.BucketMin, st.BucketMax
+		bucketMinPtr = &bucketMin
+		bucketMaxPtr = &bucketMax
+	}
 	apiPort, dashboardPort := cfg.APIPort, cfg.DashboardPort
 	healthStatus := dashboard.SummarizeHost(st, health).Status
 	if state == fleethealth.StateStopping || state == fleethealth.StateStopped {
@@ -818,8 +823,8 @@ func monitorProcessHealthSnapshot(hostname string, startedAt time.Time, state st
 		HealthStatus:              healthStatus,
 		StartedAt:                 startedAt,
 		UpdatedAt:                 time.Now().UTC(),
-		BucketMin:                 &bucketMin,
-		BucketMax:                 &bucketMax,
+		BucketMin:                 bucketMinPtr,
+		BucketMax:                 bucketMaxPtr,
 		BucketOwnership:           st.BucketOwnership,
 		APIPort:                   &apiPort,
 		DashboardPort:             &dashboardPort,

--- a/cmd/jetmon2/main_test.go
+++ b/cmd/jetmon2/main_test.go
@@ -690,6 +690,21 @@ func TestMonitorProcessHealthSnapshot(t *testing.T) {
 	}
 }
 
+func TestMonitorProcessHealthSnapshotOmitsInactiveBucketRange(t *testing.T) {
+	started := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	cfg := &config.Config{APIPort: 8090, DashboardPort: 8080}
+	st := dashboard.State{
+		BucketMin:       0,
+		BucketMax:       -1,
+		BucketOwnership: "rollout_mode=api-controlled standby",
+	}
+
+	snapshot := monitorProcessHealthSnapshot("host-a", started, fleethealth.StateRunning, cfg, st, nil)
+	if snapshot.BucketMin != nil || snapshot.BucketMax != nil {
+		t.Fatalf("bucket range = %v-%v, want nils for inactive range", snapshot.BucketMin, snapshot.BucketMax)
+	}
+}
+
 func TestDashboardListenAddrDefaultsLocalhost(t *testing.T) {
 	cfg := &config.Config{DashboardPort: 8080}
 	if got := dashboardListenAddr(cfg); got != "127.0.0.1:8080" {

--- a/docker/docker-compose.rollout-lab.yml
+++ b/docker/docker-compose.rollout-lab.yml
@@ -1,0 +1,21 @@
+services:
+  jetmon:
+    networks:
+      default:
+      rollout_public:
+
+  veriflier:
+    networks:
+      default:
+      rollout_public:
+
+  api-fixture:
+    networks:
+      default:
+      rollout_public:
+        ipv4_address: ${ROLLOUT_LAB_FIXTURE_IP:-93.184.216.20}
+
+networks:
+  rollout_public:
+    name: ${ROLLOUT_LAB_PUBLIC_NETWORK:-jetmon-rollout-lab-public}
+    external: true

--- a/docs/rollout-docker-lab.md
+++ b/docs/rollout-docker-lab.md
@@ -1,0 +1,66 @@
+# Rollout Docker Lab
+
+The Docker rollout lab rehearses the API-controlled v2 rollout flow on a single
+Docker host without touching production systems, WPCOM, or real customer sites.
+It complements the VM lab: the VM lab validates systemd and SSH host handoff,
+while this lab validates the container/API rollout sequence and staged check
+policy migration.
+
+Run it from a host that can spend local Docker resources:
+
+```bash
+make rollout-docker-lab
+```
+
+Clean up the isolated project and volumes:
+
+```bash
+make rollout-docker-lab-clean
+```
+
+## Safety Model
+
+- Uses Docker project `jetmon-rollout-lab` by default.
+- Writes an ignored local `config/config.json` with
+  `WPCOM_NOTIFY_ENABLE=false`, `EMAIL_TRANSPORT=stub`,
+  `ROLLOUT_MODE=api-controlled`, and `PEER_OFFLINE_LIMIT=1`.
+- Uses only local Docker containers for MySQL, Monitor, Veriflier, StatsD,
+  Mailpit, and the HTTP fixture.
+- Uses a dedicated Docker network with a public-looking fixture address
+  (`93.184.216.20` by default). This keeps Jetmon target-safety checks enabled
+  while fixture traffic stays inside the Docker host.
+- Does not create webhooks or alert contacts.
+- Does not force a Prometheus reload or change production state.
+
+## Flow
+
+The lab script:
+
+1. Starts the Docker environment with the rollout-lab override.
+2. Creates an admin API key inside the isolated database.
+3. Seeds fixture-backed sites in bucket `0` with HEAD/legacy policy.
+4. Runs rollout capabilities, preflight, and read-only HEAD/legacy smoke.
+5. Plans and executes seed, final reconcile, and bucket activation.
+6. Waits for the Monitor to check every seeded site.
+7. Verifies bucket coverage, activity, and projection drift gates.
+8. Compares HEAD/legacy to GET/simple_http.
+9. Stages all sites to GET/simple_http.
+10. Compares GET/simple_http to GET/full.
+11. Stages all sites to GET/full.
+12. Releases the bucket range back to standby.
+
+Outputs are written under `logs/rollout-docker-lab/`.
+
+## Environment Overrides
+
+| Variable | Default |
+| --- | --- |
+| `JETMON_ROLLOUT_DOCKER_PROJECT` | `jetmon-rollout-lab` |
+| `JETMON_ROLLOUT_DOCKER_NETWORK` | `jetmon-rollout-lab-public` |
+| `JETMON_ROLLOUT_DOCKER_SUBNET` | `93.184.216.0/24` |
+| `JETMON_ROLLOUT_DOCKER_FIXTURE_IP` | `93.184.216.20` |
+| `JETMON_ROLLOUT_DOCKER_SITE_COUNT` | `40` |
+| `JETMON_ROLLOUT_DOCKER_BUCKET_MIN` | `0` |
+| `JETMON_ROLLOUT_DOCKER_BUCKET_MAX` | `0` |
+| `JETMON_ROLLOUT_DOCKER_RUN_ID` | timestamped lab run id |
+| `JETMON_ROLLOUT_DOCKER_CHANGE_REF` | `overnight-rollout-docker-lab` |

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -437,7 +437,8 @@ func (o *Orchestrator) refreshAPIControlledRange() (bool, error) {
 
 func (o *Orchestrator) shutdown() {
 	log.Println("orchestrator: shutting down")
-	if !o.usesPinnedBuckets(config.Get()) {
+	cfg := config.Get()
+	if o.usesDynamicBuckets(cfg) {
 		if err := dbMarkHostDraining(stdctx.Background(), o.hostname); err != nil {
 			log.Printf("orchestrator: mark draining: %v", err)
 		}
@@ -445,8 +446,8 @@ func (o *Orchestrator) shutdown() {
 	if o.pool != nil {
 		o.pool.Drain()
 	}
-	if o.usesPinnedBuckets(config.Get()) {
-		log.Println("orchestrator: pinned bucket mode active; no jetmon_hosts row to release")
+	if !o.usesDynamicBuckets(cfg) {
+		log.Printf("orchestrator: rollout_mode=%s or pinned bucket mode active; no jetmon_hosts row to release", cfg.RolloutMode)
 	} else if err := dbReleaseHost(stdctx.Background(), o.hostname); err != nil {
 		log.Printf("orchestrator: release host: %v", err)
 	}
@@ -465,11 +466,18 @@ func (o *Orchestrator) runRound() roundSummary {
 		o.roundStart = time.Now()
 	}
 
-	if o.usesPinnedBuckets(cfg) {
+	switch {
+	case cfg.RolloutMode == config.RolloutModeAPIControlled:
+		if o.bucketMax < o.bucketMin {
+			log.Println("orchestrator: api-controlled rollout round skipped; no active bucket lock")
+			o.finishRound(cfg, summary)
+			return summary
+		}
+	case o.usesPinnedBuckets(cfg):
 		if err := o.ClaimBuckets(); err != nil {
 			log.Printf("orchestrator: pinned bucket claim failed: %v", err)
 		}
-	} else {
+	default:
 		// Update heartbeat.
 		if err := dbHeartbeat(o.ctx, o.hostname); err != nil {
 			log.Printf("orchestrator: heartbeat failed: %v", err)
@@ -2689,6 +2697,12 @@ func (o *Orchestrator) BucketRange() (int, int) {
 func (o *Orchestrator) usesPinnedBuckets(cfg *config.Config) bool {
 	_, _, ok := cfg.PinnedBucketRange()
 	return ok
+}
+
+func (o *Orchestrator) usesDynamicBuckets(cfg *config.Config) bool {
+	return cfg.RolloutMode != config.RolloutModeStandby &&
+		cfg.RolloutMode != config.RolloutModeAPIControlled &&
+		!o.usesPinnedBuckets(cfg)
 }
 
 // WorkerCount returns the live worker count.

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1349,6 +1349,7 @@ func stubOrchestratorDeps() func() {
 	origDBListVeriflierVantages := dbListVeriflierVantages
 	origDBUpsertVeriflierAgent := dbUpsertVeriflierAgent
 	origDBUpsertSiteSafetyFlag := dbUpsertSiteSafetyFlag
+	origDBGetActiveRolloutRange := dbGetActiveRolloutRange
 	origNotify := wpcomNotifyFunc
 	origVeriflierStatus := veriflierStatusFunc
 	origVeriflierCheck := veriflierCheckFunc
@@ -1376,6 +1377,9 @@ func stubOrchestratorDeps() func() {
 	dbUpsertVeriflierAgent = func(context.Context, db.VeriflierAgentHeartbeat) error { return nil }
 	dbUpsertSiteSafetyFlag = func(context.Context, db.SiteSafetyFlagExecer, db.SiteSafetyFlag) error {
 		return nil
+	}
+	dbGetActiveRolloutRange = func(context.Context, string) (db.RolloutActiveRange, bool, error) {
+		return db.RolloutActiveRange{}, false, nil
 	}
 	wpcomNotifyFunc = func(_ *wpcom.Client, _ wpcom.Notification) error { return nil }
 	veriflierStatusFunc = func(c *veriflier.VeriflierClient, ctx context.Context) (*veriflier.StatusV2Response, error) {
@@ -1407,6 +1411,7 @@ func stubOrchestratorDeps() func() {
 		dbListVeriflierVantages = origDBListVeriflierVantages
 		dbUpsertVeriflierAgent = origDBUpsertVeriflierAgent
 		dbUpsertSiteSafetyFlag = origDBUpsertSiteSafetyFlag
+		dbGetActiveRolloutRange = origDBGetActiveRolloutRange
 		wpcomNotifyFunc = origNotify
 		veriflierStatusFunc = origVeriflierStatus
 		veriflierCheckFunc = origVeriflierCheck
@@ -2750,6 +2755,43 @@ func TestRunRoundSkipsHeartbeatWhenPinned(t *testing.T) {
 
 	if heartbeatCalled {
 		t.Fatal("runRound updated jetmon_hosts heartbeat in pinned mode")
+	}
+}
+
+func TestRunRoundUsesAPIControlledRangeWithoutDynamicClaim(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	cfg := setTestConfig(t)
+	cfg.RolloutMode = config.RolloutModeAPIControlled
+
+	var heartbeatCalled bool
+	var dynamicClaimCalled bool
+	dbHeartbeat = func(context.Context, string) error {
+		heartbeatCalled = true
+		return nil
+	}
+	dbClaimBuckets = func(string, int, int, int) (int, int, error) {
+		dynamicClaimCalled = true
+		return 0, 0, nil
+	}
+	dbGetSitesForBucket = func(_ context.Context, gotMin, gotMax, _ int, _ bool) ([]db.Site, error) {
+		if gotMin != 7 || gotMax != 9 {
+			t.Fatalf("fetch buckets = %d-%d, want 7-9", gotMin, gotMax)
+		}
+		return nil, nil
+	}
+
+	o := &Orchestrator{ctx: context.Background(), hostname: "host-a", bucketMin: 7, bucketMax: 9}
+	o.runRound()
+
+	if heartbeatCalled {
+		t.Fatal("runRound updated jetmon_hosts heartbeat in api-controlled mode")
+	}
+	if dynamicClaimCalled {
+		t.Fatal("runRound called dynamic jetmon_hosts claim in api-controlled mode")
+	}
+	if o.bucketMin != 7 || o.bucketMax != 9 {
+		t.Fatalf("bucket range = %d-%d, want preserved 7-9", o.bucketMin, o.bucketMax)
 	}
 }
 

--- a/scripts/rollout-docker-lab.sh
+++ b/scripts/rollout-docker-lab.sh
@@ -1,0 +1,339 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
+PROJECT="${JETMON_ROLLOUT_DOCKER_PROJECT:-jetmon-rollout-lab}"
+PUBLIC_NETWORK="${JETMON_ROLLOUT_DOCKER_NETWORK:-jetmon-rollout-lab-public}"
+PUBLIC_SUBNET="${JETMON_ROLLOUT_DOCKER_SUBNET:-93.184.216.0/24}"
+FIXTURE_IP="${JETMON_ROLLOUT_DOCKER_FIXTURE_IP:-93.184.216.20}"
+SITE_COUNT="${JETMON_ROLLOUT_DOCKER_SITE_COUNT:-40}"
+BUCKET_MIN="${JETMON_ROLLOUT_DOCKER_BUCKET_MIN:-0}"
+BUCKET_MAX="${JETMON_ROLLOUT_DOCKER_BUCKET_MAX:-0}"
+RUN_ID="${JETMON_ROLLOUT_DOCKER_RUN_ID:-rollout-docker-lab-$(date -u +%Y%m%d%H%M%S)}"
+CHANGE_REF="${JETMON_ROLLOUT_DOCKER_CHANGE_REF:-overnight-rollout-docker-lab}"
+WORK_DIR="$REPO_ROOT/logs/rollout-docker-lab"
+CONFIG_FILE="$REPO_ROOT/config/config.json"
+COMPOSE=(docker compose -p "$PROJECT" -f "$REPO_ROOT/docker/docker-compose.yml" -f "$REPO_ROOT/docker/docker-compose.rollout-lab.yml")
+
+export BIND_ADDR="${BIND_ADDR:-127.0.0.1}"
+export API_BIND_ADDR="${API_BIND_ADDR:-127.0.0.1}"
+export MYSQL_HOST_PORT="${MYSQL_HOST_PORT:-16307}"
+export DASHBOARD_HOST_PORT="${DASHBOARD_HOST_PORT:-16080}"
+export API_HOST_PORT="${API_HOST_PORT:-16090}"
+export VERIFLIER_HOST_PORT="${VERIFLIER_HOST_PORT:-17803}"
+export API_FIXTURE_HTTP_HOST_PORT="${API_FIXTURE_HTTP_HOST_PORT:-18091}"
+export API_FIXTURE_HTTPS_HOST_PORT="${API_FIXTURE_HTTPS_HOST_PORT:-18443}"
+export MAILPIT_HOST_PORT="${MAILPIT_HOST_PORT:-18025}"
+export GRAPHITE_HOST_PORT="${GRAPHITE_HOST_PORT:-18088}"
+export STATSD_HOST_PORT="${STATSD_HOST_PORT:-18125}"
+export EMAIL_TRANSPORT=stub
+export ROLLOUT_LAB_PUBLIC_NETWORK="$PUBLIC_NETWORK"
+export ROLLOUT_LAB_FIXTURE_IP="$FIXTURE_IP"
+
+usage() {
+	cat <<'USAGE'
+usage: scripts/rollout-docker-lab.sh <run|cleanup>
+
+Runs a local-only Docker rollout rehearsal:
+  1. starts Jetmon in ROLLOUT_MODE=api-controlled with WPCOM disabled
+  2. seeds public-looking, Docker-internal fixture sites
+  3. activates the bucket range
+  4. verifies recent Monitor activity
+  5. stages HEAD/legacy -> GET/simple_http -> GET/full policy changes
+  6. releases the bucket range back to standby
+
+The fixture lives on a Docker network using a public-looking RFC-valid address
+so target-safety checks stay enabled while traffic never leaves the Docker host.
+USAGE
+}
+
+log() {
+	printf 'INFO %s\n' "$*"
+}
+
+pass() {
+	printf 'PASS %s\n' "$*"
+}
+
+fail() {
+	printf 'FAIL %s\n' "$*" >&2
+	exit 1
+}
+
+need_cmd() {
+	command -v "$1" >/dev/null 2>&1 || fail "missing command: $1"
+}
+
+compose() {
+	"${COMPOSE[@]}" "$@"
+}
+
+api() {
+	compose exec -T \
+		-e JETMON_API_URL=http://127.0.0.1:8090 \
+		-e JETMON_API_TOKEN="$API_TOKEN" \
+		jetmon ./jetmon2 api "$@"
+}
+
+sql() {
+	compose exec -T mysqldb mariadb \
+		-u"${MYSQL_USER:-jetmon}" "-p${MYSQL_PASSWORD:-jetmon_dev_password}" \
+		"${MYSQL_DATABASE:-jetmon_db}" "$@"
+}
+
+cleanup() {
+	cd "$REPO_ROOT"
+	compose down -v --remove-orphans >/dev/null 2>&1 || true
+	docker network rm "$PUBLIC_NETWORK" >/dev/null 2>&1 || true
+	pass "rollout_docker_lab_cleaned project=$PROJECT network=$PUBLIC_NETWORK"
+}
+
+prepare_config() {
+	mkdir -p "$WORK_DIR" "$REPO_ROOT/logs" "$REPO_ROOT/stats"
+	jq \
+		--arg auth "rollout-lab-wpcom-disabled" \
+		--arg fixture_host "veriflier" \
+		--arg verifier_token "${VERIFLIER_AUTH_TOKEN:-veriflier_1_auth_token}" \
+		'.AUTH_TOKEN = $auth
+		| .WPCOM_NOTIFY_ENABLE = false
+		| .EMAIL_TRANSPORT = "stub"
+		| .WPCOM_EMAIL_ENDPOINT = ""
+		| .WPCOM_EMAIL_AUTH_TOKEN = ""
+		| .API_PORT = 8090
+		| .DASHBOARD_PORT = 8080
+		| .DASHBOARD_BIND_ADDR = "127.0.0.1"
+		| .DEBUG_PORT = 0
+		| .ROLLOUT_MODE = "api-controlled"
+		| .DEFAULT_CHECK_METHOD = "HEAD"
+		| .DEFAULT_DETECTION_PROFILE = "legacy"
+		| .PEER_OFFLINE_LIMIT = 1
+		| .NUM_WORKERS = 12
+		| .DATASET_SIZE = 50
+		| .MIN_TIME_BETWEEN_ROUNDS_SEC = 5
+		| .NET_COMMS_TIMEOUT = 3
+		| .BODY_READ_MAX_MS = 250
+		| .USE_VARIABLE_CHECK_INTERVALS = true
+		| .BUCKET_TOTAL = 1000
+		| .BUCKET_TARGET = 1000
+		| .VERIFIERS = [{"name":"Docker Veriflier","host":$fixture_host,"port":"7803","auth_token":$verifier_token}]' \
+		"$REPO_ROOT/config/config-sample.json" >"$CONFIG_FILE"
+	pass "safe_config_written=$CONFIG_FILE wpcom_notify=false email_transport=stub rollout_mode=api-controlled"
+}
+
+prepare_fixture_sites() {
+	cat >"$WORK_DIR/sites.json" <<JSON
+[
+  {
+    "monitor_url": "http://$FIXTURE_IP:8091/health",
+    "check_keyword": "ok",
+    "redirect_policy": "follow",
+    "request_method": "HEAD",
+    "detection_profile": "legacy",
+    "timeout_seconds": 3,
+    "check_interval": 5,
+    "alert_cooldown_minutes": 0
+  },
+  {
+    "monitor_url": "http://$FIXTURE_IP:8091/ok",
+    "check_keyword": "jetmon fixture ok",
+    "redirect_policy": "follow",
+    "request_method": "HEAD",
+    "detection_profile": "legacy",
+    "timeout_seconds": 3,
+    "check_interval": 5,
+    "alert_cooldown_minutes": 0
+  },
+  {
+    "monitor_url": "http://$FIXTURE_IP:8091/keyword",
+    "check_keyword": "keyword present",
+    "redirect_policy": "follow",
+    "request_method": "HEAD",
+    "detection_profile": "legacy",
+    "timeout_seconds": 3,
+    "check_interval": 5,
+    "alert_cooldown_minutes": 0
+  },
+  {
+    "monitor_url": "http://$FIXTURE_IP:8091/redirect",
+    "redirect_policy": "follow",
+    "request_method": "HEAD",
+    "detection_profile": "legacy",
+    "timeout_seconds": 3,
+    "check_interval": 5,
+    "alert_cooldown_minutes": 0
+  }
+]
+JSON
+	pass "fixture_sites_written=$WORK_DIR/sites.json count=$SITE_COUNT fixture=$FIXTURE_IP"
+}
+
+ensure_public_network() {
+	if docker network inspect "$PUBLIC_NETWORK" >/dev/null 2>&1; then
+		pass "docker_network_exists=$PUBLIC_NETWORK"
+		return
+	fi
+	docker network create --subnet "$PUBLIC_SUBNET" "$PUBLIC_NETWORK" >/dev/null
+	pass "docker_network_created=$PUBLIC_NETWORK subnet=$PUBLIC_SUBNET"
+}
+
+wait_for_api() {
+	local deadline=$((SECONDS + 180))
+	until compose exec -T jetmon curl -fsS http://127.0.0.1:8090/api/v1/health >/dev/null 2>&1; do
+		(( SECONDS < deadline )) || fail "API did not become healthy"
+		sleep 2
+	done
+	pass "api_healthy"
+}
+
+create_api_token() {
+	local out
+	out="$(compose exec -T jetmon ./jetmon2 keys create --consumer rollout-docker-lab --scope admin --created-by rollout-docker-lab)"
+	API_TOKEN="$(printf '%s\n' "$out" | awk '/^jm_/ {print; exit}')"
+	[[ -n "$API_TOKEN" ]] || fail "could not parse API token"
+	pass "api_token_created"
+}
+
+seed_sites() {
+	api sites bulk-add \
+		--source file \
+		--file /jetmon/logs/rollout-docker-lab/sites.json \
+		--count "$SITE_COUNT" \
+		--batch rollout-docker-lab \
+		--idempotency-key-prefix rollout-docker-lab-site \
+		--output json >/dev/null
+	pass "sites_seeded count=$SITE_COUNT bucket=$BUCKET_MIN"
+}
+
+json_token() {
+	jq -r '.confirmation_token // empty'
+}
+
+require_ok_json() {
+	local name="$1"
+	local body="$2"
+	local status
+	status="$(printf '%s' "$body" | jq -r '.status // empty')"
+	[[ "$status" == "ok" ]] || {
+		printf '%s\n' "$body" | jq . >&2
+		fail "$name returned status=$status"
+	}
+}
+
+plan_execute() {
+	local name="$1"
+	shift
+	local plan token result
+	plan="$(api "$@" --dry-run --output json)"
+	require_ok_json "$name dry-run" "$plan"
+	token="$(printf '%s' "$plan" | json_token)"
+	[[ -n "$token" ]] || fail "$name dry-run did not return a confirmation token"
+	result="$(api "$@" --execute --confirm "$token" --output json)"
+	require_ok_json "$name execute" "$result"
+	printf '%s\n' "$result" >"$WORK_DIR/$name.json"
+	pass "$name executed"
+}
+
+wait_for_checked_sites() {
+	local deadline=$((SECONDS + 120))
+	local checked=0
+	while (( SECONDS < deadline )); do
+		checked="$(sql --batch --skip-column-names -e "
+			SELECT COUNT(*)
+			  FROM jetpack_monitor_sites s
+			  JOIN jetmon_site_runtime r ON r.blog_id = s.blog_id
+			 WHERE s.monitor_active = 1
+			   AND s.bucket_no BETWEEN $BUCKET_MIN AND $BUCKET_MAX
+			   AND r.last_checked_at >= UTC_TIMESTAMP() - INTERVAL 2 MINUTE")"
+		checked="${checked//[[:space:]]/}"
+		if [[ "$checked" == "$SITE_COUNT" ]]; then
+			pass "monitor_activity_checked_sites=$checked"
+			return
+		fi
+		sleep 3
+	done
+	fail "only $checked/$SITE_COUNT sites checked after activation"
+}
+
+policy_count() {
+	sql --batch --skip-column-names -e "
+		SELECT COUNT(*)
+		  FROM jetpack_monitor_sites s
+		  JOIN jetmon_site_check_config c ON c.blog_id = s.blog_id
+		 WHERE s.monitor_active = 1
+		   AND s.bucket_no BETWEEN $BUCKET_MIN AND $BUCKET_MAX
+		   AND c.request_method = '$1'
+		   AND c.detection_profile = '$2'" | tr -d '[:space:]'
+}
+
+run_policy_stage() {
+	local method="$1"
+	local profile="$2"
+	local label="$3"
+	plan_execute "$label" rollout stage-policy \
+		--bucket-min "$BUCKET_MIN" \
+		--bucket-max "$BUCKET_MAX" \
+		--run-id "$RUN_ID" \
+		--change-ref "$CHANGE_REF" \
+		--method "$method" \
+		--profile "$profile" \
+		--size 100%
+	local count
+	count="$(policy_count "$method" "$profile")"
+	[[ "$count" == "$SITE_COUNT" ]] || fail "$label changed $count/$SITE_COUNT sites"
+	pass "$label policy_count=$count"
+}
+
+run_lab() {
+	need_cmd docker
+	need_cmd jq
+	cd "$REPO_ROOT"
+	cleanup >/dev/null 2>&1 || true
+	prepare_config
+	prepare_fixture_sites
+	ensure_public_network
+
+	log "starting compose project=$PROJECT"
+	compose up -d --build
+	wait_for_api
+	create_api_token
+
+	compose exec -T jetmon curl -fsS "http://$FIXTURE_IP:8091/health" >/dev/null
+	pass "fixture_reachable_from_monitor=$FIXTURE_IP"
+
+	seed_sites
+	api rollout capabilities --output json | tee "$WORK_DIR/capabilities.json" >/dev/null
+	api rollout preflight --bucket-min "$BUCKET_MIN" --bucket-max "$BUCKET_MAX" --run-id "$RUN_ID" --change-ref "$CHANGE_REF" --output json | tee "$WORK_DIR/preflight.json" >/dev/null
+	api rollout smoke --bucket-min "$BUCKET_MIN" --bucket-max "$BUCKET_MAX" --run-id "$RUN_ID" --mode head-legacy --sample-size "$SITE_COUNT" --read-only --output json | tee "$WORK_DIR/smoke-head-legacy.json" >/dev/null
+	plan_execute seed rollout seed --bucket-min "$BUCKET_MIN" --bucket-max "$BUCKET_MAX" --run-id "$RUN_ID" --change-ref "$CHANGE_REF"
+	plan_execute final-reconcile rollout final-reconcile --bucket-min "$BUCKET_MIN" --bucket-max "$BUCKET_MAX" --run-id "$RUN_ID" --change-ref "$CHANGE_REF"
+	plan_execute activate-buckets rollout activate-buckets --bucket-min "$BUCKET_MIN" --bucket-max "$BUCKET_MAX" --run-id "$RUN_ID" --change-ref "$CHANGE_REF"
+	wait_for_checked_sites
+	api rollout bucket-coverage --bucket-min "$BUCKET_MIN" --bucket-max "$BUCKET_MAX" --output json | tee "$WORK_DIR/bucket-coverage.json" >/dev/null
+	api rollout activity-check --bucket-min "$BUCKET_MIN" --bucket-max "$BUCKET_MAX" --since 2m --output json | tee "$WORK_DIR/activity-check.json" >/dev/null
+	api rollout projection-drift --bucket-min "$BUCKET_MIN" --bucket-max "$BUCKET_MAX" --output json | tee "$WORK_DIR/projection-drift.json" >/dev/null
+	api rollout compare-methods --bucket-min "$BUCKET_MIN" --bucket-max "$BUCKET_MAX" --run-id "$RUN_ID" --from head-legacy --to get-simple --sample-size "$SITE_COUNT" --output json | tee "$WORK_DIR/compare-head-to-simple.json" >/dev/null
+	run_policy_stage GET simple_http stage-get-simple
+	api rollout compare-methods --bucket-min "$BUCKET_MIN" --bucket-max "$BUCKET_MAX" --run-id "$RUN_ID" --from get-simple --to get-full --sample-size "$SITE_COUNT" --output json | tee "$WORK_DIR/compare-simple-to-full.json" >/dev/null
+	run_policy_stage GET full stage-get-full
+	plan_execute release-buckets rollout release-buckets --bucket-min "$BUCKET_MIN" --bucket-max "$BUCKET_MAX" --run-id "$RUN_ID" --change-ref "$CHANGE_REF"
+	api rollout status --output json | tee "$WORK_DIR/status-after-release.json" >/dev/null
+	pass "rollout_docker_lab_complete project=$PROJECT run_id=$RUN_ID logs=$WORK_DIR"
+}
+
+case "${1:-run}" in
+	run)
+		run_lab
+		;;
+	cleanup)
+		cleanup
+		;;
+	-h | --help | help)
+		usage
+		;;
+	*)
+		usage >&2
+		exit 2
+		;;
+esac


### PR DESCRIPTION
## Summary
- Add an isolated Docker rollout lab for v1-to-v2 API-controlled rollout rehearsal.
- Exercise HEAD/legacy activation, GET/simple_http staging, GET/full staging, activity checks, and release cleanup without WPCOM or alert delivery.
- Preserve API-controlled rollout bucket ranges across Monitor rounds and avoid invalid inactive process-health bucket ranges.

## Validation
- go test ./internal/orchestrator
- go test ./cmd/jetmon2
- git diff --check
- host6: scripts/rollout-docker-lab.sh run passed with 40 fixture sites checked, GET/simple_http count 40, GET/full count 40, and release-buckets complete
- host6: docker run golang:1.26.3 go test ./...
- host6: scripts/rollout-docker-lab.sh cleanup

## Safety
- Lab config disables WPCOM notify and uses stub email.
- Fixture traffic stays inside a dedicated Docker network on the test host.
- No production systems are modified.