### PR TITLE
Tag v2 Docker builds with date+SHA for pinned deploys

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,6 +40,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Compute build date
+        id: date
+        if: github.event_name == 'push' && github.ref == 'refs/heads/v2'
+        run: echo "ymd=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
+
       - name: Compute image metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -47,7 +52,8 @@ jobs:
           images: ghcr.io/automattic/${{ matrix.name }}
           tags: |
             type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/v2' }}
-            type=sha,format=short,prefix=,enable=${{ github.event_name == 'pull_request' }}
+            type=sha,format=short,prefix=${{ steps.date.outputs.ymd }}-,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/v2' }}
+            type=sha,format=short,prefix=pr-,enable=${{ github.event_name == 'pull_request' }}
 
       - name: Build and push
         uses: docker/build-push-action@v5
@@ -74,6 +80,7 @@ jobs:
         with:
           script: |
             const sha = context.sha.substring(0, 7);
+            const tag = `pr-${sha}`;
             const marker = '<!-- docker-publish:pr-images -->';
             const body = [
               marker,
@@ -82,8 +89,8 @@ jobs:
               `Built from \`${sha}\`. Pull with:`,
               '',
               '```bash',
-              `docker pull ghcr.io/automattic/jetmon:${sha}`,
-              `docker pull ghcr.io/automattic/veriflier:${sha}`,
+              `docker pull ghcr.io/automattic/jetmon:${tag}`,
+              `docker pull ghcr.io/automattic/veriflier:${tag}`,
               '```',
               '',
               'Images are `linux/amd64` only. On Apple Silicon, add `--platform linux/amd64`. ' +

--- a/docs/docker-images.md
+++ b/docs/docker-images.md
@@ -18,9 +18,11 @@ stack.
 ## Tags
 
 - `latest`: current `v2` branch.
-- `<short-sha>`: PR build when the PR has the `Docker Build` label.
+- `<YYYYMMDD>-<short-sha>`: immutable tag for every push to `v2`. Use this to
+  pin production deployments to a specific build.
+- `pr-<short-sha>`: PR build when the PR has the `Docker Build` label.
 
-There are no semver tags yet. Pin to a SHA tag when reproducibility matters.
+There are no semver tags yet. Pin to a date-SHA tag when reproducibility matters.
 
 ## Authentication
 
@@ -213,8 +215,8 @@ docker exec jetmon ./jetmon2 drain
 ## Test A PR Image
 
 ```bash
-docker pull ghcr.io/automattic/jetmon:<short-sha>
-docker pull ghcr.io/automattic/veriflier:<short-sha>
+docker pull ghcr.io/automattic/jetmon:pr-<short-sha>
+docker pull ghcr.io/automattic/veriflier:pr-<short-sha>
 ```
 
 Find the short SHA in the PR's `Build and publish Docker images` workflow run.


### PR DESCRIPTION
## Summary

Pushes to `v2` currently only tag the resulting `jetmon` and `veriflier`
images as `latest`, which makes it hard to pin a production deployment to a
specific build. This PR adds an immutable `<YYYYMMDD>-<short-sha>` tag on
every v2 build alongside `latest`, and renames the PR-build tag to
`pr-<short-sha>` so ephemeral PR images can't collide with v2 release tags.

## Changes

- `.github/workflows/docker-publish.yml`:
  - New `Compute build date` step (runs only on push to `v2`) that exports
    `ymd=YYYYMMDD` in UTC.
  - `docker/metadata-action` now emits, on push to `v2`: `latest` plus
    `<YYYYMMDD>-<short-sha>` (e.g. `20260522-abc1234`).
  - PR builds emit `pr-<short-sha>` instead of bare `<short-sha>`.
  - PR-comment script updated to surface the new `pr-` tag.
- `docs/docker-images.md`: documents the new immutable tag and the
  `pr-<short-sha>` PR tag; updated the `Test A PR Image` snippet.

## Testing

- [ ] `make test` (no Go changes, but run for hygiene)
- [ ] Workflow smoke: trigger a PR with the `Docker Build` label and confirm
      the image is published as `pr-<short-sha>` and the PR comment renders
      the new pull command.
- [ ] Confirm `${{ steps.date.outputs.ymd }}` flows through the metadata
      action's `prefix=` field on the first push to `v2` after merge.

## Deployment Notes

- No runtime/config/migration impact.
- Tag scheme change is additive for v2 (still publishes `latest`); rollback
  is just reverting this PR.
- Existing PR images published before this change keep their bare-SHA tag in
  GHCR; only future PR builds use the `pr-` prefix. Any external tooling
  pinned to bare `<short-sha>` for PR images should switch to `pr-<short-sha>`.