### PR TITLE
Fix Veriflier startup without StatsD

### DIFF
--- a/veriflier2/cmd/main.go
+++ b/veriflier2/cmd/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"reflect"
 	"strings"
 	"sync"
 	"syscall"
@@ -102,6 +103,7 @@ func main() {
 	// Optional StatsD metrics. STATSD_ADDR is unset in standalone deploys,
 	// "statsd:8125" in the docker compose stack. metrics.Init failure logs and
 	// continues — the verifier should still run with metrics disabled.
+	var resourceStats resourceStatsEmitter
 	if statsdAddr, enabled, err := metrics.InitFromEnv(veriflierStatsDMetricHost(cfg, hostname), ""); err != nil {
 		log.Printf("metrics: init failed (%v) — running without metrics", err)
 	} else if enabled {
@@ -109,8 +111,9 @@ func main() {
 		if strings.TrimSpace(cfg.StatsDPath) == "" {
 			log.Printf("WARN: STATSD_HOST_PATH is unset; StatsD metrics will use Veriflier hostname %q", hostname)
 		}
+		resourceStats = metrics.Global()
 	}
-	stopResourceStats := startVeriflierResourceStats(metrics.Global(), 10*time.Second)
+	stopResourceStats := startVeriflierResourceStats(resourceStats, 10*time.Second)
 	defer stopResourceStats()
 
 	srv := veriflier.NewServerWithOptions(addr, cfg.AuthToken, hostname, version, veriflier.ServerOptions{
@@ -150,7 +153,7 @@ type resourceStatsEmitter interface {
 }
 
 func startVeriflierResourceStats(m resourceStatsEmitter, interval time.Duration) func() {
-	if m == nil || interval <= 0 {
+	if isNilResourceStatsEmitter(m) || interval <= 0 {
 		return func() {}
 	}
 	stop := make(chan struct{})
@@ -170,6 +173,19 @@ func startVeriflierResourceStats(m resourceStatsEmitter, interval time.Duration)
 	var once sync.Once
 	return func() {
 		once.Do(func() { close(stop) })
+	}
+}
+
+func isNilResourceStatsEmitter(m resourceStatsEmitter) bool {
+	if m == nil {
+		return true
+	}
+	v := reflect.ValueOf(m)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return v.IsNil()
+	default:
+		return false
 	}
 }
 

--- a/veriflier2/cmd/main_test.go
+++ b/veriflier2/cmd/main_test.go
@@ -190,6 +190,12 @@ func TestStartVeriflierResourceStats(t *testing.T) {
 	}
 }
 
+func TestStartVeriflierResourceStatsSkipsTypedNilEmitter(t *testing.T) {
+	var emitter *recordingResourceStatsEmitter
+	stop := startVeriflierResourceStats(emitter, time.Millisecond)
+	stop()
+}
+
 type recordingResourceStatsEmitter struct {
 	calls atomic.Int64
 }


### PR DESCRIPTION
## Summary

Fixes a Veriflier startup panic when StatsD is disabled. Current v2 can run `veriflier2` with `STATSD_ADDR` unset, but the resource metrics goroutine still starts with `metrics.Global()` and then calls `EmitMemStats()` on a nil StatsD client. In standalone/no-StatsD deployments this causes the Veriflier container to crash-loop before it can serve `/v2/status` or `/v2/check`.

This PR gates the Veriflier resource metrics emitter on successful StatsD initialization and makes the helper robust against typed-nil emitters.

## Validation

- `go test ./veriflier2/cmd ./internal/metrics`
- Test fleet validation was run on equivalent pre-rebase commit `63a544f` before the branch was rebased onto latest `v2` as `0849dce`.
- `jetmon-service-host-2` Monitor and `jetmon-vm-host-2` Veriflier were deployed with the fix.
- Monitor API health passed and `validate-config` passed with `WPCOM_NOTIFY_ENABLE=false`.
- Veriflier `/v2/status` returned `v2-json-http` and no legacy transport.
- uptime-bench quick lifecycle smoke passed: `/home/gaarai/code/uptime-bench/reports/20260520T152125Z-jetmon-v2-veriflier-reporting-lifecycle-smoke/report.md`.
- uptime-bench 9-cycle focused Veriflier lifecycle soak passed: `/home/gaarai/code/uptime-bench/reports/20260520T154701Z-2h-jetmon-v2-veriflier-lifecycle-soak/report.md`.

## Notes

The soak covered `HEAD + legacy`, `GET + simple_http`, and `GET + full` down/recovery paths. Across 27 lifecycle scenarios, each opened `Seems Down`, promoted the same event to `Down` via `verifier_confirmed`, and recovered with `verifier_cleared`. WPCOM notifications were classified as `disabled_by_test_plan`, observed attempts were zero as expected, and artifact scan findings were zero.
