### PR TITLE
Track adaptive Veriflier escalation follow-up

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -136,6 +136,13 @@ Open work:
 - [ ] Validate geo-scoped benchmark assumptions before changing production
   behavior for `http-geo-503`. Confirm probe source ranges, intended Jetmon
   region semantics, and the support story for partial regional failures.
+- [ ] Replace global `NUM_OF_CHECKS` escalation gating with failure-class-aware
+  Veriflier escalation. Keep local retries for ambiguous transport, timeout,
+  and low-confidence DNS failures, but escalate high-confidence HTTP, TLS,
+  redirect-policy, keyword, and full-profile failures sooner. Preserve
+  failure-pressure guardrails so Verifliers are not overloaded during broad
+  Monitor-side impairment. Deprecate `NUM_OF_CHECKS` after production evidence
+  confirms the adaptive policy is safer than a single global retry count.
 
 ## Scheduler And Scalability
 


### PR DESCRIPTION
## Summary

Adds a roadmap item to replace the global NUM_OF_CHECKS escalation gate with failure-class-aware Veriflier escalation.

## Details

The roadmap now captures the intended direction discussed for local retries and Veriflier handoff:

- keep local retries for ambiguous transport, timeout, and low-confidence DNS failures
- escalate high-confidence HTTP, TLS, redirect-policy, keyword, and full-profile failures sooner
- preserve failure-pressure guardrails so Verifliers are not overloaded during broad Monitor-side impairment
- deprecate NUM_OF_CHECKS after production evidence confirms the adaptive policy is safer than a single global retry count

This is documentation-only and does not change runtime behavior.