### PR TITLE
veriflier: Traefik blue-green topology for zero-downtime deploys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,12 @@ bin/
 
 # Secrets and local config
 .env
+.env.bak.*
 config/config.json
 config/db-config.conf
+
+# Operator-rendered Traefik dynamic config (the .sample is tracked)
+docker/traefik/dynamic/veriflier.yml
 
 # Generated TLS certificates
 certs/*.crt

--- a/docker/docker-compose.veriflier-prod.yml
+++ b/docker/docker-compose.veriflier-prod.yml
@@ -1,10 +1,35 @@
 services:
-  veriflier:
-    image: ${VERIFLIER_IMAGE:-ghcr.io/automattic/veriflier:latest}
+  # Traefik fronts the public Veriflier port for zero-downtime blue-green
+  # deploys. The deploy automation rewrites the file under
+  # ${VERIFLIER_TRAEFIK_DYNAMIC_DIR} to swap which Veriflier color receives
+  # traffic; Traefik's file provider reloads the routing within ~1s with
+  # no dropped connections.
+  traefik:
+    image: ${TRAEFIK_IMAGE:-traefik:v3.4}
     init: true
     restart: unless-stopped
     ports:
       - "${VERIFLIER_BIND_ADDR:-0.0.0.0}:${VERIFLIER_HOST_PORT:-7803}:7803"
+    volumes:
+      - ${VERIFLIER_TRAEFIK_STATIC:-./traefik/traefik.yml}:/etc/traefik/traefik.yml:ro
+      - ${VERIFLIER_TRAEFIK_DYNAMIC_DIR:-./traefik/dynamic}:/etc/traefik/dynamic:ro
+    healthcheck:
+      test: ["CMD", "traefik", "healthcheck", "--ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 5s
+
+  # Veriflier blue/green colors. Only one is brought up in steady state;
+  # the other is started briefly during a deploy. The compose `profiles:`
+  # opt-in keeps `docker compose up` from starting both unless explicitly
+  # told to. The deploy role activates a single color via
+  # `docker compose --profile blue up -d veriflier-blue` (or green).
+  veriflier-blue:
+    image: ${VERIFLIER_IMAGE:-ghcr.io/automattic/veriflier:latest}
+    init: true
+    restart: unless-stopped
+    profiles: ["blue", "all"]
     environment:
       VERIFLIER_AUTH_TOKEN: ${VERIFLIER_AUTH_TOKEN:?set VERIFLIER_AUTH_TOKEN}
       VERIFLIER_PORT: "7803"
@@ -26,7 +51,35 @@ services:
       retries: 12
       start_period: 10s
     volumes:
-      - veriflier-config:/opt/veriflier/config
+      - veriflier-blue-config:/opt/veriflier/config
+
+  veriflier-green:
+    image: ${VERIFLIER_IMAGE:-ghcr.io/automattic/veriflier:latest}
+    init: true
+    restart: unless-stopped
+    profiles: ["green", "all"]
+    environment:
+      VERIFLIER_AUTH_TOKEN: ${VERIFLIER_AUTH_TOKEN:?set VERIFLIER_AUTH_TOKEN}
+      VERIFLIER_PORT: "7803"
+      VERIFLIER_VANTAGE_ID: ${VERIFLIER_VANTAGE_ID:?set VERIFLIER_VANTAGE_ID}
+      VERIFLIER_REGION: ${VERIFLIER_REGION:?set VERIFLIER_REGION}
+      VERIFLIER_PROVIDER: ${VERIFLIER_PROVIDER:-vps}
+      VERIFLIER_ENABLE_LEGACY_HTTP: ${VERIFLIER_ENABLE_LEGACY_HTTP:-false}
+      CHECK_TARGET_SAFETY_MODE: ${CHECK_TARGET_SAFETY_MODE:-public_only}
+      STATSD_ADDR: statsd:8125
+      JETMON_HOSTNAME: ${JETMON_HOSTNAME:-}
+      STATSD_HOST_PATH: ${STATSD_HOST_PATH:-}
+    depends_on:
+      statsd:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:7803/v2/status"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+    volumes:
+      - veriflier-green-config:/opt/veriflier/config
 
   statsd:
     image: ${STATSD_GRAPHITE_IMAGE:-graphiteapp/graphite-statsd}
@@ -62,6 +115,7 @@ services:
     restart: "no"
 
 volumes:
-  veriflier-config:
+  veriflier-blue-config:
+  veriflier-green-config:
   statsd-graphite-storage:
   statsd-logs:

--- a/docker/traefik/dynamic/veriflier.yml.sample
+++ b/docker/traefik/dynamic/veriflier.yml.sample
@@ -1,0 +1,37 @@
+## Reference template for the Veriflier blue-green dynamic config.
+##
+## Both color services are declared with their fixed Docker network
+## hostnames; the router's `service:` field selects which one receives
+## traffic. The deploy automation in jetmon-secrets overwrites this file's
+## `service:` line to swap colors. Traefik's file provider watches the
+## directory and reloads the routing in <1s — no Traefik restart,
+## no `docker exec`, no dropped connections.
+##
+## Keep the router name `veriflier` and the service names stable so the
+## file-replace strategy works idempotently.
+
+http:
+  routers:
+    veriflier:
+      rule: "PathPrefix(`/`)"
+      entryPoints:
+        - veriflier-public
+      service: veriflier-blue        # rendered per-deploy: blue or green
+
+  services:
+    veriflier-blue:
+      loadBalancer:
+        servers:
+          - url: "http://veriflier-blue:7803"
+        healthCheck:
+          path: /v2/status
+          interval: 10s
+          timeout: 5s
+    veriflier-green:
+      loadBalancer:
+        servers:
+          - url: "http://veriflier-green:7803"
+        healthCheck:
+          path: /v2/status
+          interval: 10s
+          timeout: 5s

--- a/docker/traefik/traefik.yml
+++ b/docker/traefik/traefik.yml
@@ -1,0 +1,44 @@
+## Traefik static config for production Veriflier hosts.
+##
+## Combined with docker-compose.veriflier-prod.yml, Traefik fronts the public
+## :7803 port and routes to one of veriflier-blue / veriflier-green based on
+## a dynamic config file under /etc/traefik/dynamic. The blue-green deploy
+## automation rewrites that file to swap active backends with zero downtime.
+##
+## This file does not change at runtime — only Traefik restarts reload it.
+
+global:
+  checkNewVersion: false
+  sendAnonymousUsage: false
+
+entryPoints:
+  veriflier-public:
+    address: ":7803"
+
+# Built-in /ping endpoint on the public entrypoint, used as the container
+# healthcheck. Not a security concern: it returns "OK\n" and exposes no
+# routing or service info.
+ping:
+  entryPoint: veriflier-public
+
+# Traefik's API endpoint, exposed only inside the container on :8080 so the
+# deploy automation can introspect router/service state via `docker exec`.
+# Not routed to the public entrypoint.
+api:
+  insecure: true
+  dashboard: false
+
+providers:
+  # File provider supplies both the service definitions (where to forward
+  # traffic) and the router-to-service mapping. The deploy automation
+  # overwrites veriflier.yml under this directory to swap the active color.
+  # Traefik reloads the dynamic config automatically when the file changes
+  # — no exec, no signal, no Traefik restart.
+  file:
+    directory: /etc/traefik/dynamic
+    watch: true
+
+log:
+  level: INFO
+
+accessLog: {}


### PR DESCRIPTION
## Summary

Adds a Traefik reverse proxy in front of two Veriflier color slots
(`veriflier-blue` and `veriflier-green`). Only one color runs in steady
state; the deploy automation in `jetmon-secrets` brings up the inactive
color alongside, waits for it to be healthy, and rewrites a small
dynamic config file to swap which color the public router targets.
Traefik's file provider hot-reloads the routing within ~1s — no
`docker exec`, no signal, no dropped connections.

## Why

Every Veriflier deploy today stops `docker-veriflier-1` and recreates
it. Between SIGTERM and the new container reporting healthy on
`/v2/status`, the host returns connection refused. With this topology
each host has **zero serving gap** during a deploy.

## Architecture

```
public :7803 ── traefik (entrypoint veriflier-public)
                  │
                  └── file provider router ──> service = <active color>
                          │
                          ├── http://veriflier-blue:7803
                          └── http://veriflier-green:7803
```

- `traefik` always runs. Owns the host's :7803.
- `veriflier-blue` / `veriflier-green` are sibling services with
  compose `profiles: ["blue", "all"]` / `["green", "all"]` so a naive
  `docker compose up` doesn't start both.
- Per-color named volumes isolate each color's persistent
  `veriflier.json`. Combined with the entrypoint fix from #152, neither
  color ever serves stale config.
- The Veriflier services have no `ports:` block — only Traefik binds
  the host port. Inter-color isolation is via the Docker network.

## File-provider-only design

I considered the Docker provider (auto-register services from container
labels) but the file provider is simpler:

- No `/var/run/docker.sock` mount on Traefik (smaller attack surface).
- Works identically on Mac and Linux during local testing.
- Both services are statically declared in the dynamic file alongside
  the router; the deploy just rewrites one line to swap the active
  service.

## Verified locally

Set up the stack with `veriflier-blue` active. Brought up
`veriflier-green` alongside. Ran a 100ms probe loop against the public
port while editing `traefik/dynamic/veriflier.yml` to point at green:

```
50/50 probes returned HTTP 200 across the swap window.
```

Traefik's `/api/http/routers` confirmed the `veriflier@file` router's
`service` field flipped from `veriflier-blue` to `veriflier-green`. No
Traefik restart, no exec.

## Companion PR

The Ansible role that drives the actual deploy sequence (detect active
color → start inactive → wait healthy → rewrite dynamic config → drain
old) will land in a separate PR in `Automattic/jetmon-secrets`. The
compose-and-config changes here are the prerequisite.

## Compatibility

- The previous single `veriflier` service is gone. Anyone running this
  compose file directly (without the new Ansible role) must:
  - `docker compose --profile blue up -d veriflier-blue` (or `green`)
  - Place a `traefik/dynamic/veriflier.yml` with the desired `service:`
- The `docker/traefik/dynamic/veriflier.yml.sample` file is committed
  as a starting template; the rendered `veriflier.yml` is gitignored
  (operator-owned, like `.env`).

## Test plan

- [x] Local Docker Compose smoke (zero-downtime swap confirmed)
- [ ] CI green
- [ ] After merge: rebuild `:latest` and produce the next pinned tag so
      the Ansible PR can pull it
