### PR TITLE
Add rollout Docker lab doctor check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ BUILD_FLAGS := -ldflags "-X main.version=$(shell git describe --tags --always --
                          -X main.buildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ) \
                          -X main.goVersion=$(shell $(GO) version | awk '{print $$3}')"
 
-.PHONY: all build build-deliverer build-veriflier generate test test-race test-veriflier-soak lint vet migration-smoke delivery-claim-smoke rollout-docs-verify rollout-rehearsal-verify rollout-docker-lab rollout-docker-lab-clean scale-resilience-lab scale-resilience-lab-clean v2-soak-lab v2-soak-lab-clean rollout-vm-lab-sync rollout-vm-lab-sync-artifacts rollout-vm-lab-stage-v2 rollout-vm-lab-doctor rollout-vm-lab-prepare rollout-vm-lab-smoke rollout-vm-lab-execute-smoke rollout-vm-lab-failure-smoke rollout-vm-lab-resume-smoke rollout-vm-lab-post-start-rollback-smoke rollout-vm-lab-bad-ssh-smoke rollout-vm-lab-v2-start-failure-smoke rollout-vm-lab-runtime-guard-smoke rollout-vm-lab-real-activity-smoke rollout-vm-lab-snapshot-execute-smoke rollout-vm-lab-snapshot-all-smoke api-cli-smoke api-cli-validate api-cli-public-fixture-validate api-cli-public-fixture-validate-clean api-cli-token-create api-cli-token-list api-cli-token-revoke clean
+.PHONY: all build build-deliverer build-veriflier generate test test-race test-veriflier-soak lint vet migration-smoke delivery-claim-smoke rollout-docs-verify rollout-rehearsal-verify rollout-docker-lab rollout-docker-lab-doctor rollout-docker-lab-clean scale-resilience-lab scale-resilience-lab-clean v2-soak-lab v2-soak-lab-clean rollout-vm-lab-sync rollout-vm-lab-sync-artifacts rollout-vm-lab-stage-v2 rollout-vm-lab-doctor rollout-vm-lab-prepare rollout-vm-lab-smoke rollout-vm-lab-execute-smoke rollout-vm-lab-failure-smoke rollout-vm-lab-resume-smoke rollout-vm-lab-post-start-rollback-smoke rollout-vm-lab-bad-ssh-smoke rollout-vm-lab-v2-start-failure-smoke rollout-vm-lab-runtime-guard-smoke rollout-vm-lab-real-activity-smoke rollout-vm-lab-snapshot-execute-smoke rollout-vm-lab-snapshot-all-smoke api-cli-smoke api-cli-validate api-cli-public-fixture-validate api-cli-public-fixture-validate-clean api-cli-token-create api-cli-token-list api-cli-token-revoke clean
 
 all: build build-deliverer build-veriflier
 
@@ -77,6 +77,9 @@ rollout-rehearsal-verify: build
 
 rollout-docker-lab:
 	scripts/rollout-docker-lab.sh run
+
+rollout-docker-lab-doctor:
+	scripts/rollout-docker-lab.sh doctor
 
 rollout-docker-lab-clean:
 	scripts/rollout-docker-lab.sh cleanup

--- a/docs/production-rollout-lab.md
+++ b/docs/production-rollout-lab.md
@@ -38,6 +38,17 @@ Use these as a lab pool, not as fixed assignments. A good first topology is:
 - One uptime-bench controller/admin host that runs `jetmon2 api ...` commands
   against the Monitor API.
 
+Before starting a local Compose rehearsal, run:
+
+```bash
+make rollout-docker-lab-doctor
+```
+
+This checks local prerequisites and verifies that containers can resolve the
+external package hosts used by the Docker image build. If this fails, fix the
+Docker daemon resolver or networking first; otherwise the lab can fail during
+`go mod download` or `apt-get` before any rollout behavior is tested.
+
 ## Required Topology
 
 ### Database Tier

--- a/docs/rollout-docker-lab.md
+++ b/docs/rollout-docker-lab.md
@@ -9,8 +9,14 @@ policy migration.
 Run it from a host that can spend local Docker resources:
 
 ```bash
+make rollout-docker-lab-doctor
 make rollout-docker-lab
 ```
+
+The doctor checks local prerequisites and Docker daemon DNS before the full
+Compose build starts. If it cannot resolve the package hosts used by the image
+build, fix Docker networking first so a failed rehearsal is not mistaken for a
+rollout logic failure.
 
 Clean up the isolated project and volumes:
 

