### PR TITLE
Emit low-overhead runtime resource metrics

### DIFF
--- a/cmd/jetmon-deliverer/main.go
+++ b/cmd/jetmon-deliverer/main.go
@@ -166,9 +166,7 @@ func run() {
 	workersEnabled := deliveryWorkersShouldStart(cfg, hostname)
 	publishProcessHealth := func(state string) {
 		snapshot := delivererProcessHealthSnapshot(hostname, processStartedAt, state, cfg, workersEnabled, delivererDependencyHealth(context.Background(), db.DB(), metrics.Global() != nil, time.Now().UTC()))
-		if cfg.StatsdSendMemUsage {
-			emitDelivererResourceStats()
-		}
+		emitDelivererResourceStats()
 		ctx, cancel := context.WithTimeout(context.Background(), processHealthWriteTimeout)
 		if err := fleethealth.Upsert(ctx, db.DB(), snapshot); err != nil {
 			log.Printf("process health: %v", err)

--- a/cmd/jetmon-deliverer/main.go
+++ b/cmd/jetmon-deliverer/main.go
@@ -166,6 +166,9 @@ func run() {
 	workersEnabled := deliveryWorkersShouldStart(cfg, hostname)
 	publishProcessHealth := func(state string) {
 		snapshot := delivererProcessHealthSnapshot(hostname, processStartedAt, state, cfg, workersEnabled, delivererDependencyHealth(context.Background(), db.DB(), metrics.Global() != nil, time.Now().UTC()))
+		if cfg.StatsdSendMemUsage {
+			emitDelivererResourceStats()
+		}
 		ctx, cancel := context.WithTimeout(context.Background(), processHealthWriteTimeout)
 		if err := fleethealth.Upsert(ctx, db.DB(), snapshot); err != nil {
 			log.Printf("process health: %v", err)
@@ -242,6 +245,22 @@ func deliveryOwnerStatus(cfg *config.Config, hostname string) (string, string) {
 		return "INFO", fmt.Sprintf("delivery_owner_host=%q matched; delivery workers enabled on this host", owner)
 	}
 	return "INFO", fmt.Sprintf("delivery_owner_host=%q; standalone deliverer idle on host %q", owner, hostname)
+}
+
+func emitDelivererResourceStats() {
+	m := metrics.Global()
+	if m == nil {
+		return
+	}
+	m.EmitMemStats()
+	writeDB := db.WriteDB()
+	if writeDB != nil {
+		m.EmitDBStats("db.write_pool", writeDB.Stats())
+	}
+	readDB := db.ReadDB()
+	if readDB != nil && readDB != writeDB {
+		m.EmitDBStats("db.read_pool", readDB.Stats())
+	}
 }
 
 func validateDelivererConfigRequirements(cfg *config.Config, hostname string, opts delivererValidationOptions) []string {

--- a/config/config-sample.json
+++ b/config/config-sample.json
@@ -28,7 +28,6 @@
 	"ALERT_COOLDOWN_MINUTES" : 30,
 
 	"STATS_UPDATE_INTERVAL_MS"     : 10000,
-	"STATSD_SEND_MEM_USAGE"        : false,
 	"TIME_BETWEEN_NOTICES_MIN"     : 59,
 	"WPCOM_NOTIFY_ENABLE"          : true,
 	"WPCOM_NOTIFY_MODE"            : "legacy",

--- a/config/config.readme
+++ b/config/config.readme
@@ -269,11 +269,13 @@ entrypoint. Use this for production metric path compatibility instead of
 encoding the StatsD path into HOSTNAME.
 
 STATSD_SEND_MEM_USAGE
-Set to true to emit low-overhead process resource gauges to StatsD. Monitors
-emit them at round completion; standalone deliverers emit them on their health
-heartbeat. This includes RSS memory, Go runtime memory, heap allocation, open
-file descriptors, runtime goroutine/thread counts, and database pool pressure.
-Default: false.
+Deprecated v1 compatibility key. Jetmon v2 accepts this key in copied configs,
+but the value no longer controls metric output. When StatsD is configured,
+Monitors emit low-overhead process resource gauges at round completion,
+standalone Deliverers emit them on their health heartbeat, and Verifliers emit
+them every 10 seconds. This includes RSS memory, Go runtime memory, heap
+allocation, open file descriptors, runtime goroutine/thread counts, and
+Monitor/Deliverer database pool pressure.
 
 TIME_BETWEEN_NOTICES_MIN
 Legacy compatibility setting retained so copied v1-style configs parse. Jetmon

--- a/config/config.readme
+++ b/config/config.readme
@@ -269,7 +269,11 @@ entrypoint. Use this for production metric path compatibility instead of
 encoding the StatsD path into HOSTNAME.
 
 STATSD_SEND_MEM_USAGE
-Set to true to emit Go runtime memory stats to StatsD each interval. Default: false.
+Set to true to emit low-overhead process resource gauges to StatsD. Monitors
+emit them at round completion; standalone deliverers emit them on their health
+heartbeat. This includes RSS memory, Go runtime memory, heap allocation, open
+file descriptors, runtime goroutine/thread counts, and database pool pressure.
+Default: false.
 
 TIME_BETWEEN_NOTICES_MIN
 Legacy compatibility setting retained so copied v1-style configs parse. Jetmon

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -673,12 +673,11 @@ Important metric groups include:
 - Legacy projection drift
 - Low-overhead process resource gauges: RSS memory, Go runtime memory, heap
   allocation, open file descriptors, file descriptor utilization percentage,
-  and goroutine/thread scheduler counts. Monitors and standalone deliverers
-  emit these when `STATSD_SEND_MEM_USAGE=true`; Verifliers emit them whenever
-  `STATSD_ADDR` is configured. Monitors and deliverers also emit read/write
-  `sql.DB` pool pressure under the same `STATSD_SEND_MEM_USAGE` gate. Current
-  pool state is reported as gauges; cumulative `sql.DBStats` counters use
-  `_total` suffixes so dashboards can derive rates cleanly.
+  and goroutine/thread scheduler counts. Monitors, standalone deliverers, and
+  Verifliers emit these whenever `STATSD_ADDR` is configured. Monitors and
+  deliverers also emit read/write `sql.DB` pool pressure. Current pool state is
+  reported as gauges; cumulative `sql.DBStats` counters use `_total` suffixes
+  so dashboards can derive rates cleanly.
 
 StatsD is the primary metrics transport. Monitor and deliverer read
 `STATSD_ADDR`; Jetmon binaries do not assume a production StatsD endpoint when

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -676,7 +676,9 @@ Important metric groups include:
   and goroutine/thread scheduler counts. Monitors and standalone deliverers
   emit these when `STATSD_SEND_MEM_USAGE=true`; Verifliers emit them whenever
   `STATSD_ADDR` is configured. Monitors and deliverers also emit read/write
-  `sql.DB` pool pressure under the same `STATSD_SEND_MEM_USAGE` gate.
+  `sql.DB` pool pressure under the same `STATSD_SEND_MEM_USAGE` gate. Current
+  pool state is reported as gauges; cumulative `sql.DBStats` counters use
+  `_total` suffixes so dashboards can derive rates cleanly.
 
 StatsD is the primary metrics transport. Monitor and deliverer read
 `STATSD_ADDR`; Jetmon binaries do not assume a production StatsD endpoint when

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -671,10 +671,12 @@ Important metric groups include:
   recovery, or false alarm
 - Detection outcome counters by local failure class
 - Legacy projection drift
-- Low-overhead process resource gauges when `STATSD_SEND_MEM_USAGE=true`: RSS
-  memory, Go runtime memory, heap allocation, open file descriptors, file
-  descriptor utilization percentage, goroutine/thread scheduler counts, and
-  read/write `sql.DB` pool pressure
+- Low-overhead process resource gauges: RSS memory, Go runtime memory, heap
+  allocation, open file descriptors, file descriptor utilization percentage,
+  and goroutine/thread scheduler counts. Monitors and standalone deliverers
+  emit these when `STATSD_SEND_MEM_USAGE=true`; Verifliers emit them whenever
+  `STATSD_ADDR` is configured. Monitors and deliverers also emit read/write
+  `sql.DB` pool pressure under the same `STATSD_SEND_MEM_USAGE` gate.
 
 StatsD is the primary metrics transport. Monitor and deliverer read
 `STATSD_ADDR`; Jetmon binaries do not assume a production StatsD endpoint when

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -671,7 +671,10 @@ Important metric groups include:
   recovery, or false alarm
 - Detection outcome counters by local failure class
 - Legacy projection drift
-- RSS and Go Sys memory usage
+- Low-overhead process resource gauges when `STATSD_SEND_MEM_USAGE=true`: RSS
+  memory, Go runtime memory, heap allocation, open file descriptors, file
+  descriptor utilization percentage, goroutine/thread scheduler counts, and
+  read/write `sql.DB` pool pressure
 
 StatsD is the primary metrics transport. Monitor and deliverer read
 `STATSD_ADDR`; Jetmon binaries do not assume a production StatsD endpoint when

--- a/docs/production-veriflier-compose.md
+++ b/docs/production-veriflier-compose.md
@@ -26,6 +26,11 @@ published on the host. Graphite HTTP is published on
 `GRAPHITE_BIND_ADDR:GRAPHITE_HOST_PORT`; set `GRAPHITE_BIND_ADDR` to a
 private/VPN/firewalled address that central Grafana can reach.
 
+When StatsD is configured, Veriflier emits a small process-resource gauge set
+every 10 seconds so capacity tests and dashboards can spot memory,
+file-descriptor, goroutine, or OS-thread pressure without adding per-target
+metric labels.
+
 The Compose file mounts
 [../docker/graphite-storage-schemas.conf](../docker/graphite-storage-schemas.conf)
 so Jetmon metrics use the requested retention schedule:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -366,9 +366,10 @@ production telemetry branches:
   processing, sidecar freshness writes, check-history writes, SSL updates, and
   event handling so the next capacity retest can identify the exact slow stage.
 - [x] Add low-overhead process and DB-pool StatsD gauges so capacity runs can
-  correlate throughput changes with RSS/heap memory, file-descriptor pressure,
-  goroutine/thread pressure, and read/write MySQL pool waits without adding
-  per-check writes or high-cardinality metric names.
+  correlate Monitor, Deliverer, and Veriflier throughput changes with RSS/heap
+  memory, file-descriptor pressure, goroutine/thread pressure, and read/write
+  MySQL pool waits without adding per-check writes or high-cardinality metric
+  names.
 - [x] Batch passive per-check DB writes for
   `jetmon_site_runtime.last_checked_at` freshness updates and
   `jetmon_check_history` timing samples so healthy high-volume sweeps are not

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -370,6 +370,13 @@ production telemetry branches:
   memory, file-descriptor pressure, goroutine/thread pressure, and read/write
   MySQL pool waits without adding per-check writes or high-cardinality metric
   names.
+- [ ] Add low-cardinality Jetmon-native bandwidth StatsD counters so capacity
+  and real-site tests can compare request bytes, response header bytes, response
+  body bytes read, and total application-level transfer by check method and
+  detection profile. Keep this separate from host/container network accounting:
+  Jetmon should report what the checker intentionally sent and consumed, while
+  uptime-bench or server monitoring remains responsible for exact wire-level
+  interface bytes.
 - [x] Batch passive per-check DB writes for
   `jetmon_site_runtime.last_checked_at` freshness updates and
   `jetmon_check_history` timing samples so healthy high-volume sweeps are not

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -365,6 +365,10 @@ production telemetry branches:
 - [x] Add per-page scheduler phase timings for dispatch, wait, result
   processing, sidecar freshness writes, check-history writes, SSL updates, and
   event handling so the next capacity retest can identify the exact slow stage.
+- [x] Add low-overhead process and DB-pool StatsD gauges so capacity runs can
+  correlate throughput changes with RSS/heap memory, file-descriptor pressure,
+  goroutine/thread pressure, and read/write MySQL pool waits without adding
+  per-check writes or high-cardinality metric names.
 - [x] Batch passive per-check DB writes for
   `jetmon_site_runtime.last_checked_at` freshness updates and
   `jetmon_check_history` timing samples so healthy high-volume sweeps are not

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -119,7 +119,9 @@ type Config struct {
 
 	AlertCooldownMinutes int `json:"ALERT_COOLDOWN_MINUTES"`
 
-	StatsUpdateIntervalMS     int      `json:"STATS_UPDATE_INTERVAL_MS"`
+	StatsUpdateIntervalMS int `json:"STATS_UPDATE_INTERVAL_MS"`
+	// StatsdSendMemUsage is a deprecated v1 compatibility key. Jetmon v2 emits
+	// process resource gauges whenever StatsD is configured.
 	StatsdSendMemUsage        bool     `json:"STATSD_SEND_MEM_USAGE"`
 	TimeBetweenNoticesMin     int      `json:"TIME_BETWEEN_NOTICES_MIN"`
 	WPCOMNotifyEnable         bool     `json:"WPCOM_NOTIFY_ENABLE"`
@@ -386,6 +388,10 @@ var deprecatedConfigKeyWarnings = []deprecatedConfigKeyWarning{
 	{
 		key:     "TIME_BETWEEN_NOTICES_MIN",
 		message: "parsed for copied v1 config compatibility but does not gate v2 WPCOM status-change notifications; v2 notification timing follows incident state and Veriflier confirmation",
+	},
+	{
+		key:     "STATSD_SEND_MEM_USAGE",
+		message: "deprecated v1 compatibility key; Jetmon v2 emits process resource gauges whenever StatsD is configured",
 	},
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -543,6 +543,7 @@ func TestLoadWarnsForDeprecatedNoopAndUnknownKeys(t *testing.T) {
 		"SQL_UPDATE_BATCH": 1,
 		"TIME_BETWEEN_CHECKS_SEC": 30,
 		"TIME_BETWEEN_NOTICES_MIN": 59,
+		"STATSD_SEND_MEM_USAGE": true,
 		"NET_COMMS_TIMEOUT": 10,
 		"LOG_FORMAT": "text",
 		"UNEXPECTED_V1_KEY": true,
@@ -571,6 +572,7 @@ func TestLoadWarnsForDeprecatedNoopAndUnknownKeys(t *testing.T) {
 		"SQL_UPDATE_BATCH",
 		"TIME_BETWEEN_CHECKS_SEC",
 		"TIME_BETWEEN_NOTICES_MIN",
+		"STATSD_SEND_MEM_USAGE",
 		"UNEXPECTED_V1_KEY",
 		"VERIFIERS[0].grpc_port",
 	} {

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -26,6 +26,8 @@ type State struct {
 	WPCOMQueueDepth               int       `json:"wpcom_queue_depth"`
 	GoSysMemMB                    int       `json:"go_sys_mem_mb"`
 	RSSMemMB                      int       `json:"rss_mem_mb"`
+	OpenFDs                       int       `json:"open_fds"`
+	MaxFDs                        int       `json:"max_fds"`
 	RuntimeGoroutines             int       `json:"runtime_goroutines"`
 	RuntimeGoroutinesRunnable     int       `json:"runtime_goroutines_runnable"`
 	RuntimeGoroutinesRunning      int       `json:"runtime_goroutines_running"`
@@ -106,6 +108,8 @@ func (s *Server) Update(st State) {
 	mem := processmetrics.CurrentMemory()
 	st.GoSysMemMB = mem.GoSysMemMB
 	st.RSSMemMB = mem.RSSMemMB
+	st.OpenFDs = mem.OpenFDs
+	st.MaxFDs = mem.MaxFDs
 	st.RuntimeGoroutines = mem.RuntimeGoroutines
 	st.RuntimeGoroutinesRunnable = mem.RuntimeGoroutinesRunnable
 	st.RuntimeGoroutinesRunning = mem.RuntimeGoroutinesRunning
@@ -528,6 +532,7 @@ const dashboardHTML = `<!DOCTYPE html>
     <div class="card"><div class="label">Buckets</div><div class="value" id="buckets">-</div></div>
     <div class="card"><div class="label">RSS Memory</div><div class="value" id="rss-mem">-</div></div>
     <div class="card"><div class="label">Go Sys Memory</div><div class="value" id="go-sys">-</div></div>
+    <div class="card"><div class="label">File Descriptors</div><div class="value" id="file-descriptors">-</div></div>
   </div>
 
   <h2>Runtime</h2>
@@ -583,6 +588,7 @@ function renderState(d) {
   setText('buckets', d.bucket_min + '-' + d.bucket_max);
   setText('rss-mem', formatMem(d.rss_mem_mb));
   setText('go-sys', formatMem(d.go_sys_mem_mb));
+  setText('file-descriptors', formatFDs(d.open_fds, d.max_fds));
   setText('runtime-goroutines', d.runtime_goroutines);
   setText('runtime-runnable', d.runtime_goroutines_runnable);
   setText('runtime-threads', d.runtime_threads);
@@ -606,6 +612,12 @@ function renderState(d) {
 
 function formatMem(value) {
   return value > 0 ? value + 'MB' : 'n/a';
+}
+
+function formatFDs(openFDs, maxFDs) {
+  if (!openFDs) openFDs = 0;
+  if (!maxFDs) return String(openFDs);
+  return openFDs + ' / ' + maxFDs;
 }
 
 function renderSummary(summary) {

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -56,6 +56,9 @@ func TestHandleState(t *testing.T) {
 	if !strings.Contains(body, `"go_sys_mem_mb"`) {
 		t.Fatalf("state body missing go_sys_mem_mb: %s", body)
 	}
+	if !strings.Contains(body, `"open_fds"`) {
+		t.Fatalf("state body missing open_fds: %s", body)
+	}
 	var st State
 	if err := json.NewDecoder(strings.NewReader(body)).Decode(&st); err != nil {
 		t.Fatalf("decode: %v", err)
@@ -74,6 +77,9 @@ func TestHandleState(t *testing.T) {
 	}
 	if st.RuntimeGoroutines <= 0 || st.RuntimeThreads <= 0 || st.RuntimeGoroutinesCreated == 0 {
 		t.Fatalf("runtime fields = %+v, want scheduler metrics", st)
+	}
+	if st.OpenFDs < 0 || st.MaxFDs < 0 {
+		t.Fatalf("fd fields = open %d max %d, want non-negative", st.OpenFDs, st.MaxFDs)
 	}
 	if st.BucketOwnership != "pinned range=0-99" {
 		t.Fatalf("BucketOwnership = %q, want pinned range=0-99", st.BucketOwnership)
@@ -299,6 +305,9 @@ func TestHandleIndex(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "id=\"go-sys\"") {
 		t.Fatal("body does not contain Go system memory card")
+	}
+	if !strings.Contains(w.Body.String(), "id=\"file-descriptors\"") {
+		t.Fatal("body does not contain file descriptors card")
 	}
 	if !strings.Contains(w.Body.String(), "id=\"runtime-goroutines\"") {
 		t.Fatal("body does not contain runtime goroutines card")

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -147,9 +147,10 @@ func (c *Client) EmitMemStats() {
 	c.Gauge("runtime.threads.count", mem.RuntimeThreads)
 }
 
-// EmitDBStats emits a compact snapshot of one database pool. These are gauges,
-// including the cumulative sql.DB counters, so callers do not need to retain
-// previous values or add synchronization to the metrics client.
+// EmitDBStats emits a compact snapshot of one database pool. Current pool state
+// is emitted as gauges. Cumulative sql.DB counters are also emitted as gauges
+// with _total suffixes so downstream Graphite functions can derive rates
+// without callers retaining previous values.
 func (c *Client) EmitDBStats(prefix string, stats sql.DBStats) {
 	prefix = strings.Trim(strings.TrimSpace(prefix), ".")
 	if prefix == "" {
@@ -159,11 +160,11 @@ func (c *Client) EmitDBStats(prefix string, stats sql.DBStats) {
 	c.Gauge(prefix+".open_connections", stats.OpenConnections)
 	c.Gauge(prefix+".in_use", stats.InUse)
 	c.Gauge(prefix+".idle", stats.Idle)
-	c.Gauge(prefix+".wait_count", int(stats.WaitCount))
-	c.Gauge(prefix+".wait_duration_ms", int(stats.WaitDuration.Milliseconds()))
-	c.Gauge(prefix+".max_idle_closed", int(stats.MaxIdleClosed))
-	c.Gauge(prefix+".max_idle_time_closed", int(stats.MaxIdleTimeClosed))
-	c.Gauge(prefix+".max_lifetime_closed", int(stats.MaxLifetimeClosed))
+	c.Gauge(prefix+".wait_count_total", int(stats.WaitCount))
+	c.Gauge(prefix+".wait_duration_ms_total", int(stats.WaitDuration.Milliseconds()))
+	c.Gauge(prefix+".max_idle_closed_total", int(stats.MaxIdleClosed))
+	c.Gauge(prefix+".max_idle_time_closed_total", int(stats.MaxIdleTimeClosed))
+	c.Gauge(prefix+".max_lifetime_closed_total", int(stats.MaxLifetimeClosed))
 }
 
 // WriteStatsFiles writes sitespersec, sitesqueue, and totals to the stats/

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -121,8 +121,8 @@ func (c *Client) send(msg string) {
 }
 
 // EmitMemStats emits low-overhead local process resource gauges. The method
-// keeps its historical name because it is controlled by the existing
-// STATSD_SEND_MEM_USAGE config key.
+// keeps its historical name for API compatibility even though it now includes
+// file-descriptor and runtime scheduler pressure in addition to memory.
 func (c *Client) EmitMemStats() {
 	mem := processmetrics.CurrentMemory()
 	rssMB := mem.RSSMemMB

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"database/sql"
 	"fmt"
 	"net"
 	"os"
@@ -119,9 +120,9 @@ func (c *Client) send(msg string) {
 	_, _ = fmt.Fprintln(c.conn, msg)
 }
 
-// EmitMemStats emits legacy memory gauges. process.rss_mb uses operating-system
-// resident set size when available and falls back to Go runtime Sys memory when
-// procfs is unavailable; process.go_sys_mem_mb keeps the runtime value visible.
+// EmitMemStats emits low-overhead local process resource gauges. The method
+// keeps its historical name because it is controlled by the existing
+// STATSD_SEND_MEM_USAGE config key.
 func (c *Client) EmitMemStats() {
 	mem := processmetrics.CurrentMemory()
 	rssMB := mem.RSSMemMB
@@ -132,6 +133,37 @@ func (c *Client) EmitMemStats() {
 	c.Gauge("process.rss_mb", rssMB)
 	c.Gauge("process.go_sys_mem_mb", goSysMB)
 	c.Gauge("process.heap_alloc_mb", mem.HeapAllocMemMB)
+	c.Gauge("process.open_fds", mem.OpenFDs)
+	if mem.MaxFDs > 0 {
+		c.Gauge("process.max_fds", mem.MaxFDs)
+		c.Gauge("process.fd_utilization_pct", int(float64(mem.OpenFDs)*100/float64(mem.MaxFDs)))
+	}
+	c.Gauge("runtime.goroutines.count", mem.RuntimeGoroutines)
+	c.Gauge("runtime.goroutines.runnable", mem.RuntimeGoroutinesRunnable)
+	c.Gauge("runtime.goroutines.running", mem.RuntimeGoroutinesRunning)
+	c.Gauge("runtime.goroutines.waiting", mem.RuntimeGoroutinesWaiting)
+	c.Gauge("runtime.goroutines.not_in_go", mem.RuntimeGoroutinesNotInGo)
+	c.Gauge("runtime.goroutines.created_total", int(mem.RuntimeGoroutinesCreated))
+	c.Gauge("runtime.threads.count", mem.RuntimeThreads)
+}
+
+// EmitDBStats emits a compact snapshot of one database pool. These are gauges,
+// including the cumulative sql.DB counters, so callers do not need to retain
+// previous values or add synchronization to the metrics client.
+func (c *Client) EmitDBStats(prefix string, stats sql.DBStats) {
+	prefix = strings.Trim(strings.TrimSpace(prefix), ".")
+	if prefix == "" {
+		prefix = "db.pool"
+	}
+	c.Gauge(prefix+".max_open_connections", stats.MaxOpenConnections)
+	c.Gauge(prefix+".open_connections", stats.OpenConnections)
+	c.Gauge(prefix+".in_use", stats.InUse)
+	c.Gauge(prefix+".idle", stats.Idle)
+	c.Gauge(prefix+".wait_count", int(stats.WaitCount))
+	c.Gauge(prefix+".wait_duration_ms", int(stats.WaitDuration.Milliseconds()))
+	c.Gauge(prefix+".max_idle_closed", int(stats.MaxIdleClosed))
+	c.Gauge(prefix+".max_idle_time_closed", int(stats.MaxIdleTimeClosed))
+	c.Gauge(prefix+".max_lifetime_closed", int(stats.MaxLifetimeClosed))
 }
 
 // WriteStatsFiles writes sitespersec, sitesqueue, and totals to the stats/

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"bufio"
+	"database/sql"
 	"net"
 	"os"
 	"strings"
@@ -212,20 +213,14 @@ func TestRenderLegacyStatsFiles(t *testing.T) {
 
 func TestClientSendsStatsDMessages(t *testing.T) {
 	clientConn, serverConn := net.Pipe()
-	defer clientConn.Close()
-	defer serverConn.Close()
 
-	c := &Client{
-		prefix: "com.jetpack.jetmon.host_name",
-		conn:   clientConn,
-	}
-
-	lines := make(chan string, 6)
+	lines := make(chan string, 32)
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
+		defer close(lines)
 		r := bufio.NewReader(serverConn)
-		for i := 0; i < 6; i++ {
+		for {
 			line, err := r.ReadString('\n')
 			if err != nil {
 				return
@@ -234,31 +229,50 @@ func TestClientSendsStatsDMessages(t *testing.T) {
 		}
 	}()
 
+	c := &Client{
+		prefix: "com.jetpack.jetmon.host_name",
+		conn:   clientConn,
+	}
 	c.Increment("checks.total", 2)
 	c.Gauge("queue.depth", 7)
 	c.Timing("request.rtt", 1500*time.Millisecond)
 	c.EmitMemStats()
+	_ = clientConn.Close()
 
-	got := make([]string, 0, 6)
-	for len(got) < 6 {
+	got := make([]string, 0, 16)
+	for {
 		select {
-		case line := <-lines:
+		case line, ok := <-lines:
+			if !ok {
+				goto doneReading
+			}
 			got = append(got, line)
 		case <-time.After(time.Second):
 			t.Fatalf("timed out waiting for metric lines; got %v", got)
 		}
 	}
+doneReading:
 	_ = serverConn.Close()
 	<-done
 
 	wantPrefix := "com.jetpack.jetmon.host_name."
 	expected := map[string]bool{
-		wantPrefix + "checks.total:2|c":       false,
-		wantPrefix + "queue.depth:7|g":        false,
-		wantPrefix + "request.rtt:1500|ms":    false,
-		wantPrefix + "process.rss_mb:":        false,
-		wantPrefix + "process.go_sys_mem_mb:": false,
-		wantPrefix + "process.heap_alloc_mb:": false,
+		wantPrefix + "checks.total:2|c":                  false,
+		wantPrefix + "queue.depth:7|g":                   false,
+		wantPrefix + "request.rtt:1500|ms":               false,
+		wantPrefix + "process.rss_mb:":                   false,
+		wantPrefix + "process.go_sys_mem_mb:":            false,
+		wantPrefix + "process.heap_alloc_mb:":            false,
+		wantPrefix + "process.open_fds:":                 false,
+		wantPrefix + "process.max_fds:":                  false,
+		wantPrefix + "process.fd_utilization_pct:":       false,
+		wantPrefix + "runtime.goroutines.count:":         false,
+		wantPrefix + "runtime.goroutines.runnable:":      false,
+		wantPrefix + "runtime.goroutines.running:":       false,
+		wantPrefix + "runtime.goroutines.waiting:":       false,
+		wantPrefix + "runtime.goroutines.not_in_go:":     false,
+		wantPrefix + "runtime.goroutines.created_total:": false,
+		wantPrefix + "runtime.threads.count:":            false,
 	}
 	for _, line := range got {
 		if _, ok := expected[line]; ok {
@@ -280,6 +294,74 @@ func TestClientSendsStatsDMessages(t *testing.T) {
 	for line, seen := range expected {
 		if !seen {
 			t.Fatalf("missing metric line %q in %v", line, got)
+		}
+	}
+}
+
+func TestClientEmitsDBStats(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+
+	lines := make(chan string, 16)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer close(lines)
+		r := bufio.NewReader(serverConn)
+		for {
+			line, err := r.ReadString('\n')
+			if err != nil {
+				return
+			}
+			lines <- strings.TrimSpace(line)
+		}
+	}()
+
+	c := &Client{
+		prefix: "com.jetpack.jetmon.host_name",
+		conn:   clientConn,
+	}
+	c.EmitDBStats("db.write_pool", sql.DBStats{
+		MaxOpenConnections: 64,
+		OpenConnections:    12,
+		InUse:              7,
+		Idle:               5,
+		WaitCount:          9,
+		WaitDuration:       1500 * time.Millisecond,
+		MaxIdleClosed:      3,
+		MaxIdleTimeClosed:  2,
+		MaxLifetimeClosed:  1,
+	})
+	_ = clientConn.Close()
+
+	got := make(map[string]bool)
+	for {
+		select {
+		case line, ok := <-lines:
+			if !ok {
+				goto doneReading
+			}
+			got[line] = true
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for DB metric lines; got %v", got)
+		}
+	}
+doneReading:
+	_ = serverConn.Close()
+	<-done
+
+	for _, want := range []string{
+		"com.jetpack.jetmon.host_name.db.write_pool.max_open_connections:64|g",
+		"com.jetpack.jetmon.host_name.db.write_pool.open_connections:12|g",
+		"com.jetpack.jetmon.host_name.db.write_pool.in_use:7|g",
+		"com.jetpack.jetmon.host_name.db.write_pool.idle:5|g",
+		"com.jetpack.jetmon.host_name.db.write_pool.wait_count:9|g",
+		"com.jetpack.jetmon.host_name.db.write_pool.wait_duration_ms:1500|g",
+		"com.jetpack.jetmon.host_name.db.write_pool.max_idle_closed:3|g",
+		"com.jetpack.jetmon.host_name.db.write_pool.max_idle_time_closed:2|g",
+		"com.jetpack.jetmon.host_name.db.write_pool.max_lifetime_closed:1|g",
+	} {
+		if !got[want] {
+			t.Fatalf("missing DB metric line %q in %v", want, got)
 		}
 	}
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -354,11 +354,11 @@ doneReading:
 		"com.jetpack.jetmon.host_name.db.write_pool.open_connections:12|g",
 		"com.jetpack.jetmon.host_name.db.write_pool.in_use:7|g",
 		"com.jetpack.jetmon.host_name.db.write_pool.idle:5|g",
-		"com.jetpack.jetmon.host_name.db.write_pool.wait_count:9|g",
-		"com.jetpack.jetmon.host_name.db.write_pool.wait_duration_ms:1500|g",
-		"com.jetpack.jetmon.host_name.db.write_pool.max_idle_closed:3|g",
-		"com.jetpack.jetmon.host_name.db.write_pool.max_idle_time_closed:2|g",
-		"com.jetpack.jetmon.host_name.db.write_pool.max_lifetime_closed:1|g",
+		"com.jetpack.jetmon.host_name.db.write_pool.wait_count_total:9|g",
+		"com.jetpack.jetmon.host_name.db.write_pool.wait_duration_ms_total:1500|g",
+		"com.jetpack.jetmon.host_name.db.write_pool.max_idle_closed_total:3|g",
+		"com.jetpack.jetmon.host_name.db.write_pool.max_idle_time_closed_total:2|g",
+		"com.jetpack.jetmon.host_name.db.write_pool.max_lifetime_closed_total:1|g",
 	} {
 		if !got[want] {
 			t.Fatalf("missing DB metric line %q in %v", want, got)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	stdctx "context"
 	"crypto/tls"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -124,6 +125,7 @@ type metricsClient interface {
 	Gauge(stat string, value int)
 	Timing(stat string, d time.Duration)
 	EmitMemStats()
+	EmitDBStats(prefix string, stats sql.DBStats)
 }
 
 type roundSummary struct {
@@ -956,6 +958,7 @@ func (o *Orchestrator) finishRound(cfg *config.Config, summary roundSummary) {
 
 		if cfg.StatsdSendMemUsage {
 			m.EmitMemStats()
+			emitDBPoolStats(m)
 		}
 	}
 	metrics.WriteStatsFiles(metrics.StatsFilesSnapshot{
@@ -970,6 +973,20 @@ func (o *Orchestrator) finishRound(cfg *config.Config, summary roundSummary) {
 		Total:       summary.completed,
 	})
 	logRoundSummary(summary, roundDuration, sps)
+}
+
+func emitDBPoolStats(m metricsClient) {
+	if m == nil {
+		return
+	}
+	writeDB := db.WriteDB()
+	if writeDB != nil {
+		m.EmitDBStats("db.write_pool", writeDB.Stats())
+	}
+	readDB := db.ReadDB()
+	if readDB != nil && readDB != writeDB {
+		m.EmitDBStats("db.read_pool", readDB.Stats())
+	}
 }
 
 func logRoundSummary(summary roundSummary, roundDuration time.Duration, sps int) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -956,10 +956,8 @@ func (o *Orchestrator) finishRound(cfg *config.Config, summary roundSummary) {
 		m.Increment("scheduler.round.check.tls_deprecated.count", summary.checkTLSDeprecated)
 		emitCheckCohortCounters(m, "scheduler.round", summary.checkCohorts)
 
-		if cfg.StatsdSendMemUsage {
-			m.EmitMemStats()
-			emitDBPoolStats(m)
-		}
+		m.EmitMemStats()
+		emitDBPoolStats(m)
 	}
 	metrics.WriteStatsFiles(metrics.StatsFilesSnapshot{
 		SitesPerSec: sps,

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"crypto/tls"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -3854,6 +3855,8 @@ func (r *recordingMetrics) Timing(stat string, d time.Duration) {
 }
 
 func (r *recordingMetrics) EmitMemStats() {}
+
+func (r *recordingMetrics) EmitDBStats(prefix string, stats sql.DBStats) {}
 
 func (r *recordingMetrics) counter(stat string) int {
 	r.mu.Lock()

--- a/internal/processmetrics/memory.go
+++ b/internal/processmetrics/memory.go
@@ -8,6 +8,7 @@ import (
 	runtimemetrics "runtime/metrics"
 	"strconv"
 	"strings"
+	"syscall"
 )
 
 const bytesPerMB = 1024 * 1024
@@ -17,6 +18,8 @@ type MemorySnapshot struct {
 	RSSMemMB       int
 	GoSysMemMB     int
 	HeapAllocMemMB int
+	OpenFDs        int
+	MaxFDs         int
 
 	RuntimeGoroutines         int
 	RuntimeGoroutinesRunnable int
@@ -33,6 +36,8 @@ func CurrentMemory() MemorySnapshot {
 	mem := currentRuntimeMemory()
 	addRuntimeSchedulerMetrics(&mem)
 	mem.RSSMemMB = rssMemMB()
+	mem.OpenFDs = openFDCount()
+	mem.MaxFDs = maxFDLimit()
 	return mem
 }
 
@@ -104,4 +109,28 @@ func rssMemMBFromStatm(path string, pageSize int) (int, error) {
 		return 0, fmt.Errorf("parse resident pages: %w", err)
 	}
 	return int((residentPages * uint64(pageSize)) / bytesPerMB), nil
+}
+
+func openFDCount() int {
+	count, err := openFDCountFromDir("/proc/self/fd")
+	if err != nil {
+		return 0
+	}
+	return count
+}
+
+func openFDCountFromDir(path string) (int, error) {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return 0, err
+	}
+	return len(entries), nil
+}
+
+func maxFDLimit() int {
+	var limit syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
+		return 0
+	}
+	return metricUint64ToInt(limit.Cur)
 }

--- a/internal/processmetrics/memory_test.go
+++ b/internal/processmetrics/memory_test.go
@@ -50,4 +50,27 @@ func TestCurrentMemory(t *testing.T) {
 	if snapshot.RuntimeGoroutinesCreated == 0 {
 		t.Fatal("RuntimeGoroutinesCreated = 0, want non-zero count")
 	}
+	if snapshot.OpenFDs < 0 {
+		t.Fatalf("OpenFDs = %d, want non-negative file descriptor count", snapshot.OpenFDs)
+	}
+	if snapshot.MaxFDs < 0 {
+		t.Fatalf("MaxFDs = %d, want non-negative file descriptor limit", snapshot.MaxFDs)
+	}
+}
+
+func TestOpenFDCountFromDir(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"0", "1", "2"} {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte("fd"), 0644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", name, err)
+		}
+	}
+	got, err := openFDCountFromDir(dir)
+	if err != nil {
+		t.Fatalf("openFDCountFromDir() error = %v", err)
+	}
+	if got != 3 {
+		t.Fatalf("openFDCountFromDir() = %d, want 3", got)
+	}
 }

--- a/veriflier2/cmd/main.go
+++ b/veriflier2/cmd/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -109,6 +110,8 @@ func main() {
 			log.Printf("WARN: STATSD_HOST_PATH is unset; StatsD metrics will use Veriflier hostname %q", hostname)
 		}
 	}
+	stopResourceStats := startVeriflierResourceStats(metrics.Global(), 10*time.Second)
+	defer stopResourceStats()
 
 	srv := veriflier.NewServerWithOptions(addr, cfg.AuthToken, hostname, version, veriflier.ServerOptions{
 		CheckFunc: performCheckContext,
@@ -140,6 +143,34 @@ func main() {
 		log.Fatalf("listen: %v", err)
 	}
 	log.Println("veriflier2: shutdown complete")
+}
+
+type resourceStatsEmitter interface {
+	EmitMemStats()
+}
+
+func startVeriflierResourceStats(m resourceStatsEmitter, interval time.Duration) func() {
+	if m == nil || interval <= 0 {
+		return func() {}
+	}
+	stop := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		m.EmitMemStats()
+		for {
+			select {
+			case <-ticker.C:
+				m.EmitMemStats()
+			case <-stop:
+				return
+			}
+		}
+	}()
+	var once sync.Once
+	return func() {
+		once.Do(func() { close(stop) })
+	}
 }
 
 func veriflierAgentID(hostname, port string) string {

--- a/veriflier2/cmd/main_test.go
+++ b/veriflier2/cmd/main_test.go
@@ -6,7 +6,9 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/Automattic/jetmon/internal/checker"
 	"github.com/Automattic/jetmon/internal/veriflier"
@@ -167,6 +169,33 @@ func TestValidateStatsDHostPath(t *testing.T) {
 			t.Fatalf("validateStatsDHostPath(%q) = nil, want error", path)
 		}
 	}
+}
+
+func TestStartVeriflierResourceStats(t *testing.T) {
+	emitter := &recordingResourceStatsEmitter{}
+	stop := startVeriflierResourceStats(emitter, 10*time.Millisecond)
+	defer stop()
+
+	timeout := time.After(time.Second)
+	for {
+		if emitter.calls.Load() > 0 {
+			return
+		}
+		select {
+		case <-timeout:
+			t.Fatal("timed out waiting for Veriflier resource metric")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
+type recordingResourceStatsEmitter struct {
+	calls atomic.Int64
+}
+
+func (r *recordingResourceStatsEmitter) EmitMemStats() {
+	r.calls.Add(1)
 }
 
 func TestLoadConfigFallsBackToLegacyPortEnvironment(t *testing.T) {


### PR DESCRIPTION
## Summary

- add low-cardinality StatsD gauges for process memory, file descriptors, goroutine/thread pressure, and Monitor/Deliverer database pool pressure
- emit Monitor, Deliverer, and Veriflier resource metrics automatically whenever StatsD is configured
- deprecate the inherited STATSD_SEND_MEM_USAGE config key while keeping it parseable for copied v1 configs
- add host dashboard file-descriptor visibility and document a future Jetmon-native bandwidth metrics follow-up

## Validation

- go test ./...
- git diff --check