### PR TITLE
Add site safety reporting gate

### DIFF
--- a/cmd/jetmon2/site_safety.go
+++ b/cmd/jetmon2/site_safety.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -37,16 +38,60 @@ type siteSafetyUnsafeURLRow struct {
 	Reason string
 }
 
+type siteSafetyReportOptions struct {
+	Output     string
+	Status     string
+	SampleSize int
+	StaleAfter time.Duration
+	MaxOpen    int64
+}
+
+type siteSafetyFlagSummary struct {
+	FlagType    string `json:"flag_type"`
+	Status      string `json:"status"`
+	Count       int64  `json:"count"`
+	FirstSeenAt string `json:"first_seen_at,omitempty"`
+	LastSeenAt  string `json:"last_seen_at,omitempty"`
+}
+
+type siteSafetyFlagSample struct {
+	SiteID      int64  `json:"site_id"`
+	BlogID      int64  `json:"blog_id"`
+	FlagType    string `json:"flag_type"`
+	Status      string `json:"status"`
+	Reason      string `json:"reason,omitempty"`
+	URL         string `json:"url,omitempty"`
+	FirstSeenAt string `json:"first_seen_at,omitempty"`
+	LastSeenAt  string `json:"last_seen_at,omitempty"`
+}
+
+type siteSafetyReport struct {
+	Command           string                  `json:"command"`
+	OK                bool                    `json:"ok"`
+	Status            string                  `json:"status"`
+	GeneratedAt       string                  `json:"generated_at"`
+	Total             int64                   `json:"total"`
+	Open              int64                   `json:"open"`
+	StaleOpen         int64                   `json:"stale_open"`
+	StaleAfterSeconds int64                   `json:"stale_after_seconds,omitempty"`
+	MaxOpen           *int64                  `json:"max_open,omitempty"`
+	Summaries         []siteSafetyFlagSummary `json:"summaries"`
+	Samples           []siteSafetyFlagSample  `json:"samples,omitempty"`
+	Issues            []string                `json:"issues,omitempty"`
+}
+
 func cmdSiteSafety(args []string) {
 	if len(args) < 1 {
-		fmt.Fprintln(os.Stderr, "usage: jetmon2 site-safety <unsafe-urls> [args]")
+		fmt.Fprintln(os.Stderr, "usage: jetmon2 site-safety <unsafe-urls|report> [args]")
 		os.Exit(2)
 	}
 	switch args[0] {
 	case "unsafe-urls":
 		cmdSiteSafetyUnsafeURLs(args[1:])
+	case "report":
+		cmdSiteSafetyReport(args[1:])
 	default:
-		fmt.Fprintf(os.Stderr, "unknown site-safety subcommand %q (want: unsafe-urls)\n", args[0])
+		fmt.Fprintf(os.Stderr, "unknown site-safety subcommand %q (want: unsafe-urls or report)\n", args[0])
 		os.Exit(2)
 	}
 }