--- a/scripts/rollout-docker-lab.sh
+++ b/scripts/rollout-docker-lab.sh
@@ -8,6 +8,7 @@ PROJECT="${JETMON_ROLLOUT_DOCKER_PROJECT:-jetmon-rollout-lab}"
 PUBLIC_NETWORK="${JETMON_ROLLOUT_DOCKER_NETWORK:-jetmon-rollout-lab-public}"
 PUBLIC_SUBNET="${JETMON_ROLLOUT_DOCKER_SUBNET:-93.184.216.0/24}"
 FIXTURE_IP="${JETMON_ROLLOUT_DOCKER_FIXTURE_IP:-93.184.216.20}"
+DOCKER_DNS_TEST_IMAGE="${JETMON_ROLLOUT_DOCKER_DNS_TEST_IMAGE:-golang:1.26.3}"
 SITE_COUNT="${JETMON_ROLLOUT_DOCKER_SITE_COUNT:-40}"
 BUCKET_MIN="${JETMON_ROLLOUT_DOCKER_BUCKET_MIN:-0}"
 BUCKET_MAX="${JETMON_ROLLOUT_DOCKER_BUCKET_MAX:-0}"
@@ -36,7 +37,7 @@ export ROLLOUT_LAB_FIXTURE_IP="$FIXTURE_IP"
 
 usage() {
 	cat <<'USAGE'
-usage: scripts/rollout-docker-lab.sh <run|cleanup>
+usage: scripts/rollout-docker-lab.sh <run|doctor|cleanup>
 
 Runs a local-only Docker rollout rehearsal:
   1. starts Jetmon in ROLLOUT_MODE=api-controlled with WPCOM disabled
@@ -48,6 +49,9 @@ Runs a local-only Docker rollout rehearsal:
 
 The fixture lives on a Docker network using a public-looking RFC-valid address
 so target-safety checks stay enabled while traffic never leaves the Docker host.
+
+doctor checks local prerequisites, including Docker daemon DNS, before a full
+Compose build is started.
 USAGE
 }
 
@@ -70,6 +74,20 @@ need_cmd() {
 
 compose() {
 	"${COMPOSE[@]}" "$@"
+}
+
+docker_dns_preflight() {
+	local output
+	if output="$(docker run --rm "$DOCKER_DNS_TEST_IMAGE" sh -ec '
+		for host in proxy.golang.org deb.debian.org; do
+			getent hosts "$host" >/dev/null
+		done
+	' 2>&1)"; then
+		pass "docker_dns_preflight_ok image=$DOCKER_DNS_TEST_IMAGE hosts=proxy.golang.org,deb.debian.org"
+		return
+	fi
+	printf '%s\n' "$output" >&2
+	fail "Docker daemon DNS preflight failed; fix Docker resolver/networking before running rollout-docker-lab"
 }
 
 api() {
@@ -295,6 +313,7 @@ run_lab() {
 	prepare_config
 	prepare_fixture_sites
 	ensure_public_network
+	docker_dns_preflight
 
 	log "starting compose project=$PROJECT"
 	compose up -d --build
@@ -324,9 +343,21 @@ run_lab() {
 	pass "rollout_docker_lab_complete project=$PROJECT run_id=$RUN_ID logs=$WORK_DIR"
 }
 
+doctor() {
+	need_cmd docker
+	need_cmd jq
+	cd "$REPO_ROOT"
+	ensure_public_network
+	docker_dns_preflight
+	pass "rollout_docker_lab_doctor_ok project=$PROJECT network=$PUBLIC_NETWORK"
+}
+
 case "${1:-run}" in
 	run)
 		run_lab
+		;;
+	doctor)
+		doctor
 		;;
 	cleanup)
 		cleanup


### PR DESCRIPTION
## Summary

Adds a lightweight doctor command for the local rollout Docker lab. The doctor verifies required commands, creates the isolated fixture network, and checks Docker daemon DNS from inside the Go builder image before the full Compose build starts.

This makes Docker resolver failures, like timeouts resolving proxy.golang.org or deb.debian.org, fail early with a clear environment blocker instead of looking like rollout lab logic failures.

## Validation

- bash -n scripts/rollout-docker-lab.sh
- git diff --check
- make rollout-docker-lab-doctor (fails as expected in the current environment with the new Docker DNS preflight message)
- make rollout-docker-lab-clean
- make lint