### PR TITLE
Tighten JSON and local status handling

### DIFF
--- a/cmd/jetmon2/main.go
+++ b/cmd/jetmon2/main.go
@@ -37,7 +37,11 @@ import (
 	"github.com/Automattic/jetmon/internal/wpcom"
 )
 
-const processHealthWriteTimeout = 2 * time.Second
+const (
+	processHealthWriteTimeout = 2 * time.Second
+	httpGetTimeout            = 10 * time.Second
+	httpGetMaxBodyBytes       = 1 << 20
+)
 
 // Injected at build time via -ldflags.
 var (
@@ -1420,14 +1424,18 @@ func envOrDefault(key, def string) string {
 }
 
 func httpGet(url string) (string, error) {
-	resp, err := http.Get(url)
+	client := &http.Client{Timeout: httpGetTimeout}
+	resp, err := client.Get(url)
 	if err != nil {
 		return "", err
 	}
 	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, httpGetMaxBodyBytes+1))
 	if err != nil {
 		return "", err
+	}
+	if len(body) > httpGetMaxBodyBytes {
+		return "", fmt.Errorf("response body exceeds %d bytes", httpGetMaxBodyBytes)
 	}
 	if resp.StatusCode >= 400 {
 		return "", fmt.Errorf("http %d: %s", resp.StatusCode, string(body))

--- a/cmd/jetmon2/main_test.go
+++ b/cmd/jetmon2/main_test.go
@@ -53,6 +53,21 @@ func TestHTTPGetErrorStatus(t *testing.T) {
 	}
 }
 
+func TestHTTPGetRejectsOversizedBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(strings.Repeat("a", httpGetMaxBodyBytes+1)))
+	}))
+	defer srv.Close()
+
+	_, err := httpGet(srv.URL)
+	if err == nil {
+		t.Fatalf("httpGet() expected oversized body error")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("httpGet() error = %v, want body cap", err)
+	}
+}
+
 func TestEnvOrDefault(t *testing.T) {
 	const key = "JETMON_TEST_ENV_OR_DEFAULT"
 	t.Setenv(key, "")

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -68,7 +68,7 @@ services:
       JETMON_PID_FILE: /jetmon/stats/jetmon2.pid
     ports:
       - "${BIND_ADDR:-127.0.0.1}:${DASHBOARD_HOST_PORT:-8080}:8080"
-      - "${API_BIND_ADDR:-0.0.0.0}:${API_HOST_PORT:-8090}:8090"
+      - "${API_BIND_ADDR:-127.0.0.1}:${API_HOST_PORT:-8090}:8090"
     depends_on:
       mysql-user:
         condition: service_completed_successfully

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,6 +38,10 @@ Mailpit captures local alert-contact email. Open it at
 `http://localhost:8025` by default, or at the `BIND_ADDR` /
 `MAILPIT_HOST_PORT` values from `docker/.env`.
 
+The local API port also binds to loopback by default. Set
+`API_BIND_ADDR=0.0.0.0` only when the Docker host is on a trusted network and
+remote API access is intentional.
+
 ## Build And Test
 
 From the repository root:

--- a/internal/api/json_body.go
+++ b/internal/api/json_body.go
@@ -8,7 +8,7 @@ import (
 )
 
 func decodeJSONBody(w http.ResponseWriter, r *http.Request, dst any) bool {
-	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+	if err := decodeSingleJSONValue(json.NewDecoder(r.Body), dst); err != nil {
 		writeJSONBodyDecodeError(w, r, err)
 		return false
 	}
@@ -16,7 +16,7 @@ func decodeJSONBody(w http.ResponseWriter, r *http.Request, dst any) bool {
 }
 
 func decodeOptionalJSONBody(w http.ResponseWriter, r *http.Request, dst any) bool {
-	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+	if err := decodeSingleJSONValue(json.NewDecoder(r.Body), dst); err != nil {
 		if errors.Is(err, io.EOF) {
 			return true
 		}
@@ -24,6 +24,20 @@ func decodeOptionalJSONBody(w http.ResponseWriter, r *http.Request, dst any) boo
 		return false
 	}
 	return true
+}
+
+func decodeSingleJSONValue(dec *json.Decoder, dst any) error {
+	if err := dec.Decode(dst); err != nil {
+		return err
+	}
+	var extra json.RawMessage
+	if err := dec.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return errors.New("request body must contain a single JSON value")
+		}
+		return err
+	}
+	return nil
 }
 
 func writeJSONBodyDecodeError(w http.ResponseWriter, r *http.Request, err error) {

--- a/internal/api/json_body_test.go
+++ b/internal/api/json_body_test.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDecodeJSONBodyRejectsTrailingJSONValue(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/test", strings.NewReader(`{"name":"ok"} {"name":"extra"}`))
+	rec := httptest.NewRecorder()
+
+	var body struct {
+		Name string `json:"name"`
+	}
+	if decodeJSONBody(rec, req, &body) {
+		t.Fatal("decodeJSONBody accepted a second JSON value")
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "single JSON value") {
+		t.Fatalf("body = %q, want single-value diagnostic", rec.Body.String())
+	}
+}
+
+func TestDecodeOptionalJSONBodyAllowsEmptyBody(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/test", strings.NewReader(""))
+	rec := httptest.NewRecorder()
+
+	var body struct {
+		Name string `json:"name"`
+	}
+	if !decodeOptionalJSONBody(rec, req, &body) {
+		t.Fatalf("decodeOptionalJSONBody rejected empty body: status=%d body=%q", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/veriflier/server.go
+++ b/internal/veriflier/server.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -311,7 +312,7 @@ func (s *Server) handleV2Status(w http.ResponseWriter, r *http.Request) {
 
 func decodeLimitedJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
-	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+	if err := decodeSingleJSONValue(json.NewDecoder(r.Body), dst); err != nil {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
 			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
@@ -321,6 +322,20 @@ func decodeLimitedJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
 		return false
 	}
 	return true
+}
+
+func decodeSingleJSONValue(dec *json.Decoder, dst any) error {
+	if err := dec.Decode(dst); err != nil {
+		return err
+	}
+	var extra json.RawMessage
+	if err := dec.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return errors.New("request body must contain a single JSON value")
+		}
+		return err
+	}
+	return nil
 }
 
 func (s *Server) Status() StatusV2Response {

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -134,6 +134,35 @@ func TestServerHandleCheckUnauthorized(t *testing.T) {
 	}
 }
 
+func TestServerRejectsTrailingJSONValue(t *testing.T) {
+	_, ts := newV2TestServer(func(_ context.Context, req CheckRequest) ProbeResult {
+		t.Fatalf("unexpected check execution for trailing JSON request: %+v", req)
+		return ProbeResult{}
+	})
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v2/check", bytes.NewBufferString(`{"requests":[]} {"requests":[]}`))
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+	var body bytes.Buffer
+	if _, err := body.ReadFrom(resp.Body); err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if !bytes.Contains(body.Bytes(), []byte("single JSON value")) {
+		t.Fatalf("body = %q, want single-value diagnostic", body.String())
+	}
+}
+
 func TestServerHandleCheckMethodNotAllowed(t *testing.T) {
 	_, ts := newTestServer(func(req CheckRequest) CheckResult { return CheckResult{} })
 	defer ts.Close()


### PR DESCRIPTION
## Summary
- Reject trailing JSON request bodies in internal API handlers and the Veriflier /v2/check endpoint.
- Bound CLI status HTTP reads with a client timeout and 1 MiB response cap.
- Bind the Docker API port to loopback by default and document how to opt into trusted remote access.

## Validation
- go test ./cmd/jetmon2 ./internal/api ./internal/veriflier
- git diff --check
- host6: docker run golang:1.26.3 go test ./...
- host6: docker run golang:1.26.3 go vet ./...
- host6: govulncheck ./... reported no vulnerabilities

## Safety
- Compatibility-preserving JSON change: unknown fields remain accepted, but concatenated/trailing JSON values are rejected.
- Docker API remains accessible locally; remote exposure now requires explicit bind configuration.