@@ -88,6 +133,53 @@ func cmdSiteSafetyUnsafeURLs(args []string) {
 	}
 	if report.UnsafeRows > report.Deactivated && !opts.Execute {
 		fmt.Fprintln(os.Stdout, "INFO dry_run=true pass --execute to deactivate unsafe active rows")
+	}
+}
+
+func cmdSiteSafetyReport(args []string) {
+	fs := flag.NewFlagSet("site-safety report", flag.ExitOnError)
+	opts := siteSafetyReportOptions{Output: "text", Status: db.SiteSafetyStatusOpen, SampleSize: 20, StaleAfter: 24 * time.Hour, MaxOpen: -1}
+	fs.StringVar(&opts.Output, "output", opts.Output, "output format: text or json")
+	fs.StringVar(&opts.Status, "status", opts.Status, "sample status filter: open, deactivated, ignored, resolved, or all")
+	fs.IntVar(&opts.SampleSize, "sample-size", opts.SampleSize, "maximum flag examples to print")
+	fs.DurationVar(&opts.StaleAfter, "stale-after", opts.StaleAfter, "age after which open flags are reported as stale; 0 disables stale reporting")
+	fs.Int64Var(&opts.MaxOpen, "max-open", opts.MaxOpen, "fail if open flags exceed this threshold; -1 disables the threshold")
+	_ = fs.Parse(args)
+	if opts.SampleSize < 0 {
+		fmt.Fprintln(os.Stderr, "sample-size must be >= 0")
+		os.Exit(2)
+	}
+	if opts.MaxOpen < -1 {
+		fmt.Fprintln(os.Stderr, "max-open must be >= -1")
+		os.Exit(2)
+	}
+	opts.Output = strings.TrimSpace(strings.ToLower(opts.Output))
+	opts.Status = strings.TrimSpace(strings.ToLower(opts.Status))
+	if !validSiteSafetyReportStatus(opts.Status) {
+		fmt.Fprintln(os.Stderr, "status must be one of: open, deactivated, ignored, resolved, all")
+		os.Exit(2)
+	}
+
+	configPath := envOrDefault("JETMON_CONFIG", "config/config.json")
+	if err := config.Load(configPath); err != nil {
+		fmt.Fprintf(os.Stderr, "site-safety report: config parse: %v\n", err)
+		os.Exit(1)
+	}
+	config.LoadDB()
+	if err := db.ConnectWithRetry(3); err != nil {
+		fmt.Fprintf(os.Stderr, "site-safety report: db connect: %v\n", err)
+		os.Exit(1)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	report, err := runSiteSafetyReport(ctx, os.Stdout, db.DB(), opts, time.Now().UTC())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "site-safety report: %v\n", err)
+		os.Exit(1)
+	}
+	if !report.OK {
+		os.Exit(1)
 	}
 }
 
@@ -173,6 +265,211 @@ func runSiteSafetyUnsafeURLs(ctx context.Context, out io.Writer, conn *sql.DB, o
 	}
 	fmt.Fprintf(out, "INFO scanned_active=%d unsafe=%d flagged=%d deactivated=%d\n", report.ScannedActive, report.UnsafeRows, report.Flagged, report.Deactivated)
 	return report, nil
