### PR TITLE
wpcom: warn when legacy notify TLS verification is disabled

### DIFF
--- a/cmd/jetmon2/main.go
+++ b/cmd/jetmon2/main.go
@@ -131,6 +131,9 @@ func runServe() {
 	if !emailTransportDelivers(cfg) {
 		log.Printf("WARN: email_transport=%s — alert-contact emails will be logged but not delivered", emailTransportLabel(cfg))
 	}
+	if msg := wpcomLegacyInsecureTLSWarning(cfg); msg != "" {
+		log.Print(msg)
+	}
 	if cfg.DashboardPort > 0 {
 		if msg := dashboardBindWarning(cfg.DashboardBindAddr); msg != "" {
 			log.Printf("WARN: %s", msg)
@@ -774,10 +777,28 @@ func wpcomNotifyAdviceLines(cfg *config.Config) []string {
 		if _, err := os.Stat(cfg.WPCOMNotifyLegacyKeyPath); err != nil {
 			lines = append(lines, fmt.Sprintf("WARN wpcom legacy client key not readable at %s: %v", cfg.WPCOMNotifyLegacyKeyPath, err))
 		}
+		if msg := wpcomLegacyInsecureTLSWarning(cfg); msg != "" {
+			lines = append(lines, msg)
+		}
 		return lines
 	default:
 		return nil
 	}
+}
+
+// wpcomLegacyInsecureTLSWarning returns a WARN line when WPCOM notifications run
+// in legacy mode with server TLS verification disabled (the default, kept for v1
+// parity). It returns "" when notifications are disabled, the mode is not
+// legacy, or verification is enabled. Startup logging and validate-config share
+// it so the operator sees the same message in both places.
+func wpcomLegacyInsecureTLSWarning(cfg *config.Config) string {
+	if cfg == nil || !cfg.WPCOMNotifyEnable {
+		return ""
+	}
+	if cfg.WPCOMNotifyMode != config.WPCOMNotifyModeLegacy || !cfg.WPCOMNotifyLegacyInsecure {
+		return ""
+	}
+	return "WARN WPCOM_NOTIFY_LEGACY_INSECURE_SKIP_VERIFY=true; legacy WPCOM notifications skip server TLS certificate verification and are exposed to man-in-the-middle. Set it false once the WPCOM legacy endpoint is confirmed to work with normal verification."
 }
 
 func checkDNSResolversLabel(servers []string) string {

--- a/cmd/jetmon2/main_test.go
+++ b/cmd/jetmon2/main_test.go
@@ -206,6 +206,61 @@ func TestEmailTransportLabelAndDelivery(t *testing.T) {
 	}
 }
 
+func TestWPCOMLegacyInsecureTLSWarning(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  config.Config
+		warn bool
+	}{
+		{
+			name: "legacy enabled insecure warns",
+			cfg:  config.Config{WPCOMNotifyEnable: true, WPCOMNotifyMode: config.WPCOMNotifyModeLegacy, WPCOMNotifyLegacyInsecure: true},
+			warn: true,
+		},
+		{
+			name: "legacy enabled verifying is silent",
+			cfg:  config.Config{WPCOMNotifyEnable: true, WPCOMNotifyMode: config.WPCOMNotifyModeLegacy, WPCOMNotifyLegacyInsecure: false},
+			warn: false,
+		},
+		{
+			name: "modern mode is silent even when insecure flag set",
+			cfg:  config.Config{WPCOMNotifyEnable: true, WPCOMNotifyMode: config.WPCOMNotifyModeModern, WPCOMNotifyLegacyInsecure: true},
+			warn: false,
+		},
+		{
+			name: "notifications disabled is silent",
+			cfg:  config.Config{WPCOMNotifyEnable: false, WPCOMNotifyMode: config.WPCOMNotifyModeLegacy, WPCOMNotifyLegacyInsecure: true},
+			warn: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := wpcomLegacyInsecureTLSWarning(&tt.cfg)
+			if tt.warn && got == "" {
+				t.Fatal("wpcomLegacyInsecureTLSWarning() = \"\", want a warning")
+			}
+			if !tt.warn && got != "" {
+				t.Fatalf("wpcomLegacyInsecureTLSWarning() = %q, want \"\"", got)
+			}
+			// When it warns, validate-config advice must surface the same line.
+			if tt.warn {
+				advice := wpcomNotifyAdviceLines(&tt.cfg)
+				found := false
+				for _, line := range advice {
+					if line == got {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("wpcomNotifyAdviceLines() = %v, missing insecure-TLS warning", advice)
+				}
+			}
+		})
+	}
+}
+
 func TestDeliveryWorkersShouldStart(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/config/config.readme
+++ b/config/config.readme
@@ -185,10 +185,14 @@ are production secrets; mount or inject them outside the repo and image. The
 default paths match the v1 repo layout: certs/jetmon.crt and certs/jetmon.key.
 
 WPCOM_NOTIFY_LEGACY_INSECURE_SKIP_VERIFY
+WARNING: When true (the default) legacy WPCOM notifications skip server TLS
+certificate verification and are exposed to man-in-the-middle.
 Whether legacy WPCOM mode skips remote TLS certificate verification. Default:
 true to preserve v1's rejectUnauthorized=false behavior for initial
 compatibility. Set false only after confirming the WPCOM legacy endpoint works
-with normal TLS verification from the production container network.
+with normal TLS verification from the production container network. While it is
+true and WPCOM notifications are enabled in legacy mode, jetmon2 logs a WARN at
+startup and in validate-config output.
 
 VERIFLIER_BATCH_SIZE
 Legacy compatibility setting retained so copied v1-style configs parse. The

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -812,6 +812,17 @@ Recently completed candidate branches:
     API contract and dispatch performance are unaffected.
   - **Also:** amend ADR-0003 from "accepted plaintext" to "encryption available,
     opt-in" when the first PR lands, so the ADR and plan doc do not drift.
+- **Flip `WPCOM_NOTIFY_LEGACY_INSECURE_SKIP_VERIFY` to default `false`
+  (secure-by-default) once the production WPCOM legacy endpoint is confirmed to
+  pass normal TLS verification.** Today it defaults `true` for v1 parity
+  (`rejectUnauthorized=false`), so legacy WPCOM notifications skip server cert
+  verification and are MITM-exposed; jetmon2 now logs a WARN at startup and in
+  `validate-config` while that holds (`wpcomLegacyInsecureTLSWarning`). The flag
+  must stay for explicit opt-in, but the default should invert after an operator
+  verifies the endpoint works with verification from the production container
+  network — the staged path already described in `config/config.readme`. Until
+  then this stays a documented, warned default rather than a hard gate, since
+  the channel is mTLS-authenticated and only active in legacy notify mode.
 
 ### P2 - v3 and product-driven extensions
 


### PR DESCRIPTION
## Why
Review (Lens 4 / Lens 7) flagged that `WPCOM_NOTIFY_LEGACY_INSECURE_SKIP_VERIFY` defaults to `true` with no operator signal. Validated: it defaults `true` (`config.go:386`) and feeds the legacy WPCOM client's `tls.Config{InsecureSkipVerify: ...}` (`client.go:394`). The legacy path is mTLS (presents a client cert) but with verification off it does **not** authenticate the server — so the WPCOM notification channel is exposed to MITM (impersonation / forged acceptance responses / eavesdropping of `blog_id`+status). Bounded (mTLS still authenticates the client; only legacy notify mode; only when `WPCOM_NOTIFY_ENABLE=true`), but silently on by default.

This is **Option B** from the discussion: surface a warning, no behavior change. Option C (flip the default to `false`) is deferred to a roadmap follow-up gated on endpoint confirmation, per the staged path `config.readme` already prescribes.

## What
- Adds `wpcomLegacyInsecureTLSWarning(cfg)`, shared by **startup logging** and **`validate-config`**, emitting a `WARN` when WPCOM notifications are enabled in legacy mode with verification disabled. Gated so it stays silent when notifications are off, the mode is modern, or verification is on.
- Wires it into the startup sequence (next to the existing `email_transport` WARN) and into `wpcomNotifyAdviceLines` (validate-config), reusing one helper so the message stays in sync.
- Documents the warning in `config/config.readme`.
- Roadmaps the secure-by-default follow-up (flip default to `false` after the production WPCOM legacy endpoint is confirmed to verify).

**No behavior change** — notifications send exactly as before; this only adds a log line. New table test `TestWPCOMLegacyInsecureTLSWarning` covers all four gating cases and asserts both surfaces emit the same line.

## Validation
`go build`, `go test ./cmd/jetmon2/`, `go vet`, `gofmt -l`, `make rollout-docs-verify` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
