### PR TITLE
Expose Veriflier build metadata in status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ GOCACHE     ?= /tmp/jetmon-go-cache
 GOMODCACHE  ?= /tmp/jetmon-gomod-cache
 GO_ENV      := GOCACHE=$(GOCACHE) GOMODCACHE=$(GOMODCACHE)
 BUILD_FLAGS := -ldflags "-X main.version=$(shell git describe --tags --always --dirty) \
+                         -X main.commit=$(shell git rev-parse HEAD) \
                          -X main.buildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ) \
                          -X main.goVersion=$(shell $(GO) version | awk '{print $$3}')"
 

--- a/cmd/jetmon-deliverer/main.go
+++ b/cmd/jetmon-deliverer/main.go
@@ -29,6 +29,7 @@ const (
 // Injected at build time via -ldflags.
 var (
 	version   = "dev"
+	commit    = "unknown"
 	buildDate = "unknown"
 	goVersion = "unknown"
 )

--- a/cmd/jetmon2/main.go
+++ b/cmd/jetmon2/main.go
@@ -46,6 +46,7 @@ const (
 // Injected at build time via -ldflags.
 var (
 	version   = "dev"
+	commit    = "unknown"
 	buildDate = "unknown"
 	goVersion = "unknown"
 )

--- a/internal/veriflier/server.go
+++ b/internal/veriflier/server.go
@@ -32,6 +32,9 @@ type Server struct {
 	addr      string
 	hostname  string
 	version   string
+	commit    string
+	buildDate string
+	goVersion string
 	vantage   Vantage
 	agent     Agent
 	executor  *Executor
@@ -43,6 +46,9 @@ type ServerOptions struct {
 	CheckFunc      CheckFunc
 	Vantage        Vantage
 	AgentID        string
+	Commit         string
+	BuildDate      string
+	GoVersion      string
 	MaxConcurrency int
 	QueueCapacity  int
 	EnableLegacy   bool
@@ -103,12 +109,27 @@ func NewServerWithOptions(addr, authToken, hostname, version string, opts Server
 	if agentID == "" {
 		agentID = hostname
 	}
+	commit := opts.Commit
+	if commit == "" {
+		commit = "unknown"
+	}
+	buildDate := opts.BuildDate
+	if buildDate == "" {
+		buildDate = "unknown"
+	}
+	goVersion := opts.GoVersion
+	if goVersion == "" {
+		goVersion = "unknown"
+	}
 	executor := NewExecutor(opts.CheckFunc, opts.MaxConcurrency, opts.QueueCapacity)
 	return &Server{
 		addr:      addr,
 		authToken: authToken,
 		hostname:  hostname,
 		version:   version,
+		commit:    commit,
+		buildDate: buildDate,
+		goVersion: goVersion,
 		vantage:   vantage,
 		agent: Agent{
 			ID:       agentID,
@@ -346,6 +367,9 @@ func (s *Server) Status() StatusV2Response {
 	return StatusV2Response{
 		Status:    "OK",
 		Version:   s.version,
+		Commit:    s.commit,
+		BuildDate: s.buildDate,
+		GoVersion: s.goVersion,
 		Protocols: protocols,
 		Vantage:   s.vantage,
 		Agent:     s.agent,

--- a/internal/veriflier/types.go
+++ b/internal/veriflier/types.go
@@ -87,6 +87,9 @@ type Capacity struct {
 type StatusV2Response struct {
 	Status    string   `json:"status"`
 	Version   string   `json:"version"`
+	Commit    string   `json:"commit"`
+	BuildDate string   `json:"build_date"`
+	GoVersion string   `json:"go_version"`
 	Protocols []string `json:"protocols"`
 	Vantage   Vantage  `json:"vantage"`
 	Agent     Agent    `json:"agent"`

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -34,6 +34,9 @@ func newV2TestServer(checkFn CheckFunc, opts ...ServerOptions) (*Server, *httpte
 		CheckFunc:      checkFn,
 		Vantage:        Vantage{ID: "test-vantage", Region: "test-region", Provider: "test-provider"},
 		AgentID:        "test-agent",
+		Commit:         "test-commit",
+		BuildDate:      "test-build-date",
+		GoVersion:      "test-go",
 		MaxConcurrency: 4,
 		QueueCapacity:  4,
 	}
@@ -47,6 +50,15 @@ func newV2TestServer(checkFn CheckFunc, opts ...ServerOptions) (*Server, *httpte
 		}
 		if override.AgentID != "" {
 			cfg.AgentID = override.AgentID
+		}
+		if override.Commit != "" {
+			cfg.Commit = override.Commit
+		}
+		if override.BuildDate != "" {
+			cfg.BuildDate = override.BuildDate
+		}
+		if override.GoVersion != "" {
+			cfg.GoVersion = override.GoVersion
 		}
 		if override.MaxConcurrency != 0 {
 			cfg.MaxConcurrency = override.MaxConcurrency
@@ -1225,6 +1237,18 @@ func TestServerHandleV2Status(t *testing.T) {
 	}
 	if status.Agent.ID != "test-agent" {
 		t.Fatalf("agent id = %q, want test-agent", status.Agent.ID)
+	}
+	if status.Version != "1.0" {
+		t.Fatalf("version = %q, want 1.0", status.Version)
+	}
+	if status.Commit != "test-commit" {
+		t.Fatalf("commit = %q, want test-commit", status.Commit)
+	}
+	if status.BuildDate != "test-build-date" {
+		t.Fatalf("build date = %q, want test-build-date", status.BuildDate)
+	}
+	if status.GoVersion != "test-go" {
+		t.Fatalf("go version = %q, want test-go", status.GoVersion)
 	}
 	if status.Capacity.MaxConcurrency != 4 {
 		t.Fatalf("max concurrency = %d, want 4", status.Capacity.MaxConcurrency)

--- a/veriflier2/cmd/main.go
+++ b/veriflier2/cmd/main.go
@@ -23,7 +23,13 @@ import (
 	"github.com/Automattic/jetmon/internal/veriflier"
 )
 
-var version = "dev"
+// Injected at build time via -ldflags.
+var (
+	version   = "dev"
+	commit    = "unknown"
+	buildDate = "unknown"
+	goVersion = "unknown"
+)
 var enforceOutboundTargetSafety = true
 
 const shutdownGracePeriod = 30 * time.Second
@@ -89,6 +95,9 @@ func main() {
 	defer stopResourceStats()
 
 	srv := veriflier.NewServerWithOptions(addr, cfg.AuthToken, hostname, version, veriflier.ServerOptions{
+		Commit:    commit,
+		BuildDate: buildDate,
+		GoVersion: goVersion,
 		CheckFunc: performCheckContext,
 		Vantage: veriflier.Vantage{
 			ID:       cfg.VantageID,


### PR DESCRIPTION
Summary:
- Add build commit injection to the shared Makefile build flags.
- Expose `commit`, `build_date`, and `go_version` from `/v2/status` while preserving `version`.
- Wire Veriflier build metadata through server options and cover the status response in tests.

Tests:
- `go test ./internal/veriflier ./veriflier2/cmd`
- `make build-veriflier`
- `go test ./cmd/jetmon2 ./cmd/jetmon-deliverer`
- `make build`
- `make build-deliverer`
- `go test ./...`