### PR TITLE
docs: record decided plan for outbound-credential encryption (P1)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -771,12 +771,47 @@ Recently completed candidate branches:
   schema refs plus a generated Go client smoke source. If production consumers
   standardize on a specific generator, add that exact tool to CI so tool-specific
   schema drift breaks before release.
-- **Plan encryption-at-rest for outbound credentials before public/customer
-  secret management.** Plaintext webhook secrets and alert-contact
-  destination credentials are acceptable for the current internal threat
-  model, but KMS-style encryption should be planned before exposing
-  customer-managed secrets more broadly. See
-  [`outbound-credential-encryption-plan.md`](outbound-credential-encryption-plan.md).
+- **Encrypt outbound credentials at rest (application-level envelope
+  encryption).** `jetpack_monitor_webhooks.secret` (HMAC signing key) and
+  `jetpack_monitor_alert_contacts.destination` (PagerDuty/Slack/Teams/SMTP creds) are
+  stored plaintext today (ADR-0003). The live-DB threat is bounded by the
+  internal-only gateway, but **backups, replicas, and SQL dumps have a wider
+  access profile than live event reads**, so a DB-only compromise leaks every
+  signing key (forge any webhook delivery) and every alert credential. This is
+  defense-in-depth worth doing before — not only at — the customer-facing
+  trigger. Net-new v2 surface; v1 has no credential storage, so there is no
+  migration interop.
+
+  Decided approach (analysis 2026-05; see
+  [`outbound-credential-encryption-plan.md`](outbound-credential-encryption-plan.md)
+  for the full phase plan):
+  - **Mechanism:** AES-256-GCM per credential with a versioned data key held
+    in memory; ciphertext/nonce/key_id/alg columns alongside the existing
+    plaintext + preview columns. No KMS round-trip on the dispatch hot path
+    (decrypt is local, ~µs; key unwrapped once at startup). Storage-layer
+    encryption (TDE/encrypted volumes) is a useful complement but not a
+    substitute — it does not protect against a live `SELECT`/replica read.
+  - **Key source:** env var (`CREDENTIAL_ENCRYPTION_KEY` base64-32B +
+    `CREDENTIAL_ENCRYPTION_KEY_ID`) behind a `KeySource` interface, so a
+    KMS-backed provider can be added later without touching crypto or dispatch
+    code. File-based source is a one-method alternative.
+  - **First PR scope:** phases 1–4 (crypto helpers + nullable encrypted columns
+    + dual-write on create/rotate + encrypted-preferred reads with plaintext
+    fallback + a `jetmon2 encrypt-credentials` backfill command), defaulting to
+    `CREDENTIAL_ENCRYPTION_MODE=plaintext` so merging is a no-op until an
+    operator opts in. `encrypted_required` and dropping the plaintext columns
+    are later operator-driven phases (5–6).
+  - **Operational profile when enabled:** one new production secret distributed
+    to every host that runs delivery workers (`jetmon2` with `API_PORT` and
+    every `jetmon-deliverer`); a key-rotation runbook (add key_id → dual-write →
+    rewrap rows → retire old key); a backup/restore coupling (backups hold
+    ciphertext, not the key — losing the key loses recoverability of existing
+    credentials); four new metrics (encrypt/decrypt failures, plaintext-fallback
+    count, unknown-key-id count); and a fail-fast startup check + break-glass
+    when the key source is unavailable in `dual_write`/`encrypted_required`. The
+    API contract and dispatch performance are unaffected.
+  - **Also:** amend ADR-0003 from "accepted plaintext" to "encryption available,
+    opt-in" when the first PR lands, so the ADR and plan doc do not drift.
 
 ### P2 - v3 and product-driven extensions
 


### PR DESCRIPTION
## Why
Review Lens 1 flagged that outbound credentials — `jetpack_monitor_webhooks.secret` (HMAC signing keys) and `jetpack_monitor_alert_contacts.destination` (PagerDuty/Slack/Teams/SMTP creds) — are stored plaintext (ADR-0003). The user's decision was **not to implement now** but to record the decided approach on the roadmap so the analysis isn't lost. This PR is docs-only.

## What
Expands the short P1 roadmap bullet into the **decided plan** for application-level envelope encryption, and points at the existing full phase plan in [`docs/outbound-credential-encryption-plan.md`](docs/outbound-credential-encryption-plan.md):

- **Mechanism:** AES-256-GCM per credential, versioned in-memory data key, ciphertext/nonce/key_id/alg columns beside the plaintext+preview columns; no KMS round-trip on the dispatch hot path.
- **Key source:** `CREDENTIAL_ENCRYPTION_KEY` (base64-32B) + `_KEY_ID` behind a `KeySource` interface so a KMS provider can be added later without touching crypto/dispatch.
- **First-PR scope:** phases 1–4 (crypto helpers, nullable encrypted columns, dual-write on create/rotate, encrypted-preferred reads with plaintext fallback, a `jetmon2 encrypt-credentials` backfill), defaulting `CREDENTIAL_ENCRYPTION_MODE=plaintext` so the merge is a no-op until an operator opts in. `encrypted_required` + dropping plaintext columns are later operator-driven phases (5–6).
- **Operational profile when enabled:** one new prod secret on every delivery-worker host, a key-rotation runbook, backup/restore key coupling, four new metrics, and a fail-fast startup check. API contract and dispatch perf unaffected.
- Note to amend ADR-0003 from "accepted plaintext" → "encryption available, opt-in" when the first implementation PR lands.

## Notes
- Rebased onto current `v2` (post pool-race-fix and DB-UTC merges).
- Table names corrected to the post-rename `jetpack_monitor_*` (the branch predated PR #46 and still said `jetmon_*`).
- `make rollout-docs-verify` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
