### PR TITLE
Add rollout canary examples for API gates

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ including the Veriflier discovery trust decision in
 | [`getting-started.md`](getting-started.md) | Local Docker setup, build/test commands, API CLI smoke runs, fixture failure simulation, and tenant import basics. |
 | [`operations-guide.md`](operations-guide.md) | Production configuration, host setup, rollout modes, delivery workers, metrics, dashboard checks, and debugging. |
 | [`rollout-quick-reference.md`](rollout-quick-reference.md) | One-page operator checklist for the v1-to-v2 rollout, linked back to the full migration runbook. |
+| [`rollout-canaries.example.json`](rollout-canaries.example.json) | Template for operator-supplied synthetic canaries used by API rollout preflight and smoke gates. |
 | [`rollout-vm-lab.md`](rollout-vm-lab.md) | KVM/libvirt lab harness for rehearsing rollout flows with DB, v1, and fresh v2 VMs plus snapshots. |
 | [`scale-resilience-lab.md`](scale-resilience-lab.md) | Internal-only Docker lab for dynamic bucket ownership, Monitor failure takeover, Veriflier telemetry, and DB disruption recovery. |
 | [`v2-soak-lab.md`](v2-soak-lab.md) | Internal-only Docker soak for sustained normal v2 operation with Monitors, Verifliers, fixture sites, and no outbound side effects. |

--- a/docs/internal-api-reference.md
+++ b/docs/internal-api-reference.md
@@ -233,6 +233,9 @@ passes them at runtime:
 Pass that file to the guided flow or individual gates:
 
 ```bash
+cp docs/rollout-canaries.example.json rollout-canaries.json
+# Edit rollout-canaries.json so every URL points at an approved controlled
+# canary or uptime-bench fixture before using it against a Monitor API.
 ./bin/jetmon2 api rollout guided --bucket-min=0 --bucket-max=99 --canary-file=rollout-canaries.json --allow-remote
 ./bin/jetmon2 api rollout preflight --bucket-min=0 --bucket-max=99 --canary-file=rollout-canaries.json --allow-remote
 ./bin/jetmon2 api rollout smoke --bucket-min=0 --bucket-max=99 --mode=head-legacy --sample-size=100 --read-only --canary-file=rollout-canaries.json --allow-remote

--- a/docs/rollout-canaries.example.json
+++ b/docs/rollout-canaries.example.json
@@ -1,0 +1,34 @@
+{
+  "canaries": [
+    {
+      "name": "known-up-head-legacy",
+      "url": "https://replace-with-approved-canary.invalid/health",
+      "mode": "head-legacy",
+      "expect_success": true,
+      "expect_http_code": 200
+    },
+    {
+      "name": "controlled-down-get-simple",
+      "url": "https://replace-with-approved-canary.invalid/down",
+      "method": "GET",
+      "profile": "simple_http",
+      "expect_success": false,
+      "expect_http_code": 503
+    },
+    {
+      "name": "waf-blocked-get-simple",
+      "url": "https://replace-with-approved-canary.invalid/blocked",
+      "mode": "get-simple",
+      "expect_success": false,
+      "expect_http_code": 403
+    },
+    {
+      "name": "keyword-get-full",
+      "url": "https://replace-with-approved-canary.invalid/keyword",
+      "mode": "get-full",
+      "keyword": "expected controlled text",
+      "expect_success": true,
+      "expect_http_code": 200
+    }
+  ]
+}

--- a/docs/rollout-docker-lab.md
+++ b/docs/rollout-docker-lab.md
@@ -45,7 +45,8 @@ The lab script:
 1. Starts the Docker environment with the rollout-lab override.
 2. Creates an admin API key inside the isolated database.
 3. Seeds fixture-backed sites in bucket `0` with HEAD/legacy policy.
-4. Runs rollout capabilities, preflight, and read-only HEAD/legacy smoke.
+4. Generates a fixture canary file and passes it through rollout preflight and
+   read-only HEAD/legacy smoke.
 5. Plans and executes seed, final reconcile, and bucket activation.
 6. Waits for the Monitor to check every seeded site.
 7. Verifies bucket coverage, activity, and projection drift gates.
@@ -58,6 +59,9 @@ The lab script:
 Outputs are written under `logs/rollout-docker-lab/`. The site fixture JSON is
 staged under `stats/rollout-docker-lab/` so the Monitor container can read it
 through the existing `/jetmon/stats` mount without adding a runtime log mount.
+The generated canary file is staged in the same directory and covers a known-up
+HEAD/legacy check, a controlled GET/simple_http 503, and a GET/full keyword
+check against the internal fixture.
 
 ## Environment Overrides
 

--- a/docs/rollout-quick-reference.md
+++ b/docs/rollout-quick-reference.md
@@ -44,6 +44,8 @@ still require `--allow-remote`.
 Preferred interactive wrapper:
 
 ```bash
+cp docs/rollout-canaries.example.json rollout-canaries.json
+# Edit rollout-canaries.json to use approved controlled canaries or uptime-bench fixtures.
 ./jetmon2 api rollout guided \
   --bucket-min=<min> \
   --bucket-max=<max> \

