### PR TITLE
checker: fix Drain/scale data race on the worker WaitGroup

### DIFF
--- a/internal/checker/pool.go
+++ b/internal/checker/pool.go
@@ -131,8 +131,18 @@ func (p *Pool) WorkerCount() int {
 }
 
 // Drain stops accepting new work and waits for in-flight checks to complete.
+//
+// The closed flag is flipped under p.mu so it serializes with scale(), which
+// checks closed and spawns workers (wg.Add) while holding p.mu. Without this,
+// scale() could call wg.Add concurrently with the wg.Wait below — a data race
+// and a WaitGroup misuse. Taking p.mu guarantees every wg.Add either completed
+// before closed was set (scale ran first) or never happens (scale sees closed
+// and returns), so no Add overlaps Wait.
 func (p *Pool) Drain() {
-	if !p.closed.CompareAndSwap(false, true) {
+	p.mu.Lock()
+	swapped := p.closed.CompareAndSwap(false, true)
+	p.mu.Unlock()
+	if !swapped {
 		return
 	}
 	p.workMu.Lock()


### PR DESCRIPTION
## Why
PR CI (`go test -race`) intermittently fails with a `WARNING: DATA RACE` in `internal/checker`: a write to the worker `WaitGroup` counter by `Pool.Drain` racing a read by `Pool.scale()`. This is a **pre-existing** bug in already-merged `v2` code — it surfaced after the autoscale-signal change (#126) gave `scale()` more opportunities to run — and it can flake *any* PR's race job, not just the one that happened to catch it.

## Root cause
`Drain()` flipped `closed` with a bare `CompareAndSwap` and then called `wg.Wait()`. `scale()` checks `closed` and spawns workers (`wg.Add(1)` via `spawnWorker`) while holding `p.mu`. Because `Drain` did **not** take `p.mu` when flipping `closed`, an in-flight `scale()` could call `wg.Add` concurrently with `Drain`'s `wg.Wait()` — both a data race on the counter and a `sync.WaitGroup` misuse (Add must not run concurrently with Wait).

## Fix
Flip `closed` under `p.mu` in `Drain()`. This serializes against `scale()`, so every `wg.Add` either completes before `Drain` proceeds to `wg.Wait()` (scale ran first, then saw nothing more to do) or never happens (scale observes `closed` and returns early). No `Add` can overlap `Wait`.

One-line semantic change; no API or behavior change to draining.

## Validation
- `go test -race -count=30 ./internal/checker/` — clean (previously flaked).
- `go test -race ./...`, `go test ./...`, `go vet ./...`, `gofmt -l` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
