### PR TITLE
Add scale resilience Docker lab

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ BUILD_FLAGS := -ldflags "-X main.version=$(shell git describe --tags --always --
                          -X main.buildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ) \
                          -X main.goVersion=$(shell $(GO) version | awk '{print $$3}')"
 
-.PHONY: all build build-deliverer build-veriflier generate test test-race test-veriflier-soak lint vet migration-smoke delivery-claim-smoke rollout-docs-verify rollout-rehearsal-verify scale-resilience-lab scale-resilience-lab-clean rollout-vm-lab-sync rollout-vm-lab-sync-artifacts rollout-vm-lab-stage-v2 rollout-vm-lab-doctor rollout-vm-lab-prepare rollout-vm-lab-smoke rollout-vm-lab-execute-smoke rollout-vm-lab-failure-smoke rollout-vm-lab-resume-smoke rollout-vm-lab-post-start-rollback-smoke rollout-vm-lab-bad-ssh-smoke rollout-vm-lab-v2-start-failure-smoke rollout-vm-lab-runtime-guard-smoke rollout-vm-lab-real-activity-smoke rollout-vm-lab-snapshot-execute-smoke rollout-vm-lab-snapshot-all-smoke api-cli-smoke api-cli-validate api-cli-token-create api-cli-token-list api-cli-token-revoke clean
+.PHONY: all build build-deliverer build-veriflier generate test test-race test-veriflier-soak lint vet migration-smoke delivery-claim-smoke rollout-docs-verify rollout-rehearsal-verify scale-resilience-lab scale-resilience-lab-clean v2-soak-lab v2-soak-lab-clean rollout-vm-lab-sync rollout-vm-lab-sync-artifacts rollout-vm-lab-stage-v2 rollout-vm-lab-doctor rollout-vm-lab-prepare rollout-vm-lab-smoke rollout-vm-lab-execute-smoke rollout-vm-lab-failure-smoke rollout-vm-lab-resume-smoke rollout-vm-lab-post-start-rollback-smoke rollout-vm-lab-bad-ssh-smoke rollout-vm-lab-v2-start-failure-smoke rollout-vm-lab-runtime-guard-smoke rollout-vm-lab-real-activity-smoke rollout-vm-lab-snapshot-execute-smoke rollout-vm-lab-snapshot-all-smoke api-cli-smoke api-cli-validate api-cli-token-create api-cli-token-list api-cli-token-revoke clean
 
 all: build build-deliverer build-veriflier
 
@@ -80,6 +80,12 @@ scale-resilience-lab:
 
 scale-resilience-lab-clean:
 	scripts/scale-resilience-lab.sh cleanup
+
+v2-soak-lab:
+	scripts/v2-soak-lab.sh run
+
+v2-soak-lab-clean:
+	scripts/v2-soak-lab.sh cleanup
 
 rollout-vm-lab-sync:
 	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'mkdir -p ~/jetmon-rollout-tools/scripts ~/jetmon-rollout-tools/docs'

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ BUILD_FLAGS := -ldflags "-X main.version=$(shell git describe --tags --always --
                          -X main.buildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ) \
                          -X main.goVersion=$(shell $(GO) version | awk '{print $$3}')"
 
-.PHONY: all build build-deliverer build-veriflier generate test test-race test-veriflier-soak lint vet migration-smoke delivery-claim-smoke rollout-docs-verify rollout-rehearsal-verify rollout-vm-lab-sync rollout-vm-lab-sync-artifacts rollout-vm-lab-stage-v2 rollout-vm-lab-doctor rollout-vm-lab-prepare rollout-vm-lab-smoke rollout-vm-lab-execute-smoke rollout-vm-lab-failure-smoke rollout-vm-lab-resume-smoke rollout-vm-lab-post-start-rollback-smoke rollout-vm-lab-bad-ssh-smoke rollout-vm-lab-v2-start-failure-smoke rollout-vm-lab-runtime-guard-smoke rollout-vm-lab-real-activity-smoke rollout-vm-lab-snapshot-execute-smoke rollout-vm-lab-snapshot-all-smoke api-cli-smoke api-cli-validate api-cli-token-create api-cli-token-list api-cli-token-revoke clean
+.PHONY: all build build-deliverer build-veriflier generate test test-race test-veriflier-soak lint vet migration-smoke delivery-claim-smoke rollout-docs-verify rollout-rehearsal-verify scale-resilience-lab scale-resilience-lab-clean rollout-vm-lab-sync rollout-vm-lab-sync-artifacts rollout-vm-lab-stage-v2 rollout-vm-lab-doctor rollout-vm-lab-prepare rollout-vm-lab-smoke rollout-vm-lab-execute-smoke rollout-vm-lab-failure-smoke rollout-vm-lab-resume-smoke rollout-vm-lab-post-start-rollback-smoke rollout-vm-lab-bad-ssh-smoke rollout-vm-lab-v2-start-failure-smoke rollout-vm-lab-runtime-guard-smoke rollout-vm-lab-real-activity-smoke rollout-vm-lab-snapshot-execute-smoke rollout-vm-lab-snapshot-all-smoke api-cli-smoke api-cli-validate api-cli-token-create api-cli-token-list api-cli-token-revoke clean
 
 all: build build-deliverer build-veriflier
 
@@ -74,6 +74,12 @@ rollout-docs-verify: all test lint
 
 rollout-rehearsal-verify: build
 	scripts/rollout-rehearsal-verify.sh
+
+scale-resilience-lab:
+	scripts/scale-resilience-lab.sh run
+
+scale-resilience-lab-clean:
+	scripts/scale-resilience-lab.sh cleanup
 
 rollout-vm-lab-sync:
 	$(ROLLOUT_VM_LAB_SSH) $(ROLLOUT_VM_LAB_HOST) 'mkdir -p ~/jetmon-rollout-tools/scripts ~/jetmon-rollout-tools/docs'

--- a/docker/docker-compose.scale-lab.yml
+++ b/docker/docker-compose.scale-lab.yml
@@ -1,0 +1,140 @@
+x-jetmon-scale-env: &jetmon_scale_env
+  DB_HOST: mysqldb
+  DB_USER: ${MYSQL_USER:-jetmon}
+  DB_PASSWORD: ${MYSQL_PASSWORD:-jetmon_dev_password}
+  DB_NAME: ${MYSQL_DATABASE:-jetmon_db}
+  DB_PORT: "3306"
+  VERIFLIER_AUTH_TOKEN: ${VERIFLIER_AUTH_TOKEN:-veriflier_1_auth_token}
+  VERIFLIER_PORT: "7803"
+  WPCOM_AUTH_TOKEN: ${WPCOM_AUTH_TOKEN:-change_me}
+  EMAIL_TRANSPORT: ${EMAIL_TRANSPORT:-stub}
+  EMAIL_FROM: ${EMAIL_FROM:-jetmon@noreply.invalid}
+  SMTP_HOST: ${SMTP_HOST:-mailpit}
+  SMTP_PORT: ${SMTP_PORT:-1025}
+  SMTP_USERNAME: ${SMTP_USERNAME:-}
+  SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+  SMTP_USE_TLS: ${SMTP_USE_TLS:-false}
+
+x-jetmon-scale-service: &jetmon_scale_service
+  build:
+    context: ../
+    dockerfile: docker/Dockerfile_jetmon
+  init: true
+  restart: unless-stopped
+  user: "${UID:-1000}:${GID:-1000}"
+  volumes:
+    - ../config:/jetmon/config
+    - ../logs:/jetmon/logs
+    - ../stats:/jetmon/stats
+  depends_on:
+    mysql-user:
+      condition: service_completed_successfully
+    mailpit:
+      condition: service_healthy
+  healthcheck:
+    test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8090/api/v1/health"]
+    interval: 10s
+    timeout: 5s
+    retries: 12
+    start_period: 30s
+  networks:
+    default:
+    scale_public:
+
+x-veriflier-scale-service: &veriflier_scale_service
+  build:
+    context: ../
+    dockerfile: docker/Dockerfile_veriflier
+  init: true
+  restart: unless-stopped
+  environment:
+    VERIFLIER_AUTH_TOKEN: ${VERIFLIER_AUTH_TOKEN:-veriflier_1_auth_token}
+    VERIFLIER_PORT: "7803"
+    VERIFLIER_REGION: ${VERIFLIER_REGION:-scale-lab}
+    VERIFLIER_PROVIDER: ${VERIFLIER_PROVIDER:-docker}
+    VERIFLIER_ENABLE_LEGACY_HTTP: ${VERIFLIER_ENABLE_LEGACY_HTTP:-false}
+    STATSD_ADDR: statsd:8125
+  healthcheck:
+    test: ["CMD", "curl", "-fsS", "http://127.0.0.1:7803/v2/status"]
+    interval: 10s
+    timeout: 5s
+    retries: 12
+    start_period: 10s
+  networks:
+    default:
+    scale_public:
+
+services:
+  jetmon:
+    hostname: jetmon-scale-1
+    environment:
+      <<: *jetmon_scale_env
+      JETMON_PID_FILE: /jetmon/stats/jetmon2-scale-1.pid
+    networks:
+      default:
+      scale_public:
+
+  jetmon2:
+    <<: *jetmon_scale_service
+    hostname: jetmon-scale-2
+    environment:
+      <<: *jetmon_scale_env
+      JETMON_PID_FILE: /jetmon/stats/jetmon2-scale-2.pid
+
+  jetmon3:
+    <<: *jetmon_scale_service
+    hostname: jetmon-scale-3
+    environment:
+      <<: *jetmon_scale_env
+      JETMON_PID_FILE: /jetmon/stats/jetmon2-scale-3.pid
+
+  jetmon4:
+    <<: *jetmon_scale_service
+    hostname: jetmon-scale-4
+    environment:
+      <<: *jetmon_scale_env
+      JETMON_PID_FILE: /jetmon/stats/jetmon2-scale-4.pid
+
+  veriflier:
+    environment:
+      VERIFLIER_VANTAGE_ID: scale-v1
+      VERIFLIER_REGION: scale-lab
+      VERIFLIER_PROVIDER: docker
+    networks:
+      default:
+      scale_public:
+
+  veriflier2:
+    <<: *veriflier_scale_service
+    hostname: veriflier-scale-2
+    environment:
+      VERIFLIER_AUTH_TOKEN: ${VERIFLIER_AUTH_TOKEN:-veriflier_1_auth_token}
+      VERIFLIER_PORT: "7803"
+      VERIFLIER_VANTAGE_ID: scale-v2
+      VERIFLIER_REGION: scale-lab
+      VERIFLIER_PROVIDER: docker
+      VERIFLIER_ENABLE_LEGACY_HTTP: ${VERIFLIER_ENABLE_LEGACY_HTTP:-false}
+      STATSD_ADDR: statsd:8125
+
+  veriflier3:
+    <<: *veriflier_scale_service
+    hostname: veriflier-scale-3
+    environment:
+      VERIFLIER_AUTH_TOKEN: ${VERIFLIER_AUTH_TOKEN:-veriflier_1_auth_token}
+      VERIFLIER_PORT: "7803"
+      VERIFLIER_VANTAGE_ID: scale-v3
+      VERIFLIER_REGION: scale-lab
+      VERIFLIER_PROVIDER: docker
+      VERIFLIER_ENABLE_LEGACY_HTTP: ${VERIFLIER_ENABLE_LEGACY_HTTP:-false}
+      STATSD_ADDR: statsd:8125
+
+  api-fixture:
+    networks:
+      default:
+      scale_public:
+        ipv4_address: ${SCALE_LAB_FIXTURE_IP:-93.184.217.20}
+
+networks:
+  scale_public:
+    name: ${SCALE_LAB_PUBLIC_NETWORK:-jetmon-scale-lab-public}
+    external: true

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,8 @@ including the Veriflier discovery trust decision in
 | [`operations-guide.md`](operations-guide.md) | Production configuration, host setup, rollout modes, delivery workers, metrics, dashboard checks, and debugging. |
 | [`rollout-quick-reference.md`](rollout-quick-reference.md) | One-page operator checklist for the v1-to-v2 rollout, linked back to the full migration runbook. |
 | [`rollout-vm-lab.md`](rollout-vm-lab.md) | KVM/libvirt lab harness for rehearsing rollout flows with DB, v1, and fresh v2 VMs plus snapshots. |
