### PR TITLE
veriflier: render config to the persistent path so env changes always win

### DIFF
--- a/docker/run-veriflier.sh
+++ b/docker/run-veriflier.sh
@@ -42,7 +42,14 @@ render_config() {
 }
 
 config_render_target() {
-	printf '%s\n' "${VERIFLIER_CONFIG:-/tmp/veriflier-rendered-config/veriflier.json}"
+	# Default to the in-image (and named-volume backed in prod) location so
+	# operators inspecting the container see the same config the binary is
+	# using. With render_mode=always (the default), this file is overwritten
+	# on every container start from the current environment — no stale data
+	# can survive a token rotation, FQDN rename, or vantage_id change.
+	# Override via VERIFLIER_CONFIG to point elsewhere (e.g. tmpfs) when
+	# write-back to the config dir is undesirable.
+	printf '%s\n' "${VERIFLIER_CONFIG:-config/veriflier.json}"
 }
 
 render_mode() {


### PR DESCRIPTION
## Summary

`docker/run-veriflier.sh` defaulted its render target to a tmpfs path and exported `VERIFLIER_CONFIG` to that path. The Go binary reads from there correctly — but a stale `veriflier.json` left over from earlier deploys lingers in the named-volume-backed `/opt/veriflier/config/`, which is exactly what `docker/docker-compose.veriflier-prod.yml` mounts:

```yaml
volumes:
  - veriflier-config:/opt/veriflier/config
```

The binary's fallback path (when `VERIFLIER_CONFIG` is unset) is `config/veriflier.json` relative to the working dir — i.e. `/opt/veriflier/config/veriflier.json`. Any future entrypoint bug or manual `docker run`/`docker start` that drops the env var would silently load that stale file: old auth tokens, old hostnames, old vantage IDs.

One-line behavior change in the entrypoint plus a comment block:

```diff
-	printf '%s\n' "${VERIFLIER_CONFIG:-/tmp/veriflier-rendered-config/veriflier.json}"
+	printf '%s\n' "${VERIFLIER_CONFIG:-config/veriflier.json}"
```

`render_mode=always` remains the default, so on every container start the file in the persistent dir is rewritten from the current environment. Operators who want write-back disabled (read-only volumes, tmpfs, etc.) can still set `VERIFLIER_CONFIG` explicitly.

## Real-world incident this would have prevented

A Veriflier operator rotated the auth token, renamed `JETMON_HOSTNAME` from a synthetic label to an FQDN, and re-ran `docker compose up -d` several times. On inspection:

| Source | Token first 20 chars | Hostname |
|---|---|---|
| `.env` on host | `Z8WIML5$mRJTyC6hP8$G…` (fresh) | `nyc-do-jetmon-veriflier-1.downtime.party` (FQDN) |
| `/tmp/.../veriflier.json` | `Z8WIML5$mRJTyC6hP8$G…` (fresh) | FQDN |
| **`/opt/veriflier/config/veriflier.json`** | **`Z8WIML5^Rzy66V@…`** (corrupted, persisted forever) | **`nyc1.do-nyc1-1`** (old synthetic) |

The binary used the `/tmp` copy and was correct at runtime — but anyone diagnosing by reading the on-disk persistent file was led down the wrong path. With this patch the persistent file matches the `/tmp` copy because they're the same file.

## Verification

Pre-seeded a volume with `{"auth_token":"STALE-MUST-BE-OVERWRITTEN"}`, started the container with the patched entrypoint and fresh env (including a `$`-bearing token):

```
STEP 3: file in volume now
{
    "auth_token" : "FRESH$mR$Gl-with-dollars",
    "hostname"   : "fresh.example",
    "vantage_id" : "fresh-v",
    "region"     : "fresh-r",
    ...
}
```

`$mR`, `$Gl` are preserved verbatim — JSON literal, no docker-compose interpolation between env var and rendered file.

## Compatibility

- Same default behavior on first start of a fresh container — the rendered file ends up at `/opt/veriflier/config/veriflier.json` instead of `/tmp/...`. The binary reads from `VERIFLIER_CONFIG` (still exported by the entrypoint), so the read path is unchanged.
- Containers that explicitly set `VERIFLIER_CONFIG` keep their behavior verbatim.
- The named volume in `docker-compose.veriflier-prod.yml` now actually persists the rendered config across restarts, refreshed on every start.

## Test plan

- [x] Pre-seeded volume + fresh-env restart overwrites stale file (verified locally)
- [ ] CI green (`veriflier2/cmd/main_test.go` tests use absolute `VERIFLIER_CONFIG` via `t.TempDir()`, unaffected by the default change)
- [ ] After merge: existing-deploy hosts get clean state automatically on next `docker compose pull && docker compose up -d` of the rebuilt `:latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