+}
+
+func runSiteSafetyReport(ctx context.Context, out io.Writer, conn *sql.DB, opts siteSafetyReportOptions, now time.Time) (siteSafetyReport, error) {
+	if out == nil {
+		out = io.Discard
+	}
+	if conn == nil {
+		return siteSafetyReport{}, fmt.Errorf("db is required")
+	}
+	if opts.Output == "" {
+		opts.Output = "text"
+	}
+	opts.Output = strings.TrimSpace(strings.ToLower(opts.Output))
+	if opts.Status == "" {
+		opts.Status = db.SiteSafetyStatusOpen
+	}
+	opts.Status = strings.TrimSpace(strings.ToLower(opts.Status))
+	if opts.SampleSize < 0 {
+		opts.SampleSize = 0
+	}
+	if opts.MaxOpen < -1 {
+		opts.MaxOpen = -1
+	}
+	if !validSiteSafetyReportStatus(opts.Status) {
+		return siteSafetyReport{}, fmt.Errorf("status must be one of: open, deactivated, ignored, resolved, all")
+	}
+	now = now.UTC()
+	report := siteSafetyReport{
+		Command:           "site-safety report",
+		OK:                true,
+		Status:            "green",
+		GeneratedAt:       now.Format(time.RFC3339),
+		StaleAfterSeconds: int64(opts.StaleAfter / time.Second),
+	}
+	if opts.MaxOpen >= 0 {
+		maxOpen := opts.MaxOpen
+		report.MaxOpen = &maxOpen
+	}
+
+	summaries, err := querySiteSafetySummaries(ctx, conn)
+	if err != nil {
+		return report, err
+	}
+	report.Summaries = summaries
+	for _, summary := range summaries {
+		report.Total += summary.Count
+		if summary.Status == db.SiteSafetyStatusOpen {
+			report.Open += summary.Count
+		}
+	}
+	if opts.StaleAfter > 0 {
+		staleOpen, err := querySiteSafetyStaleOpen(ctx, conn, now.Add(-opts.StaleAfter))
+		if err != nil {
+			return report, err
+		}
+		report.StaleOpen = staleOpen
+	}
+	samples, err := querySiteSafetySamples(ctx, conn, opts.Status, opts.SampleSize)
+	if err != nil {
+		return report, err
+	}
+	report.Samples = samples
+
+	if opts.MaxOpen >= 0 && report.Open > opts.MaxOpen {
+		report.Issues = append(report.Issues, fmt.Sprintf("open safety flags %d exceed max-open %d", report.Open, opts.MaxOpen))
+	}
+	if report.StaleOpen > 0 {
+		report.Issues = append(report.Issues, fmt.Sprintf("%d open safety flag(s) are older than %s", report.StaleOpen, opts.StaleAfter))
+	}
+	if len(report.Issues) > 0 {
+		report.OK = false
+		report.Status = "red"
+	}
+	if err := renderSiteSafetyReport(out, report, opts.Output); err != nil {
+		return report, err
+	}
+	return report, nil
+}
+
+func querySiteSafetySummaries(ctx context.Context, conn *sql.DB) ([]siteSafetyFlagSummary, error) {
+	rows, err := conn.QueryContext(ctx, `
+		SELECT flag_type, status, COUNT(*), MIN(first_seen_at), MAX(last_seen_at)
+		  FROM jetpack_monitor_site_safety_flags
+		 GROUP BY flag_type, status
+		 ORDER BY flag_type, status`)
+	if err != nil {
+		return nil, fmt.Errorf("query site safety summary: %w", err)
+	}
+	defer rows.Close()
+
+	var summaries []siteSafetyFlagSummary
+	for rows.Next() {
+		var summary siteSafetyFlagSummary
+		var firstSeen sql.NullTime
+		var lastSeen sql.NullTime
+		if err := rows.Scan(&summary.FlagType, &summary.Status, &summary.Count, &firstSeen, &lastSeen); err != nil {
+			return nil, fmt.Errorf("scan site safety summary: %w", err)
+		}
+		summary.FirstSeenAt = formatNullTime(firstSeen)
+		summary.LastSeenAt = formatNullTime(lastSeen)
+		summaries = append(summaries, summary)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate site safety summary: %w", err)
+	}
+	return summaries, nil
+}
+
+func querySiteSafetyStaleOpen(ctx context.Context, conn *sql.DB, cutoff time.Time) (int64, error) {
+	var count int64
+	err := conn.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		  FROM jetpack_monitor_site_safety_flags
+		 WHERE status = ?
+		   AND last_seen_at < ?`, db.SiteSafetyStatusOpen, cutoff).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("query stale site safety flags: %w", err)
+	}
+	return count, nil
+}
+
+func querySiteSafetySamples(ctx context.Context, conn *sql.DB, status string, limit int) ([]siteSafetyFlagSample, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	query := `
+		SELECT monitor_site_id, blog_id, flag_type, status, reason, monitor_url, first_seen_at, last_seen_at
+		  FROM jetpack_monitor_site_safety_flags`
+	var args []any
+	if status != "all" {
+		query += "\n WHERE status = ?"
+		args = append(args, status)
+	}
+	query += "\n ORDER BY last_seen_at DESC, id DESC LIMIT ?"
+	args = append(args, limit)
+
+	rows, err := conn.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query site safety samples: %w", err)
+	}
+	defer rows.Close()
+
+	var samples []siteSafetyFlagSample
+	for rows.Next() {
+		var sample siteSafetyFlagSample
+		var firstSeen sql.NullTime
+		var lastSeen sql.NullTime
+		if err := rows.Scan(&sample.SiteID, &sample.BlogID, &sample.FlagType, &sample.Status, &sample.Reason, &sample.URL, &firstSeen, &lastSeen); err != nil {
+			return nil, fmt.Errorf("scan site safety sample: %w", err)
+		}
+		sample.FirstSeenAt = formatNullTime(firstSeen)
+		sample.LastSeenAt = formatNullTime(lastSeen)
+		samples = append(samples, sample)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate site safety samples: %w", err)
+	}
+	return samples, nil
+}
+
+func renderSiteSafetyReport(out io.Writer, report siteSafetyReport, output string) error {
+	switch output {
+	case "json":
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	case "text", "":
+		renderSiteSafetyReportText(out, report)
+		return nil
+	default:
+		return fmt.Errorf("unsupported output %q", output)
+	}
+}
+
+func renderSiteSafetyReportText(out io.Writer, report siteSafetyReport) {
+	level := "PASS"
+	if !report.OK {
+		level = "FAIL"
+	}
+	fmt.Fprintf(out, "%s site_safety_flags_report=%s total=%d open=%d stale_open=%d issues=%d\n", level, report.Status, report.Total, report.Open, report.StaleOpen, len(report.Issues))
+	for _, issue := range report.Issues {
+		fmt.Fprintf(out, "WARN issue=%q\n", issue)
+	}
+	for _, summary := range report.Summaries {
+		fmt.Fprintf(out, "INFO flag_type=%s status=%s count=%d first_seen=%s last_seen=%s\n", summary.FlagType, summary.Status, summary.Count, summary.FirstSeenAt, summary.LastSeenAt)
+	}
+	for _, sample := range report.Samples {
+		fmt.Fprintf(out, "WARN sample site_id=%d blog_id=%d flag_type=%s status=%s last_seen=%s reason=%q url=%q\n", sample.SiteID, sample.BlogID, sample.FlagType, sample.Status, sample.LastSeenAt, sample.Reason, sample.URL)
+	}
+}
+
+func validSiteSafetyReportStatus(status string) bool {
+	switch strings.TrimSpace(status) {
+	case db.SiteSafetyStatusOpen, db.SiteSafetyStatusDeactivated, db.SiteSafetyStatusIgnored, db.SiteSafetyStatusResolved, "all":
+		return true
+	default:
+		return false
+	}
+}
+
+func formatNullTime(t sql.NullTime) string {
+	if !t.Valid {
+		return ""
+	}
+	return t.Time.UTC().Format(time.RFC3339)
 }
 
 func classifyUnsafeMonitorURL(rawURL string) string {

--- a/cmd/jetmon2/site_safety_test.go
+++ b/cmd/jetmon2/site_safety_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Automattic/jetmon/internal/db"
 	"github.com/DATA-DOG/go-sqlmock"
@@ -143,6 +144,90 @@ func TestDeactivateUnsafeMonitorURLsChunksLargeBatches(t *testing.T) {
 	}
 	if deactivated != 1001 {
 		t.Fatalf("deactivated = %d, want 1001", deactivated)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestRunSiteSafetyReportSummarizesFlags(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	firstSeen := now.Add(-2 * time.Hour)
+	lastSeen := now.Add(-30 * time.Minute)
+
+	mock.ExpectQuery("SELECT flag_type, status, COUNT").
+		WillReturnRows(sqlmock.NewRows([]string{"flag_type", "status", "count", "first_seen_at", "last_seen_at"}).
+			AddRow(db.SiteSafetyFlagProbeSafetyBlock, db.SiteSafetyStatusOpen, int64(2), firstSeen, lastSeen).
+			AddRow(db.SiteSafetyFlagUnsafeMonitorURL, db.SiteSafetyStatusDeactivated, int64(1), firstSeen, lastSeen))
+	mock.ExpectQuery("SELECT COUNT").
+		WithArgs(db.SiteSafetyStatusOpen, now.Add(-time.Hour)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(0)))
+	mock.ExpectQuery("SELECT monitor_site_id, blog_id, flag_type").
+		WithArgs(db.SiteSafetyStatusOpen, 2).
+		WillReturnRows(sqlmock.NewRows([]string{"monitor_site_id", "blog_id", "flag_type", "status", "reason", "monitor_url", "first_seen_at", "last_seen_at"}).
+			AddRow(int64(12), int64(42), db.SiteSafetyFlagProbeSafetyBlock, db.SiteSafetyStatusOpen, "blocked", "http://127.0.0.1", firstSeen, lastSeen))
+
+	var out bytes.Buffer
+	report, err := runSiteSafetyReport(context.Background(), &out, conn, siteSafetyReportOptions{
+		Output:     "text",
+		Status:     db.SiteSafetyStatusOpen,
+		SampleSize: 2,
+		StaleAfter: time.Hour,
+		MaxOpen:    5,
+	}, now)
+	if err != nil {
+		t.Fatalf("runSiteSafetyReport: %v", err)
+	}
+	if !report.OK || report.Total != 3 || report.Open != 2 || report.StaleOpen != 0 {
+		t.Fatalf("report = %+v", report)
+	}
+	if !strings.Contains(out.String(), "PASS site_safety_flags_report=green total=3 open=2 stale_open=0") {
+		t.Fatalf("unexpected output: %s", out.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestRunSiteSafetyReportFailsOnThresholds(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	oldSeen := now.Add(-48 * time.Hour)
+
+	mock.ExpectQuery("SELECT flag_type, status, COUNT").
+		WillReturnRows(sqlmock.NewRows([]string{"flag_type", "status", "count", "first_seen_at", "last_seen_at"}).
+			AddRow(db.SiteSafetyFlagProbeSafetyBlock, db.SiteSafetyStatusOpen, int64(3), oldSeen, oldSeen))
+	mock.ExpectQuery("SELECT COUNT").
+		WithArgs(db.SiteSafetyStatusOpen, now.Add(-24*time.Hour)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(3)))
+
+	var out bytes.Buffer
+	report, err := runSiteSafetyReport(context.Background(), &out, conn, siteSafetyReportOptions{
+		Output:     "text",
+		Status:     db.SiteSafetyStatusOpen,
+		SampleSize: 0,
+		StaleAfter: 24 * time.Hour,
+		MaxOpen:    1,
+	}, now)
+	if err != nil {
+		t.Fatalf("runSiteSafetyReport: %v", err)
+	}
+	if report.OK || report.Status != "red" || len(report.Issues) != 2 {
+		t.Fatalf("report = %+v, want red with two issues", report)
+	}
+	if !strings.Contains(out.String(), "FAIL site_safety_flags_report=red") {
+		t.Fatalf("unexpected output: %s", out.String())
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -131,6 +131,9 @@ timestamps, and remediation status. It intentionally does not replace the
 legacy site table or event tables: `monitor_active` still controls whether a
 site is checked, and probe-safety blocks remain excluded from SLA downtime,
 WPCOM down/recovery notifications, webhooks, and alert-contact delivery.
+Use `jetmon2 site-safety report` for read-only operator reporting over these
+flags, and `jetmon2 site-safety unsafe-urls` when scanning active legacy rows
+for shape-unsafe stored URLs.
 
 ## Site Runtime
 

--- a/docs/jetmon-v2-prelaunch-readiness.md
+++ b/docs/jetmon-v2-prelaunch-readiness.md
@@ -513,9 +513,12 @@ Evidence:
   file location, read-only Monitor mount, `DB_SERVER_MAP_*` values, reload
   cadence, and `/api/v1/monitor/db-config` / dashboard status are acceptable
   before rollout.
-- [ ] Owner: `Jetmon` - Add or open follow-up tracking for scheduled
+- [x] Owner: `Jetmon` - Add scheduled
   `jetpack_monitor_site_safety_flags` reporting so unsafe legacy row counts and runtime
   probe-safety blocks are visible before and after API rejection rolls out.
+  Use `jetmon2 site-safety report` for the durable flag table, and pair it
+  with scheduled dry-run `site-safety unsafe-urls` scans when active legacy URL
+  shape counts are needed.
 - [ ] Owner: `Jetmon` - Add or open follow-up tracking for authoritative DNS
   rebinding coverage: public address on first lookup, then private/reserved
   address on redirect or later check.
@@ -531,8 +534,8 @@ Evidence:
 
 - MariaDB runtime exercise transcript, including server versions and pass/fail
   output for each covered write path.
-- Links to follow-up issues or roadmap entries for safety-flag reporting, DNS
-  rebinding tests, TLS pathology tests, and keyword short-circuiting.
+- `site-safety report` output and links to follow-up issues or roadmap entries
+  for DNS rebinding tests, TLS pathology tests, and keyword short-circuiting.
 
 ## Early Canary Gates
 

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -172,6 +172,14 @@ webhook, or alert-contact notifications. Runtime probe-safety blocks also write
 open `jetpack_monitor_site_safety_flags` rows when the monitor row is known, so
 operators can query one table for cleanup and recurring unsafe-target findings.
 
+Use `./jetmon2 site-safety report` as the read-only scheduled gate for that
+table. It prints open, stale-open, and per-type/status counts plus bounded
+examples. Add `--output=json` for automation, `--max-open=N` to fail when open
+flags exceed an approved threshold, and `--stale-after=24h` or another rollout
+threshold to surface flags that have not been remediated. Pair this with a
+scheduled dry-run `site-safety unsafe-urls` scan when operators need to watch
+unsafe legacy URL counts before or after API rejection changes.
+
 ## Production Host Setup
 
 1. Install `bin/jetmon2` as `/opt/jetmon2/jetmon2`, or update the service unit

--- a/docs/security-adversarial-probe-analysis.md
+++ b/docs/security-adversarial-probe-analysis.md
@@ -355,7 +355,7 @@ Deferred product options:
 
 1. Add a first-class non-downtime event state, for example `Probe Blocked` or `Probe Safety Blocked`, with severity 2 and `check_type=probe_safety`. Do this if dashboards or API consumers need probe-safety findings in the normal event feed. It must be excluded from SLA downtime and WPCOM down/recovery notifications.
 2. Treat public-host hostile responses as degraded states only after repeat evidence. Oversized headers, body-read budget exhaustion, and TLS pathology can be real site problems or adversarial behavior. If represented as events, they should use thresholds and cooldowns to avoid opening transient one-probe noise.
-3. Add scheduled reporting over `jetpack_monitor_site_safety_flags` and dry-run scans so operators can watch unsafe legacy row counts before and after API rejection rolls out.
+3. Schedule `site-safety report` and dry-run `site-safety unsafe-urls` scans so operators can watch durable safety flags and unsafe legacy row counts before and after API rejection rolls out.
 
 API behavior should remain strict regardless of which product option is chosen: new or updated monitor URLs should be rejected at write time when they are shape-unsafe, and runtime target-safety should remain in place for already-stored rows and DNS changes.
 
@@ -368,7 +368,7 @@ If more checker result fields become shared protocol semantics, move the stable 
 ## Remaining High-Value Scenarios
 
 1. Run an end-to-end MariaDB 11.4 runtime exercise before production rollout, covering bucket claiming, runtime freshness writes, SSL expiry batches, `ON DUPLICATE KEY UPDATE ... VALUES(...)`, and webhook / alert delivery claims.
-2. Add scheduled reporting over `jetpack_monitor_site_safety_flags` and dry-run scans so the unsafe legacy row count can be watched before and after API rejection rolls out.
+2. Schedule `jetmon2 site-safety report` over `jetpack_monitor_site_safety_flags` and dry-run `site-safety unsafe-urls` scans so the unsafe legacy row count can be watched before and after API rejection rolls out.
 3. Exercise DNS rebinding with an authoritative test DNS responder: public address on first lookup, private address on a redirect hop or later check.
 4. Exercise TLS pathology with uptime-bench responders: TLS 1.0/1.1, no common cipher, handshake close/alert, large certificate chains, expired/self-signed/hostname mismatch certificates.
 5. Consider streaming keyword matching that can stop as soon as a required-only keyword is found instead of reading until EOF/limit/budget.


### PR DESCRIPTION
## Summary

This adds a read-only `jetmon2 site-safety report` command so probe-safety remediation state can be monitored without ad hoc SQL.

## What changed

- Added `site-safety report` with text and JSON output.
- Summarizes `jetpack_monitor_site_safety_flags` by flag type and status, reports open and stale-open totals, and prints bounded examples.
- Added `--max-open` and `--stale-after` thresholds so scheduled jobs can fail when safety flags exceed the rollout policy.
- Updated operations, data-model, prelaunch, and probe-safety docs to describe how this report pairs with dry-run unsafe URL scans.

## Testing

- `go test ./cmd/jetmon2 -run 'Test(RunSiteSafety|ClassifyUnsafe|DeactivateUnsafe)'`
- `go test ./cmd/jetmon2`
- `git diff --check`
