### PR TITLE
ci: add lint/test/race/vuln gate on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,74 @@
+name: CI
+
+# Lint, test, race, and vulnerability gate for every pull request and every
+# push to the integration branch. This is the correctness/quality gate that
+# the image-build workflow (docker-publish.yml) deliberately does not provide.
+on:
+  push:
+    branches: [v2]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  # Cancel superseded runs for the same ref so a force-push doesn't queue.
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: gofmt, vet, test, race
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          # Pin the toolchain to the version declared in go.mod so CI matches
+          # local builds and the Docker builder image.
+          go-version-file: go.mod
+          cache: true
+
+      - name: gofmt
+        run: |
+          unformatted="$(gofmt -l .)"
+          if [ -n "$unformatted" ]; then
+            echo "The following files are not gofmt-clean:"
+            echo "$unformatted"
+            echo "Run: gofmt -w ."
+            exit 1
+          fi
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go test
+        run: go test ./...
+
+      - name: go test -race
+        run: go test -race ./...
+
+  vuln:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # govulncheck is call-graph-aware: it only fails on vulnerabilities the
+      # code actually reaches, keeping the blocking gate low-noise. A reachable
+      # vulnerability fails this job and blocks merge.
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck ./...


### PR DESCRIPTION
The only existing workflow (`docker-publish.yml`) builds images and runs only on push-to-`v2` or labeled PRs — nothing enforced that code compiles, is formatted, passes vet/tests, is race-clean, or is free of reachable vulnerabilities (review finding #3).

Adds `.github/workflows/ci.yml`, on every `pull_request` and push to `v2`:
- `gofmt -l` (fails on unformatted files)
- `go vet ./...`
- `go test ./...`
- `go test -race ./...`
- `govulncheck ./...` (separate job; call-graph-aware, so low-noise enough to **block** on reachable vulns)

Toolchain pinned via `go-version-file: go.mod`; runs deduped per-ref with cancel-in-progress.

Verified green against the current `v2` tree locally: gofmt clean, vet clean, all tests + race pass, `govulncheck` reports no vulnerabilities — so the gate does not block existing work on introduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)