--- a/docs/v1-to-v2-migration.md
+++ b/docs/v1-to-v2-migration.md
@@ -128,6 +128,8 @@ The API-driven rollout flow is:
 The preferred operator command is the guided API wrapper:
 
 ```bash
+cp docs/rollout-canaries.example.json rollout-canaries.json
+# Edit rollout-canaries.json to use approved controlled canaries or uptime-bench fixtures.
 ./jetmon2 api rollout guided \
   --bucket-min=0 \
   --bucket-max=99 \

--- a/scripts/rollout-docker-lab.sh
+++ b/scripts/rollout-docker-lab.sh
@@ -17,6 +17,8 @@ CHANGE_REF="${JETMON_ROLLOUT_DOCKER_CHANGE_REF:-overnight-rollout-docker-lab}"
 WORK_DIR="$REPO_ROOT/logs/rollout-docker-lab"
 SITE_FIXTURE_FILE="$REPO_ROOT/stats/rollout-docker-lab/sites.json"
 SITE_FIXTURE_CONTAINER_FILE="/jetmon/stats/rollout-docker-lab/sites.json"
+CANARY_FIXTURE_FILE="$REPO_ROOT/stats/rollout-docker-lab/canaries.json"
+CANARY_FIXTURE_CONTAINER_FILE="/jetmon/stats/rollout-docker-lab/canaries.json"
 CONFIG_FILE="$REPO_ROOT/config/config.json"
 COMPOSE=(docker compose -p "$PROJECT" -f "$REPO_ROOT/docker/docker-compose.yml" -f "$REPO_ROOT/docker/docker-compose.rollout-lab.yml")
 
@@ -186,7 +188,37 @@ prepare_fixture_sites() {
   }
 ]
 JSON
+	cat >"$CANARY_FIXTURE_FILE" <<JSON
+{
+  "canaries": [
+    {
+      "name": "fixture-known-up-head",
+      "url": "http://$FIXTURE_IP:8091/health",
+      "mode": "head-legacy",
+      "expect_success": true,
+      "expect_http_code": 200
+    },
+    {
+      "name": "fixture-controlled-down-get",
+      "url": "http://$FIXTURE_IP:8091/status/503",
+      "method": "GET",
+      "profile": "simple_http",
+      "expect_success": false,
+      "expect_http_code": 503
+    },
+    {
+      "name": "fixture-keyword-full",
+      "url": "http://$FIXTURE_IP:8091/keyword",
+      "mode": "get-full",
+      "keyword": "keyword present",
+      "expect_success": true,
+      "expect_http_code": 200
+    }
+  ]
+}
+JSON
 	pass "fixture_sites_written=$SITE_FIXTURE_FILE count=$SITE_COUNT fixture=$FIXTURE_IP"
+	pass "fixture_canaries_written=$CANARY_FIXTURE_FILE count=3"
 }
 
 ensure_public_network() {
@@ -325,8 +357,8 @@ run_lab() {
 
 	seed_sites
 	api rollout capabilities --output json | tee "$WORK_DIR/capabilities.json" >/dev/null
-	api rollout preflight --bucket-min "$BUCKET_MIN" --bucket-max "$BUCKET_MAX" --run-id "$RUN_ID" --change-ref "$CHANGE_REF" --output json | tee "$WORK_DIR/preflight.json" >/dev/null
-	api rollout smoke --bucket-min "$BUCKET_MIN" --bucket-max "$BUCKET_MAX" --run-id "$RUN_ID" --mode head-legacy --sample-size "$SITE_COUNT" --read-only --output json | tee "$WORK_DIR/smoke-head-legacy.json" >/dev/null
+	api rollout preflight --bucket-min "$BUCKET_MIN" --bucket-max "$BUCKET_MAX" --run-id "$RUN_ID" --change-ref "$CHANGE_REF" --canary-file "$CANARY_FIXTURE_CONTAINER_FILE" --output json | tee "$WORK_DIR/preflight.json" >/dev/null
+	api rollout smoke --bucket-min "$BUCKET_MIN" --bucket-max "$BUCKET_MAX" --run-id "$RUN_ID" --mode head-legacy --sample-size "$SITE_COUNT" --read-only --canary-file "$CANARY_FIXTURE_CONTAINER_FILE" --output json | tee "$WORK_DIR/smoke-head-legacy.json" >/dev/null
 	plan_execute seed rollout seed --bucket-min "$BUCKET_MIN" --bucket-max "$BUCKET_MAX" --run-id "$RUN_ID" --change-ref "$CHANGE_REF"
 	plan_execute final-reconcile rollout final-reconcile --bucket-min "$BUCKET_MIN" --bucket-max "$BUCKET_MAX" --run-id "$RUN_ID" --change-ref "$CHANGE_REF"
 	plan_execute activate-buckets rollout activate-buckets --bucket-min "$BUCKET_MIN" --bucket-max "$BUCKET_MAX" --run-id "$RUN_ID" --change-ref "$CHANGE_REF"


### PR DESCRIPTION
## Summary

This adds a concrete rollout canary template and wires the Docker rollout lab to exercise the synthetic canary path once the lab can run end-to-end.

## What changed

- Added `docs/rollout-canaries.example.json` with known-up, controlled-down, blocked, and keyword canary examples that operators can copy and replace with approved controlled targets.
- Updated the API reference, migration runbook, rollout quick reference, Docker lab notes, and docs index so the canary workflow is easier to find from the rollout path.
- Updated `scripts/rollout-docker-lab.sh` to generate fixture canaries and pass them through `api rollout preflight` and read-only `api rollout smoke`.

## Testing

- `bash -n scripts/rollout-docker-lab.sh`
- `jq . docs/rollout-canaries.example.json`
- `git diff --check`
- `scripts/rollout-docker-lab.sh doctor` still stops at the known Docker daemon DNS preflight, before any Compose build.