+| [`scale-resilience-lab.md`](scale-resilience-lab.md) | Internal-only Docker lab for dynamic bucket ownership, Monitor failure takeover, Veriflier telemetry, and DB disruption recovery. |
+| [`v2-soak-lab.md`](v2-soak-lab.md) | Internal-only Docker soak for sustained normal v2 operation with Monitors, Verifliers, fixture sites, and no outbound side effects. |
 | [`jetmon-v2-prelaunch-readiness.md`](jetmon-v2-prelaunch-readiness.md) | Launch-readiness gates, canary checks, owner split, and service-side hardening map for the v2 drop-in rollout. |
 | [`data-model.md`](data-model.md) | Legacy and v2 tables, additive migrations, event-sourced incident state, legacy projection, and tenant mapping. |
 | [`support-guide.md`](support-guide.md) | Happiness Engineer workflows for explaining alerts, missed alerts, false positives, maintenance windows, and WPCOM payloads. |

--- a/docs/scale-resilience-lab.md
+++ b/docs/scale-resilience-lab.md
@@ -50,6 +50,11 @@ The lab script:
 
 JSON outputs are written under `logs/scale-resilience-lab/`.
 
+The lab validates graceful shutdown rebalancing as well as startup claiming.
+When a Monitor exits cleanly, it releases its `jetmon_hosts` row and the
+remaining active host rows are redistributed in the same database transaction;
+hard failures are still recovered by the normal heartbeat/grace-period path.
+
 ## Environment Overrides
 
 | Variable | Default |

--- a/docs/scale-resilience-lab.md
+++ b/docs/scale-resilience-lab.md
@@ -1,0 +1,62 @@
+# Scale Resilience Lab
+
+The scale resilience lab is an internal-only Docker rehearsal for dynamic
+Monitor bucket ownership, Monitor failure takeover, Veriflier telemetry, and
+fleet dashboard visibility.
+
+Run it from a Docker host that can spend temporary CPU and database resources:
+
+```bash
+make scale-resilience-lab
+```
+
+Clean up the isolated project and volumes:
+
+```bash
+make scale-resilience-lab-clean
+```
+
+## Safety Model
+
+- Uses Docker project `jetmon-scale-lab` by default.
+- Writes an ignored local `config/config.json` with
+  `WPCOM_NOTIFY_ENABLE=false`, `EMAIL_TRANSPORT=stub`, `DEBUG_PORT=0`, and
+  dynamic bucket ownership enabled.
+- Uses only local Docker containers for MySQL, Monitors, Verifliers, StatsD,
+  Mailpit, and the HTTP fixture.
+- Uses a dedicated Docker network with a public-looking fixture address
+  (`93.184.217.20` by default). Target safety stays enabled, but fixture
+  traffic stays inside the Docker host.
+- Does not create webhooks or alert contacts.
+- Does not contact WPCOM or change production systems.
+
+## Flow
+
+The lab script:
+
+1. Starts one Monitor and three Verifliers.
+2. Seeds fixture-backed sites directly into the isolated Docker database across
+   the configured bucket space, avoiding API rate-limit tuning in the product.
+3. Waits for healthy dynamic bucket coverage and recent check activity with one
+   Monitor.
+4. Adds a second Monitor and verifies bucket redistribution.
+5. Adds two more Monitors and verifies four-way redistribution.
+6. Stops one Monitor and then a second Monitor, verifying the survivors reclaim
+   bucket coverage and keep checking every site after each change.
+7. Recovers stopped Monitors and verifies four-way coverage again.
+8. Stops one Veriflier and then a second Veriflier, verifying fresh agent
+   telemetry and fleet dashboard snapshots report the degraded Veriflier state.
+9. Recovers Verifliers and captures the final fleet snapshot.
+
+JSON outputs are written under `logs/scale-resilience-lab/`.
+
+## Environment Overrides
+
+| Variable | Default |
+| --- | --- |
+| `JETMON_SCALE_LAB_PROJECT` | `jetmon-scale-lab` |
+| `JETMON_SCALE_LAB_NETWORK` | `jetmon-scale-lab-public` |
+| `JETMON_SCALE_LAB_SUBNET` | `93.184.217.0/24` |
+| `JETMON_SCALE_LAB_FIXTURE_IP` | `93.184.217.20` |
+| `JETMON_SCALE_LAB_SITE_COUNT` | `600` |
+| `JETMON_SCALE_LAB_BUCKET_TOTAL` | `12` |

--- a/docs/scale-resilience-lab.md
+++ b/docs/scale-resilience-lab.md
@@ -21,7 +21,9 @@ make scale-resilience-lab-clean
 - Uses Docker project `jetmon-scale-lab` by default.
 - Writes an ignored local `config/config.json` with
   `WPCOM_NOTIFY_ENABLE=false`, `EMAIL_TRANSPORT=stub`, `DEBUG_PORT=0`, and
-  dynamic bucket ownership enabled.
+  dynamic bucket ownership enabled. `DELIVERY_OWNER_HOST` is pinned to the
+  first Monitor so the fleet summary does not report multi-owner delivery
+  posture while the lab scales Monitor processes.
 - Uses only local Docker containers for MySQL, Monitors, Verifliers, StatsD,
   Mailpit, and the HTTP fixture.
 - Uses a dedicated Docker network with a public-looking fixture address
@@ -34,21 +36,35 @@ make scale-resilience-lab-clean
 
 The lab script:
 
-1. Starts one Monitor and three Verifliers.
-2. Seeds fixture-backed sites directly into the isolated Docker database across
+1. Builds every lab image, including each named Monitor service image, so
+   scale-out services cannot accidentally reuse stale per-service Docker images.
+2. Starts one Monitor and three Verifliers.
+3. Seeds fixture-backed sites directly into the isolated Docker database across
    the configured bucket space, avoiding API rate-limit tuning in the product.
-3. Waits for healthy dynamic bucket coverage and recent check activity with one
+4. Waits for healthy dynamic bucket coverage and recent check activity with one
    Monitor.
-4. Adds a second Monitor and verifies bucket redistribution.
-5. Adds two more Monitors and verifies four-way redistribution.
-6. Stops one Monitor and then a second Monitor, verifying the survivors reclaim
+5. Adds a second Monitor and verifies bucket redistribution.
+6. Adds two more Monitors and verifies four-way redistribution.
+7. Stops one Monitor and then a second Monitor, verifying the survivors reclaim
    bucket coverage and keep checking every site after each change.
-7. Recovers stopped Monitors and verifies four-way coverage again.
-8. Stops one Veriflier and then a second Veriflier, verifying fresh agent
+8. Recovers stopped Monitors and verifies four-way coverage again.
+9. Hard-kills one Monitor without graceful release, waits for heartbeat/grace
+   takeover, verifies full bucket coverage and site activity, then recovers it.
+10. Injects database disruption in the isolated lab database: a runtime-table
+   lock, temporary read-only mode, a paused database container, and a database
+   restart. Each disruption must recover to full Monitor coverage and site
+   activity.
+11. Stops one Veriflier and then a second Veriflier, verifying fresh agent
    telemetry and fleet dashboard snapshots report the degraded Veriflier state.
-9. Recovers Verifliers and captures the final fleet snapshot.
+12. Recovers Verifliers and captures the final fleet snapshot.
 
 JSON outputs are written under `logs/scale-resilience-lab/`.
+
+Fleet snapshots are asserted against expected states. Stable checkpoints must
+report green summary, green bucket coverage, green Verifliers, and three fresh
+Veriflier agents. Intentional failure checkpoints must report degraded
+red/amber summaries while still proving bucket coverage or Veriflier telemetry
+is in the expected state.
 
 The lab validates graceful shutdown rebalancing as well as startup claiming.
 When a Monitor exits cleanly, it releases its `jetmon_hosts` row and the

--- a/docs/v2-soak-lab.md
+++ b/docs/v2-soak-lab.md
@@ -1,0 +1,76 @@
+# V2 Soak Lab
+
+The v2 soak lab is an internal-only Docker run for checking sustained normal
+operation beyond short smoke tests. It runs four Monitors and three Verifliers
+against fixture-backed sites inside the Docker host.
+
+Run it from a host that can spend temporary CPU and database resources:
+
+```bash
+make v2-soak-lab
+```
+
+Clean up the isolated project and volumes:
+
+```bash
+make v2-soak-lab-clean
+```
+
+## Safety Model
+
+- Uses Docker project `jetmon-v2-soak-lab` by default.
+- Writes an ignored local `config/config.json` with
+  `WPCOM_NOTIFY_ENABLE=false`, `EMAIL_TRANSPORT=stub`, `DEBUG_PORT=0`, dynamic
+  bucket ownership enabled, and `DELIVERY_OWNER_HOST` pinned to the first
+  Monitor.
+- Uses only local Docker containers for MySQL, Monitors, Verifliers, StatsD,
+  Mailpit, and the HTTP fixture.
+- Uses a dedicated Docker network with a public-looking fixture address
+  (`93.184.218.20` by default). Target safety stays enabled, but fixture
+  traffic stays inside the Docker host.
+- Does not create webhooks or alert contacts.
+- Asserts that WPCOM audit rows, webhooks, alert contacts, and Mailpit messages
+  remain at zero during the run.
+- Cleans up the isolated Docker project after a successful run unless
+  `JETMON_SOAK_LAB_KEEP_RUNNING=1` is set.
+
+## Flow
+
+The lab script:
+
+1. Builds every lab image, including each named Monitor service image.
+2. Starts four Monitors and three Verifliers.
+3. Seeds fixture-backed sites directly into the isolated Docker database across
+   the configured bucket space.
+4. Waits for healthy dynamic bucket coverage, green fleet status, and full
+   fixture-site check coverage.
+5. Runs a timed soak loop and samples once per full interval.
+
+Each sample requires:
+
+- four active Monitor host rows;
+- green fleet summary, bucket coverage, and Veriflier status;
+- three fresh Veriflier agents;
+- every fixture site checked since the previous sample;
+- at least one check-history row per fixture site since the previous sample;
+- no open events;
+- no stale Monitor process-health rows;
+- no WPCOM audit rows, alert contacts, webhooks, or Mailpit messages.
+
+JSON fleet snapshots and the seed SQL are written under `logs/v2-soak-lab/`.
+
+## Environment Overrides
+
+| Variable | Default |
+| --- | --- |
+| `JETMON_SOAK_LAB_PROJECT` | `jetmon-v2-soak-lab` |
+| `JETMON_SOAK_LAB_NETWORK` | `jetmon-v2-soak-lab-public` |
+| `JETMON_SOAK_LAB_SUBNET` | `93.184.218.0/24` |
+| `JETMON_SOAK_LAB_FIXTURE_IP` | `93.184.218.20` |
+| `JETMON_SOAK_LAB_SITE_COUNT` | `360` |
+| `JETMON_SOAK_LAB_BUCKET_TOTAL` | `12` |
+| `JETMON_SOAK_LAB_DURATION_SEC` | `1800` |
+| `JETMON_SOAK_LAB_WARMUP_SEC` | `120` |
+| `JETMON_SOAK_LAB_SAMPLE_INTERVAL_SEC` | `60` |
+| `JETMON_SOAK_LAB_MAX_LAST_CHECKED_AGE_SEC` | `90` |
+| `JETMON_SOAK_LAB_KEEP_RUNNING` | `0` |

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -754,6 +754,57 @@ func ReleaseHost(ctx context.Context, hostID string) error {
 	return err
 }
 
+// ReleaseHostAndRebalance removes this host's row and immediately redistributes
+// buckets across the remaining active hosts. This shortens the graceful rolling
+// restart window where jetmon_hosts can have a coverage gap until a surviving
+// monitor reaches its next round.
+func ReleaseHostAndRebalance(ctx context.Context, hostID string, bucketTotal, bucketTarget int) error {
+	if bucketTotal <= 0 || bucketTarget <= 0 {
+		return ReleaseHost(ctx, hostID)
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM jetmon_hosts WHERE host_id = ?`, hostID); err != nil {
+		return fmt.Errorf("delete host: %w", err)
+	}
+
+	rows, err := tx.QueryContext(ctx, `SELECT host_id FROM jetmon_hosts WHERE status = 'active' ORDER BY host_id FOR UPDATE`)
+	if err != nil {
+		return fmt.Errorf("query active hosts: %w", err)
+	}
+	var hostIDs []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return err
+		}
+		hostIDs = append(hostIDs, id)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	assignments := assignBucketRanges(hostIDs, bucketTotal, bucketTarget)
+	for _, id := range hostIDs {
+		rng := assignments[id]
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE jetmon_hosts SET bucket_min = ?, bucket_max = ?, last_heartbeat = NOW() WHERE host_id = ?`,
+			rng[0], rng[1], id,
+		); err != nil {
+			return fmt.Errorf("update host %s: %w", id, err)
+		}
+	}
+
+	return tx.Commit()
+}
+
 // HostRowExists reports whether a host currently has a jetmon_hosts ownership
 // row.
 func HostRowExists(ctx context.Context, hostID string) (bool, error) {

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -665,18 +665,21 @@ func ClaimBuckets(hostID string, bucketTotal, bucketTarget int, graceSec int) (i
 		return 0, 0, fmt.Errorf("delete expired hosts: %w", err)
 	}
 
-	rows, err := tx.Query(`SELECT host_id FROM jetmon_hosts WHERE host_id != ? AND status = 'active' FOR UPDATE`, hostID)
+	rows, err := tx.Query(`SELECT host_id, last_heartbeat FROM jetmon_hosts WHERE host_id != ? AND status = 'active' FOR UPDATE`, hostID)
 	if err != nil {
 		return 0, 0, fmt.Errorf("query hosts: %w", err)
 	}
 	hostIDs := []string{hostID}
+	lastHeartbeats := make(map[string]time.Time)
 	for rows.Next() {
 		var id string
-		if err := rows.Scan(&id); err != nil {
+		var lastHeartbeat time.Time
+		if err := rows.Scan(&id, &lastHeartbeat); err != nil {
 			rows.Close()
 			return 0, 0, err
 		}
 		hostIDs = append(hostIDs, id)
+		lastHeartbeats[id] = lastHeartbeat
 	}
 	rows.Close()
 	if err := rows.Err(); err != nil {
@@ -688,13 +691,24 @@ func ClaimBuckets(hostID string, bucketTotal, bucketTarget int, graceSec int) (i
 
 	for _, id := range hostIDs {
 		rng := assignments[id]
-		_, err = tx.Exec(
-			`INSERT INTO jetmon_hosts (host_id, bucket_min, bucket_max, last_heartbeat, status)
-			 VALUES (?, ?, ?, NOW(), 'active')
-			 ON DUPLICATE KEY UPDATE bucket_min = VALUES(bucket_min), bucket_max = VALUES(bucket_max),
-			 last_heartbeat = NOW(), status = 'active'`,
-			id, rng[0], rng[1],
-		)
+		if id == hostID {
+			_, err = tx.Exec(
+				`INSERT INTO jetmon_hosts (host_id, bucket_min, bucket_max, last_heartbeat, status)
+				 VALUES (?, ?, ?, NOW(), 'active')
+				 ON DUPLICATE KEY UPDATE bucket_min = VALUES(bucket_min), bucket_max = VALUES(bucket_max),
+				 last_heartbeat = NOW(), status = 'active'`,
+				id, rng[0], rng[1],
+			)
+		} else {
+			// MariaDB can advance TIMESTAMP columns when bucket columns change
+			// even when the table definition does not print an ON UPDATE clause.
+			// Preserve peer heartbeats with the locked value so dead peers can
+			// age out instead of being refreshed by survivors.
+			_, err = tx.Exec(
+				`UPDATE jetmon_hosts SET bucket_min = ?, bucket_max = ?, last_heartbeat = ? WHERE host_id = ?`,
+				rng[0], rng[1], lastHeartbeats[id], id,
+			)
+		}
 		if err != nil {
 			return 0, 0, fmt.Errorf("upsert host %s: %w", id, err)
 		}
@@ -773,18 +787,21 @@ func ReleaseHostAndRebalance(ctx context.Context, hostID string, bucketTotal, bu
 		return fmt.Errorf("delete host: %w", err)
 	}
 
-	rows, err := tx.QueryContext(ctx, `SELECT host_id FROM jetmon_hosts WHERE status = 'active' ORDER BY host_id FOR UPDATE`)
+	rows, err := tx.QueryContext(ctx, `SELECT host_id, last_heartbeat FROM jetmon_hosts WHERE status = 'active' ORDER BY host_id FOR UPDATE`)
 	if err != nil {
 		return fmt.Errorf("query active hosts: %w", err)
 	}
 	var hostIDs []string
+	lastHeartbeats := make(map[string]time.Time)
 	for rows.Next() {
 		var id string
-		if err := rows.Scan(&id); err != nil {
+		var lastHeartbeat time.Time
+		if err := rows.Scan(&id, &lastHeartbeat); err != nil {
 			rows.Close()
 			return err
 		}
 		hostIDs = append(hostIDs, id)
+		lastHeartbeats[id] = lastHeartbeat
 	}
 	rows.Close()
 	if err := rows.Err(); err != nil {
@@ -794,9 +811,11 @@ func ReleaseHostAndRebalance(ctx context.Context, hostID string, bucketTotal, bu
 	assignments := assignBucketRanges(hostIDs, bucketTotal, bucketTarget)
 	for _, id := range hostIDs {
 		rng := assignments[id]
+		// Preserve peer heartbeats explicitly; bucket redistribution must not
+		// make stale hosts appear alive.
 		if _, err := tx.ExecContext(ctx,
-			`UPDATE jetmon_hosts SET bucket_min = ?, bucket_max = ?, last_heartbeat = NOW() WHERE host_id = ?`,
-			rng[0], rng[1], id,
+			`UPDATE jetmon_hosts SET bucket_min = ?, bucket_max = ?, last_heartbeat = ? WHERE host_id = ?`,
+			rng[0], rng[1], lastHeartbeats[id], id,
 		); err != nil {
 			return fmt.Errorf("update host %s: %w", id, err)
 		}

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -659,15 +659,16 @@ func TestClaimBucketsRebalancesKnownHosts(t *testing.T) {
 	mock, cleanup := withMockDB(t)
 	defer cleanup()
 
+	now := time.Now().UTC()
 	mock.ExpectBegin()
 	mock.ExpectExec("DELETE FROM jetmon_hosts").
 		WithArgs(60, "host-b").
 		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectQuery("SELECT host_id FROM jetmon_hosts").
+	mock.ExpectQuery("SELECT host_id, last_heartbeat FROM jetmon_hosts").
 		WithArgs("host-b").
-		WillReturnRows(sqlmock.NewRows([]string{"host_id"}).AddRow("host-a"))
-	mock.ExpectExec("INSERT INTO jetmon_hosts").
-		WithArgs("host-a", 0, 4).
+		WillReturnRows(sqlmock.NewRows([]string{"host_id", "last_heartbeat"}).AddRow("host-a", now))
+	mock.ExpectExec("last_heartbeat = \\?").
+		WithArgs(0, 4, now, "host-a").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("INSERT INTO jetmon_hosts").
 		WithArgs("host-b", 5, 9).
@@ -686,21 +687,55 @@ func TestClaimBucketsRebalancesKnownHosts(t *testing.T) {
 	}
 }
 
+func TestClaimBucketsDeletesExpiredHostWithoutRefreshingPeers(t *testing.T) {
+	mock, cleanup := withMockDB(t)
+	defer cleanup()
+
+	now := time.Now().UTC()
+	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM jetmon_hosts").
+		WithArgs(8, "host-c").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("SELECT host_id, last_heartbeat FROM jetmon_hosts").
+		WithArgs("host-c").
+		WillReturnRows(sqlmock.NewRows([]string{"host_id", "last_heartbeat"}).AddRow("host-a", now))
+	mock.ExpectExec("last_heartbeat = \\?").
+		WithArgs(0, 4, now, "host-a").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO jetmon_hosts").
+		WithArgs("host-c", 5, 9).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	minBucket, maxBucket, err := ClaimBuckets("host-c", 10, 10, 8)
+	if err != nil {
+		t.Fatalf("ClaimBuckets: %v", err)
+	}
+	if minBucket != 5 || maxBucket != 9 {
+		t.Fatalf("claimed range = %d..%d, want 5..9", minBucket, maxBucket)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
 func TestReleaseHostAndRebalanceUpdatesRemainingHosts(t *testing.T) {
 	mock, cleanup := withMockDB(t)
 	defer cleanup()
 
+	nowA := time.Now().UTC()
+	nowC := nowA.Add(time.Second)
 	mock.ExpectBegin()
 	mock.ExpectExec("DELETE FROM jetmon_hosts").
 		WithArgs("host-b").
 		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectQuery("SELECT host_id FROM jetmon_hosts").
-		WillReturnRows(sqlmock.NewRows([]string{"host_id"}).AddRow("host-a").AddRow("host-c"))
-	mock.ExpectExec("UPDATE jetmon_hosts SET bucket_min").
-		WithArgs(0, 4, "host-a").
+	mock.ExpectQuery("SELECT host_id, last_heartbeat FROM jetmon_hosts").
+		WillReturnRows(sqlmock.NewRows([]string{"host_id", "last_heartbeat"}).AddRow("host-a", nowA).AddRow("host-c", nowC))
+	mock.ExpectExec("last_heartbeat = \\?").
+		WithArgs(0, 4, nowA, "host-a").
 		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec("UPDATE jetmon_hosts SET bucket_min").
-		WithArgs(5, 9, "host-c").
+	mock.ExpectExec("last_heartbeat = \\?").
+		WithArgs(5, 9, nowC, "host-c").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -686,6 +686,32 @@ func TestClaimBucketsRebalancesKnownHosts(t *testing.T) {
 	}
 }
 
+func TestReleaseHostAndRebalanceUpdatesRemainingHosts(t *testing.T) {
+	mock, cleanup := withMockDB(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM jetmon_hosts").
+		WithArgs("host-b").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("SELECT host_id FROM jetmon_hosts").
+		WillReturnRows(sqlmock.NewRows([]string{"host_id"}).AddRow("host-a").AddRow("host-c"))
+	mock.ExpectExec("UPDATE jetmon_hosts SET bucket_min").
+		WithArgs(0, 4, "host-a").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE jetmon_hosts SET bucket_min").
+		WithArgs(5, 9, "host-c").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	if err := ReleaseHostAndRebalance(context.Background(), "host-b", 10, 10); err != nil {
+		t.Fatalf("ReleaseHostAndRebalance: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
 func TestMigrateAppliesOnlyPendingMigrations(t *testing.T) {
 	mock, cleanup := withMockDB(t)
 	defer cleanup()

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -82,7 +82,7 @@ var (
 	nowFunc                 = time.Now
 	dbClaimBuckets          = db.ClaimBuckets
 	dbHeartbeat             = db.Heartbeat
-	dbReleaseHost           = db.ReleaseHost
+	dbReleaseHost           = db.ReleaseHostAndRebalance
 	dbMarkHostDraining      = db.MarkHostDraining
 	dbGetSitesForBucket     = db.GetSitesForBucket
 	dbListActiveSites       = db.ListActiveSitesForBucketRange
@@ -437,7 +437,8 @@ func (o *Orchestrator) refreshAPIControlledRange() (bool, error) {
 
 func (o *Orchestrator) shutdown() {
 	log.Println("orchestrator: shutting down")
-	if !o.usesPinnedBuckets(config.Get()) {
+	cfg := config.Get()
+	if !o.usesPinnedBuckets(cfg) {
 		if err := dbMarkHostDraining(stdctx.Background(), o.hostname); err != nil {
 			log.Printf("orchestrator: mark draining: %v", err)
 		}
@@ -445,9 +446,9 @@ func (o *Orchestrator) shutdown() {
 	if o.pool != nil {
 		o.pool.Drain()
 	}
-	if o.usesPinnedBuckets(config.Get()) {
+	if o.usesPinnedBuckets(cfg) {
 		log.Println("orchestrator: pinned bucket mode active; no jetmon_hosts row to release")
-	} else if err := dbReleaseHost(stdctx.Background(), o.hostname); err != nil {
+	} else if err := dbReleaseHost(stdctx.Background(), o.hostname, cfg.BucketTotal, cfg.BucketTarget); err != nil {
 		log.Printf("orchestrator: release host: %v", err)
 	}
 }

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1357,7 +1357,7 @@ func stubOrchestratorDeps() func() {
 	nowFunc = time.Now
 	dbClaimBuckets = func(string, int, int, int) (int, int, error) { return 0, 0, nil }
 	dbHeartbeat = func(context.Context, string) error { return nil }
-	dbReleaseHost = func(context.Context, string) error { return nil }
+	dbReleaseHost = func(context.Context, string, int, int) error { return nil }
 	dbMarkHostDraining = func(context.Context, string) error { return nil }
 	dbGetSitesForBucket = func(context.Context, int, int, int, bool) ([]db.Site, error) { return nil, nil }
 	dbUpdateSiteStatus = func(context.Context, int64, int, time.Time) error { return nil }

--- a/scripts/scale-resilience-lab.sh
+++ b/scripts/scale-resilience-lab.sh
@@ -38,8 +38,9 @@ Runs an isolated Docker resilience lab that:
   2. seeds many public-looking Docker-internal fixture sites
   3. validates dynamic bucket coverage and recent site activity
   4. adds Monitors to two and then four active owners
-  5. stops Monitors and verifies surviving owners take over
-  6. stops Verifliers and verifies telemetry/dashboard visibility
+  5. stops and hard-kills Monitors and verifies surviving owners take over
+  6. injects isolated database disruption and verifies recovery
+  7. stops Verifliers and verifies telemetry/dashboard visibility
 
 No WPCOM calls or alert deliveries are configured.
 USAGE
@@ -76,6 +77,11 @@ sql() {
 		"${MYSQL_DATABASE:-jetmon_db}" "$@"
 }
 
+root_sql() {
+	compose exec -T mysqldb mariadb \
+		-u root "-p${MYSQL_ROOT_PASSWORD:-123456}" "$@"
+}
+
 api() {
 	compose exec -T \
 		-e JETMON_API_URL=http://127.0.0.1:8090 \
@@ -104,6 +110,7 @@ prepare_config() {
 		| .API_PORT = 8090
 		| .DASHBOARD_PORT = 8080
 		| .DASHBOARD_BIND_ADDR = "127.0.0.1"
+		| .DELIVERY_OWNER_HOST = "jetmon-scale-1"
 		| .DEBUG_PORT = 0
 		| .ROLLOUT_MODE = "active"
 		| .DEFAULT_CHECK_METHOD = "GET"
@@ -257,6 +264,19 @@ scalar_sql() {
 	sql --batch --skip-column-names -e "$1" | tr -d '[:space:]'
 }
 
+wait_for_sql() {
+	local label="$1"
+	local deadline=$((SECONDS + 120))
+	while (( SECONDS < deadline )); do
+		if root_sql --batch --skip-column-names -e "SELECT 1" >/dev/null 2>&1; then
+			pass "$label db_available"
+			return
+		fi
+		sleep 2
+	done
+	fail "$label database did not become available"
+}
+
 wait_for_host_count() {
 	local expected="$1"
 	local label="$2"
@@ -352,20 +372,131 @@ wait_for_fresh_veriflier_agents() {
 
 capture_fleet_snapshot() {
 	local label="$1"
-	compose exec -T jetmon curl -fsS http://127.0.0.1:8080/api/fleet >"$WORK_DIR/fleet-$label.json"
-	jq -r '"summary=\(.summary.status) monitors=\(.summary.monitor_processes) bucket=\(.bucket_coverage.status) verifliers=\(.verifliers.status) fresh_agents=\(.verifliers.fresh_agents)"' "$WORK_DIR/fleet-$label.json"
-	pass "$label fleet_snapshot=$WORK_DIR/fleet-$label.json"
+	local expected_summary="${2:-any}"
+	local expected_bucket="${3:-green}"
+	local expected_verifliers="${4:-green}"
+	local expected_fresh_agents="${5:-3}"
+	local snapshot="$WORK_DIR/fleet-$label.json"
+	local summary
+	local bucket
+	local verifliers
+	local fresh_agents
+	local monitor_processes
+
+	compose exec -T jetmon curl -fsS http://127.0.0.1:8080/api/fleet >"$snapshot"
+	summary="$(jq -r '.summary.status' "$snapshot")"
+	bucket="$(jq -r '.bucket_coverage.status' "$snapshot")"
+	verifliers="$(jq -r '.verifliers.status' "$snapshot")"
+	fresh_agents="$(jq -r '.verifliers.fresh_agents' "$snapshot")"
+	monitor_processes="$(jq -r '.summary.monitor_processes' "$snapshot")"
+
+	if [[ "$expected_bucket" != "any" && "$bucket" != "$expected_bucket" ]]; then
+		fail "$label bucket_status=$bucket want=$expected_bucket snapshot=$snapshot"
+	fi
+	if [[ "$expected_verifliers" != "any" && "$verifliers" != "$expected_verifliers" ]]; then
+		fail "$label veriflier_status=$verifliers want=$expected_verifliers snapshot=$snapshot"
+	fi
+	if [[ "$expected_fresh_agents" != "any" && "$fresh_agents" != "$expected_fresh_agents" ]]; then
+		fail "$label fresh_veriflier_agents=$fresh_agents want=$expected_fresh_agents snapshot=$snapshot"
+	fi
+	case "$expected_summary" in
+		any)
+			;;
+		stable)
+			if [[ "$summary" != "green" ]]; then
+				fail "$label summary=$summary want=green snapshot=$snapshot"
+			fi
+			;;
+		degraded)
+			if [[ "$summary" != "red" && "$summary" != "amber" ]]; then
+				fail "$label summary=$summary want=red_or_amber snapshot=$snapshot"
+			fi
+			;;
+		green | amber | red)
+			if [[ "$summary" != "$expected_summary" ]]; then
+				fail "$label summary=$summary want=$expected_summary snapshot=$snapshot"
+			fi
+			;;
+		*)
+			fail "$label unknown expected summary class: $expected_summary"
+			;;
+	esac
+
+	jq -r '"summary=\(.summary.status) monitors=\(.summary.monitor_processes) bucket=\(.bucket_coverage.status) verifliers=\(.verifliers.status) fresh_agents=\(.verifliers.fresh_agents)"' "$snapshot"
+	pass "$label fleet_snapshot=$snapshot expected_summary=$expected_summary monitor_processes=$monitor_processes"
 }
 
 validate_activity_step() {
 	local label="$1"
 	local expected_hosts="$2"
+	local expected_summary="${3:-stable}"
+	local expected_bucket="${4:-green}"
+	local expected_verifliers="${5:-green}"
+	local expected_fresh_agents="${6:-3}"
 	local since
 	wait_for_host_count "$expected_hosts" "$label"
 	run_dynamic_check "$label"
 	since="$(checkpoint_utc)"
 	wait_for_checked_since "$label" "$since"
-	capture_fleet_snapshot "$label"
+	capture_fleet_snapshot "$label" "$expected_summary" "$expected_bucket" "$expected_verifliers" "$expected_fresh_agents"
+}
+
+hard_kill_monitor() {
+	local service="$1"
+	local cid
+	cid="$(compose ps -q "$service")"
+	[[ -n "$cid" ]] || fail "could not find container for $service"
+	docker update --restart=no "$cid" >/dev/null
+	docker kill --signal=SIGKILL "$cid" >/dev/null
+	pass "$service hard_killed"
+}
+
+recover_monitor() {
+	local service="$1"
+	compose up -d --build --force-recreate "$service" >/dev/null
+	pass "$service recovered"
+}
+
+inject_db_runtime_lock() {
+	local label="db-runtime-lock"
+	log "injecting temporary database table lock"
+	(root_sql -e "LOCK TABLES jetmon_site_runtime WRITE; DO SLEEP(10); UNLOCK TABLES;" "${MYSQL_DATABASE:-jetmon_db}" >/dev/null) &
+	local lock_pid=$!
+	sleep 2
+	capture_fleet_snapshot "$label-during" "any" "any" "any" "any"
+	if ! wait "$lock_pid"; then
+		fail "$label lock session failed"
+	fi
+	pass "$label released"
+	validate_activity_step "$label-recovery" 4 stable green green 3
+}
+
+inject_db_read_only() {
+	local label="db-read-only"
+	log "enabling temporary database read-only mode"
+	root_sql -e "SET GLOBAL read_only = ON"
+	sleep 10
+	root_sql -e "SET GLOBAL read_only = OFF"
+	pass "$label disabled"
+	validate_activity_step "$label-recovery" 4 stable green green 3
+}
+
+inject_db_pause() {
+	local label="db-pause"
+	log "pausing database container"
+	compose pause mysqldb >/dev/null
+	sleep 10
+	compose unpause mysqldb >/dev/null
+	wait_for_sql "$label"
+	validate_activity_step "$label-recovery" 4 stable green green 3
+}
+
+inject_db_restart() {
+	local label="db-restart"
+	log "restarting database container"
+	compose restart mysqldb >/dev/null
+	wait_for_sql "$label"
+	validate_activity_step "$label-recovery" 4 stable green green 3
 }
 
 run_lab() {
@@ -377,54 +508,70 @@ run_lab() {
 	prepare_fixture_sites
 	ensure_public_network
 
+	log "building lab images"
+	compose build api-fixture jetmon jetmon2 jetmon3 jetmon4 veriflier veriflier2 veriflier3
+
 	log "starting base services project=$PROJECT"
-	compose up -d --build mysqldb mysql-user mailpit statsd api-fixture veriflier veriflier2 veriflier3 jetmon
+	compose up -d mysqldb mysql-user mailpit statsd api-fixture veriflier veriflier2 veriflier3 jetmon
 	wait_for_api
 	create_api_token
 	compose exec -T jetmon curl -fsS "http://$FIXTURE_IP:8091/health" >/dev/null
 	pass "fixture_reachable_from_monitor=$FIXTURE_IP"
 	seed_sites
 
-	validate_activity_step single-monitor 1
+	validate_activity_step single-monitor 1 stable green green 3
 	wait_for_worker_scale 13
 	wait_for_fresh_veriflier_agents 3 verifliers-initial
 
 	log "adding second Monitor"
-	compose up -d jetmon2
-	validate_activity_step two-monitors 2
+	compose up -d --build jetmon2
+	validate_activity_step two-monitors 2 stable green green 3
 
 	log "adding two more Monitors"
-	compose up -d jetmon3 jetmon4
-	validate_activity_step four-monitors 4
+	compose up -d --build jetmon3 jetmon4
+	validate_activity_step four-monitors 4 stable green green 3
 
 	log "stopping one Monitor"
 	compose stop jetmon2 >/dev/null
-	validate_activity_step three-monitors-after-failure 3
+	validate_activity_step three-monitors-after-failure 3 degraded green green 3
 
 	log "stopping another Monitor"
 	compose stop jetmon3 >/dev/null
-	validate_activity_step two-monitors-after-failure 2
+	validate_activity_step two-monitors-after-failure 2 degraded green green 3
 
 	log "recovering stopped Monitors"
-	compose up -d jetmon2 jetmon3
-	validate_activity_step four-monitors-recovered 4
+	compose up -d --build jetmon2 jetmon3
+	validate_activity_step four-monitors-recovered 4 stable green green 3
+
+	log "hard-killing one Monitor"
+	hard_kill_monitor jetmon2
+	validate_activity_step three-monitors-after-hard-kill 3 degraded green green 3
+
+	log "recovering hard-killed Monitor"
+	recover_monitor jetmon2
+	validate_activity_step four-monitors-after-hard-kill-recovery 4 stable green green 3
+
+	inject_db_runtime_lock
+	inject_db_read_only
+	inject_db_pause
+	inject_db_restart
 
 	log "stopping one Veriflier"
 	compose stop veriflier3 >/dev/null
 	wait_for_fresh_veriflier_agents 2 veriflier-one-failed
-	capture_fleet_snapshot veriflier-one-failed
+	capture_fleet_snapshot veriflier-one-failed degraded green amber 2
 
 	log "stopping second Veriflier"
 	compose stop veriflier2 >/dev/null
 	wait_for_fresh_veriflier_agents 1 veriflier-two-failed
-	capture_fleet_snapshot veriflier-two-failed
+	capture_fleet_snapshot veriflier-two-failed degraded green amber 1
 	since="$(checkpoint_utc)"
 	wait_for_checked_since veriflier-degraded-monitor-activity "$since"
 
 	log "recovering Verifliers"
 	compose up -d veriflier2 veriflier3
 	wait_for_fresh_veriflier_agents 3 verifliers-recovered
-	capture_fleet_snapshot verifliers-recovered
+	capture_fleet_snapshot verifliers-recovered stable green green 3
 
 	pass "scale_resilience_lab_complete project=$PROJECT sites=$SITE_COUNT bucket_total=$BUCKET_TOTAL logs=$WORK_DIR"
 }

--- a/scripts/scale-resilience-lab.sh
+++ b/scripts/scale-resilience-lab.sh
@@ -1,0 +1,446 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
+PROJECT="${JETMON_SCALE_LAB_PROJECT:-jetmon-scale-lab}"
+PUBLIC_NETWORK="${JETMON_SCALE_LAB_NETWORK:-jetmon-scale-lab-public}"
+PUBLIC_SUBNET="${JETMON_SCALE_LAB_SUBNET:-93.184.217.0/24}"
+FIXTURE_IP="${JETMON_SCALE_LAB_FIXTURE_IP:-93.184.217.20}"
+SITE_COUNT="${JETMON_SCALE_LAB_SITE_COUNT:-600}"
+BUCKET_TOTAL="${JETMON_SCALE_LAB_BUCKET_TOTAL:-12}"
+WORK_DIR="$REPO_ROOT/logs/scale-resilience-lab"
+CONFIG_FILE="$REPO_ROOT/config/config.json"
+COMPOSE=(docker compose -p "$PROJECT" -f "$REPO_ROOT/docker/docker-compose.yml" -f "$REPO_ROOT/docker/docker-compose.scale-lab.yml")
+
+export BIND_ADDR="${BIND_ADDR:-127.0.0.1}"
+export API_BIND_ADDR="${API_BIND_ADDR:-127.0.0.1}"
+export MYSQL_HOST_PORT="${MYSQL_HOST_PORT:-17307}"
+export DASHBOARD_HOST_PORT="${DASHBOARD_HOST_PORT:-17080}"
+export API_HOST_PORT="${API_HOST_PORT:-17090}"
+export VERIFLIER_HOST_PORT="${VERIFLIER_HOST_PORT:-17813}"
+export API_FIXTURE_HTTP_HOST_PORT="${API_FIXTURE_HTTP_HOST_PORT:-18191}"
+export API_FIXTURE_HTTPS_HOST_PORT="${API_FIXTURE_HTTPS_HOST_PORT:-18543}"
+export MAILPIT_HOST_PORT="${MAILPIT_HOST_PORT:-18125}"
+export GRAPHITE_HOST_PORT="${GRAPHITE_HOST_PORT:-18188}"
+export STATSD_HOST_PORT="${STATSD_HOST_PORT:-18225}"
+export EMAIL_TRANSPORT=stub
+export SCALE_LAB_PUBLIC_NETWORK="$PUBLIC_NETWORK"
+export SCALE_LAB_FIXTURE_IP="$FIXTURE_IP"
+
+usage() {
+	cat <<'USAGE'
+usage: scripts/scale-resilience-lab.sh <run|cleanup>
+
+Runs an isolated Docker resilience lab that:
+  1. starts one Monitor and three Verifliers
+  2. seeds many public-looking Docker-internal fixture sites
+  3. validates dynamic bucket coverage and recent site activity
+  4. adds Monitors to two and then four active owners
+  5. stops Monitors and verifies surviving owners take over
+  6. stops Verifliers and verifies telemetry/dashboard visibility
+
+No WPCOM calls or alert deliveries are configured.
+USAGE
+}
+
+log() {
+	printf 'INFO %s\n' "$*"
+}
+
+pass() {
+	printf 'PASS %s\n' "$*"
+}
+
+warn() {
+	printf 'WARN %s\n' "$*" >&2
+}
+
+fail() {
+	printf 'FAIL %s\n' "$*" >&2
+	exit 1
+}
+
+need_cmd() {
+	command -v "$1" >/dev/null 2>&1 || fail "missing command: $1"
+}
+
+compose() {
+	"${COMPOSE[@]}" "$@"
+}
+
+sql() {
+	compose exec -T mysqldb mariadb \
+		-u"${MYSQL_USER:-jetmon}" "-p${MYSQL_PASSWORD:-jetmon_dev_password}" \
+		"${MYSQL_DATABASE:-jetmon_db}" "$@"
+}
+
+api() {
+	compose exec -T \
+		-e JETMON_API_URL=http://127.0.0.1:8090 \
+		-e JETMON_API_TOKEN="$API_TOKEN" \
+		jetmon ./jetmon2 api "$@"
+}
+
+cleanup() {
+	cd "$REPO_ROOT"
+	compose down -v --remove-orphans >/dev/null 2>&1 || true
+	docker network rm "$PUBLIC_NETWORK" >/dev/null 2>&1 || true
+	pass "scale_resilience_lab_cleaned project=$PROJECT network=$PUBLIC_NETWORK"
+}
+
+prepare_config() {
+	mkdir -p "$WORK_DIR" "$REPO_ROOT/logs" "$REPO_ROOT/stats"
+	rm -f "$REPO_ROOT/veriflier2/config/veriflier.json"
+	jq \
+		--argjson bucket_total "$BUCKET_TOTAL" \
+		--arg token "${VERIFLIER_AUTH_TOKEN:-veriflier_1_auth_token}" \
+		'.AUTH_TOKEN = "scale-lab-wpcom-disabled"
+		| .WPCOM_NOTIFY_ENABLE = false
+		| .EMAIL_TRANSPORT = "stub"
+		| .WPCOM_EMAIL_ENDPOINT = ""
+		| .WPCOM_EMAIL_AUTH_TOKEN = ""
+		| .API_PORT = 8090
+		| .DASHBOARD_PORT = 8080
+		| .DASHBOARD_BIND_ADDR = "127.0.0.1"
+		| .DEBUG_PORT = 0
+		| .ROLLOUT_MODE = "active"
+		| .DEFAULT_CHECK_METHOD = "GET"
+		| .DEFAULT_DETECTION_PROFILE = "simple_http"
+		| .PEER_OFFLINE_LIMIT = 1
+		| .NUM_WORKERS = 24
+		| .DATASET_SIZE = 100
+		| .MIN_TIME_BETWEEN_ROUNDS_SEC = 5
+		| .NET_COMMS_TIMEOUT = 3
+		| .BODY_READ_MAX_MS = 250
+		| .USE_VARIABLE_CHECK_INTERVALS = false
+		| .BUCKET_TOTAL = $bucket_total
+		| .BUCKET_TARGET = $bucket_total
+		| .BUCKET_HEARTBEAT_GRACE_SEC = 8
+		| .STATS_UPDATE_INTERVAL_MS = 1000
+		| .VERIFIERS = [
+			{"name":"Scale Veriflier 1","host":"veriflier","port":"7803","auth_token":$token},
+			{"name":"Scale Veriflier 2","host":"veriflier2","port":"7803","auth_token":$token},
+			{"name":"Scale Veriflier 3","host":"veriflier3","port":"7803","auth_token":$token}
+		]' \
+		"$REPO_ROOT/config/config-sample.json" >"$CONFIG_FILE"
+	pass "safe_config_written=$CONFIG_FILE wpcom_notify=false email_transport=stub bucket_total=$BUCKET_TOTAL"
+}
+
+prepare_fixture_sites() {
+	cat >"$WORK_DIR/sites.json" <<JSON
+[
+  {
+    "monitor_url": "http://$FIXTURE_IP:8091/slow?delay=150ms",
+    "redirect_policy": "follow",
+    "request_method": "GET",
+    "detection_profile": "simple_http",
+    "timeout_seconds": 3,
+    "check_interval": 1,
+    "alert_cooldown_minutes": 0
+  },
+  {
+    "monitor_url": "http://$FIXTURE_IP:8091/ok",
+    "redirect_policy": "follow",
+    "request_method": "GET",
+    "detection_profile": "simple_http",
+    "timeout_seconds": 3,
+    "check_interval": 1,
+    "alert_cooldown_minutes": 0
+  },
+  {
+    "monitor_url": "http://$FIXTURE_IP:8091/keyword",
+    "check_keyword": "keyword present",
+    "redirect_policy": "follow",
+    "request_method": "GET",
+    "detection_profile": "full",
+    "timeout_seconds": 3,
+    "check_interval": 1,
+    "alert_cooldown_minutes": 0
+  },
+  {
+    "monitor_url": "http://$FIXTURE_IP:8091/redirect",
+    "redirect_policy": "follow",
+    "request_method": "GET",
+    "detection_profile": "simple_http",
+    "timeout_seconds": 3,
+    "check_interval": 1,
+    "alert_cooldown_minutes": 0
+  }
+]
+JSON
+	pass "fixture_sites_written=$WORK_DIR/sites.json count=$SITE_COUNT fixture=$FIXTURE_IP"
+}
+
+ensure_public_network() {
+	if docker network inspect "$PUBLIC_NETWORK" >/dev/null 2>&1; then
+		pass "docker_network_exists=$PUBLIC_NETWORK"
+		return
+	fi
+	docker network create --subnet "$PUBLIC_SUBNET" "$PUBLIC_NETWORK" >/dev/null
+	pass "docker_network_created=$PUBLIC_NETWORK subnet=$PUBLIC_SUBNET"
+}
+
+wait_for_api() {
+	local deadline=$((SECONDS + 180))
+	until compose exec -T jetmon curl -fsS http://127.0.0.1:8090/api/v1/health >/dev/null 2>&1; do
+		(( SECONDS < deadline )) || fail "API did not become healthy"
+		sleep 2
+	done
+	pass "api_healthy"
+}
+
+create_api_token() {
+	local out
+	out="$(compose exec -T jetmon ./jetmon2 keys create --consumer scale-resilience-lab --scope admin --created-by scale-resilience-lab)"
+	API_TOKEN="$(printf '%s\n' "$out" | awk '/^jm_/ {print; exit}')"
+	[[ -n "$API_TOKEN" ]] || fail "could not parse API token"
+	pass "api_token_created"
+}
+
+seed_sites() {
+	local created=0
+	local sql_file="$WORK_DIR/seed.sql"
+	local blog_id
+	local bucket
+	local url
+	local profile
+	local keyword
+
+	{
+		printf 'START TRANSACTION;\n'
+		printf 'DELETE FROM jetmon_site_runtime WHERE blog_id >= 910000000 AND blog_id < %d;\n' "$(( 910000000 + SITE_COUNT ))"
+		printf 'DELETE FROM jetmon_site_check_config WHERE blog_id >= 910000000 AND blog_id < %d;\n' "$(( 910000000 + SITE_COUNT ))"
+		printf 'DELETE FROM jetpack_monitor_sites WHERE blog_id >= 910000000 AND blog_id < %d;\n' "$(( 910000000 + SITE_COUNT ))"
+		while (( created < SITE_COUNT )); do
+			blog_id=$(( 910000000 + created ))
+			bucket=$(( created % BUCKET_TOTAL ))
+			case $(( created % 4 )) in
+				0)
+					url="http://$FIXTURE_IP:8091/slow?delay=150ms"
+					profile="simple_http"
+					keyword="NULL"
+					;;
+				1)
+					url="http://$FIXTURE_IP:8091/ok"
+					profile="simple_http"
+					keyword="NULL"
+					;;
+				2)
+					url="http://$FIXTURE_IP:8091/keyword"
+					profile="full"
+					keyword="'keyword present'"
+					;;
+				*)
+					url="http://$FIXTURE_IP:8091/redirect"
+					profile="simple_http"
+					keyword="NULL"
+					;;
+			esac
+			printf "INSERT INTO jetpack_monitor_sites (blog_id, bucket_no, monitor_url, monitor_active, site_status, check_interval) VALUES (%d, %d, '%s', 1, 1, 1);\n" "$blog_id" "$bucket" "$url"
+			printf "INSERT INTO jetmon_site_check_config (blog_id, request_method, detection_profile, check_keyword, timeout_seconds, redirect_policy, alert_cooldown_minutes) VALUES (%d, 'GET', '%s', %s, 3, 'follow', 0);\n" "$blog_id" "$profile" "$keyword"
+			created=$(( created + 1 ))
+		done
+		printf 'COMMIT;\n'
+	} >"$sql_file"
+
+	sql <"$sql_file"
+	pass "sites_seeded count=$SITE_COUNT bucket_total=$BUCKET_TOTAL"
+}
+
+checkpoint_utc() {
+	sql --batch --skip-column-names -e "SELECT UTC_TIMESTAMP(6)" | tr -d '\r'
+}
+
+scalar_sql() {
+	sql --batch --skip-column-names -e "$1" | tr -d '[:space:]'
+}
+
+wait_for_host_count() {
+	local expected="$1"
+	local label="$2"
+	local deadline=$((SECONDS + 120))
+	local count=0
+	while (( SECONDS < deadline )); do
+		count="$(scalar_sql "SELECT COUNT(*) FROM jetmon_hosts WHERE status = 'active'")"
+		if [[ "$count" == "$expected" ]]; then
+			pass "$label active_monitor_hosts=$count"
+			sql -e "SELECT host_id, bucket_min, bucket_max, status, last_heartbeat FROM jetmon_hosts ORDER BY bucket_min, host_id"
+			return
+		fi
+		sleep 3
+	done
+	fail "$label active_monitor_hosts=$count want=$expected"
+}
+
+wait_for_dynamic_coverage() {
+	local label="$1"
+	local deadline=$((SECONDS + 120))
+	while (( SECONDS < deadline )); do
+		if compose exec -T jetmon ./jetmon2 rollout dynamic-check --output json >"$WORK_DIR/dynamic-$label.json" 2>/dev/null &&
+			jq -e '.ok == true' "$WORK_DIR/dynamic-$label.json" >/dev/null; then
+			pass "$label dynamic_bucket_coverage"
+			return
+		fi
+		sleep 3
+	done
+	cat "$WORK_DIR/dynamic-$label.json" >&2 || true
+	fail "$label dynamic bucket coverage did not become healthy"
+}
+
+run_dynamic_check() {
+	local label="$1"
+	wait_for_dynamic_coverage "$label"
+}
+
+wait_for_checked_since() {
+	local label="$1"
+	local since="$2"
+	local deadline=$((SECONDS + 150))
+	local checked=0
+	while (( SECONDS < deadline )); do
+		checked="$(scalar_sql "
+			SELECT COUNT(DISTINCT s.jetpack_monitor_site_id)
+			  FROM jetpack_monitor_sites s
+			  JOIN jetmon_site_runtime r ON r.blog_id = s.blog_id
+			 WHERE s.monitor_active = 1
+			   AND r.last_checked_at >= TIMESTAMP('$since')")"
+		if [[ "$checked" == "$SITE_COUNT" ]]; then
+			pass "$label checked_sites_since_checkpoint=$checked"
+			return
+		fi
+		sleep 3
+	done
+	fail "$label only $checked/$SITE_COUNT sites checked since $since"
+}
+
+wait_for_worker_scale() {
+	local min_workers="$1"
+	local deadline=$((SECONDS + 90))
+	local workers=0
+	while (( SECONDS < deadline )); do
+		workers="$(scalar_sql "SELECT COALESCE(MAX(worker_count), 0) FROM jetmon_process_health WHERE process_type = 'monitor' AND state = 'running'")"
+		if (( workers >= min_workers )); then
+			pass "vertical_autoscale_observed max_worker_count=$workers"
+			return
+		fi
+		sleep 2
+	done
+	warn "vertical_autoscale_not_observed max_worker_count=$workers min_expected=$min_workers"
+}
+
+fresh_veriflier_agents() {
+	scalar_sql "SELECT COUNT(*) FROM jetmon_veriflier_agents WHERE last_seen >= UTC_TIMESTAMP() - INTERVAL 15 SECOND"
+}
+
+wait_for_fresh_veriflier_agents() {
+	local expected="$1"
+	local label="$2"
+	local deadline=$((SECONDS + 90))
+	local count=0
+	while (( SECONDS < deadline )); do
+		count="$(fresh_veriflier_agents)"
+		if [[ "$count" == "$expected" ]]; then
+			pass "$label fresh_veriflier_agents=$count"
+			return
+		fi
+		sleep 3
+	done
+	fail "$label fresh_veriflier_agents=$count want=$expected"
+}
+
+capture_fleet_snapshot() {
+	local label="$1"
+	compose exec -T jetmon curl -fsS http://127.0.0.1:8080/api/fleet >"$WORK_DIR/fleet-$label.json"
+	jq -r '"summary=\(.summary.status) monitors=\(.summary.monitor_processes) bucket=\(.bucket_coverage.status) verifliers=\(.verifliers.status) fresh_agents=\(.verifliers.fresh_agents)"' "$WORK_DIR/fleet-$label.json"
+	pass "$label fleet_snapshot=$WORK_DIR/fleet-$label.json"
+}
+
+validate_activity_step() {
+	local label="$1"
+	local expected_hosts="$2"
+	local since
+	wait_for_host_count "$expected_hosts" "$label"
+	run_dynamic_check "$label"
+	since="$(checkpoint_utc)"
+	wait_for_checked_since "$label" "$since"
+	capture_fleet_snapshot "$label"
+}
+
+run_lab() {
+	need_cmd docker
+	need_cmd jq
+	cd "$REPO_ROOT"
+	cleanup >/dev/null 2>&1 || true
+	prepare_config
+	prepare_fixture_sites
+	ensure_public_network
+
+	log "starting base services project=$PROJECT"
+	compose up -d --build mysqldb mysql-user mailpit statsd api-fixture veriflier veriflier2 veriflier3 jetmon
+	wait_for_api
+	create_api_token
+	compose exec -T jetmon curl -fsS "http://$FIXTURE_IP:8091/health" >/dev/null
+	pass "fixture_reachable_from_monitor=$FIXTURE_IP"
+	seed_sites
+
+	validate_activity_step single-monitor 1
+	wait_for_worker_scale 13
+	wait_for_fresh_veriflier_agents 3 verifliers-initial
+
+	log "adding second Monitor"
+	compose up -d jetmon2
+	validate_activity_step two-monitors 2
+
+	log "adding two more Monitors"
+	compose up -d jetmon3 jetmon4
+	validate_activity_step four-monitors 4
+
+	log "stopping one Monitor"
+	compose stop jetmon2 >/dev/null
+	validate_activity_step three-monitors-after-failure 3
+
+	log "stopping another Monitor"
+	compose stop jetmon3 >/dev/null
+	validate_activity_step two-monitors-after-failure 2
+
+	log "recovering stopped Monitors"
+	compose up -d jetmon2 jetmon3
+	validate_activity_step four-monitors-recovered 4
+
+	log "stopping one Veriflier"
+	compose stop veriflier3 >/dev/null
+	wait_for_fresh_veriflier_agents 2 veriflier-one-failed
+	capture_fleet_snapshot veriflier-one-failed
+
+	log "stopping second Veriflier"
+	compose stop veriflier2 >/dev/null
+	wait_for_fresh_veriflier_agents 1 veriflier-two-failed
+	capture_fleet_snapshot veriflier-two-failed
+	since="$(checkpoint_utc)"
+	wait_for_checked_since veriflier-degraded-monitor-activity "$since"
+
+	log "recovering Verifliers"
+	compose up -d veriflier2 veriflier3
+	wait_for_fresh_veriflier_agents 3 verifliers-recovered
+	capture_fleet_snapshot verifliers-recovered
+
+	pass "scale_resilience_lab_complete project=$PROJECT sites=$SITE_COUNT bucket_total=$BUCKET_TOTAL logs=$WORK_DIR"
+}
+
+case "${1:-run}" in
+	run)
+		run_lab
+		;;
+	cleanup)
+		cleanup
+		;;
+	-h | --help | help)
+		usage
+		;;
+	*)
+		usage >&2
+		exit 2
+		;;
+esac

--- a/scripts/v2-soak-lab.sh
+++ b/scripts/v2-soak-lab.sh
@@ -1,0 +1,419 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
+PROJECT="${JETMON_SOAK_LAB_PROJECT:-jetmon-v2-soak-lab}"
+PUBLIC_NETWORK="${JETMON_SOAK_LAB_NETWORK:-jetmon-v2-soak-lab-public}"
+PUBLIC_SUBNET="${JETMON_SOAK_LAB_SUBNET:-93.184.218.0/24}"
+FIXTURE_IP="${JETMON_SOAK_LAB_FIXTURE_IP:-93.184.218.20}"
+SITE_COUNT="${JETMON_SOAK_LAB_SITE_COUNT:-360}"
+BUCKET_TOTAL="${JETMON_SOAK_LAB_BUCKET_TOTAL:-12}"
+DURATION_SEC="${JETMON_SOAK_LAB_DURATION_SEC:-1800}"
+WARMUP_SEC="${JETMON_SOAK_LAB_WARMUP_SEC:-120}"
+SAMPLE_INTERVAL_SEC="${JETMON_SOAK_LAB_SAMPLE_INTERVAL_SEC:-60}"
+MAX_LAST_CHECKED_AGE_SEC="${JETMON_SOAK_LAB_MAX_LAST_CHECKED_AGE_SEC:-90}"
+KEEP_RUNNING="${JETMON_SOAK_LAB_KEEP_RUNNING:-0}"
+WORK_DIR="$REPO_ROOT/logs/v2-soak-lab"
+CONFIG_FILE="$REPO_ROOT/config/config.json"
+COMPOSE=(docker compose -p "$PROJECT" -f "$REPO_ROOT/docker/docker-compose.yml" -f "$REPO_ROOT/docker/docker-compose.scale-lab.yml")
+
+export BIND_ADDR="${BIND_ADDR:-127.0.0.1}"
+export API_BIND_ADDR="${API_BIND_ADDR:-127.0.0.1}"
+export MYSQL_HOST_PORT="${MYSQL_HOST_PORT:-27307}"
+export DASHBOARD_HOST_PORT="${DASHBOARD_HOST_PORT:-27080}"
+export API_HOST_PORT="${API_HOST_PORT:-27090}"
+export VERIFLIER_HOST_PORT="${VERIFLIER_HOST_PORT:-27813}"
+export API_FIXTURE_HTTP_HOST_PORT="${API_FIXTURE_HTTP_HOST_PORT:-28191}"
+export API_FIXTURE_HTTPS_HOST_PORT="${API_FIXTURE_HTTPS_HOST_PORT:-28543}"
+export MAILPIT_HOST_PORT="${MAILPIT_HOST_PORT:-28125}"
+export GRAPHITE_HOST_PORT="${GRAPHITE_HOST_PORT:-28188}"
+export STATSD_HOST_PORT="${STATSD_HOST_PORT:-28225}"
+export EMAIL_TRANSPORT=stub
+export SCALE_LAB_PUBLIC_NETWORK="$PUBLIC_NETWORK"
+export SCALE_LAB_FIXTURE_IP="$FIXTURE_IP"
+
+usage() {
+	cat <<'USAGE'
+usage: scripts/v2-soak-lab.sh <run|cleanup>
+
+Runs an isolated, internal-only v2 soak with four Monitors, three Verifliers,
+and fixture-backed sites. WPCOM notifications are disabled, email uses the stub
+transport, no alert contacts or webhooks are created, and target traffic stays
+inside the Docker host.
+
+Useful overrides:
+  JETMON_SOAK_LAB_DURATION_SEC=1800
+  JETMON_SOAK_LAB_SITE_COUNT=360
+  JETMON_SOAK_LAB_KEEP_RUNNING=1
+USAGE
+}
+
+log() {
+	printf 'INFO %s\n' "$*"
+}
+
+pass() {
+	printf 'PASS %s\n' "$*"
+}
+
+warn() {
+	printf 'WARN %s\n' "$*" >&2
+}
+
+fail() {
+	printf 'FAIL %s\n' "$*" >&2
+	exit 1
+}
+
+need_cmd() {
+	command -v "$1" >/dev/null 2>&1 || fail "missing command: $1"
+}
+
+compose() {
+	"${COMPOSE[@]}" "$@"
+}
+
+sql() {
+	compose exec -T mysqldb mariadb \
+		-u"${MYSQL_USER:-jetmon}" "-p${MYSQL_PASSWORD:-jetmon_dev_password}" \
+		"${MYSQL_DATABASE:-jetmon_db}" "$@"
+}
+
+cleanup() {
+	cd "$REPO_ROOT"
+	compose down -v --remove-orphans >/dev/null 2>&1 || true
+	docker network rm "$PUBLIC_NETWORK" >/dev/null 2>&1 || true
+	pass "v2_soak_lab_cleaned project=$PROJECT network=$PUBLIC_NETWORK"
+}
+
+prepare_config() {
+	mkdir -p "$WORK_DIR" "$REPO_ROOT/logs" "$REPO_ROOT/stats"
+	rm -f "$REPO_ROOT/veriflier2/config/veriflier.json"
+	jq \
+		--argjson bucket_total "$BUCKET_TOTAL" \
+		--arg token "${VERIFLIER_AUTH_TOKEN:-veriflier_1_auth_token}" \
+		'.AUTH_TOKEN = "v2-soak-lab-wpcom-disabled"
+		| .WPCOM_NOTIFY_ENABLE = false
+		| .EMAIL_TRANSPORT = "stub"
+		| .WPCOM_EMAIL_ENDPOINT = ""
+		| .WPCOM_EMAIL_AUTH_TOKEN = ""
+		| .API_PORT = 8090
+		| .DASHBOARD_PORT = 8080
+		| .DASHBOARD_BIND_ADDR = "127.0.0.1"
+		| .DELIVERY_OWNER_HOST = "jetmon-scale-1"
+		| .DEBUG_PORT = 0
+		| .ROLLOUT_MODE = "active"
+		| .DEFAULT_CHECK_METHOD = "GET"
+		| .DEFAULT_DETECTION_PROFILE = "simple_http"
+		| .PEER_OFFLINE_LIMIT = 1
+		| .NUM_WORKERS = 12
+		| .DATASET_SIZE = 75
+		| .MIN_TIME_BETWEEN_ROUNDS_SEC = 5
+		| .NET_COMMS_TIMEOUT = 3
+		| .BODY_READ_MAX_MS = 250
+		| .USE_VARIABLE_CHECK_INTERVALS = false
+		| .BUCKET_TOTAL = $bucket_total
+		| .BUCKET_TARGET = $bucket_total
+		| .BUCKET_HEARTBEAT_GRACE_SEC = 15
+		| .ALERT_COOLDOWN_MINUTES = 60
+		| .STATS_UPDATE_INTERVAL_MS = 1000
+		| .VERIFIERS = [
+			{"name":"Soak Veriflier 1","host":"veriflier","port":"7803","auth_token":$token},
+			{"name":"Soak Veriflier 2","host":"veriflier2","port":"7803","auth_token":$token},
+			{"name":"Soak Veriflier 3","host":"veriflier3","port":"7803","auth_token":$token}
+		]' \
+		"$REPO_ROOT/config/config-sample.json" >"$CONFIG_FILE"
+	pass "safe_config_written=$CONFIG_FILE wpcom_notify=false email_transport=stub bucket_total=$BUCKET_TOTAL"
+}
+
+ensure_public_network() {
+	if docker network inspect "$PUBLIC_NETWORK" >/dev/null 2>&1; then
+		pass "docker_network_exists=$PUBLIC_NETWORK"
+		return
+	fi
+	docker network create --subnet "$PUBLIC_SUBNET" "$PUBLIC_NETWORK" >/dev/null
+	pass "docker_network_created=$PUBLIC_NETWORK subnet=$PUBLIC_SUBNET"
+}
+
+wait_for_api() {
+	local deadline=$((SECONDS + 180))
+	until compose exec -T jetmon curl -fsS http://127.0.0.1:8090/api/v1/health >/dev/null 2>&1; do
+		((SECONDS < deadline)) || fail "API did not become healthy"
+		sleep 2
+	done
+	pass "api_healthy"
+}
+
+seed_sites() {
+	local created=0
+	local sql_file="$WORK_DIR/seed.sql"
+	local blog_id
+	local bucket
+	local url
+	local profile
+	local keyword
+
+	{
+		printf 'START TRANSACTION;\n'
+		printf 'DELETE FROM jetmon_site_runtime WHERE blog_id >= 920000000 AND blog_id < %d;\n' "$((920000000 + SITE_COUNT))"
+		printf 'DELETE FROM jetmon_site_check_config WHERE blog_id >= 920000000 AND blog_id < %d;\n' "$((920000000 + SITE_COUNT))"
+		printf 'DELETE FROM jetpack_monitor_sites WHERE blog_id >= 920000000 AND blog_id < %d;\n' "$((920000000 + SITE_COUNT))"
+		while ((created < SITE_COUNT)); do
+			blog_id=$((920000000 + created))
+			bucket=$((created % BUCKET_TOTAL))
+			case $((created % 4)) in
+				0)
+					url="http://$FIXTURE_IP:8091/slow?delay=120ms"
+					profile="simple_http"
+					keyword="NULL"
+					;;
+				1)
+					url="http://$FIXTURE_IP:8091/ok"
+					profile="simple_http"
+					keyword="NULL"
+					;;
+				2)
+					url="http://$FIXTURE_IP:8091/keyword"
+					profile="full"
+					keyword="'keyword present'"
+					;;
+				*)
+					url="http://$FIXTURE_IP:8091/redirect"
+					profile="simple_http"
+					keyword="NULL"
+					;;
+			esac
+			printf "INSERT INTO jetpack_monitor_sites (blog_id, bucket_no, monitor_url, monitor_active, site_status, check_interval) VALUES (%d, %d, '%s', 1, 1, 1);\n" "$blog_id" "$bucket" "$url"
+			printf "INSERT INTO jetmon_site_check_config (blog_id, request_method, detection_profile, check_keyword, timeout_seconds, redirect_policy, alert_cooldown_minutes) VALUES (%d, 'GET', '%s', %s, 3, 'follow', 60);\n" "$blog_id" "$profile" "$keyword"
+			created=$((created + 1))
+		done
+		printf 'COMMIT;\n'
+	} >"$sql_file"
+
+	sql <"$sql_file"
+	pass "sites_seeded count=$SITE_COUNT bucket_total=$BUCKET_TOTAL"
+}
+
+checkpoint_utc() {
+	sql --batch --skip-column-names -e "SELECT UTC_TIMESTAMP(6)" | tr -d '\r'
+}
+
+scalar_sql() {
+	sql --batch --skip-column-names -e "$1" | tr -d '[:space:]'
+}
+
+wait_for_host_count() {
+	local expected="$1"
+	local label="$2"
+	local deadline=$((SECONDS + 180))
+	local count=0
+	while ((SECONDS < deadline)); do
+		count="$(scalar_sql "SELECT COUNT(*) FROM jetmon_hosts WHERE status = 'active'")"
+		if [[ "$count" == "$expected" ]]; then
+			pass "$label active_monitor_hosts=$count"
+			return
+		fi
+		sleep 3
+	done
+	fail "$label active_monitor_hosts=$count want=$expected"
+}
+
+wait_for_dynamic_coverage() {
+	local label="$1"
+	local deadline=$((SECONDS + 180))
+	while ((SECONDS < deadline)); do
+		if compose exec -T jetmon ./jetmon2 rollout dynamic-check --output json >"$WORK_DIR/dynamic-$label.json" 2>/dev/null &&
+			jq -e '.ok == true' "$WORK_DIR/dynamic-$label.json" >/dev/null; then
+			pass "$label dynamic_bucket_coverage"
+			return
+		fi
+		sleep 3
+	done
+	cat "$WORK_DIR/dynamic-$label.json" >&2 || true
+	fail "$label dynamic bucket coverage did not become healthy"
+}
+
+checked_since() {
+	local since="$1"
+	scalar_sql "
+		SELECT COUNT(DISTINCT s.jetpack_monitor_site_id)
+		  FROM jetpack_monitor_sites s
+		  JOIN jetmon_site_runtime r ON r.blog_id = s.blog_id
+		 WHERE s.monitor_active = 1
+		   AND r.last_checked_at >= TIMESTAMP('$since')"
+}
+
+wait_for_checked_since() {
+	local label="$1"
+	local since="$2"
+	local deadline=$((SECONDS + 180))
+	local checked=0
+	while ((SECONDS < deadline)); do
+		checked="$(checked_since "$since")"
+		if [[ "$checked" == "$SITE_COUNT" ]]; then
+			pass "$label checked_sites_since_checkpoint=$checked"
+			return
+		fi
+		sleep 3
+	done
+	fail "$label only $checked/$SITE_COUNT sites checked since $since"
+}
+
+capture_fleet_snapshot() {
+	local label="$1"
+	local snapshot="$WORK_DIR/fleet-$label.json"
+	local summary
+	local bucket
+	local verifliers
+	local fresh_agents
+
+	compose exec -T jetmon curl -fsS http://127.0.0.1:8080/api/fleet >"$snapshot"
+	summary="$(jq -r '.summary.status' "$snapshot")"
+	bucket="$(jq -r '.bucket_coverage.status' "$snapshot")"
+	verifliers="$(jq -r '.verifliers.status' "$snapshot")"
+	fresh_agents="$(jq -r '.verifliers.fresh_agents' "$snapshot")"
+
+	if [[ "$summary" != "green" || "$bucket" != "green" || "$verifliers" != "green" || "$fresh_agents" != "3" ]]; then
+		fail "$label fleet_not_green summary=$summary bucket=$bucket verifliers=$verifliers fresh_agents=$fresh_agents snapshot=$snapshot"
+	fi
+	pass "$label fleet_snapshot=$snapshot summary=$summary bucket=$bucket verifliers=$verifliers fresh_agents=$fresh_agents"
+}
+
+mailpit_message_count() {
+	curl -fsS "http://127.0.0.1:$MAILPIT_HOST_PORT/api/v1/messages" | jq -r '.total'
+}
+
+assert_no_outbound_side_effects() {
+	local label="$1"
+	local wpcom_audit
+	local alert_contacts
+	local webhooks
+	local mailpit_messages
+
+	wpcom_audit="$(scalar_sql "SELECT COUNT(*) FROM jetmon_audit_log WHERE event_type IN ('wpcom_sent','wpcom_retry','wpcom_failure')")"
+	alert_contacts="$(scalar_sql "SELECT COUNT(*) FROM jetmon_alert_contacts")"
+	webhooks="$(scalar_sql "SELECT COUNT(*) FROM jetmon_webhooks")"
+	mailpit_messages="$(mailpit_message_count)"
+
+	[[ "$wpcom_audit" == "0" ]] || fail "$label wpcom_audit_rows=$wpcom_audit want=0"
+	[[ "$alert_contacts" == "0" ]] || fail "$label alert_contacts=$alert_contacts want=0"
+	[[ "$webhooks" == "0" ]] || fail "$label webhooks=$webhooks want=0"
+	[[ "$mailpit_messages" == "0" ]] || fail "$label mailpit_messages=$mailpit_messages want=0"
+	pass "$label no_wpcom_no_alert_side_effects"
+}
+
+sample_soak() {
+	local sample_no="$1"
+	local since="$2"
+	local checked
+	local max_age
+	local history_rows
+	local open_events
+	local active_hosts
+	local stale_processes
+
+	checked="$(checked_since "$since")"
+	max_age="$(scalar_sql "
+		SELECT COALESCE(MAX(TIMESTAMPDIFF(SECOND, r.last_checked_at, UTC_TIMESTAMP())), 999999)
+		  FROM jetpack_monitor_sites s
+		  JOIN jetmon_site_runtime r ON r.blog_id = s.blog_id
+		 WHERE s.monitor_active = 1")"
+	history_rows="$(scalar_sql "SELECT COUNT(*) FROM jetmon_check_history WHERE checked_at >= TIMESTAMP('$since')")"
+	open_events="$(scalar_sql "SELECT COUNT(*) FROM jetmon_events WHERE ended_at IS NULL")"
+	active_hosts="$(scalar_sql "SELECT COUNT(*) FROM jetmon_hosts WHERE status = 'active'")"
+	stale_processes="$(scalar_sql "
+		SELECT COUNT(*)
+		  FROM jetmon_process_health
+		 WHERE process_type = 'monitor'
+		   AND state = 'running'
+		   AND updated_at < UTC_TIMESTAMP() - INTERVAL 20 SECOND")"
+
+	[[ "$active_hosts" == "4" ]] || fail "sample=$sample_no active_monitor_hosts=$active_hosts want=4"
+	[[ "$checked" == "$SITE_COUNT" ]] || fail "sample=$sample_no checked_sites=$checked want=$SITE_COUNT since=$since"
+	((max_age <= MAX_LAST_CHECKED_AGE_SEC)) || fail "sample=$sample_no max_last_checked_age_sec=$max_age limit=$MAX_LAST_CHECKED_AGE_SEC"
+	((history_rows >= SITE_COUNT)) || fail "sample=$sample_no history_rows=$history_rows want_at_least=$SITE_COUNT since=$since"
+	[[ "$open_events" == "0" ]] || fail "sample=$sample_no open_events=$open_events want=0"
+	[[ "$stale_processes" == "0" ]] || fail "sample=$sample_no stale_monitor_processes=$stale_processes want=0"
+
+	capture_fleet_snapshot "sample-$sample_no"
+	assert_no_outbound_side_effects "sample-$sample_no"
+	pass "sample=$sample_no checked_sites=$checked history_rows=$history_rows max_last_checked_age_sec=$max_age"
+}
+
+run_lab() {
+	need_cmd curl
+	need_cmd docker
+	need_cmd jq
+	cd "$REPO_ROOT"
+	cleanup >/dev/null 2>&1 || true
+	prepare_config
+	ensure_public_network
+
+	log "building lab images"
+	compose build api-fixture jetmon jetmon2 jetmon3 jetmon4 veriflier veriflier2 veriflier3
+
+	log "starting soak services project=$PROJECT duration_sec=$DURATION_SEC sites=$SITE_COUNT"
+	compose up -d mysqldb mysql-user mailpit statsd api-fixture veriflier veriflier2 veriflier3 jetmon jetmon2 jetmon3 jetmon4
+	wait_for_api
+	compose exec -T jetmon curl -fsS "http://$FIXTURE_IP:8091/health" >/dev/null
+	pass "fixture_reachable_from_monitor=$FIXTURE_IP"
+	seed_sites
+
+	wait_for_host_count 4 startup
+	wait_for_dynamic_coverage startup
+	capture_fleet_snapshot startup
+
+	log "warming up duration_sec=$WARMUP_SEC"
+	warmup_since="$(checkpoint_utc)"
+	sleep "$WARMUP_SEC"
+	wait_for_checked_since warmup "$warmup_since"
+	assert_no_outbound_side_effects warmup
+
+	local sample_no=0
+	local sample_since
+	local remaining
+	local sleep_for
+	local started_at
+	started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+	sample_since="$(checkpoint_utc)"
+	local deadline=$((SECONDS + DURATION_SEC))
+	while ((SECONDS < deadline)); do
+		remaining=$((deadline - SECONDS))
+		if ((remaining < SAMPLE_INTERVAL_SEC)); then
+			log "finishing soak tail duration_sec=$remaining without full-window sample"
+			sleep "$remaining"
+			break
+		fi
+		sleep "$SAMPLE_INTERVAL_SEC"
+		sample_no=$((sample_no + 1))
+		sample_soak "$sample_no" "$sample_since"
+		sample_since="$(checkpoint_utc)"
+	done
+
+	assert_no_outbound_side_effects final
+	pass "v2_soak_lab_complete project=$PROJECT sites=$SITE_COUNT monitors=4 verifliers=3 duration_sec=$DURATION_SEC samples=$sample_no started_at=$started_at logs=$WORK_DIR"
+
+	if [[ "$KEEP_RUNNING" == "1" ]]; then
+		warn "soak lab left running because JETMON_SOAK_LAB_KEEP_RUNNING=1"
+	else
+		cleanup
+	fi
+}
+
+case "${1:-run}" in
+	run)
+		run_lab
+		;;
+	cleanup)
+		cleanup
+		;;
+	-h | --help | help)
+		usage
+		;;
+	*)
+		usage >&2
+		exit 2
+		;;
+esac


### PR DESCRIPTION
## Summary
- Add an isolated Docker scale-resilience lab for dynamic Monitor bucket ownership, horizontal scaling, Monitor failure/recovery, Veriflier degradation/recovery, and fleet dashboard snapshots.
- Seed 600 fixture-backed internal-only sites directly into the isolated Docker database so product API rate limits remain unchanged.
- Rebalance remaining active jetmon_hosts rows during graceful Monitor release to shorten transient rolling-restart coverage gaps.

## Validation
- bash -n scripts/scale-resilience-lab.sh
- docker compose config for the scale lab overlay
- git diff --check
- go test ./internal/db ./internal/orchestrator
- host6: scripts/scale-resilience-lab.sh run passed with 600 sites, 1/2/4 Monitor scaling, Monitor stop/recovery, Veriflier stop/recovery, and fleet snapshots
- host6: scripts/scale-resilience-lab.sh cleanup
- host6: docker run golang:1.26.3 go test ./...
- host6: docker run golang:1.26.3 go vet ./...

## Safety
- Lab config disables WPCOM notify, uses stub email, does not create webhooks or alert contacts, and keeps fixture traffic inside a dedicated Docker network on host6.
- The scale lab binds externally exposed lab ports to loopback.