### PR TITLE
Harden Veriflier batch isolation and semantic body detection

### DIFF
--- a/config/config.readme
+++ b/config/config.readme
@@ -334,7 +334,9 @@ observed rate/latency, and avoids per-probe healthy freshness writes.
 - Notes: `legacy` matches v1-style reachability. `simple_http` checks
   status/connect/timeout using the selected method. `full` enables v2 HTTP,
   body, redirect, TLS, keyword, forbidden-content, and conservative semantic
-  HTML detections such as WordPress error pages and near-empty HTML responses.
+  HTML detections such as WordPress fatal/database/configuration pages, default
+  virtual-host pages, host suspension pages, Jetpack probe echo pages, and
+  near-empty HTML responses.
   HEAD checks automatically cap the effective profile to `simple_http` because
   body checks cannot run against HEAD responses.
 

--- a/config/config.readme
+++ b/config/config.readme
@@ -335,7 +335,8 @@ observed rate/latency, and avoids per-probe healthy freshness writes.
   status/connect/timeout using the selected method. `full` enables v2 HTTP,
   body, redirect, TLS, keyword, forbidden-content, and conservative semantic
   HTML detections such as WordPress database repair, fatal PHP, unsupported PHP,
-  maintenance, setup/configuration, and critical-error pages, default
+  Redis object-cache connection errors, maintenance, setup/configuration, and
+  critical-error pages, default
   virtual-host pages, host suspension pages, Jetpack probe echo pages, and
   near-empty HTML responses.
   HEAD checks automatically cap the effective profile to `simple_http` because

--- a/config/config.readme
+++ b/config/config.readme
@@ -334,7 +334,8 @@ observed rate/latency, and avoids per-probe healthy freshness writes.
 - Notes: `legacy` matches v1-style reachability. `simple_http` checks
   status/connect/timeout using the selected method. `full` enables v2 HTTP,
   body, redirect, TLS, keyword, forbidden-content, and conservative semantic
-  HTML detections such as WordPress fatal/database/configuration pages, default
+  HTML detections such as WordPress database repair, fatal PHP, unsupported PHP,
+  maintenance, setup/configuration, and critical-error pages, default
   virtual-host pages, host suspension pages, Jetpack probe echo pages, and
   near-empty HTML responses.
   HEAD checks automatically cap the effective profile to `simple_http` because

--- a/config/config.readme
+++ b/config/config.readme
@@ -333,9 +333,10 @@ observed rate/latency, and avoids per-probe healthy freshness writes.
 - Purpose: fleet default detection profile for sites without a per-site row.
 - Notes: `legacy` matches v1-style reachability. `simple_http` checks
   status/connect/timeout using the selected method. `full` enables v2 HTTP,
-  body, redirect, TLS, keyword, and forbidden-content detections. HEAD checks
-  automatically cap the effective profile to `simple_http` because body checks
-  cannot run against HEAD responses.
+  body, redirect, TLS, keyword, forbidden-content, and conservative semantic
+  HTML detections such as WordPress error pages and near-empty HTML responses.
+  HEAD checks automatically cap the effective profile to `simple_http` because
+  body checks cannot run against HEAD responses.
 
 ### NET_COMMS_TIMEOUT
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -336,7 +336,7 @@ reclaim by surviving hosts.
 | `ErrorConnect` | TCP connection, DNS, or dial failure |
 | `ErrorSSL` | TLS handshake or certificate error |
 | `ErrorRedirect` | Redirect failure when policy is `fail` |
-| `ErrorKeyword` | Required keyword missing or forbidden keyword present |
+| `ErrorKeyword` | Required keyword missing, forbidden keyword present, or GET/full semantic body failure |
 | `ErrorTLSExpired` | Certificate expired |
 | `ErrorTLSDeprecated` | TLS 1.0 or 1.1 observed; advisory only |
 | `ErrorBodyRead` | GET response body closed early or could not be read |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -176,6 +176,13 @@ Authorization: Bearer <token>
 `agent.id`, and capacity. `/v2/check` accepts batches of site probe requests and
 returns typed per-request outcomes.
 
+Batch isolation is a contract requirement. Unsafe URLs, unsupported per-site
+probe options, checker panics, and omitted identified results are scoped to the
+affected request as `unknown` / probe-safety or internal-error outcomes. They
+must not fail healthy siblings in the same batch or shift results onto the
+wrong site. Batch-level failures are reserved for malformed envelopes,
+authentication failures, or Veriflier endpoint overload.
+
 Important identity rules:
 
 - `vantage.id` is the quorum vote identity.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -341,7 +341,9 @@ reclaim by surviving hosts.
 | `ErrorTLSDeprecated` | TLS 1.0 or 1.1 observed; advisory only |
 | `ErrorBodyRead` | GET response body closed early or could not be read |
 | `ErrorProbeSafety` | Probe blocked by public-target safety guard |
+| `ErrorInternal` | Monitor-side checker panic recovered as an operational unknown |
 
-`ErrorTLSDeprecated` and `ErrorProbeSafety` do not open customer downtime.
-`ErrorProbeSafety` is an operator safety finding, not a signal that the customer
-site is down.
+`ErrorTLSDeprecated`, `ErrorProbeSafety`, and `ErrorInternal` do not open
+customer downtime. `ErrorProbeSafety` is an operator safety finding, and
+`ErrorInternal` is a Monitor-side fault to investigate; neither is a signal that
+the customer site is down.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -89,7 +89,12 @@ NULL values inherit fleet defaults. During rollout, the intended path is:
 3. `GET` + `full` for the complete v2 detection set.
 
 A `HEAD` request automatically caps the effective profile to `simple_http`.
-Body-based keyword and forbidden-content checks require `GET`.
+Body-based keyword and forbidden-content checks require `GET`. In `GET` +
+`full`, Jetmon also applies conservative semantic body checks for successful
+HTML responses, including common WordPress error pages and near-empty HTML
+documents. Those checks are intentionally not active in `HEAD`/legacy or
+`GET`/`simple_http` so rollout cohorts can separate method migration from the
+full v2 detection surface.
 
 The API can expose a derived `cli_batch` field for local API CLI test data when
 `include_cli_metadata=true` and `custom_headers` contains

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -91,7 +91,8 @@ NULL values inherit fleet defaults. During rollout, the intended path is:
 A `HEAD` request automatically caps the effective profile to `simple_http`.
 Body-based keyword and forbidden-content checks require `GET`. In `GET` +
 `full`, Jetmon also applies conservative semantic body checks for successful
-HTML responses, including common WordPress fatal/database/configuration pages,
+HTML responses, including common WordPress database repair, fatal PHP,
+unsupported PHP, maintenance, setup/configuration, and critical-error pages,
 default virtual-host pages, host suspension pages, Jetpack probe echo pages, and
 near-empty HTML documents. Those checks are intentionally not active in
 `HEAD`/legacy or `GET`/`simple_http` so rollout cohorts can separate method

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -92,9 +92,10 @@ A `HEAD` request automatically caps the effective profile to `simple_http`.
 Body-based keyword and forbidden-content checks require `GET`. In `GET` +
 `full`, Jetmon also applies conservative semantic body checks for successful
 HTML responses, including common WordPress database repair, fatal PHP,
-unsupported PHP, maintenance, setup/configuration, and critical-error pages,
-default virtual-host pages, host suspension pages, Jetpack probe echo pages, and
-near-empty HTML documents. Those checks are intentionally not active in
+unsupported PHP/database, Redis object-cache connection errors, maintenance,
+setup/configuration, and critical-error pages, default virtual-host pages, host
+suspension pages, Jetpack probe echo pages, and near-empty HTML documents. Those
+checks are intentionally not active in
 `HEAD`/legacy or `GET`/`simple_http` so rollout cohorts can separate method
 migration from the full v2 detection surface.
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -91,10 +91,11 @@ NULL values inherit fleet defaults. During rollout, the intended path is:
 A `HEAD` request automatically caps the effective profile to `simple_http`.
 Body-based keyword and forbidden-content checks require `GET`. In `GET` +
 `full`, Jetmon also applies conservative semantic body checks for successful
-HTML responses, including common WordPress error pages and near-empty HTML
-documents. Those checks are intentionally not active in `HEAD`/legacy or
-`GET`/`simple_http` so rollout cohorts can separate method migration from the
-full v2 detection surface.
+HTML responses, including common WordPress fatal/database/configuration pages,
+default virtual-host pages, host suspension pages, Jetpack probe echo pages, and
+near-empty HTML documents. Those checks are intentionally not active in
+`HEAD`/legacy or `GET`/`simple_http` so rollout cohorts can separate method
+migration from the full v2 detection surface.
 
 The API can expose a derived `cli_batch` field for local API CLI test data when
 `include_cli_metadata=true` and `custom_headers` contains

--- a/docs/project.md
+++ b/docs/project.md
@@ -97,7 +97,8 @@ Jetmon 2 currently detects and records:
 - HTTP availability failures by status code, timeout, connection failure, and
   resolver failure.
 - Staged `HEAD` and `GET` probe behavior for rollout-safe migration.
-- Full-profile body checks for required and forbidden content.
+- Full-profile body checks for required content, forbidden content, common
+  WordPress error pages, and near-empty HTML responses.
 - Redirect policy failures or warnings.
 - TLS certificate expiry warnings.
 - Deprecated TLS protocol observations.

--- a/docs/project.md
+++ b/docs/project.md
@@ -98,7 +98,8 @@ Jetmon 2 currently detects and records:
   resolver failure.
 - Staged `HEAD` and `GET` probe behavior for rollout-safe migration.
 - Full-profile body checks for required content, forbidden content, common
-  WordPress error pages, and near-empty HTML responses.
+  WordPress fatal/database/configuration pages, default virtual-host pages, host
+  suspension pages, Jetpack probe echo pages, and near-empty HTML responses.
 - Redirect policy failures or warnings.
 - TLS certificate expiry warnings.
 - Deprecated TLS protocol observations.

--- a/docs/project.md
+++ b/docs/project.md
@@ -98,8 +98,9 @@ Jetmon 2 currently detects and records:
   resolver failure.
 - Staged `HEAD` and `GET` probe behavior for rollout-safe migration.
 - Full-profile body checks for required content, forbidden content, common
-  WordPress fatal/database/configuration pages, default virtual-host pages, host
-  suspension pages, Jetpack probe echo pages, and near-empty HTML responses.
+  WordPress fatal/database/configuration pages, Redis object-cache connection
+  errors, default virtual-host pages, host suspension pages, Jetpack probe echo
+  pages, and near-empty HTML responses.
 - Redirect policy failures or warnings.
 - TLS certificate expiry warnings.
 - Deprecated TLS protocol observations.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -121,9 +121,10 @@ Open work:
 - [x] Add conservative semantic body detectors for common WordPress and hosting
   failure pages before full content baselining. The shipped detector set catches
   WordPress database, database repair, fatal PHP, unsupported PHP,
-  setup/configuration, maintenance, and critical-error pages, default
-  virtual-host pages, account-suspended pages, Jetpack probe echo pages, and
-  near-empty HTML while keeping alerts explainable.
+  setup/configuration, maintenance, database-update, and critical-error pages,
+  default virtual-host pages, account-suspended pages, XML-RPC / Jetpack probe
+  echo pages, WordPress directory listings, and near-empty HTML while keeping
+  alerts explainable.
 - [ ] Design a content-integrity baseline mode separately from explicit required
   or forbidden patterns. Production users need a controlled way to detect large
   unexpected body changes without turning normal content churn into false

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -118,9 +118,11 @@ Open work:
 
 Open work:
 
-- [ ] Add a conservative body-size or near-empty-body detector as a scoped
-  follow-up before full content baselining. This should catch white-screen and
-  empty-body failures while keeping alerts explainable.
+- [x] Add conservative semantic body detectors for common WordPress and hosting
+  failure pages before full content baselining. The shipped detector set catches
+  WordPress database/fatal/configuration/maintenance pages, missing MySQL
+  extension pages, default virtual-host pages, account-suspended pages, Jetpack
+  probe echo pages, and near-empty HTML while keeping alerts explainable.
 - [ ] Design a content-integrity baseline mode separately from explicit required
   or forbidden patterns. Production users need a controlled way to detect large
   unexpected body changes without turning normal content churn into false

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -120,9 +120,10 @@ Open work:
 
 - [x] Add conservative semantic body detectors for common WordPress and hosting
   failure pages before full content baselining. The shipped detector set catches
-  WordPress database/fatal/configuration/maintenance pages, missing MySQL
-  extension pages, default virtual-host pages, account-suspended pages, Jetpack
-  probe echo pages, and near-empty HTML while keeping alerts explainable.
+  WordPress database, database repair, fatal PHP, unsupported PHP,
+  setup/configuration, maintenance, and critical-error pages, default
+  virtual-host pages, account-suspended pages, Jetpack probe echo pages, and
+  near-empty HTML while keeping alerts explainable.
 - [ ] Design a content-integrity baseline mode separately from explicit required
   or forbidden patterns. Production users need a controlled way to detect large
   unexpected body changes without turning normal content churn into false

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -121,8 +121,8 @@ Open work:
 - [x] Add conservative semantic body detectors for common WordPress and hosting
   failure pages before full content baselining. The shipped detector set catches
   WordPress database, missing/corrupt database table, database repair, fatal
-  PHP, unsupported PHP/database, setup/configuration, maintenance,
-  database-update, and critical-error pages,
+  PHP, unsupported PHP/database, Redis object-cache connection errors,
+  setup/configuration, maintenance, database-update, and critical-error pages,
   default virtual-host pages, account-suspended pages, XML-RPC / Jetpack probe
   echo pages, WordPress directory listings, and near-empty HTML while keeping
   alerts explainable.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -120,8 +120,9 @@ Open work:
 
 - [x] Add conservative semantic body detectors for common WordPress and hosting
   failure pages before full content baselining. The shipped detector set catches
-  WordPress database, database repair, fatal PHP, unsupported PHP,
-  setup/configuration, maintenance, database-update, and critical-error pages,
+  WordPress database, missing/corrupt database table, database repair, fatal
+  PHP, unsupported PHP/database, setup/configuration, maintenance,
+  database-update, and critical-error pages,
   default virtual-host pages, account-suspended pages, XML-RPC / Jetpack probe
   echo pages, WordPress directory listings, and near-empty HTML while keeping
   alerts explainable.

--- a/docs/support-guide.md
+++ b/docs/support-guide.md
@@ -116,6 +116,7 @@ proof that all visitors saw downtime.
 | `tls_deprecated` | Site serves TLS 1.0 or 1.1. |
 | `keyword_missing` | Required keyword was absent. |
 | `keyword_forbidden` | Forbidden keyword was present. |
+| `semantic_*` | GET/full saw a high-confidence WordPress, Jetpack, hosting, or empty-body failure page behind HTTP 200. |
 | `success` | Site recovered. |
 
 For resolver failures, inspect event metadata for `dns_error_kind`,

--- a/docs/taxonomy.md
+++ b/docs/taxonomy.md
@@ -229,6 +229,7 @@ The response is valid HTTP — but is the payload actually correct? Layer 5 spli
 ### Correctness: silent application failures
 - **[v1]** CMS fatal error rendered with 200 OK (WSOD)
 - **[v1]** "Error establishing a database connection" served as HTML with 200
+- **[v1]** WordPress object-cache connection failure served as HTML with 200
 - **[v1]** PHP fatal errors or stack traces in response body
 - **[v1]** White-screen-of-death (empty or near-empty body, 200 OK)
 - **[v1]** WordPress setup/configuration page served to visitors

--- a/docs/taxonomy.md
+++ b/docs/taxonomy.md
@@ -231,13 +231,15 @@ The response is valid HTTP — but is the payload actually correct? Layer 5 spli
 - **[v1]** "Error establishing a database connection" served as HTML with 200
 - **[v1]** PHP fatal errors or stack traces in response body
 - **[v1]** White-screen-of-death (empty or near-empty body, 200 OK)
+- **[v1]** WordPress setup/configuration page served to visitors
 - **[v2]** Python/Ruby/Node tracebacks leaked to response body
 
 ### Correctness: maintenance and transitional states
-- **[v2]** Maintenance mode page served with 200 (should be 503 with Retry-After)
+- **[v1]** Maintenance mode page served with 200 (should be 503 with Retry-After)
+- **[v1]** Holding page from registrar/host
+- **[v1]** Default server welcome page (nginx, Apache, IIS default)
+- **[v1]** Jetpack probe echo page served as the homepage
 - **[v2]** "Coming soon" or placeholder content served unexpectedly
-- **[v2]** Holding page from registrar/host
-- **[v2]** Default server welcome page (nginx, Apache, IIS default)
 
 ### Correctness: security-relevant content
 - **[v2]** Defacement (body diff against baseline exceeds threshold)

--- a/internal/api/handlers_events_write.go
+++ b/internal/api/handlers_events_write.go
@@ -234,7 +234,7 @@ func (s *Server) handleTriggerNow(w http.ResponseWriter, r *http.Request) {
 		req.ForbiddenKeywords = checker.ParseForbiddenKeywords(site.forbiddenKeywordsPtr())
 		req.RedirectPolicy = checker.RedirectPolicy(redirectPolicy)
 	}
-	res := checker.Check(ctx, req)
+	res := checker.SafeCheck(ctx, req)
 
 	payload := checkResultPayload{
 		Method:           res.Method,

--- a/internal/api/handlers_rollout.go
+++ b/internal/api/handlers_rollout.go
@@ -1419,7 +1419,7 @@ func rolloutCheckSites(ctx context.Context, sites []jetdb.Site, mode rolloutMode
 						Timestamp:        time.Now().UTC(),
 					}
 				default:
-					results[job.i] = checker.Check(ctx, rolloutCheckRequest(cfg, job.site, mode))
+					results[job.i] = checker.SafeCheck(ctx, rolloutCheckRequest(cfg, job.site, mode))
 				}
 			}
 		}()
@@ -1516,7 +1516,7 @@ func (s *Server) rolloutRunCanaries(ctx context.Context, specs []rolloutCanarySp
 			defer wg.Done()
 			for idx := range work {
 				job := jobs[idx]
-				res := checker.Check(ctx, job.req)
+				res := checker.SafeCheck(ctx, job.req)
 				results[idx] = rolloutEvaluateCanary(job.spec, job.mode, res, idx+1)
 			}
 		}()

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -32,6 +32,7 @@ const (
 	EventConfigChange      = "config_change"
 	EventAPIAccess         = "api_access"
 	EventProbeSafetyBlock  = "probe_safety_blocked"
+	EventCheckInternal     = "check_internal_error"
 	EventRetentionCleanup  = "retention_cleanup"
 )
 
@@ -94,7 +95,7 @@ func shouldLog(m, eventType, httpMethod string) bool {
 	if m == ModeWrites {
 		switch eventType {
 		case EventWPCOMSent, EventWPCOMRetry, EventConfigChange,
-			EventRetryDispatched, EventProbeSafetyBlock, EventRetentionCleanup:
+			EventRetryDispatched, EventProbeSafetyBlock, EventCheckInternal, EventRetentionCleanup:
 			// retention_cleanup deletes rows, so it counts as a data mutation.
 			return true
 		default:

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -1427,8 +1427,9 @@ func semanticBodyFailure(resp *http.Response, body []byte, bytesRead int64) (str
 
 	bodyText := string(body)
 	lowerBody := strings.ToLower(bodyText)
+	strippedLowerBody := strings.ToLower(stripHTMLTags(bodyText))
 	for _, pattern := range semanticFailurePatterns {
-		if strings.Contains(lowerBody, pattern.needle) {
+		if strings.Contains(lowerBody, pattern.needle) || strings.Contains(strippedLowerBody, pattern.needle) {
 			return pattern.rule, pattern.detail
 		}
 	}

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -1429,7 +1429,7 @@ func semanticBodyFailure(resp *http.Response, body []byte, bytesRead int64) (str
 }
 
 func compoundSemanticBodyFailure(lowerBody string) (string, string) {
-	if looksLikeWordPressPHPError(lowerBody) {
+	if looksLikeWordPressPHPError(lowerBody) || looksLikeWordPressPHPError(strings.ToLower(stripHTMLTags(lowerBody))) {
 		return "semantic_wp_php_error", "WordPress PHP error output returned with HTTP 200"
 	}
 	if strings.Contains(lowerBody, "hi jetpack!") && strings.Contains(lowerBody, "all systems go") {

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -96,6 +96,11 @@ var semanticFailurePatterns = []struct {
 		detail: "WordPress maintenance page returned with HTTP 200",
 	},
 	{
+		needle: "xml-rpc server accepts post requests only",
+		rule:   "semantic_wp_xmlrpc_echo",
+		detail: "WordPress XML-RPC endpoint response was served as the homepage with HTTP 200",
+	},
+	{
 		needle: "your php installation appears to be missing the mysql extension which is required by wordpress",
 		rule:   "semantic_wp_missing_mysql_extension",
 		detail: "WordPress missing MySQL extension page returned with HTTP 200",
@@ -106,9 +111,19 @@ var semanticFailurePatterns = []struct {
 		detail: "WordPress setup/configuration page returned with HTTP 200",
 	},
 	{
+		needle: "there doesn't seem to be a wp-config.php file",
+		rule:   "semantic_wp_setup_config",
+		detail: "WordPress setup/configuration page returned with HTTP 200",
+	},
+	{
 		needle: "one or more database tables are unavailable. the database may need to be repaired",
 		rule:   "semantic_wp_db_repair",
 		detail: "WordPress database repair page returned with HTTP 200",
+	},
+	{
+		needle: "database update required",
+		rule:   "semantic_wp_db_update_required",
+		detail: "WordPress database update page returned with HTTP 200",
 	},
 	{
 		needle: "your server is running php version",
@@ -1444,6 +1459,9 @@ func compoundSemanticBodyFailure(lowerBody string) (string, string) {
 	if looksLikeAccountSuspendedPage(lowerBody) {
 		return "semantic_host_account_suspended", "hosting account suspension page returned with HTTP 200"
 	}
+	if looksLikeWordPressDirectoryListing(lowerBody) {
+		return "semantic_wp_directory_listing", "WordPress directory listing returned with HTTP 200"
+	}
 	return "", ""
 }
 
@@ -1489,6 +1507,15 @@ func looksLikeAccountSuspendedPage(lowerBody string) bool {
 		strings.Contains(lowerBody, "contact your web host") ||
 		strings.Contains(lowerBody, "<title>account suspended</title>") ||
 		strings.Contains(lowerBody, "<title>this account has been suspended</title>")
+}
+
+func looksLikeWordPressDirectoryListing(lowerBody string) bool {
+	if !strings.Contains(lowerBody, "index of /") {
+		return false
+	}
+	return strings.Contains(lowerBody, "wp-admin") ||
+		strings.Contains(lowerBody, "wp-content") ||
+		strings.Contains(lowerBody, "wp-includes")
 }
 
 func looksLikeHTML(contentType, lowerBody string) bool {

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -1451,8 +1451,57 @@ func semanticBodyFailure(resp *http.Response, body []byte, bytesRead int64) (str
 
 func semanticPagePhraseMatch(lowerBody, strippedLowerBody, needle string) bool {
 	return strings.HasPrefix(strings.TrimSpace(strippedLowerBody), needle) ||
-		strings.Contains(lowerBody, "<title>"+needle) ||
-		strings.Contains(lowerBody, "<h1>"+needle)
+		tagTextStartsWith(lowerBody, "title", needle) ||
+		tagTextStartsWith(lowerBody, "h1", needle)
+}
+
+func tagTextStartsWith(lowerBody, tag, needle string) bool {
+	openPrefix := "<" + tag
+	closeTag := "</" + tag + ">"
+	for offset := 0; offset < len(lowerBody); {
+		idx := strings.Index(lowerBody[offset:], openPrefix)
+		if idx < 0 {
+			return false
+		}
+		tagStart := offset + idx
+		tagNameEnd := tagStart + len(openPrefix)
+		if tagNameEnd < len(lowerBody) {
+			next := lowerBody[tagNameEnd]
+			if next != '>' && !isASCIIHTMLSpace(next) {
+				offset = tagNameEnd
+				continue
+			}
+		}
+		openEndRel := strings.IndexByte(lowerBody[tagNameEnd:], '>')
+		if openEndRel < 0 {
+			return false
+		}
+		contentStart := tagNameEnd + openEndRel + 1
+		closeRel := strings.Index(lowerBody[contentStart:], closeTag)
+		contentEnd := len(lowerBody)
+		if closeRel >= 0 {
+			contentEnd = contentStart + closeRel
+		}
+		tagText := strings.TrimSpace(stripHTMLTags(lowerBody[contentStart:contentEnd]))
+		if strings.HasPrefix(tagText, needle) {
+			return true
+		}
+		if closeRel >= 0 {
+			offset = contentEnd + len(closeTag)
+		} else {
+			offset = contentStart
+		}
+	}
+	return false
+}
+
+func isASCIIHTMLSpace(b byte) bool {
+	switch b {
+	case ' ', '\t', '\n', '\r', '\f':
+		return true
+	default:
+		return false
+	}
 }
 
 func compoundSemanticBodyFailure(lowerBody string) (string, string) {

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -1462,6 +1462,9 @@ func compoundSemanticBodyFailure(lowerBody string) (string, string) {
 	if looksLikeWordPressUnsupportedDatabase(lowerBody) {
 		return "semantic_wp_unsupported_database", "WordPress unsupported database version page returned with HTTP 200"
 	}
+	if looksLikeWordPressRedisConnectionError(lowerBody) {
+		return "semantic_wp_redis_connection", "WordPress Redis object-cache connection error returned with HTTP 200"
+	}
 	if strings.Contains(lowerBody, "apache2 ubuntu default page") && strings.Contains(lowerBody, "it works") {
 		return "semantic_default_vhost_apache", "Apache default virtual-host page returned with HTTP 200"
 	}
@@ -1507,6 +1510,18 @@ func looksLikeWordPressUnsupportedDatabase(lowerBody string) bool {
 	return strings.Contains(lowerBody, "error:") ||
 		strings.Contains(lowerBody, "you are running") ||
 		strings.Contains(lowerBody, "your server is running")
+}
+
+func looksLikeWordPressRedisConnectionError(lowerBody string) bool {
+	if !strings.Contains(lowerBody, "error establishing a redis connection") &&
+		!strings.Contains(lowerBody, "error establishing connection. to disable redis") {
+		return false
+	}
+	return strings.Contains(lowerBody, "wordpress is unable to establish a connection to redis") ||
+		strings.Contains(lowerBody, "object-cache.php") ||
+		strings.Contains(lowerBody, "/wp-content/") ||
+		strings.Contains(lowerBody, "redis object cache") ||
+		strings.Contains(lowerBody, "wp_redis")
 }
 
 func containsWordPressPathHint(lowerBody string) bool {

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -38,6 +38,7 @@ const (
 	ErrorTLSDeprecated = 7
 	ErrorBodyRead      = 8
 	ErrorProbeSafety   = 9
+	ErrorInternal      = 10
 	ErrorBodyTruncated = ErrorBodyRead
 )
 
@@ -939,6 +940,8 @@ func (r *Result) StatusType() string {
 		return "success"
 	case r.ErrorCode == ErrorProbeSafety:
 		return "probe_safety"
+	case r.ErrorCode == ErrorInternal:
+		return "internal"
 	case r.ErrorCode == ErrorSSL || r.ErrorCode == ErrorTLSExpired:
 		return "https"
 	case r.ErrorCode == ErrorTimeout || r.ErrorCode == ErrorBodyRead:
@@ -958,7 +961,7 @@ func (r *Result) StatusType() string {
 
 // IsFailure reports whether the result should enter the downtime pipeline.
 func (r *Result) IsFailure() bool {
-	if r.ErrorCode == ErrorProbeSafety {
+	if r.ErrorCode == ErrorProbeSafety || r.ErrorCode == ErrorInternal {
 		return false
 	}
 	if !r.Success {
@@ -976,6 +979,12 @@ func (r *Result) IsFailure() bool {
 // probe because the target would be unsafe for an untrusted remote site check.
 func (r *Result) IsProbeSafetyBlock() bool {
 	return r != nil && r.ErrorCode == ErrorProbeSafety
+}
+
+// IsOperationalUnknown reports an internal Monitor-side problem that should be
+// recorded for operators without opening, closing, or confirming site downtime.
+func (r *Result) IsOperationalUnknown() bool {
+	return r != nil && r.ErrorCode == ErrorInternal
 }
 
 // Check performs an HTTP check and returns the result.

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -44,6 +44,7 @@ const (
 const (
 	maxBodyIntegrityBytes      int64 = 64 << 10
 	maxKeywordBodyBytes        int64 = 1 << 20
+	maxSemanticBodyPrefixBytes       = 4 << 10
 	maxResultURLDetailBytes          = 2048
 	maxResponseHeaderBytes     int64 = 64 << 10
 	checkDNSCacheTTL                 = 15 * time.Minute
@@ -58,6 +59,33 @@ const (
 
 var errBodyReadBudgetExceeded = errors.New("response body read budget exceeded")
 var errProbeSafetyBlock = errors.New("probe safety block")
+
+var semanticFailurePatterns = []struct {
+	needle string
+	rule   string
+	detail string
+}{
+	{
+		needle: "error establishing a database connection",
+		rule:   "semantic_wp_db_error",
+		detail: "WordPress database error page returned with HTTP 200",
+	},
+	{
+		needle: "there has been a critical error on this website",
+		rule:   "semantic_wp_critical_error",
+		detail: "WordPress critical error page returned with HTTP 200",
+	},
+	{
+		needle: "this site is experiencing technical difficulties",
+		rule:   "semantic_wp_technical_difficulties",
+		detail: "WordPress technical difficulties page returned with HTTP 200",
+	},
+	{
+		needle: "briefly unavailable for scheduled maintenance",
+		rule:   "semantic_wp_maintenance",
+		detail: "WordPress maintenance page returned with HTTP 200",
+	},
+}
 
 // RedirectPolicy controls how redirect responses are handled.
 type RedirectPolicy string
@@ -1107,6 +1135,12 @@ func Check(ctx context.Context, req Request) Result {
 			res.ErrorDetail = res.BodyReadError
 			return res
 		}
+		if rule, detail := semanticBodyFailure(resp, body, bodyRead.BytesRead); rule != "" {
+			res.KeywordRule = rule
+			res.ErrorCode = ErrorKeyword
+			res.ErrorDetail = detail
+			return res
+		}
 
 		// Keyword check uses the same bounded body read as integrity checks.
 		if needsBody {
@@ -1263,11 +1297,13 @@ func readResponseBody(resp *http.Response, needKeyword bool, req Request) bodyRe
 	stopBudget := startBodyReadBudget(resp.Body, responseBodyReadBudget(mode, needKeyword, req))
 
 	if !needKeyword {
-		n, err := io.Copy(io.Discard, io.LimitReader(resp.Body, limit+1))
+		prefix := &bodyPrefixCapture{limit: maxSemanticBodyPrefixBytes}
+		n, err := io.Copy(io.MultiWriter(io.Discard, prefix), io.LimitReader(resp.Body, limit+1))
 		if stopBodyReadBudget(stopBudget) {
 			err = bodyReadBudgetError(err)
 		}
 		result := bodyReadResult{
+			Body:          prefix.Bytes(),
 			Err:           err,
 			Mode:          mode,
 			BytesRead:     n,
@@ -1309,6 +1345,91 @@ func readResponseBody(resp *http.Response, needKeyword bool, req Request) bodyRe
 		return result
 	}
 	return result
+}
+
+type bodyPrefixCapture struct {
+	buf   []byte
+	limit int
+}
+
+func (c *bodyPrefixCapture) Write(p []byte) (int, error) {
+	if c == nil || c.limit <= 0 {
+		return len(p), nil
+	}
+	if len(c.buf) < c.limit {
+		remaining := c.limit - len(c.buf)
+		if len(p) < remaining {
+			remaining = len(p)
+		}
+		c.buf = append(c.buf, p[:remaining]...)
+	}
+	return len(p), nil
+}
+
+func (c *bodyPrefixCapture) Bytes() []byte {
+	if c == nil || len(c.buf) == 0 {
+		return nil
+	}
+	out := make([]byte, len(c.buf))
+	copy(out, c.buf)
+	return out
+}
+
+func semanticBodyFailure(resp *http.Response, body []byte, bytesRead int64) (string, string) {
+	if resp == nil || resp.StatusCode != http.StatusOK {
+		return "", ""
+	}
+
+	bodyText := string(body)
+	lowerBody := strings.ToLower(bodyText)
+	for _, pattern := range semanticFailurePatterns {
+		if strings.Contains(lowerBody, pattern.needle) {
+			return pattern.rule, pattern.detail
+		}
+	}
+
+	if looksLikeHTML(resp.Header.Get("Content-Type"), lowerBody) && bodyLooksNearEmptyHTML(bodyText, bytesRead) {
+		return "semantic_empty_html", "empty or near-empty HTML response body returned with HTTP 200"
+	}
+
+	return "", ""
+}
+
+func looksLikeHTML(contentType, lowerBody string) bool {
+	contentType = strings.ToLower(strings.TrimSpace(strings.Split(contentType, ";")[0]))
+	if contentType == "text/html" || contentType == "application/xhtml+xml" {
+		return true
+	}
+	trimmed := strings.TrimSpace(lowerBody)
+	return strings.HasPrefix(trimmed, "<!doctype html") || strings.HasPrefix(trimmed, "<html")
+}
+
+func bodyLooksNearEmptyHTML(bodyText string, bytesRead int64) bool {
+	if bytesRead == 0 {
+		return true
+	}
+	if bytesRead > 256 {
+		return false
+	}
+	return stripHTMLTags(bodyText) == ""
+}
+
+func stripHTMLTags(bodyText string) string {
+	var b strings.Builder
+	inTag := false
+	for _, r := range bodyText {
+		switch r {
+		case '<':
+			inTag = true
+		case '>':
+			inTag = false
+		default:
+			if !inTag {
+				b.WriteRune(r)
+			}
+		}
+	}
+	return strings.Join(strings.Fields(b.String()), " ")
 }
 
 func responseBodyReadBudget(mode string, needKeyword bool, req Request) time.Duration {

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -1513,8 +1513,15 @@ func looksLikeWordPressUnsupportedDatabase(lowerBody string) bool {
 }
 
 func looksLikeWordPressRedisConnectionError(lowerBody string) bool {
-	if !strings.Contains(lowerBody, "error establishing a redis connection") &&
+	const phrase = "error establishing a redis connection"
+	if !strings.Contains(lowerBody, phrase) &&
 		!strings.Contains(lowerBody, "error establishing connection. to disable redis") {
+		return false
+	}
+	stripped := strings.TrimSpace(strings.ToLower(stripHTMLTags(lowerBody)))
+	if !strings.Contains(lowerBody, "<title>"+phrase) &&
+		!strings.Contains(lowerBody, "<h1>"+phrase) &&
+		!strings.HasPrefix(stripped, phrase) {
 		return false
 	}
 	return strings.Contains(lowerBody, "wordpress is unable to establish a connection to redis") ||

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -85,6 +85,21 @@ var semanticFailurePatterns = []struct {
 		rule:   "semantic_wp_maintenance",
 		detail: "WordPress maintenance page returned with HTTP 200",
 	},
+	{
+		needle: "your php installation appears to be missing the mysql extension which is required by wordpress",
+		rule:   "semantic_wp_missing_mysql_extension",
+		detail: "WordPress missing MySQL extension page returned with HTTP 200",
+	},
+	{
+		needle: "hi jetpack! all systems go.",
+		rule:   "semantic_jetpack_probe_echo",
+		detail: "Jetpack probe response was served as the homepage with HTTP 200",
+	},
+	{
+		needle: "welcome to wordpress. before getting started",
+		rule:   "semantic_wp_setup_config",
+		detail: "WordPress setup/configuration page returned with HTTP 200",
+	},
 }
 
 // RedirectPolicy controls how redirect responses are handled.
@@ -1387,12 +1402,72 @@ func semanticBodyFailure(resp *http.Response, body []byte, bytesRead int64) (str
 			return pattern.rule, pattern.detail
 		}
 	}
+	if rule, detail := compoundSemanticBodyFailure(lowerBody); rule != "" {
+		return rule, detail
+	}
 
 	if looksLikeHTML(resp.Header.Get("Content-Type"), lowerBody) && bodyLooksNearEmptyHTML(bodyText, bytesRead) {
 		return "semantic_empty_html", "empty or near-empty HTML response body returned with HTTP 200"
 	}
 
 	return "", ""
+}
+
+func compoundSemanticBodyFailure(lowerBody string) (string, string) {
+	if looksLikeWordPressPHPError(lowerBody) {
+		return "semantic_wp_php_error", "WordPress PHP error output returned with HTTP 200"
+	}
+	if strings.Contains(lowerBody, "apache2 ubuntu default page") && strings.Contains(lowerBody, "it works") {
+		return "semantic_default_vhost_apache", "Apache default virtual-host page returned with HTTP 200"
+	}
+	if strings.Contains(lowerBody, "welcome to nginx!") && strings.Contains(lowerBody, "nginx web server is successfully installed") {
+		return "semantic_default_vhost_nginx", "nginx default virtual-host page returned with HTTP 200"
+	}
+	if looksLikeAccountSuspendedPage(lowerBody) {
+		return "semantic_host_account_suspended", "hosting account suspension page returned with HTTP 200"
+	}
+	return "", ""
+}
+
+func looksLikeWordPressPHPError(lowerBody string) bool {
+	if !strings.Contains(lowerBody, " on line ") {
+		return false
+	}
+	if !strings.Contains(lowerBody, "fatal error") &&
+		!(strings.Contains(lowerBody, "parse error:") && strings.Contains(lowerBody, "syntax error")) {
+		return false
+	}
+	return containsWordPressPathHint(lowerBody)
+}
+
+func containsWordPressPathHint(lowerBody string) bool {
+	for _, hint := range []string{
+		"/wp-content/",
+		"/wp-includes/",
+		"/wp-admin/",
+		"wp-config.php",
+		"wp-settings.php",
+		"wp-load.php",
+		"wp-blog-header.php",
+	} {
+		if strings.Contains(lowerBody, hint) {
+			return true
+		}
+	}
+	return false
+}
+
+func looksLikeAccountSuspendedPage(lowerBody string) bool {
+	if strings.Contains(lowerBody, "cgi-sys/suspendedpage.cgi") {
+		return true
+	}
+	if !strings.Contains(lowerBody, "account has been suspended") {
+		return false
+	}
+	return strings.Contains(lowerBody, "contact your hosting provider") ||
+		strings.Contains(lowerBody, "contact your web host") ||
+		strings.Contains(lowerBody, "<title>account suspended</title>") ||
+		strings.Contains(lowerBody, "<title>this account has been suspended</title>")
 }
 
 func looksLikeHTML(contentType, lowerBody string) bool {

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -121,6 +121,11 @@ var semanticFailurePatterns = []struct {
 		detail: "WordPress database repair page returned with HTTP 200",
 	},
 	{
+		needle: "database tables are missing",
+		rule:   "semantic_wp_db_missing_tables",
+		detail: "WordPress missing database tables page returned with HTTP 200",
+	},
+	{
 		needle: "database update required",
 		rule:   "semantic_wp_db_update_required",
 		detail: "WordPress database update page returned with HTTP 200",
@@ -1451,6 +1456,12 @@ func compoundSemanticBodyFailure(lowerBody string) (string, string) {
 	if strings.Contains(lowerBody, "hi jetpack!") && strings.Contains(lowerBody, "all systems go") {
 		return "semantic_jetpack_probe_echo", "Jetpack probe response was served as the homepage with HTTP 200"
 	}
+	if looksLikeWordPressDatabaseCrash(lowerBody) {
+		return "semantic_wp_db_table_crashed", "WordPress database table crash output returned with HTTP 200"
+	}
+	if looksLikeWordPressUnsupportedDatabase(lowerBody) {
+		return "semantic_wp_unsupported_database", "WordPress unsupported database version page returned with HTTP 200"
+	}
 	if strings.Contains(lowerBody, "apache2 ubuntu default page") && strings.Contains(lowerBody, "it works") {
 		return "semantic_default_vhost_apache", "Apache default virtual-host page returned with HTTP 200"
 	}
@@ -1478,6 +1489,24 @@ func looksLikeWordPressPHPError(lowerBody string) bool {
 		return false
 	}
 	return containsWordPressPathHint(lowerBody)
+}
+
+func looksLikeWordPressDatabaseCrash(lowerBody string) bool {
+	return strings.Contains(lowerBody, "wordpress database error") &&
+		strings.Contains(lowerBody, "marked as crashed") &&
+		(strings.Contains(lowerBody, "should be repaired") || strings.Contains(lowerBody, "repair failed"))
+}
+
+func looksLikeWordPressUnsupportedDatabase(lowerBody string) bool {
+	if !strings.Contains(lowerBody, "wordpress") || !strings.Contains(lowerBody, "requires") {
+		return false
+	}
+	if !strings.Contains(lowerBody, "mysql") && !strings.Contains(lowerBody, "mariadb") {
+		return false
+	}
+	return strings.Contains(lowerBody, "error:") ||
+		strings.Contains(lowerBody, "you are running") ||
+		strings.Contains(lowerBody, "your server is running")
 }
 
 func containsWordPressPathHint(lowerBody string) bool {

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -76,6 +76,11 @@ var semanticFailurePatterns = []struct {
 		detail: "WordPress critical error page returned with HTTP 200",
 	},
 	{
+		needle: "there has been a critical error on your website",
+		rule:   "semantic_wp_critical_error",
+		detail: "WordPress critical error page returned with HTTP 200",
+	},
+	{
 		needle: "this site is experiencing technical difficulties",
 		rule:   "semantic_wp_technical_difficulties",
 		detail: "WordPress technical difficulties page returned with HTTP 200",
@@ -89,11 +94,6 @@ var semanticFailurePatterns = []struct {
 		needle: "your php installation appears to be missing the mysql extension which is required by wordpress",
 		rule:   "semantic_wp_missing_mysql_extension",
 		detail: "WordPress missing MySQL extension page returned with HTTP 200",
-	},
-	{
-		needle: "hi jetpack! all systems go.",
-		rule:   "semantic_jetpack_probe_echo",
-		detail: "Jetpack probe response was served as the homepage with HTTP 200",
 	},
 	{
 		needle: "welcome to wordpress. before getting started",
@@ -1416,6 +1416,9 @@ func semanticBodyFailure(resp *http.Response, body []byte, bytesRead int64) (str
 func compoundSemanticBodyFailure(lowerBody string) (string, string) {
 	if looksLikeWordPressPHPError(lowerBody) {
 		return "semantic_wp_php_error", "WordPress PHP error output returned with HTTP 200"
+	}
+	if strings.Contains(lowerBody, "hi jetpack!") && strings.Contains(lowerBody, "all systems go") {
+		return "semantic_jetpack_probe_echo", "Jetpack probe response was served as the homepage with HTTP 200"
 	}
 	if strings.Contains(lowerBody, "apache2 ubuntu default page") && strings.Contains(lowerBody, "it works") {
 		return "semantic_default_vhost_apache", "Apache default virtual-host page returned with HTTP 200"

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -86,6 +86,11 @@ var semanticFailurePatterns = []struct {
 		detail: "WordPress technical difficulties page returned with HTTP 200",
 	},
 	{
+		needle: "the site is experiencing technical difficulties",
+		rule:   "semantic_wp_technical_difficulties",
+		detail: "WordPress technical difficulties page returned with HTTP 200",
+	},
+	{
 		needle: "briefly unavailable for scheduled maintenance",
 		rule:   "semantic_wp_maintenance",
 		detail: "WordPress maintenance page returned with HTTP 200",
@@ -99,6 +104,16 @@ var semanticFailurePatterns = []struct {
 		needle: "welcome to wordpress. before getting started",
 		rule:   "semantic_wp_setup_config",
 		detail: "WordPress setup/configuration page returned with HTTP 200",
+	},
+	{
+		needle: "one or more database tables are unavailable. the database may need to be repaired",
+		rule:   "semantic_wp_db_repair",
+		detail: "WordPress database repair page returned with HTTP 200",
+	},
+	{
+		needle: "your server is running php version",
+		rule:   "semantic_wp_unsupported_php",
+		detail: "WordPress unsupported PHP version page returned with HTTP 200",
 	},
 }
 
@@ -1437,6 +1452,9 @@ func looksLikeWordPressPHPError(lowerBody string) bool {
 		return false
 	}
 	if !strings.Contains(lowerBody, "fatal error") &&
+		!strings.Contains(lowerBody, "allowed memory size") &&
+		!strings.Contains(lowerBody, "maximum execution time") &&
+		!strings.Contains(lowerBody, "call to undefined function") &&
 		!(strings.Contains(lowerBody, "parse error:") && strings.Contains(lowerBody, "syntax error")) {
 		return false
 	}

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -1434,7 +1434,7 @@ func semanticBodyFailure(resp *http.Response, body []byte, bytesRead int64) (str
 	lowerBody := strings.ToLower(bodyText)
 	strippedLowerBody := strings.ToLower(stripHTMLTags(bodyText))
 	for _, pattern := range semanticFailurePatterns {
-		if strings.Contains(lowerBody, pattern.needle) || strings.Contains(strippedLowerBody, pattern.needle) {
+		if semanticPagePhraseMatch(lowerBody, strippedLowerBody, pattern.needle) {
 			return pattern.rule, pattern.detail
 		}
 	}
@@ -1447,6 +1447,12 @@ func semanticBodyFailure(resp *http.Response, body []byte, bytesRead int64) (str
 	}
 
 	return "", ""
+}
+
+func semanticPagePhraseMatch(lowerBody, strippedLowerBody, needle string) bool {
+	return strings.HasPrefix(strings.TrimSpace(strippedLowerBody), needle) ||
+		strings.Contains(lowerBody, "<title>"+needle) ||
+		strings.Contains(lowerBody, "<h1>"+needle)
 }
 
 func compoundSemanticBodyFailure(lowerBody string) (string, string) {

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -834,7 +834,7 @@ func TestCheckFullProfileDoesNotTreatGenericFatalErrorArticleAsSemanticFailure(t
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("<html><body><article>How to troubleshoot a fatal error: look at your logs and fix the plugin.</article><article>How to fix Error establishing a Redis connection after a migration.</article></body></html>"))
+		_, _ = w.Write([]byte("<html><body><article>How to troubleshoot a fatal error: look at your logs and fix the plugin.</article><article>How to fix Error establishing a Redis connection after a migration: delete object-cache.php from /wp-content/ if the migrated site still points at the old Redis server.</article></body></html>"))
 	}))
 	defer srv.Close()
 

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -706,6 +706,11 @@ func TestCheckFullProfileDetectsCommonWordPressAndHostingSemanticFailures(t *tes
 			rule: "semantic_wp_php_error",
 		},
 		{
+			name: "html formatted php parse error with wordpress path",
+			body: "<!DOCTYPE html><html><body><br /><b>Parse error</b>: syntax error, unexpected token \"}\" in <b>/var/www/html/wp-content/plugins/broken/plugin.php</b> on line <b>17</b><br /></body></html>",
+			rule: "semantic_wp_php_error",
+		},
+		{
 			name: "technical difficulties alternate wording",
 			body: "<html><body>The site is experiencing technical difficulties.</body></html>",
 			rule: "semantic_wp_technical_difficulties",

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -731,6 +731,16 @@ func TestCheckFullProfileDetectsCommonWordPressAndHostingSemanticFailures(t *tes
 			rule: "semantic_wp_db_repair",
 		},
 		{
+			name: "database tables missing",
+			body: "<html><body><p><strong>Database tables are missing.</strong> This means that your host's database server is not running, WordPress was not installed properly, or someone deleted <code>wp_blogs</code>.</p></body></html>",
+			rule: "semantic_wp_db_missing_tables",
+		},
+		{
+			name: "database table marked crashed",
+			body: "WordPress database error Table './example/wp_options' is marked as crashed and should be repaired for query SELECT option_value FROM wp_options",
+			rule: "semantic_wp_db_table_crashed",
+		},
+		{
 			name: "database update required",
 			body: "<html><head><title>Database Update Required</title></head><body><h1>Database Update Required</h1><p>WordPress has been updated! Before we send you on your way, we have to update your database.</p></body></html>",
 			rule: "semantic_wp_db_update_required",
@@ -739,6 +749,11 @@ func TestCheckFullProfileDetectsCommonWordPressAndHostingSemanticFailures(t *tes
 			name: "unsupported php version",
 			body: "<html><body>Your server is running PHP version 7.0.33 but WordPress requires at least 7.2.24.</body></html>",
 			rule: "semantic_wp_unsupported_php",
+		},
+		{
+			name: "unsupported database version",
+			body: "<html><body><strong>Error:</strong> WordPress 6.7 requires MySQL 8.0 or higher. You are running 5.7.</body></html>",
+			rule: "semantic_wp_unsupported_database",
 		},
 		{
 			name: "apache default vhost",

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -669,6 +669,28 @@ func TestCheckFullProfileDetectsWordPressDatabaseErrorBody(t *testing.T) {
 	}
 }
 
+func TestCheckFullProfileDetectsSemanticFailureInAttributedHeading(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`<html><head><title>Example Site</title></head><body><h1 class="wp-die-message"><span>Error establishing a database connection</span></h1></body></html>`))
+	}))
+	defer srv.Close()
+
+	res := Check(context.Background(), Request{
+		BlogID:           1,
+		URL:              srv.URL,
+		TimeoutSeconds:   5,
+		DetectionProfile: "full",
+	})
+	if res.Success {
+		t.Fatalf("Success = true for semantic failure in attributed heading, want false; result=%+v", res)
+	}
+	if res.KeywordRule != "semantic_wp_db_error" {
+		t.Fatalf("KeywordRule = %q, want semantic_wp_db_error", res.KeywordRule)
+	}
+}
+
 func TestCheckFullProfileDetectsCommonWordPressAndHostingSemanticFailures(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -681,6 +681,16 @@ func TestCheckFullProfileDetectsCommonWordPressAndHostingSemanticFailures(t *tes
 			rule: "semantic_wp_missing_mysql_extension",
 		},
 		{
+			name: "wordpress maintenance mode",
+			body: "<html><body>Briefly unavailable for scheduled maintenance. Check back in a minute.</body></html>",
+			rule: "semantic_wp_maintenance",
+		},
+		{
+			name: "xmlrpc endpoint served as homepage",
+			body: "<html><body>XML-RPC server accepts POST requests only.</body></html>",
+			rule: "semantic_wp_xmlrpc_echo",
+		},
+		{
 			name: "critical error your website wording",
 			body: "<html><body>There has been a critical error on your website.</body></html>",
 			rule: "semantic_wp_critical_error",
@@ -721,6 +731,11 @@ func TestCheckFullProfileDetectsCommonWordPressAndHostingSemanticFailures(t *tes
 			rule: "semantic_wp_db_repair",
 		},
 		{
+			name: "database update required",
+			body: "<html><head><title>Database Update Required</title></head><body><h1>Database Update Required</h1><p>WordPress has been updated! Before we send you on your way, we have to update your database.</p></body></html>",
+			rule: "semantic_wp_db_update_required",
+		},
+		{
 			name: "unsupported php version",
 			body: "<html><body>Your server is running PHP version 7.0.33 but WordPress requires at least 7.2.24.</body></html>",
 			rule: "semantic_wp_unsupported_php",
@@ -754,6 +769,16 @@ func TestCheckFullProfileDetectsCommonWordPressAndHostingSemanticFailures(t *tes
 			name: "wordpress setup config",
 			body: "<html><body><h1>Welcome to WordPress. Before getting started, we need some information on the database.</h1></body></html>",
 			rule: "semantic_wp_setup_config",
+		},
+		{
+			name: "missing wp config setup",
+			body: "<html><body><p>There doesn't seem to be a wp-config.php file. I need this before we can get started.</p></body></html>",
+			rule: "semantic_wp_setup_config",
+		},
+		{
+			name: "wordpress directory listing",
+			body: "<html><head><title>Index of /</title></head><body><h1>Index of /</h1><a href=\"wp-admin/\">wp-admin/</a><a href=\"wp-content/\">wp-content/</a></body></html>",
+			rule: "semantic_wp_directory_listing",
 		},
 	}
 

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -641,6 +641,106 @@ func TestCheckForbiddenKeywordsPresent(t *testing.T) {
 	}
 }
 
+func TestCheckFullProfileDetectsWordPressDatabaseErrorBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<html><body><h1>Error establishing a database connection</h1></body></html>"))
+	}))
+	defer srv.Close()
+
+	res := Check(context.Background(), Request{
+		BlogID:           1,
+		URL:              srv.URL,
+		TimeoutSeconds:   5,
+		DetectionProfile: "full",
+	})
+	if res.Success {
+		t.Fatalf("Success = true for semantic failure body, want false; result=%+v", res)
+	}
+	if res.ErrorCode != ErrorKeyword {
+		t.Fatalf("ErrorCode = %d, want ErrorKeyword", res.ErrorCode)
+	}
+	if res.KeywordRule != "semantic_wp_db_error" {
+		t.Fatalf("KeywordRule = %q, want semantic_wp_db_error", res.KeywordRule)
+	}
+	if res.ErrorDetail == "" {
+		t.Fatal("ErrorDetail is empty, want semantic diagnostic")
+	}
+}
+
+func TestCheckFullProfileDetectsNearEmptyHTMLBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<html></html>"))
+	}))
+	defer srv.Close()
+
+	res := Check(context.Background(), Request{
+		BlogID:           1,
+		URL:              srv.URL,
+		TimeoutSeconds:   5,
+		DetectionProfile: "full",
+	})
+	if res.Success {
+		t.Fatalf("Success = true for near-empty HTML body, want false; result=%+v", res)
+	}
+	if res.ErrorCode != ErrorKeyword {
+		t.Fatalf("ErrorCode = %d, want ErrorKeyword", res.ErrorCode)
+	}
+	if res.KeywordRule != "semantic_empty_html" {
+		t.Fatalf("KeywordRule = %q, want semantic_empty_html", res.KeywordRule)
+	}
+}
+
+func TestCheckSimpleHTTPDoesNotRunSemanticBodyDetectors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<html><body><h1>Error establishing a database connection</h1></body></html>"))
+	}))
+	defer srv.Close()
+
+	res := Check(context.Background(), Request{
+		BlogID:           1,
+		URL:              srv.URL,
+		TimeoutSeconds:   5,
+		DetectionProfile: "simple_http",
+	})
+	if !res.Success {
+		t.Fatalf("Success = false for simple_http semantic body, want true; result=%+v", res)
+	}
+	if res.ErrorCode != ErrorNone {
+		t.Fatalf("ErrorCode = %d, want ErrorNone", res.ErrorCode)
+	}
+	if res.BodyBytesRead != 0 {
+		t.Fatalf("BodyBytesRead = %d, want 0 for simple_http", res.BodyBytesRead)
+	}
+}
+
+func TestCheckFullProfileAllowsSmallNonHTMLBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	res := Check(context.Background(), Request{
+		BlogID:           1,
+		URL:              srv.URL,
+		TimeoutSeconds:   5,
+		DetectionProfile: "full",
+	})
+	if !res.Success {
+		t.Fatalf("Success = false for small non-HTML body, want true; result=%+v", res)
+	}
+	if res.ErrorCode != ErrorNone {
+		t.Fatalf("ErrorCode = %d, want ErrorNone", res.ErrorCode)
+	}
+}
+
 func TestCheckTruncatedBodyFailsWithoutKeyword(t *testing.T) {
 	srv := truncatedBodyServer(t, "partial response")
 	defer srv.Close()

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -681,6 +681,11 @@ func TestCheckFullProfileDetectsCommonWordPressAndHostingSemanticFailures(t *tes
 			rule: "semantic_wp_missing_mysql_extension",
 		},
 		{
+			name: "critical error your website wording",
+			body: "<html><body>There has been a critical error on your website.</body></html>",
+			rule: "semantic_wp_critical_error",
+		},
+		{
 			name: "php fatal with wordpress path",
 			body: "<br /><b>Fatal error</b>: Uncaught Error: Call to undefined function broken_plugin() in /srv/www/example.com/wp-content/plugins/broken/plugin.php on line 42",
 			rule: "semantic_wp_php_error",
@@ -706,8 +711,13 @@ func TestCheckFullProfileDetectsCommonWordPressAndHostingSemanticFailures(t *tes
 			rule: "semantic_host_account_suspended",
 		},
 		{
-			name: "jetpack probe echo",
+			name: "jetpack probe echo with space",
 			body: "<html><body>Hi Jetpack! All Systems go.</body></html>",
+			rule: "semantic_jetpack_probe_echo",
+		},
+		{
+			name: "jetpack probe echo without space",
+			body: "<html><body>Hi Jetpack!All Systems go</body></html>",
 			rule: "semantic_jetpack_probe_echo",
 		},
 		{

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -691,9 +691,34 @@ func TestCheckFullProfileDetectsCommonWordPressAndHostingSemanticFailures(t *tes
 			rule: "semantic_wp_php_error",
 		},
 		{
+			name: "php memory exhausted with wordpress path",
+			body: "Fatal error: Allowed memory size of 268435456 bytes exhausted (tried to allocate 4096 bytes) in /srv/www/example.com/wp-includes/class-wpdb.php on line 2425",
+			rule: "semantic_wp_php_error",
+		},
+		{
+			name: "php max execution time with wordpress path",
+			body: "Fatal error: Maximum execution time of 30 seconds exceeded in /srv/www/example.com/wp-content/plugins/slow/plugin.php on line 12",
+			rule: "semantic_wp_php_error",
+		},
+		{
 			name: "php parse error with wordpress path",
 			body: "Parse error: syntax error, unexpected token \"}\" in /srv/www/example.com/wp-includes/functions.php on line 123",
 			rule: "semantic_wp_php_error",
+		},
+		{
+			name: "technical difficulties alternate wording",
+			body: "<html><body>The site is experiencing technical difficulties.</body></html>",
+			rule: "semantic_wp_technical_difficulties",
+		},
+		{
+			name: "database repair unavailable tables",
+			body: "<html><body>One or more database tables are unavailable. The database may need to be repaired.</body></html>",
+			rule: "semantic_wp_db_repair",
+		},
+		{
+			name: "unsupported php version",
+			body: "<html><body>Your server is running PHP version 7.0.33 but WordPress requires at least 7.2.24.</body></html>",
+			rule: "semantic_wp_unsupported_php",
 		},
 		{
 			name: "apache default vhost",

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -772,7 +772,7 @@ func TestCheckFullProfileDetectsCommonWordPressAndHostingSemanticFailures(t *tes
 		},
 		{
 			name: "missing wp config setup",
-			body: "<html><body><p>There doesn't seem to be a wp-config.php file. I need this before we can get started.</p></body></html>",
+			body: "<html><body><p>There doesn't seem to be a <code>wp-config.php</code> file. I need this before we can get started.</p></body></html>",
 			rule: "semantic_wp_setup_config",
 		},
 		{

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -33,6 +33,7 @@ func TestResultStatusType(t *testing.T) {
 		{name: "body read", res: Result{ErrorCode: ErrorBodyRead}, want: "intermittent"},
 		{name: "redirect", res: Result{ErrorCode: ErrorRedirect}, want: "redirect"},
 		{name: "probe safety", res: Result{ErrorCode: ErrorProbeSafety}, want: "probe_safety"},
+		{name: "internal checker error", res: Result{ErrorCode: ErrorInternal}, want: "internal"},
 		{name: "403 blocked", res: Result{HTTPCode: 403}, want: "blocked"},
 		{name: "500 server error", res: Result{HTTPCode: 500}, want: "server"},
 		{name: "503 server error", res: Result{HTTPCode: 503}, want: "server"},
@@ -117,6 +118,11 @@ func TestResultIsFailure(t *testing.T) {
 			res:  Result{Success: false, ErrorCode: ErrorProbeSafety},
 			want: false,
 		},
+		{
+			name: "internal checker error is non-downtime",
+			res:  Result{Success: false, ErrorCode: ErrorInternal},
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -125,6 +131,50 @@ func TestResultIsFailure(t *testing.T) {
 				t.Fatalf("IsFailure() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestPoolRecoversCheckPanicAsOperationalUnknown(t *testing.T) {
+	orig := poolCheckFunc
+	poolCheckFunc = func(_ context.Context, req Request) Result {
+		if req.BlogID == 2 {
+			panic("synthetic checker failure")
+		}
+		return Result{BlogID: req.BlogID, URL: req.URL, Success: true, HTTPCode: 200}
+	}
+
+	p := NewPoolWithQueueCap(1, 1, 1, 2)
+	t.Cleanup(func() {
+		p.Drain()
+		poolCheckFunc = orig
+	})
+
+	if !p.Submit(Request{BlogID: 1, URL: "https://example.com/one"}) {
+		t.Fatal("Submit(first) returned false")
+	}
+	if !p.Submit(Request{BlogID: 2, URL: "https://example.com/two"}) {
+		t.Fatal("Submit(second) returned false")
+	}
+
+	seen := map[int64]Result{}
+	deadline := time.After(2 * time.Second)
+	for len(seen) < 2 {
+		select {
+		case res := <-p.Results():
+			seen[res.BlogID] = res
+		case <-deadline:
+			t.Fatalf("timed out waiting for results; seen=%+v", seen)
+		}
+	}
+	if !seen[1].Success || seen[1].ErrorCode != ErrorNone {
+		t.Fatalf("first result = %+v, want success", seen[1])
+	}
+	got := seen[2]
+	if got.Success || got.ErrorCode != ErrorInternal || !got.IsOperationalUnknown() || got.IsFailure() {
+		t.Fatalf("panic result = %+v, want non-downtime internal error", got)
+	}
+	if got.ErrorDetail == "" {
+		t.Fatal("panic result ErrorDetail is empty")
 	}
 }
 

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -852,6 +852,37 @@ func TestCheckFullProfileDoesNotTreatGenericFatalErrorArticleAsSemanticFailure(t
 	}
 }
 
+func TestCheckFullProfileDoesNotTreatTroubleshootingArticleAsSemanticFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`<html><head><title>How to fix common WordPress errors</title></head><body><article>
+			<h1>How to fix common WordPress errors</h1>
+			<p>A common message is Error establishing a database connection. Check wp-config.php and database credentials.</p>
+			<h2>Briefly unavailable for scheduled maintenance</h2>
+			<p>If visitors see Briefly unavailable for scheduled maintenance. Check back in a minute., remove the stale maintenance file.</p>
+			<h2>There has been a critical error on this website</h2>
+			<p>When WordPress shows There has been a critical error on this website, inspect the debug log.</p>
+			<h2>Database Update Required</h2>
+			<p>Database Update Required means WordPress needs an admin-driven database upgrade.</p>
+			</article></body></html>`))
+	}))
+	defer srv.Close()
+
+	res := Check(context.Background(), Request{
+		BlogID:           1,
+		URL:              srv.URL,
+		TimeoutSeconds:   5,
+		DetectionProfile: "full",
+	})
+	if !res.Success {
+		t.Fatalf("Success = false for troubleshooting article, want true; result=%+v", res)
+	}
+	if res.ErrorCode != ErrorNone {
+		t.Fatalf("ErrorCode = %d, want ErrorNone", res.ErrorCode)
+	}
+}
+
 func TestCheckFullProfileDetectsNearEmptyHTMLBody(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -756,6 +756,11 @@ func TestCheckFullProfileDetectsCommonWordPressAndHostingSemanticFailures(t *tes
 			rule: "semantic_wp_unsupported_database",
 		},
 		{
+			name: "redis object cache connection error",
+			body: "<html><body><h1>Error establishing a Redis connection</h1><p>WordPress is unable to establish a connection to Redis.</p><p>To disable Redis, delete the <code>object-cache.php</code> file in the <code>/wp-content/</code> directory.</p></body></html>",
+			rule: "semantic_wp_redis_connection",
+		},
+		{
 			name: "apache default vhost",
 			body: "<html><head><title>Apache2 Ubuntu Default Page: It works</title></head><body>It works!</body></html>",
 			rule: "semantic_default_vhost_apache",
@@ -829,7 +834,7 @@ func TestCheckFullProfileDoesNotTreatGenericFatalErrorArticleAsSemanticFailure(t
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("<html><body><article>How to troubleshoot a fatal error: look at your logs and fix the plugin.</article></body></html>"))
+		_, _ = w.Write([]byte("<html><body><article>How to troubleshoot a fatal error: look at your logs and fix the plugin.</article><article>How to fix Error establishing a Redis connection after a migration.</article></body></html>"))
 	}))
 	defer srv.Close()
 

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -669,6 +669,104 @@ func TestCheckFullProfileDetectsWordPressDatabaseErrorBody(t *testing.T) {
 	}
 }
 
+func TestCheckFullProfileDetectsCommonWordPressAndHostingSemanticFailures(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		rule string
+	}{
+		{
+			name: "missing mysql extension",
+			body: "<html><body>Your PHP installation appears to be missing the MySQL extension which is required by WordPress.</body></html>",
+			rule: "semantic_wp_missing_mysql_extension",
+		},
+		{
+			name: "php fatal with wordpress path",
+			body: "<br /><b>Fatal error</b>: Uncaught Error: Call to undefined function broken_plugin() in /srv/www/example.com/wp-content/plugins/broken/plugin.php on line 42",
+			rule: "semantic_wp_php_error",
+		},
+		{
+			name: "php parse error with wordpress path",
+			body: "Parse error: syntax error, unexpected token \"}\" in /srv/www/example.com/wp-includes/functions.php on line 123",
+			rule: "semantic_wp_php_error",
+		},
+		{
+			name: "apache default vhost",
+			body: "<html><head><title>Apache2 Ubuntu Default Page: It works</title></head><body>It works!</body></html>",
+			rule: "semantic_default_vhost_apache",
+		},
+		{
+			name: "nginx default vhost",
+			body: "<html><head><title>Welcome to nginx!</title></head><body>If you see this page, the nginx web server is successfully installed and working.</body></html>",
+			rule: "semantic_default_vhost_nginx",
+		},
+		{
+			name: "hosting account suspended",
+			body: "<html><head><title>Account Suspended</title></head><body>This account has been suspended. Contact your hosting provider for more information.</body></html>",
+			rule: "semantic_host_account_suspended",
+		},
+		{
+			name: "jetpack probe echo",
+			body: "<html><body>Hi Jetpack! All Systems go.</body></html>",
+			rule: "semantic_jetpack_probe_echo",
+		},
+		{
+			name: "wordpress setup config",
+			body: "<html><body><h1>Welcome to WordPress. Before getting started, we need some information on the database.</h1></body></html>",
+			rule: "semantic_wp_setup_config",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+
+			res := Check(context.Background(), Request{
+				BlogID:           1,
+				URL:              srv.URL,
+				TimeoutSeconds:   5,
+				DetectionProfile: "full",
+			})
+			if res.Success {
+				t.Fatalf("Success = true for semantic failure body, want false; result=%+v", res)
+			}
+			if res.ErrorCode != ErrorKeyword {
+				t.Fatalf("ErrorCode = %d, want ErrorKeyword", res.ErrorCode)
+			}
+			if res.KeywordRule != tt.rule {
+				t.Fatalf("KeywordRule = %q, want %q", res.KeywordRule, tt.rule)
+			}
+		})
+	}
+}
+
+func TestCheckFullProfileDoesNotTreatGenericFatalErrorArticleAsSemanticFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<html><body><article>How to troubleshoot a fatal error: look at your logs and fix the plugin.</article></body></html>"))
+	}))
+	defer srv.Close()
+
+	res := Check(context.Background(), Request{
+		BlogID:           1,
+		URL:              srv.URL,
+		TimeoutSeconds:   5,
+		DetectionProfile: "full",
+	})
+	if !res.Success {
+		t.Fatalf("Success = false for generic fatal error article, want true; result=%+v", res)
+	}
+	if res.ErrorCode != ErrorNone {
+		t.Fatalf("ErrorCode = %d, want ErrorNone", res.ErrorCode)
+	}
+}
+
 func TestCheckFullProfileDetectsNearEmptyHTMLBody(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/internal/checker/pool.go
+++ b/internal/checker/pool.go
@@ -2,6 +2,9 @@ package checker
 
 import (
 	"context"
+	"fmt"
+	"log"
+	"runtime/debug"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -169,7 +172,7 @@ func (p *Pool) spawnWorker() {
 					return
 				}
 				p.active.Add(1)
-				res := poolCheckFunc(context.Background(), req)
+				res := runPoolCheck(context.Background(), req)
 				p.active.Add(-1)
 				if p.closed.Load() {
 					continue
@@ -182,6 +185,27 @@ func (p *Pool) spawnWorker() {
 			}
 		}
 	}()
+}
+
+func runPoolCheck(ctx context.Context, req Request) (res Result) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err := fmt.Errorf("checker panic: %v", recovered)
+			log.Printf("checker: recovered panic blog_id=%d url=%q: %v\n%s", req.BlogID, req.URL, recovered, debug.Stack())
+			res = Result{
+				MonitorSiteID:    req.MonitorSiteID,
+				BlogID:           req.BlogID,
+				URL:              req.URL,
+				Method:           req.Method,
+				DetectionProfile: req.DetectionProfile,
+				Success:          false,
+				ErrorCode:        ErrorInternal,
+				ErrorDetail:      boundedErrorDetail(err),
+				Timestamp:        time.Now().UTC(),
+			}
+		}
+	}()
+	return poolCheckFunc(ctx, req)
 }
 
 // autoScale adjusts the pool size every 5 seconds based on queue depth and

--- a/internal/checker/pool.go
+++ b/internal/checker/pool.go
@@ -190,22 +190,38 @@ func (p *Pool) spawnWorker() {
 func runPoolCheck(ctx context.Context, req Request) (res Result) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			err := fmt.Errorf("checker panic: %v", recovered)
-			log.Printf("checker: recovered panic blog_id=%d url=%q: %v\n%s", req.BlogID, req.URL, recovered, debug.Stack())
-			res = Result{
-				MonitorSiteID:    req.MonitorSiteID,
-				BlogID:           req.BlogID,
-				URL:              req.URL,
-				Method:           req.Method,
-				DetectionProfile: req.DetectionProfile,
-				Success:          false,
-				ErrorCode:        ErrorInternal,
-				ErrorDetail:      boundedErrorDetail(err),
-				Timestamp:        time.Now().UTC(),
-			}
+			res = recoveredCheckPanicResult(req, recovered)
 		}
 	}()
 	return poolCheckFunc(ctx, req)
+}
+
+// SafeCheck wraps Check with the same operational panic boundary used by the
+// worker pool. It is intended for low-volume direct probes from API and rollout
+// handlers that do not pass through Pool.
+func SafeCheck(ctx context.Context, req Request) (res Result) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			res = recoveredCheckPanicResult(req, recovered)
+		}
+	}()
+	return Check(ctx, req)
+}
+
+func recoveredCheckPanicResult(req Request, recovered any) Result {
+	err := fmt.Errorf("checker panic: %v", recovered)
+	log.Printf("checker: recovered panic blog_id=%d url=%q: %v\n%s", req.BlogID, req.URL, recovered, debug.Stack())
+	return Result{
+		MonitorSiteID:    req.MonitorSiteID,
+		BlogID:           req.BlogID,
+		URL:              req.URL,
+		Method:           req.Method,
+		DetectionProfile: req.DetectionProfile,
+		Success:          false,
+		ErrorCode:        ErrorInternal,
+		ErrorDetail:      boundedErrorDetail(err),
+		Timestamp:        time.Now().UTC(),
+	}
 }
 
 // autoScale adjusts the pool size every 5 seconds based on queue depth and

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -742,11 +742,14 @@ func (o *Orchestrator) recordStreamingHistoryRows(rows []db.CheckHistoryRow) res
 			); err != nil {
 				summary.historyErrors++
 				log.Printf("orchestrator: streaming record check history blog_id=%d: %v", row.BlogID, err)
+				continue
 			}
+			summary.historyRows++
 		}
+	} else {
+		summary.historyRows += len(rows)
 	}
 	summary.historyDuration += time.Since(start)
-	summary.historyRows += len(rows)
 	return summary
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -484,6 +484,8 @@ func (o *Orchestrator) processResults(results map[int64]checker.Result, sites ma
 		// it in jetpack_monitor_audit_log was retired with the operational/site-state split.
 		if record.res.IsProbeSafetyBlock() {
 			o.handleProbeSafetyBlock(record.site, record.res)
+		} else if record.res.IsOperationalUnknown() {
+			o.handleOperationalCheckError(record.site, record.res)
 		} else if !record.res.IsFailure() {
 			o.handleRecovery(record.site, record.res)
 		} else {
@@ -1190,6 +1192,21 @@ func (o *Orchestrator) handleProbeSafetyBlock(site db.Site, res checker.Result) 
 		Detail:    "probe safety blocked outbound check",
 		Metadata:  meta,
 	})
+}
+
+func (o *Orchestrator) handleOperationalCheckError(site db.Site, res checker.Result) {
+	emitCounter("detection.check_internal_error.count", 1)
+	metaMap := checkResultMetadata(site, res, resultCheckedAt(res))
+	metaMap["operational_unknown"] = true
+	meta, _ := json.Marshal(metaMap)
+	o.auditLog(audit.Entry{
+		BlogID:    site.BlogID,
+		EventType: audit.EventCheckInternal,
+		Source:    o.hostname,
+		Detail:    "checker internal error",
+		Metadata:  meta,
+	})
+	log.Printf("orchestrator: checker internal error blog_id=%d site_id=%d: %s", site.BlogID, site.ID, res.ErrorDetail)
 }
 
 func (o *Orchestrator) shouldSuppressPostRecoveryTransientFailure(site db.Site, res checker.Result) bool {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1486,6 +1486,12 @@ func (o *Orchestrator) escalateToVerifliers(site db.Site, entry *retryEntry) {
 		if duplicateVote {
 			continue
 		}
+		if verifierSiteScopedNonVote(vr.res) {
+			emitCounter("verifier.vote.non_vote.count", 1)
+			emitCounter("verifier.host."+hostSegment+".vote.non_vote.count", 1)
+			log.Printf("orchestrator: veriflier %s returned site-scoped non-vote outcome %q error_code=%d; leaving decision pending", vr.host, vr.res.Outcome, vr.res.ErrorCode)
+			continue
+		}
 		if verifierOperationalNonVote(vr.res) {
 			emitCounter("verifier.vote.non_vote.count", 1)
 			emitCounter("verifier.host."+hostSegment+".vote.non_vote.count", 1)
@@ -1652,6 +1658,13 @@ func verifierOperationalNonVote(res *veriflier.CheckResult) bool {
 	default:
 		return false
 	}
+}
+
+func verifierSiteScopedNonVote(res *veriflier.CheckResult) bool {
+	if res == nil || res.Outcome != veriflier.OutcomeUnknown {
+		return false
+	}
+	return res.ErrorCode == checker.ErrorProbeSafety || res.ErrorCode == checker.ErrorInternal
 }
 
 func shouldDeferVerifierRetry(entry *retryEntry, checkedAt time.Time) bool {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -584,6 +584,24 @@ func emitCheckCohortCounters(m metricsClient, prefix string, cohorts map[checkCo
 	}
 }
 
+func emitKeywordRuleCounters(m metricsClient, prefix string, rules map[string]int) {
+	if m == nil || len(rules) == 0 {
+		return
+	}
+	names := make([]string, 0, len(rules))
+	for name := range rules {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		count := rules[name]
+		if count <= 0 {
+			continue
+		}
+		m.Increment(fmt.Sprintf("%s.check.keyword_rule.%s.count", prefix, metricSegment(name)), count)
+	}
+}
+
 func (o *Orchestrator) updateSSLExpiries(updates []db.SiteSSLExpiry, summary *resultProcessSummary) {
 	if len(updates) == 0 {
 		return

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2202,6 +2202,58 @@ func TestProcessResultsProbeSafetyBlockAuditsWithoutStateChange(t *testing.T) {
 	}
 }
 
+func TestProcessResultsOperationalUnknownAuditsWithoutStateChange(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+	setTestConfig(t)
+
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqlDB.Close()
+	audit.Init(sqlDB)
+	t.Cleanup(func() { audit.Init(nil) })
+
+	dbUpdateSiteStatus = func(context.Context, int64, int, time.Time) error {
+		t.Fatal("operational unknown must not update site status")
+		return nil
+	}
+	wpcomNotifyFunc = func(_ *wpcom.Client, _ wpcom.Notification) error {
+		t.Fatal("operational unknown must not send notifications")
+		return nil
+	}
+
+	mock.ExpectExec(`INSERT INTO jetpack_monitor_audit_log`).
+		WithArgs(int64(42), nil, audit.EventCheckInternal, "local", "checker internal error", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		hostname: "local",
+		ctx:      context.Background(),
+	}
+
+	res := checker.Result{
+		BlogID:      42,
+		URL:         "https://example.com",
+		Success:     false,
+		ErrorCode:   checker.ErrorInternal,
+		ErrorDetail: "checker panic: synthetic failure",
+		Timestamp:   time.Now().UTC(),
+	}
+	sites := map[int64]db.Site{42: {ID: 123, BlogID: 42, MonitorURL: "https://example.com", SiteStatus: statusRunning, CheckInterval: 5}}
+	o.processResults(map[int64]checker.Result{42: res}, sites)
+
+	if retry := o.retries.get(42); retry != nil {
+		t.Fatalf("retry entry = %+v, want nil for operational unknown", retry)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("audit expectations: %v", err)
+	}
+}
+
 func TestProcessResultsSchedulesFailedChecksSoonerThanNormalInterval(t *testing.T) {
 	restore := stubOrchestratorDeps()
 	defer restore()

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2452,6 +2452,34 @@ func TestProcessResultsFallsBackWhenBatchWritesFail(t *testing.T) {
 	}
 }
 
+func TestRecordStreamingHistoryRowsCountsFallbackSuccesses(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+
+	dbRecordCheckHistories = func(context.Context, []db.CheckHistoryRow) error {
+		return fmt.Errorf("batch history failed")
+	}
+	dbRecordCheckHistory = func(blogID int64, _ string, _ int, _ int, _ int64, _ int64, _ int64, _ int64, _ int64) error {
+		if blogID == 2 {
+			return fmt.Errorf("poisoned history row")
+		}
+		return nil
+	}
+
+	o := &Orchestrator{ctx: context.Background()}
+	summary := o.recordStreamingHistoryRows([]db.CheckHistoryRow{
+		{BlogID: 1, RequestMethod: http.MethodGet, HTTPCode: 200},
+		{BlogID: 2, RequestMethod: http.MethodGet, HTTPCode: 200},
+	})
+
+	if summary.historyRows != 1 {
+		t.Fatalf("history rows = %d, want one successful fallback row", summary.historyRows)
+	}
+	if summary.historyErrors != 2 {
+		t.Fatalf("history errors = %d, want batch error plus poisoned-row error", summary.historyErrors)
+	}
+}
+
 func TestEventMutationRetryRetriesDeadlocks(t *testing.T) {
 	restore := stubOrchestratorDeps()
 	defer restore()

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1049,6 +1049,62 @@ func TestEscalateToVerifliersKeepsRetryOnOperationalNonVote(t *testing.T) {
 	}
 }
 
+func TestEscalateToVerifliersDoesNotCooldownForSiteScopedNonVote(t *testing.T) {
+	restore := stubOrchestratorDeps()
+	defer restore()
+
+	cfg := setTestConfig(t)
+	cfg.PeerOfflineLimit = 1
+
+	rec := newRecordingMetrics()
+	metricsClientFunc = func() metricsClient { return rec }
+	dbRecordFalsePositive = func(blogID int64, _ int, _ int, _ int64) error {
+		t.Fatalf("false positive recorded for site-scoped non-vote blog_id=%d", blogID)
+		return nil
+	}
+	wpcomNotifyFunc = func(_ *wpcom.Client, _ wpcom.Notification) error {
+		t.Fatal("site-scoped non-vote should not confirm downtime")
+		return nil
+	}
+	veriflierCheckFunc = func(c *veriflier.VeriflierClient, _ context.Context, req veriflier.CheckRequest) (*veriflier.CheckResult, error) {
+		return &veriflier.CheckResult{
+			BlogID:    req.BlogID,
+			Host:      c.Addr(),
+			Success:   false,
+			ErrorCode: checker.ErrorProbeSafety,
+			Outcome:   veriflier.OutcomeUnknown,
+			RequestID: req.RequestID,
+		}, nil
+	}
+
+	client := veriflier.NewVeriflierClient("v1", "")
+	o := &Orchestrator{
+		retries:  newRetryQueue(),
+		wpcom:    &wpcom.Client{},
+		ctx:      context.Background(),
+		hostname: "local-host",
+		veriflierClients: []*veriflier.VeriflierClient{
+			client,
+		},
+	}
+
+	fail := checkerResultFailure(668)
+	o.retries.record(fail)
+	entry := o.retries.get(668)
+	o.escalateToVerifliers(db.Site{BlogID: 668, MonitorURL: "https://example.com", SiteStatus: statusRunning}, entry)
+
+	if entry := o.retries.get(668); entry == nil {
+		t.Fatal("retry entry was cleared after site-scoped non-vote")
+	}
+	if got := rec.counter("verifier.vote.non_vote.count"); got != 1 {
+		t.Fatalf("non-vote counter = %d, want 1", got)
+	}
+	available, skipped := o.availableVeriflierClients([]*veriflier.VeriflierClient{client}, nowFunc().UTC().Add(time.Second))
+	if len(available) != 1 || skipped != 0 {
+		t.Fatalf("available verifliers after site-scoped non-vote = len %d skipped %d, want still available", len(available), skipped)
+	}
+}
+
 func TestHandleFailureBacksOffVerifierAfterOperationalNonVotes(t *testing.T) {
 	restore := stubOrchestratorDeps()
 	defer restore()

--- a/internal/orchestrator/streaming.go
+++ b/internal/orchestrator/streaming.go
@@ -360,6 +360,7 @@ type streamingStats struct {
 	errorTLSDeprecated int
 	errorOther         int
 	checkCohorts       map[checkCohortKey]int
+	keywordRules       map[string]int
 }
 
 func (s *streamingStats) addResult(res checker.Result, lag time.Duration, siteStatus int) {
@@ -386,6 +387,12 @@ func (s *streamingStats) addResult(res checker.Result, lag time.Duration, siteSt
 	}
 	if res.ErrorCode != checker.ErrorNone {
 		s.addErrorCode(res.ErrorCode)
+	}
+	if res.ErrorCode == checker.ErrorKeyword && res.KeywordRule != "" {
+		if s.keywordRules == nil {
+			s.keywordRules = make(map[string]int)
+		}
+		s.keywordRules[res.KeywordRule]++
 	}
 }
 
@@ -1467,6 +1474,7 @@ func (o *Orchestrator) reportStreamingStats(cfg *config.Config, planner *streami
 		m.Increment("scheduler.streaming.check.error.tls_deprecated.count", stats.errorTLSDeprecated)
 		m.Increment("scheduler.streaming.check.error.other.count", stats.errorOther)
 		emitCheckCohortCounters(m, "scheduler.streaming", stats.checkCohorts)
+		emitKeywordRuleCounters(m, "scheduler.streaming", stats.keywordRules)
 		m.Increment("scheduler.streaming.side_effect.processed.count", stats.sideEffectRows)
 		m.Increment("scheduler.streaming.history.row.count", stats.historyRows)
 		m.Increment("scheduler.streaming.history.error.count", stats.historyErrors)

--- a/internal/orchestrator/streaming.go
+++ b/internal/orchestrator/streaming.go
@@ -1181,6 +1181,8 @@ func (o *Orchestrator) processStreamingSideEffects(site db.Site, res checker.Res
 	eventStart := time.Now()
 	if res.IsProbeSafetyBlock() {
 		o.handleProbeSafetyBlock(site, res)
+	} else if res.IsOperationalUnknown() {
+		o.handleOperationalCheckError(site, res)
 	} else if !res.IsFailure() {
 		o.handleRecovery(site, res)
 		site.SiteStatus = statusRunning

--- a/internal/orchestrator/streaming.go
+++ b/internal/orchestrator/streaming.go
@@ -1501,7 +1501,7 @@ func (o *Orchestrator) reportStreamingStats(cfg *config.Config, planner *streami
 		Total:       stats.completed,
 	})
 
-	config.Debugf("orchestrator: streaming summary active=%d required_rate=%.2f/s selected=%d dispatched=%d completed=%d side_effects=%d pending=%d active_checks=%d queue_depth=%d result_depth=%d side_effect_depth=%d workers=%d worker_target=%d sps=%d elapsed=%s max_lag=%s avg_latency=%s scale_latency=%s successes=%d failures=%d failure_pressure=%t pressure_suppressed=%d error_timeout=%d error_connect=%d error_ssl=%d error_redirect=%d error_keyword=%d error_body_read=%d error_tls_expired=%d error_tls_deprecated=%d error_other=%d history_rows=%d ssl_rows=%d stale_results=%d backpressure_waits=%d side_effect_waits=%d result_pauses=%d side_effect_pauses=%d dispatch_limited=%d",
+	log.Printf("orchestrator: streaming summary active=%d required_rate=%.2f/s selected=%d dispatched=%d completed=%d side_effects=%d pending=%d active_checks=%d queue_depth=%d result_depth=%d side_effect_depth=%d workers=%d worker_target=%d sps=%d elapsed=%s max_lag=%s avg_latency=%s scale_latency=%s successes=%d failures=%d failure_pressure=%t pressure_suppressed=%d error_timeout=%d error_connect=%d error_ssl=%d error_redirect=%d error_keyword=%d error_body_read=%d error_tls_expired=%d error_tls_deprecated=%d error_other=%d history_rows=%d ssl_rows=%d stale_results=%d backpressure_waits=%d side_effect_waits=%d result_pauses=%d side_effect_pauses=%d dispatch_limited=%d",
 		planner.activeCount(),
 		planner.requiredChecksPerSecond(),
 		stats.selected,

--- a/internal/orchestrator/streaming_test.go
+++ b/internal/orchestrator/streaming_test.go
@@ -544,6 +544,21 @@ func TestStreamingStatsCountsCheckCohorts(t *testing.T) {
 	assertCheckCohortCount(t, stats.checkCohorts, http.MethodGet, "full", 2)
 }
 
+func TestStreamingStatsCountsKeywordRules(t *testing.T) {
+	var stats streamingStats
+	stats.addResult(checker.Result{ErrorCode: checker.ErrorKeyword, KeywordRule: "semantic_wp_db_error"}, 0, statusRunning)
+	stats.addResult(checker.Result{ErrorCode: checker.ErrorKeyword, KeywordRule: "semantic_wp_db_error"}, 0, statusRunning)
+	stats.addResult(checker.Result{ErrorCode: checker.ErrorKeyword, KeywordRule: "required"}, 0, statusRunning)
+	stats.addResult(checker.Result{ErrorCode: checker.ErrorConnect, KeywordRule: "semantic_wp_db_error"}, 0, statusRunning)
+
+	if stats.keywordRules["semantic_wp_db_error"] != 2 {
+		t.Fatalf("semantic_wp_db_error count = %d, want 2", stats.keywordRules["semantic_wp_db_error"])
+	}
+	if stats.keywordRules["required"] != 1 {
+		t.Fatalf("required count = %d, want 1", stats.keywordRules["required"])
+	}
+}
+
 func TestStreamingBacklogWorkerTargetUsesSpareHeadroom(t *testing.T) {
 	if got := streamingBacklogWorkerTarget(700, 100000, 42000); got != 875 {
 		t.Fatalf("backlog worker target = %d, want base plus backlog catch-up", got)
@@ -824,6 +839,13 @@ func TestStreamingSideEffectsNeededSuppressesNewLocalFailuresUnderPressure(t *te
 	}
 	if streamingSideEffectsSuppressedByPressure(target, checker.Result{BlogID: 42, HTTPCode: 500}, nil, nil, nil, true) {
 		t.Fatal("HTTP failures should not be counted as pressure-suppressed")
+	}
+	semantic := checker.Result{BlogID: 42, HTTPCode: 200, ErrorCode: checker.ErrorKeyword, KeywordRule: "semantic_wp_db_error"}
+	if !streamingSideEffectsNeeded(target, semantic, nil, nil, nil, true) {
+		t.Fatal("semantic body failures should still flow through side effects under pressure")
+	}
+	if streamingSideEffectsSuppressedByPressure(target, semantic, nil, nil, nil, true) {
+		t.Fatal("semantic body failures should not be counted as pressure-suppressed")
 	}
 	if !streamingSideEffectsNeeded(target, timeout, map[int64]int{42: 1}, nil, nil, true) {
 		t.Fatal("pending side effects should preserve ordering under pressure")

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -329,8 +329,16 @@ func (b *singleCheckBatcher) flush(batch []singleCheckCall) {
 	results, err := b.client.CheckBatch(ctx, reqs)
 	cancel()
 	if err != nil {
+		if payloadTooLargeError(err) && len(calls) > 1 {
+			mid := len(calls) / 2
+			b.flush(calls[:mid])
+			b.flush(calls[mid:])
+			return
+		}
 		for _, call := range calls {
-			if operationalOverloadError(err) {
+			if payloadTooLargeError(err) {
+				call.respond(payloadTooLargeCheckResult(call.req), nil)
+			} else if operationalOverloadError(err) {
 				call.respond(agentOverloadedCheckResult(call.req), nil)
 			} else {
 				call.respond(nil, err)
@@ -405,6 +413,18 @@ func agentOverloadedCheckResult(req CheckRequest) *CheckResult {
 		Outcome:       OutcomeAgentOverloaded,
 		Success:       false,
 		ErrorCode:     1,
+		RequestID:     req.RequestID,
+	}
+}
+
+func payloadTooLargeCheckResult(req CheckRequest) *CheckResult {
+	return &CheckResult{
+		MonitorSiteID: req.MonitorSiteID,
+		BlogID:        req.BlogID,
+		URL:           req.URL,
+		Outcome:       OutcomeUnknown,
+		Success:       false,
+		ErrorCode:     checkerErrorProbeSafety,
 		RequestID:     req.RequestID,
 	}
 }
@@ -558,6 +578,13 @@ func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest)
 		results[i] = checkResultFromV2(req, res)
 	}
 	return results, nil
+}
+
+func payloadTooLargeError(err error) bool {
+	if se, ok := errors.AsType[statusError](err); ok {
+		return se.status == http.StatusRequestEntityTooLarge
+	}
+	return false
 }
 
 func v2ResultsByRequestID(results []CheckV2Result) map[string]CheckV2Result {

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -349,14 +349,21 @@ func (b *singleCheckBatcher) flush(batch []singleCheckCall) {
 
 	resultsByRequestID := checkResultsByRequestID(results)
 	for i, call := range calls {
-		result, ok := resultsByRequestID[call.req.RequestID]
-		if !ok {
-			if i >= len(results) {
-				call.respond(nil, fmt.Errorf("veriflier returned %d results for %d requests", len(results), len(calls)))
+		if call.req.RequestID != "" {
+			result, ok := resultsByRequestID[call.req.RequestID]
+			if !ok {
+				call.respond(nil, fmt.Errorf("veriflier omitted result for request_id %s (%d results for %d requests)", call.req.RequestID, len(results), len(calls)))
 				continue
 			}
-			result = results[i]
+			call.respond(&result, nil)
+			continue
 		}
+
+		if i >= len(results) {
+			call.respond(nil, fmt.Errorf("veriflier returned %d results for %d requests", len(results), len(calls)))
+			continue
+		}
+		result := results[i]
 		call.respond(&result, nil)
 	}
 }

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -462,7 +462,25 @@ func (c *VeriflierClient) checkBatchLegacy(ctx context.Context, reqs []CheckRequ
 	if err := json.NewDecoder(resp.Body).Decode(&br); err != nil {
 		return nil, fmt.Errorf("decode veriflier response: %w", err)
 	}
-	return br.Results, nil
+	results := make([]CheckResult, len(reqs))
+	resultsByRequestID := legacyResultsByRequestID(br.Results)
+	for i, req := range reqs {
+		var res CheckResult
+		var ok bool
+		if req.RequestID != "" {
+			res, ok = resultsByRequestID[req.RequestID]
+		}
+		if !ok && i < len(br.Results) && br.Results[i].RequestID == "" {
+			res = br.Results[i]
+			ok = true
+		}
+		if !ok {
+			results[i] = missingLegacyResult(req)
+			continue
+		}
+		results[i] = checkResultFromLegacy(req, res)
+	}
+	return results, nil
 }
 
 func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest) ([]CheckResult, error) {
@@ -554,6 +572,35 @@ func v2ResultsByRequestID(results []CheckV2Result) map[string]CheckV2Result {
 	return out
 }
 
+func legacyResultsByRequestID(results []CheckResult) map[string]CheckResult {
+	out := make(map[string]CheckResult, len(results))
+	for _, result := range results {
+		if result.RequestID != "" {
+			if _, exists := out[result.RequestID]; !exists {
+				out[result.RequestID] = result
+			}
+		}
+	}
+	return out
+}
+
+func checkResultFromLegacy(orig CheckRequest, res CheckResult) CheckResult {
+	return CheckResult{
+		MonitorSiteID: orig.MonitorSiteID,
+		BlogID:        orig.BlogID,
+		URL:           orig.URL,
+		Host:          res.Host,
+		VantageID:     res.VantageID,
+		AgentID:       res.AgentID,
+		Outcome:       res.Outcome,
+		Success:       res.Success,
+		HTTPCode:      res.HTTPCode,
+		ErrorCode:     res.ErrorCode,
+		RTTMs:         res.RTTMs,
+		RequestID:     res.RequestID,
+	}
+}
+
 func checkResultFromV2(orig CheckRequest, res CheckV2Result) CheckResult {
 	return CheckResult{
 		MonitorSiteID: orig.MonitorSiteID,
@@ -572,6 +619,14 @@ func checkResultFromV2(orig CheckRequest, res CheckV2Result) CheckResult {
 }
 
 func missingV2Result(req CheckRequest) CheckResult {
+	return missingResult(req)
+}
+
+func missingLegacyResult(req CheckRequest) CheckResult {
+	return missingResult(req)
+}
+
+func missingResult(req CheckRequest) CheckResult {
 	return CheckResult{
 		MonitorSiteID: req.MonitorSiteID,
 		BlogID:        req.BlogID,

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -557,8 +557,8 @@ func v2ResultsByRequestID(results []CheckV2Result) map[string]CheckV2Result {
 func checkResultFromV2(orig CheckRequest, res CheckV2Result) CheckResult {
 	return CheckResult{
 		MonitorSiteID: orig.MonitorSiteID,
-		BlogID:        res.BlogID,
-		URL:           res.URL,
+		BlogID:        orig.BlogID,
+		URL:           orig.URL,
 		Host:          res.VantageID,
 		VantageID:     res.VantageID,
 		AgentID:       res.AgentID,

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -521,48 +521,66 @@ func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest)
 		return nil, fmt.Errorf("decode veriflier v2 response: %w", err)
 	}
 
-	results := make([]CheckResult, 0, len(br.Results))
-	var reqByRequestID map[string]CheckRequest
-	for i, res := range br.Results {
-		var orig CheckRequest
-		if i < len(reqs) && (res.RequestID == "" || res.RequestID == reqs[i].RequestID) {
-			orig = reqs[i]
-		} else {
-			if reqByRequestID == nil {
-				reqByRequestID = checkRequestsByRequestID(reqs)
-			}
-			var ok bool
-			orig, ok = reqByRequestID[res.RequestID]
-			if !ok && i < len(reqs) {
-				orig = reqs[i]
-			}
+	results := make([]CheckResult, len(reqs))
+	resultsByRequestID := v2ResultsByRequestID(br.Results)
+	for i, req := range reqs {
+		var res CheckV2Result
+		var ok bool
+		if req.RequestID != "" {
+			res, ok = resultsByRequestID[req.RequestID]
 		}
-		results = append(results, CheckResult{
-			MonitorSiteID: orig.MonitorSiteID,
-			BlogID:        res.BlogID,
-			URL:           res.URL,
-			Host:          res.VantageID,
-			VantageID:     res.VantageID,
-			AgentID:       res.AgentID,
-			Outcome:       res.Outcome,
-			Success:       res.Success,
-			HTTPCode:      res.HTTPCode,
-			ErrorCode:     res.ErrorCode,
-			RTTMs:         res.RTTMs,
-			RequestID:     res.RequestID,
-		})
+		if !ok && i < len(br.Results) && br.Results[i].RequestID == "" {
+			res = br.Results[i]
+			ok = true
+		}
+		if !ok {
+			results[i] = missingV2Result(req)
+			continue
+		}
+		results[i] = checkResultFromV2(req, res)
 	}
 	return results, nil
 }
 
-func checkRequestsByRequestID(reqs []CheckRequest) map[string]CheckRequest {
-	out := make(map[string]CheckRequest, len(reqs))
-	for _, req := range reqs {
-		if req.RequestID != "" {
-			out[req.RequestID] = req
+func v2ResultsByRequestID(results []CheckV2Result) map[string]CheckV2Result {
+	out := make(map[string]CheckV2Result, len(results))
+	for _, result := range results {
+		if result.RequestID != "" {
+			if _, exists := out[result.RequestID]; !exists {
+				out[result.RequestID] = result
+			}
 		}
 	}
 	return out
+}
+
+func checkResultFromV2(orig CheckRequest, res CheckV2Result) CheckResult {
+	return CheckResult{
+		MonitorSiteID: orig.MonitorSiteID,
+		BlogID:        res.BlogID,
+		URL:           res.URL,
+		Host:          res.VantageID,
+		VantageID:     res.VantageID,
+		AgentID:       res.AgentID,
+		Outcome:       res.Outcome,
+		Success:       res.Success,
+		HTTPCode:      res.HTTPCode,
+		ErrorCode:     res.ErrorCode,
+		RTTMs:         res.RTTMs,
+		RequestID:     res.RequestID,
+	}
+}
+
+func missingV2Result(req CheckRequest) CheckResult {
+	return CheckResult{
+		MonitorSiteID: req.MonitorSiteID,
+		BlogID:        req.BlogID,
+		URL:           req.URL,
+		Outcome:       OutcomeUnknown,
+		Success:       false,
+		ErrorCode:     checkerErrorInternal,
+		RequestID:     req.RequestID,
+	}
 }
 
 func checkBatchDeadlineReserve(_ []CheckRequest) time.Duration {

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -133,11 +133,11 @@ func (c *VeriflierClient) Check(ctx context.Context, req CheckRequest) (*CheckRe
 func (c *VeriflierClient) CheckBatch(ctx context.Context, reqs []CheckRequest) ([]CheckResult, error) {
 	switch c.cachedProtocol() {
 	case ProtocolLegacy:
-		return c.checkBatchLegacy(ctx, reqs)
+		return c.checkBatchLegacyIsolated(ctx, reqs)
 	case ProtocolV2:
-		return c.checkBatchV2(ctx, reqs)
+		return c.checkBatchV2Isolated(ctx, reqs)
 	default:
-		results, err := c.checkBatchV2(ctx, reqs)
+		results, err := c.checkBatchV2Isolated(ctx, reqs)
 		if err == nil {
 			c.setProtocol(ProtocolV2)
 			return results, nil
@@ -146,7 +146,7 @@ func (c *VeriflierClient) CheckBatch(ctx context.Context, reqs []CheckRequest) (
 			return nil, err
 		}
 		c.setProtocol(ProtocolLegacy)
-		return c.checkBatchLegacy(ctx, reqs)
+		return c.checkBatchLegacyIsolated(ctx, reqs)
 	}
 }
 
@@ -475,7 +475,7 @@ func (c *VeriflierClient) checkBatchLegacy(ctx context.Context, reqs []CheckRequ
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("veriflier returned %d", resp.StatusCode)
+		return nil, statusError{endpoint: "/check", status: resp.StatusCode}
 	}
 
 	var br batchResp
@@ -501,6 +501,10 @@ func (c *VeriflierClient) checkBatchLegacy(ctx context.Context, reqs []CheckRequ
 		results[i] = checkResultFromLegacy(req, res)
 	}
 	return results, nil
+}
+
+func (c *VeriflierClient) checkBatchLegacyIsolated(ctx context.Context, reqs []CheckRequest) ([]CheckResult, error) {
+	return c.checkBatchPayloadIsolated(ctx, reqs, c.checkBatchLegacy)
 }
 
 func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest) ([]CheckResult, error) {
@@ -578,6 +582,37 @@ func (c *VeriflierClient) checkBatchV2(ctx context.Context, reqs []CheckRequest)
 		results[i] = checkResultFromV2(req, res)
 	}
 	return results, nil
+}
+
+func (c *VeriflierClient) checkBatchV2Isolated(ctx context.Context, reqs []CheckRequest) ([]CheckResult, error) {
+	return c.checkBatchPayloadIsolated(ctx, reqs, c.checkBatchV2)
+}
+
+func (c *VeriflierClient) checkBatchPayloadIsolated(ctx context.Context, reqs []CheckRequest, send func(context.Context, []CheckRequest) ([]CheckResult, error)) ([]CheckResult, error) {
+	results, err := send(ctx, reqs)
+	if err == nil {
+		return results, nil
+	}
+	if !payloadTooLargeError(err) {
+		return nil, err
+	}
+	if len(reqs) == 1 {
+		return []CheckResult{*payloadTooLargeCheckResult(reqs[0])}, nil
+	}
+
+	mid := len(reqs) / 2
+	left, leftErr := c.checkBatchPayloadIsolated(ctx, reqs[:mid], send)
+	if leftErr != nil {
+		return nil, leftErr
+	}
+	right, rightErr := c.checkBatchPayloadIsolated(ctx, reqs[mid:], send)
+	if rightErr != nil {
+		return nil, rightErr
+	}
+	out := make([]CheckResult, 0, len(left)+len(right))
+	out = append(out, left...)
+	out = append(out, right...)
+	return out, nil
 }
 
 func payloadTooLargeError(err error) bool {

--- a/internal/veriflier/executor.go
+++ b/internal/veriflier/executor.go
@@ -3,7 +3,9 @@ package veriflier
 import (
 	"context"
 	"errors"
+	"log"
 	"runtime"
+	"runtime/debug"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -22,8 +24,9 @@ const (
 	deadlineResultDrainGrace = 25 * time.Millisecond
 	// Wire-compatible checker error code for probe safety blocks. Keep this
 	// private to avoid a production dependency from veriflier back to checker;
-	// executor tests assert it stays in sync with checker.ErrorProbeSafety.
+	// executor tests assert these stay in sync with checker error codes.
 	checkerErrorProbeSafety = 9
+	checkerErrorInternal    = 10
 )
 
 type CheckFunc func(context.Context, CheckRequest) ProbeResult
@@ -286,7 +289,7 @@ func (e *Executor) worker(ctx context.Context) {
 			start := time.Now()
 			jobCtx, cancel := context.WithCancel(job.ctx)
 			stopShutdownCancel := context.AfterFunc(ctx, cancel)
-			res := e.checkFn(jobCtx, job.req)
+			res := e.runCheck(jobCtx, job.req)
 			stopShutdownCancel()
 			cancel()
 			operationalOverload := shouldTreatResultAsOperationalOverload(job.ctx, res)
@@ -320,6 +323,26 @@ func (e *Executor) worker(ctx context.Context) {
 			<-e.slots
 		}
 	}
+}
+
+func (e *Executor) runCheck(ctx context.Context, req CheckRequest) (res ProbeResult) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			log.Printf("veriflier: recovered checker panic blog_id=%d url=%q: %v\n%s", req.BlogID, req.URL, recovered, debug.Stack())
+			res = ProbeResult{
+				CheckResult: CheckResult{
+					MonitorSiteID: req.MonitorSiteID,
+					BlogID:        req.BlogID,
+					URL:           req.URL,
+					Success:       false,
+					ErrorCode:     checkerErrorInternal,
+					RequestID:     req.RequestID,
+				},
+				Outcome: OutcomeUnknown,
+			}
+		}
+	}()
+	return e.checkFn(ctx, req)
 }
 
 func shouldTreatResultAsOperationalOverload(ctx context.Context, res ProbeResult) bool {
@@ -414,6 +437,9 @@ func outcomeFromResult(res CheckResult) string {
 		return OutcomeUp
 	}
 	if res.ErrorCode == checkerErrorProbeSafety {
+		return OutcomeUnknown
+	}
+	if res.ErrorCode == checkerErrorInternal {
 		return OutcomeUnknown
 	}
 	if res.ErrorCode == 1 {

--- a/internal/veriflier/executor_test.go
+++ b/internal/veriflier/executor_test.go
@@ -14,9 +14,16 @@ func TestCheckerProbeSafetyErrorCodeContract(t *testing.T) {
 	if checkerErrorProbeSafety != checker.ErrorProbeSafety {
 		t.Fatalf("checkerErrorProbeSafety = %d, want checker.ErrorProbeSafety %d", checkerErrorProbeSafety, checker.ErrorProbeSafety)
 	}
+	if checkerErrorInternal != checker.ErrorInternal {
+		t.Fatalf("checkerErrorInternal = %d, want checker.ErrorInternal %d", checkerErrorInternal, checker.ErrorInternal)
+	}
 	got := outcomeFromResult(CheckResult{Success: false, ErrorCode: int32(checkerErrorProbeSafety)})
 	if got != OutcomeUnknown {
 		t.Fatalf("outcomeFromResult(probe safety) = %q, want %q", got, OutcomeUnknown)
+	}
+	got = outcomeFromResult(CheckResult{Success: false, ErrorCode: int32(checkerErrorInternal)})
+	if got != OutcomeUnknown {
+		t.Fatalf("outcomeFromResult(internal) = %q, want %q", got, OutcomeUnknown)
 	}
 }
 
@@ -46,6 +53,39 @@ func TestExecutorPreservesInputOrder(t *testing.T) {
 	}
 	if results[0].BlogID != 1 || results[1].BlogID != 2 {
 		t.Fatalf("results order = [%d, %d], want [1, 2]", results[0].BlogID, results[1].BlogID)
+	}
+}
+
+func TestExecutorRecoversCheckPanicAsPerRequestUnknown(t *testing.T) {
+	exec := NewExecutor(func(_ context.Context, req CheckRequest) ProbeResult {
+		if req.BlogID == 2 {
+			panic("synthetic veriflier checker failure")
+		}
+		return ProbeResult{CheckResult: CheckResult{
+			BlogID:    req.BlogID,
+			URL:       req.URL,
+			Success:   true,
+			HTTPCode:  200,
+			RequestID: req.RequestID,
+		}, Outcome: OutcomeUp}
+	}, 1, 2)
+	defer exec.Shutdown()
+
+	results, err := exec.ExecuteBatch(context.Background(), []CheckRequest{
+		{BlogID: 1, URL: "https://example.com/one", RequestID: "one"},
+		{BlogID: 2, URL: "https://example.com/two", RequestID: "two"},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteBatch() error = %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results len = %d, want 2", len(results))
+	}
+	if !results[0].Success || results[0].Outcome != OutcomeUp || results[0].RequestID != "one" {
+		t.Fatalf("first result = %+v, want success", results[0])
+	}
+	if results[1].Success || results[1].Outcome != OutcomeUnknown || results[1].ErrorCode != checkerErrorInternal || results[1].RequestID != "two" {
+		t.Fatalf("panic result = %+v, want per-request unknown", results[1])
 	}
 }
 

--- a/internal/veriflier/live_payload_test.go
+++ b/internal/veriflier/live_payload_test.go
@@ -1,0 +1,64 @@
+package veriflier
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLiveVeriflierOversizedBatchIsolation(t *testing.T) {
+	addr := strings.TrimSpace(os.Getenv("JETMON_LIVE_VERIFLIER_ADDR"))
+	if addr == "" {
+		t.Skip("set JETMON_LIVE_VERIFLIER_ADDR to run against a deployed Veriflier")
+	}
+	token := strings.TrimSpace(os.Getenv("JETMON_LIVE_VERIFLIER_TOKEN"))
+	if token == "" {
+		tokenFile := strings.TrimSpace(os.Getenv("JETMON_LIVE_VERIFLIER_TOKEN_FILE"))
+		if tokenFile != "" {
+			raw, err := os.ReadFile(tokenFile)
+			if err != nil {
+				t.Fatalf("read token file: %v", err)
+			}
+			token = strings.TrimSpace(string(raw))
+		}
+	}
+	if token == "" {
+		t.Skip("set JETMON_LIVE_VERIFLIER_TOKEN or JETMON_LIVE_VERIFLIER_TOKEN_FILE")
+	}
+
+	client := NewVeriflierClient(addr, token)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	results, err := client.CheckBatch(ctx, []CheckRequest{
+		{BlogID: 9000000000000001, URL: "https://example.com/", Method: "GET", DetectionProfile: "simple_http", RequestID: "safe-before"},
+		{
+			BlogID:           9000000000000002,
+			URL:              "https://example.com/",
+			Method:           "GET",
+			DetectionProfile: "simple_http",
+			RequestID:        "oversized",
+			CustomHeaders: map[string]string{
+				"X-Jetmon-Oversized-Payload": strings.Repeat("x", maxRequestBodyBytes+1024),
+			},
+		},
+		{BlogID: 9000000000000003, URL: "https://example.com/", Method: "GET", DetectionProfile: "simple_http", RequestID: "safe-after"},
+	})
+	if err != nil {
+		t.Fatalf("CheckBatch() error = %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("results len = %d, want 3", len(results))
+	}
+	if !results[0].Success || results[0].RequestID != "safe-before" {
+		t.Fatalf("safe-before result = %+v, want success for request_id safe-before", results[0])
+	}
+	if results[1].Success || results[1].RequestID != "oversized" || results[1].Outcome != OutcomeUnknown || results[1].ErrorCode != checkerErrorProbeSafety {
+		t.Fatalf("oversized result = %+v, want site-scoped probe-safety unknown", results[1])
+	}
+	if !results[2].Success || results[2].RequestID != "safe-after" {
+		t.Fatalf("safe-after result = %+v, want success for request_id safe-after", results[2])
+	}
+}

--- a/internal/veriflier/server.go
+++ b/internal/veriflier/server.go
@@ -211,37 +211,44 @@ func (s *Server) handleCheck(w http.ResponseWriter, r *http.Request) {
 	if !decodeLimitedJSON(w, r, &req) {
 		return
 	}
-	for i := range req.Sites {
-		if err := validateCheckURL(req.Sites[i].URL); err != nil {
-			http.Error(w, fmt.Sprintf("site %d: %v", i, err), http.StatusBadRequest)
-			return
-		}
-	}
 
+	results := make([]CheckResult, len(req.Sites))
+	legacyReqs := make([]CheckRequest, 0, len(req.Sites))
+	legacyResultIndexes := make([]int, 0, len(req.Sites))
 	for i := range req.Sites {
 		if req.Sites[i].RequestID == "" {
 			req.Sites[i].RequestID = NewRequestID()
 		}
+		if err := validateCheckURL(req.Sites[i].URL); err != nil {
+			results[i] = legacyRequestErrorResult(req.Sites[i], s.hostname)
+			continue
+		}
+		legacyReqs = append(legacyReqs, req.Sites[i])
+		legacyResultIndexes = append(legacyResultIndexes, i)
 	}
 
-	probeResults, err := s.executor.ExecuteBatch(r.Context(), req.Sites)
-	if err != nil {
-		if errors.Is(err, ErrOverloaded) {
-			incrementMetric("verifier.checks.overloaded.count", 1)
-			http.Error(w, "veriflier overloaded", http.StatusServiceUnavailable)
+	if len(legacyReqs) > 0 {
+		probeResults, err := s.executor.ExecuteBatch(r.Context(), legacyReqs)
+		if err != nil {
+			if errors.Is(err, ErrOverloaded) {
+				incrementMetric("verifier.checks.overloaded.count", 1)
+				http.Error(w, "veriflier overloaded", http.StatusServiceUnavailable)
+				return
+			}
+			http.Error(w, err.Error(), http.StatusGatewayTimeout)
 			return
 		}
-		http.Error(w, err.Error(), http.StatusGatewayTimeout)
-		return
-	}
-	results := make([]CheckResult, 0, len(probeResults))
-	for _, probeResult := range probeResults {
-		res := probeResult.CheckResult
-		res.Host = s.hostname
-		if res.RequestID == "" {
-			res.RequestID = probeResult.RequestID
+		for i, probeResult := range probeResults {
+			if i >= len(legacyResultIndexes) {
+				break
+			}
+			res := probeResult.CheckResult
+			res.Host = s.hostname
+			if res.RequestID == "" {
+				res.RequestID = probeResult.RequestID
+			}
+			results[legacyResultIndexes[i]] = res
 		}
-		results = append(results, res)
 	}
 
 	incrementMetric("verifier.checks.received.count", len(req.Sites))
@@ -435,6 +442,19 @@ func (s *Server) v2RequestErrorResult(req CheckV2Request) CheckV2Result {
 	}
 }
 
+func legacyRequestErrorResult(req CheckRequest, host string) CheckResult {
+	return CheckResult{
+		MonitorSiteID: req.MonitorSiteID,
+		BlogID:        req.BlogID,
+		URL:           req.URL,
+		Host:          host,
+		Outcome:       OutcomeUnknown,
+		Success:       false,
+		ErrorCode:     checkerErrorProbeSafety,
+		RequestID:     req.RequestID,
+	}
+}
+
 type perRequestValidationError struct {
 	err error
 }
@@ -459,11 +479,11 @@ func v2RequestToLegacy(req CheckV2Request) (CheckRequest, error) {
 	}
 	method, err := checkmode.NormalizeMethod(req.Method, checkmode.MethodGET)
 	if err != nil {
-		return CheckRequest{}, fmt.Errorf("unsupported method %q", req.Method)
+		return CheckRequest{}, &perRequestValidationError{err: fmt.Errorf("unsupported method %q", req.Method)}
 	}
 	profile, err := checkmode.NormalizeProfile(req.DetectionProfile, checkmode.ProfileFull)
 	if err != nil {
-		return CheckRequest{}, fmt.Errorf("unsupported detection_profile %q", req.DetectionProfile)
+		return CheckRequest{}, &perRequestValidationError{err: fmt.Errorf("unsupported detection_profile %q", req.DetectionProfile)}
 	}
 	profile = checkmode.EffectiveProfile(method, profile)
 	requestID := req.RequestID
@@ -489,7 +509,7 @@ func v2RequestToLegacy(req CheckV2Request) (CheckRequest, error) {
 		RequestID:           requestID,
 	}
 	if len(req.BodyRules.Required) > 1 {
-		return CheckRequest{}, fmt.Errorf("only one required body rule is supported")
+		return CheckRequest{}, &perRequestValidationError{err: fmt.Errorf("only one required body rule is supported")}
 	}
 	if len(req.BodyRules.Required) > 0 {
 		legacyReq.Keyword = req.BodyRules.Required[0]

--- a/internal/veriflier/server.go
+++ b/internal/veriflier/server.go
@@ -288,30 +288,42 @@ func (s *Server) handleV2Check(w http.ResponseWriter, r *http.Request) {
 		defer cancel()
 	}
 
+	results := make([]CheckV2Result, len(req.Requests))
 	legacyReqs := make([]CheckRequest, 0, len(req.Requests))
-	for _, site := range req.Requests {
+	legacyResultIndexes := make([]int, 0, len(req.Requests))
+	for i, site := range req.Requests {
 		legacyReq, err := v2RequestToLegacy(site)
 		if err != nil {
+			var perRequestErr *perRequestValidationError
+			if errors.As(err, &perRequestErr) {
+				results[i] = s.v2RequestErrorResult(site)
+				continue
+			}
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 		legacyReqs = append(legacyReqs, legacyReq)
+		legacyResultIndexes = append(legacyResultIndexes, i)
 	}
 
-	probeResults, err := s.executor.ExecuteBatch(ctx, legacyReqs)
-	if err != nil {
-		if errors.Is(err, ErrOverloaded) {
-			incrementMetric("verifier.checks.overloaded.count", 1)
-			writeV2Error(w, http.StatusServiceUnavailable, OutcomeAgentOverloaded, "veriflier overloaded")
+	if len(legacyReqs) > 0 {
+		probeResults, err := s.executor.ExecuteBatch(ctx, legacyReqs)
+		if err != nil {
+			if errors.Is(err, ErrOverloaded) {
+				incrementMetric("verifier.checks.overloaded.count", 1)
+				writeV2Error(w, http.StatusServiceUnavailable, OutcomeAgentOverloaded, "veriflier overloaded")
+				return
+			}
+			writeV2Error(w, http.StatusGatewayTimeout, OutcomeUnknown, err.Error())
 			return
 		}
-		writeV2Error(w, http.StatusGatewayTimeout, OutcomeUnknown, err.Error())
-		return
-	}
 
-	results := make([]CheckV2Result, 0, len(probeResults))
-	for _, probeResult := range probeResults {
-		results = append(results, s.v2Result(probeResult))
+		for i, probeResult := range probeResults {
+			if i >= len(legacyResultIndexes) {
+				break
+			}
+			results[legacyResultIndexes[i]] = s.v2Result(probeResult)
+		}
 	}
 
 	incrementMetric("verifier.checks.received.count", len(req.Requests))
@@ -406,9 +418,44 @@ func (s *Server) v2Result(res ProbeResult) CheckV2Result {
 	}
 }
 
+func (s *Server) v2RequestErrorResult(req CheckV2Request) CheckV2Result {
+	requestID := req.RequestID
+	if requestID == "" {
+		requestID = NewRequestID()
+	}
+	return CheckV2Result{
+		RequestID: requestID,
+		BlogID:    req.BlogID,
+		URL:       req.URL,
+		VantageID: s.vantage.ID,
+		AgentID:   s.agent.ID,
+		Outcome:   OutcomeUnknown,
+		Success:   false,
+		ErrorCode: checkerErrorProbeSafety,
+	}
+}
+
+type perRequestValidationError struct {
+	err error
+}
+
+func (e *perRequestValidationError) Error() string {
+	if e == nil || e.err == nil {
+		return ""
+	}
+	return e.err.Error()
+}
+
+func (e *perRequestValidationError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
 func v2RequestToLegacy(req CheckV2Request) (CheckRequest, error) {
 	if err := validateCheckURL(req.URL); err != nil {
-		return CheckRequest{}, err
+		return CheckRequest{}, &perRequestValidationError{err: err}
 	}
 	method, err := checkmode.NormalizeMethod(req.Method, checkmode.MethodGET)
 	if err != nil {

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -468,6 +468,56 @@ func TestClientBatchReturnsUnknownForOmittedV2Result(t *testing.T) {
 	}
 }
 
+func TestClientBatchKeepsLocalIdentityAuthoritative(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/check" {
+			http.NotFound(w, r)
+			return
+		}
+		var req CheckV2BatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		if len(req.Requests) != 1 {
+			t.Errorf("request len = %d, want 1", len(req.Requests))
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(CheckV2BatchResponse{Results: []CheckV2Result{{
+			RequestID: req.Requests[0].RequestID,
+			BlogID:    9999,
+			URL:       "https://wrong.example.test/",
+			VantageID: "test-vantage",
+			AgentID:   "test-agent",
+			Outcome:   OutcomeUp,
+			Success:   true,
+			HTTPCode:  200,
+		}}})
+	}))
+	defer ts.Close()
+
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
+	client.setProtocol(ProtocolV2)
+	res, err := client.CheckBatch(context.Background(), []CheckRequest{
+		{MonitorSiteID: 101, BlogID: 1, URL: "https://example.com/one", RequestID: "one"},
+	})
+	if err != nil {
+		t.Fatalf("CheckBatch() error = %v", err)
+	}
+	if len(res) != 1 {
+		t.Fatalf("CheckBatch() len = %d, want 1", len(res))
+	}
+	if res[0].BlogID != 1 || res[0].URL != "https://example.com/one" || res[0].MonitorSiteID != 101 {
+		t.Fatalf("result identity = %+v, want local request identity", res[0])
+	}
+	if !res[0].Success || res[0].Outcome != OutcomeUp || res[0].Host != "test-vantage" {
+		t.Fatalf("result outcome/vantage = %+v", res[0])
+	}
+}
+
 func TestClientBatchSendsServerDeadlineWithReserve(t *testing.T) {
 	origReserve := singleCheckBatchDeadlineReserve
 	origLargeReserve := singleCheckLargeBatchDeadlineReserve

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -1231,6 +1231,84 @@ func TestClientCheckKeepsLightLaneMovingDuringFullBatch(t *testing.T) {
 	}
 }
 
+func TestSingleCheckBatcherSplitsPayloadTooLargeBatches(t *testing.T) {
+	const hugeURL = "https://example.com/huge"
+	var requestCount atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/check" {
+			http.NotFound(w, r)
+			return
+		}
+		requestCount.Add(1)
+		var req CheckV2BatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		for _, check := range req.Requests {
+			if check.URL == hugeURL {
+				http.Error(w, "request entity too large", http.StatusRequestEntityTooLarge)
+				return
+			}
+		}
+		results := make([]CheckV2Result, 0, len(req.Requests))
+		for _, check := range req.Requests {
+			results = append(results, CheckV2Result{
+				RequestID: check.RequestID,
+				BlogID:    check.BlogID,
+				URL:       check.URL,
+				VantageID: "test-vantage",
+				AgentID:   "test-agent",
+				Outcome:   OutcomeUp,
+				Success:   true,
+				HTTPCode:  200,
+			})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(CheckV2BatchResponse{Results: results})
+	}))
+	defer ts.Close()
+
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
+	batcher := &singleCheckBatcher{client: client}
+	calls := []singleCheckCall{
+		{ctx: context.Background(), req: CheckRequest{BlogID: 1, URL: "https://example.com/safe-before", RequestID: "safe-before"}, resp: make(chan singleCheckResponse, 1)},
+		{ctx: context.Background(), req: CheckRequest{BlogID: 2, URL: hugeURL, RequestID: "huge"}, resp: make(chan singleCheckResponse, 1)},
+		{ctx: context.Background(), req: CheckRequest{BlogID: 3, URL: "https://example.com/safe-after", RequestID: "safe-after"}, resp: make(chan singleCheckResponse, 1)},
+	}
+
+	batcher.flush(calls)
+
+	for _, idx := range []int{0, 2} {
+		select {
+		case got := <-calls[idx].resp:
+			if got.err != nil {
+				t.Fatalf("safe call %d error = %v, want success", idx, got.err)
+			}
+			if got.result == nil || !got.result.Success || got.result.RequestID != calls[idx].req.RequestID {
+				t.Fatalf("safe call %d result = %+v, want matching success", idx, got.result)
+			}
+		default:
+			t.Fatalf("safe call %d did not receive a response", idx)
+		}
+	}
+	select {
+	case got := <-calls[1].resp:
+		if got.err != nil {
+			t.Fatalf("huge call error = %v, want site-scoped result", got.err)
+		}
+		if got.result == nil || got.result.Success || got.result.Outcome != OutcomeUnknown || got.result.ErrorCode != checkerErrorProbeSafety {
+			t.Fatalf("huge call result = %+v, want probe-safety unknown", got.result)
+		}
+	default:
+		t.Fatal("huge call did not receive a response")
+	}
+	if requestCount.Load() < 4 {
+		t.Fatalf("request count = %d, want recursive split retries", requestCount.Load())
+	}
+}
+
 func TestSingleCheckBatcherPrunesExpiredCallsWhileWaitingForFlight(t *testing.T) {
 	origPoll := singleCheckBatchFlightWaitPoll
 	singleCheckBatchFlightWaitPoll = time.Millisecond

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -1309,6 +1309,136 @@ func TestSingleCheckBatcherSplitsPayloadTooLargeBatches(t *testing.T) {
 	}
 }
 
+func TestClientBatchSplitsPayloadTooLargeV2Batches(t *testing.T) {
+	const hugeURL = "https://example.com/huge"
+	var requestCount atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/check" {
+			http.NotFound(w, r)
+			return
+		}
+		requestCount.Add(1)
+		var req CheckV2BatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		for _, check := range req.Requests {
+			if check.URL == hugeURL {
+				http.Error(w, "request entity too large", http.StatusRequestEntityTooLarge)
+				return
+			}
+		}
+		results := make([]CheckV2Result, 0, len(req.Requests))
+		for _, check := range req.Requests {
+			results = append(results, CheckV2Result{
+				RequestID: check.RequestID,
+				BlogID:    check.BlogID,
+				URL:       check.URL,
+				Outcome:   OutcomeUp,
+				Success:   true,
+				HTTPCode:  200,
+			})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(CheckV2BatchResponse{Results: results})
+	}))
+	defer ts.Close()
+
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
+	client.setProtocol(ProtocolV2)
+	results, err := client.CheckBatch(context.Background(), []CheckRequest{
+		{BlogID: 1, URL: "https://example.com/safe-before", RequestID: "safe-before"},
+		{BlogID: 2, URL: hugeURL, RequestID: "huge"},
+		{BlogID: 3, URL: "https://example.com/safe-after", RequestID: "safe-after"},
+	})
+	if err != nil {
+		t.Fatalf("CheckBatch() error = %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("results len = %d, want 3", len(results))
+	}
+	for _, idx := range []int{0, 2} {
+		if !results[idx].Success || results[idx].RequestID == "" {
+			t.Fatalf("safe result %d = %+v, want success", idx, results[idx])
+		}
+	}
+	if results[1].Success || results[1].Outcome != OutcomeUnknown || results[1].ErrorCode != checkerErrorProbeSafety {
+		t.Fatalf("huge result = %+v, want probe-safety unknown", results[1])
+	}
+	if requestCount.Load() < 4 {
+		t.Fatalf("request count = %d, want recursive split retries", requestCount.Load())
+	}
+}
+
+func TestClientBatchSplitsPayloadTooLargeLegacyBatches(t *testing.T) {
+	const hugeURL = "https://example.com/huge"
+	var requestCount atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/check" {
+			http.NotFound(w, r)
+			return
+		}
+		requestCount.Add(1)
+		var req struct {
+			Sites []CheckRequest `json:"sites"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		for _, check := range req.Sites {
+			if check.URL == hugeURL {
+				http.Error(w, "request entity too large", http.StatusRequestEntityTooLarge)
+				return
+			}
+		}
+		results := make([]CheckResult, 0, len(req.Sites))
+		for _, check := range req.Sites {
+			results = append(results, CheckResult{
+				RequestID: check.RequestID,
+				BlogID:    check.BlogID,
+				URL:       check.URL,
+				Outcome:   OutcomeUp,
+				Success:   true,
+				HTTPCode:  200,
+			})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(struct {
+			Results []CheckResult `json:"results"`
+		}{Results: results})
+	}))
+	defer ts.Close()
+
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
+	client.setProtocol(ProtocolLegacy)
+	results, err := client.CheckBatch(context.Background(), []CheckRequest{
+		{BlogID: 1, URL: "https://example.com/safe-before", RequestID: "safe-before"},
+		{BlogID: 2, URL: hugeURL, RequestID: "huge"},
+		{BlogID: 3, URL: "https://example.com/safe-after", RequestID: "safe-after"},
+	})
+	if err != nil {
+		t.Fatalf("CheckBatch() error = %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("results len = %d, want 3", len(results))
+	}
+	for _, idx := range []int{0, 2} {
+		if !results[idx].Success || results[idx].RequestID == "" {
+			t.Fatalf("safe result %d = %+v, want success", idx, results[idx])
+		}
+	}
+	if results[1].Success || results[1].Outcome != OutcomeUnknown || results[1].ErrorCode != checkerErrorProbeSafety {
+		t.Fatalf("huge result = %+v, want probe-safety unknown", results[1])
+	}
+	if requestCount.Load() < 4 {
+		t.Fatalf("request count = %d, want recursive split retries", requestCount.Load())
+	}
+}
+
 func TestSingleCheckBatcherPrunesExpiredCallsWhileWaitingForFlight(t *testing.T) {
 	origPoll := singleCheckBatchFlightWaitPoll
 	singleCheckBatchFlightWaitPoll = time.Millisecond

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -193,7 +193,7 @@ func TestServerHandleCheckMethodNotAllowed(t *testing.T) {
 	}
 }
 
-func TestServerHandleCheckRejectsUnsafeURL(t *testing.T) {
+func TestServerHandleCheckReturnsUnsafeURLResult(t *testing.T) {
 	var called atomic.Bool
 	_, ts := newTestServer(func(req CheckRequest) CheckResult {
 		called.Store(true)
@@ -212,11 +212,83 @@ func TestServerHandleCheckRejectsUnsafeURL(t *testing.T) {
 		t.Fatalf("request error: %v", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
 	if called.Load() {
 		t.Fatal("check function was called for unsafe URL")
+	}
+	var result struct {
+		Results []CheckResult `json:"results"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(result.Results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(result.Results))
+	}
+	got := result.Results[0]
+	if got.BlogID != 1 || got.URL != "http://127.0.0.1/admin" || got.Host != "test-host" {
+		t.Fatalf("unsafe result identity = %+v", got)
+	}
+	if got.Success || got.ErrorCode != checkerErrorProbeSafety || got.Outcome != OutcomeUnknown {
+		t.Fatalf("unsafe result = %+v, want probe-safety unknown", got)
+	}
+}
+
+func TestServerHandleCheckIsolatesUnsafeURLInMixedLegacyBatch(t *testing.T) {
+	var calledMu sync.Mutex
+	var calledURLs []string
+	_, ts := newTestServer(func(req CheckRequest) CheckResult {
+		calledMu.Lock()
+		calledURLs = append(calledURLs, req.URL)
+		calledMu.Unlock()
+		return CheckResult{BlogID: req.BlogID, URL: req.URL, Success: true, HTTPCode: 200}
+	})
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/check", checkReqBody(t, []CheckRequest{
+		{RequestID: "req-safe-before", BlogID: 1, URL: "https://example.com/before"},
+		{RequestID: "req-unsafe", BlogID: 2, URL: "http://localhost/admin"},
+		{RequestID: "req-safe-after", BlogID: 3, URL: "https://example.com/after"},
+	}))
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var result struct {
+		Results []CheckResult `json:"results"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(result.Results) != 3 {
+		t.Fatalf("results len = %d, want 3", len(result.Results))
+	}
+	calledMu.Lock()
+	defer calledMu.Unlock()
+	called := make(map[string]bool, len(calledURLs))
+	for _, url := range calledURLs {
+		called[url] = true
+	}
+	if len(calledURLs) != 2 || !called["https://example.com/before"] || !called["https://example.com/after"] {
+		t.Fatalf("called URLs = %#v, want only safe siblings", calledURLs)
+	}
+	if !result.Results[0].Success || result.Results[0].RequestID != "req-safe-before" {
+		t.Fatalf("safe-before result = %+v", result.Results[0])
+	}
+	if result.Results[1].Success || result.Results[1].RequestID != "req-unsafe" || result.Results[1].ErrorCode != checkerErrorProbeSafety || result.Results[1].Outcome != OutcomeUnknown {
+		t.Fatalf("unsafe result = %+v", result.Results[1])
+	}
+	if !result.Results[2].Success || result.Results[2].RequestID != "req-safe-after" {
+		t.Fatalf("safe-after result = %+v", result.Results[2])
 	}
 }
 
@@ -1735,7 +1807,7 @@ func TestServerHandleV2CheckAppliesBatchDeadline(t *testing.T) {
 	}
 }
 
-func TestServerHandleV2CheckRejectsMultipleRequiredBodyRules(t *testing.T) {
+func TestServerHandleV2CheckReturnsRequestErrorForMultipleRequiredBodyRules(t *testing.T) {
 	srv, ts := newV2TestServer(func(_ context.Context, req CheckRequest) ProbeResult {
 		t.Fatal("checkFn should not be called for invalid body rules")
 		return ProbeResult{}
@@ -1764,8 +1836,88 @@ func TestServerHandleV2CheckRejectsMultipleRequiredBodyRules(t *testing.T) {
 		t.Fatalf("request error: %v", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var result CheckV2BatchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(result.Results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(result.Results))
+	}
+	got := result.Results[0]
+	if got.Success || got.ErrorCode != checkerErrorProbeSafety || got.Outcome != OutcomeUnknown {
+		t.Fatalf("result = %+v, want probe-safety unknown", got)
+	}
+}
+
+func TestServerHandleV2CheckIsolatesBadPerSiteOptionsInMixedBatch(t *testing.T) {
+	var calledMu sync.Mutex
+	var calledURLs []string
+	srv, ts := newV2TestServer(func(_ context.Context, req CheckRequest) ProbeResult {
+		calledMu.Lock()
+		calledURLs = append(calledURLs, req.URL)
+		calledMu.Unlock()
+		return ProbeResult{CheckResult: CheckResult{
+			BlogID:    req.BlogID,
+			URL:       req.URL,
+			Success:   true,
+			HTTPCode:  200,
+			RequestID: req.RequestID,
+		}, Outcome: OutcomeUp}
+	})
+	defer srv.executor.Shutdown()
+	defer ts.Close()
+
+	body := bytes.NewBuffer(nil)
+	if err := json.NewEncoder(body).Encode(CheckV2BatchRequest{
+		Requests: []CheckV2Request{
+			{RequestID: "req-safe-before", BlogID: 1, URL: "https://example.com/before"},
+			{RequestID: "req-bad-method", BlogID: 2, URL: "https://example.com/bad-method", Method: "POST"},
+			{RequestID: "req-bad-profile", BlogID: 3, URL: "https://example.com/bad-profile", DetectionProfile: "imaginary"},
+			{RequestID: "req-safe-after", BlogID: 4, URL: "https://example.com/after"},
+		},
+	}); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v2/check", body)
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var result CheckV2BatchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(result.Results) != 4 {
+		t.Fatalf("results len = %d, want 4", len(result.Results))
+	}
+	calledMu.Lock()
+	defer calledMu.Unlock()
+	called := make(map[string]bool, len(calledURLs))
+	for _, url := range calledURLs {
+		called[url] = true
+	}
+	if len(calledURLs) != 2 || !called["https://example.com/before"] || !called["https://example.com/after"] {
+		t.Fatalf("called URLs = %#v, want only safe siblings", calledURLs)
+	}
+	for _, idx := range []int{0, 3} {
+		if !result.Results[idx].Success || result.Results[idx].Outcome != OutcomeUp {
+			t.Fatalf("safe result %d = %+v", idx, result.Results[idx])
+		}
+	}
+	for _, idx := range []int{1, 2} {
+		if result.Results[idx].Success || result.Results[idx].ErrorCode != checkerErrorProbeSafety || result.Results[idx].Outcome != OutcomeUnknown {
+			t.Fatalf("bad-options result %d = %+v", idx, result.Results[idx])
+		}
 	}
 }
 

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -2021,6 +2021,109 @@ func TestClientFallsBackToLegacyWhenUnknownV2ConnectionCloses(t *testing.T) {
 	}
 }
 
+func TestClientLegacyBatchMapsOutOfOrderResultsByRequestID(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/check", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Sites []CheckRequest `json:"sites"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode legacy request: %v", err)
+		}
+		if len(req.Sites) != 2 {
+			t.Fatalf("sites len = %d, want 2", len(req.Sites))
+		}
+		results := []CheckResult{
+			{
+				RequestID:     req.Sites[1].RequestID,
+				MonitorSiteID: 999,
+				BlogID:        999,
+				URL:           "https://wrong.example/after",
+				Host:          "legacy-host",
+				Success:       false,
+				HTTPCode:      500,
+			},
+			{
+				RequestID:     req.Sites[0].RequestID,
+				MonitorSiteID: 999,
+				BlogID:        999,
+				URL:           "https://wrong.example/before",
+				Host:          "legacy-host",
+				Success:       true,
+				HTTPCode:      200,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(struct {
+			Results []CheckResult `json:"results"`
+		}{Results: results})
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
+	client.setProtocol(ProtocolLegacy)
+	res, err := client.CheckBatch(context.Background(), []CheckRequest{
+		{MonitorSiteID: 11, BlogID: 1, URL: "https://example.com/before", RequestID: "req-before"},
+		{MonitorSiteID: 22, BlogID: 2, URL: "https://example.com/after", RequestID: "req-after"},
+	})
+	if err != nil {
+		t.Fatalf("CheckBatch() error = %v", err)
+	}
+	if len(res) != 2 {
+		t.Fatalf("results len = %d, want 2", len(res))
+	}
+	if !res[0].Success || res[0].RequestID != "req-before" || res[0].BlogID != 1 || res[0].MonitorSiteID != 11 || res[0].URL != "https://example.com/before" {
+		t.Fatalf("first result = %+v", res[0])
+	}
+	if res[1].Success || res[1].RequestID != "req-after" || res[1].BlogID != 2 || res[1].MonitorSiteID != 22 || res[1].URL != "https://example.com/after" {
+		t.Fatalf("second result = %+v", res[1])
+	}
+}
+
+func TestClientLegacyBatchReturnsUnknownForOmittedResult(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/check", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Sites []CheckRequest `json:"sites"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode legacy request: %v", err)
+		}
+		results := []CheckResult{{
+			RequestID: req.Sites[0].RequestID,
+			Host:      "legacy-host",
+			Success:   true,
+			HTTPCode:  200,
+		}}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(struct {
+			Results []CheckResult `json:"results"`
+		}{Results: results})
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
+	client.setProtocol(ProtocolLegacy)
+	res, err := client.CheckBatch(context.Background(), []CheckRequest{
+		{BlogID: 1, URL: "https://example.com/one", RequestID: "req-one"},
+		{BlogID: 2, URL: "https://example.com/two", RequestID: "req-two"},
+	})
+	if err != nil {
+		t.Fatalf("CheckBatch() error = %v", err)
+	}
+	if len(res) != 2 {
+		t.Fatalf("results len = %d, want 2", len(res))
+	}
+	if !res[0].Success || res[0].RequestID != "req-one" {
+		t.Fatalf("first result = %+v", res[0])
+	}
+	if res[1].Success || res[1].RequestID != "req-two" || res[1].Outcome != OutcomeUnknown || res[1].ErrorCode != checkerErrorInternal {
+		t.Fatalf("missing result = %+v", res[1])
+	}
+}
+
 func TestClientTreatsCachedV2EOFAsAgentOverloaded(t *testing.T) {
 	var legacyHits atomic.Int64
 

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -771,6 +771,71 @@ func TestSingleCheckBatcherMapsOutOfOrderResultsByRequestID(t *testing.T) {
 	}
 }
 
+func TestSingleCheckBatcherDoesNotMisattributePartialResultByPosition(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/check" {
+			http.NotFound(w, r)
+			return
+		}
+		var req CheckV2BatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		if len(req.Requests) != 2 {
+			t.Errorf("request len = %d, want 2", len(req.Requests))
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(CheckV2BatchResponse{Results: []CheckV2Result{{
+			RequestID: req.Requests[1].RequestID,
+			BlogID:    req.Requests[1].BlogID,
+			URL:       req.Requests[1].URL,
+			VantageID: "test-vantage",
+			AgentID:   "test-agent",
+			Outcome:   OutcomeUp,
+			Success:   true,
+			HTTPCode:  200,
+		}}})
+	}))
+	defer ts.Close()
+
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
+	client.setProtocol(ProtocolV2)
+	batcher := &singleCheckBatcher{client: client}
+	calls := []singleCheckCall{
+		{
+			ctx:  context.Background(),
+			req:  CheckRequest{BlogID: 1, URL: "https://example.com/one", RequestID: "one"},
+			resp: make(chan singleCheckResponse, 1),
+		},
+		{
+			ctx:  context.Background(),
+			req:  CheckRequest{BlogID: 2, URL: "https://example.com/two", RequestID: "two"},
+			resp: make(chan singleCheckResponse, 1),
+		},
+	}
+	batcher.flush(calls)
+
+	missing := <-calls[0].resp
+	if missing.err == nil {
+		t.Fatalf("missing first result error = nil, result=%+v; want omission error instead of sibling result", missing.result)
+	}
+	if missing.result != nil {
+		t.Fatalf("missing first result = %+v, want nil result", missing.result)
+	}
+
+	got := <-calls[1].resp
+	if got.err != nil {
+		t.Fatalf("second result error = %v", got.err)
+	}
+	if got.result == nil || got.result.RequestID != "two" || got.result.BlogID != 2 || !got.result.Success {
+		t.Fatalf("second result = %+v", got.result)
+	}
+}
+
 func TestClientCheckReturnsAgentOverloadedOnDeadlinePressure(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v2/check" {

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -1412,7 +1412,7 @@ func TestServerHandleV2Check(t *testing.T) {
 	}
 }
 
-func TestServerHandleV2CheckRejectsUnsafeURL(t *testing.T) {
+func TestServerHandleV2CheckReturnsUnsafeURLResult(t *testing.T) {
 	var called atomic.Bool
 	srv, ts := newV2TestServer(func(_ context.Context, req CheckRequest) ProbeResult {
 		called.Store(true)
@@ -1440,11 +1440,89 @@ func TestServerHandleV2CheckRejectsUnsafeURL(t *testing.T) {
 		t.Fatalf("request error: %v", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
 	if called.Load() {
 		t.Fatal("check function was called for unsafe URL")
+	}
+
+	var result CheckV2BatchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(result.Results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(result.Results))
+	}
+	got := result.Results[0]
+	if got.RequestID != "req-unsafe" || got.BlogID != 42 || got.URL != "http://169.254.169.254/latest/meta-data/" {
+		t.Fatalf("result identity = %+v", got)
+	}
+	if got.Success || got.ErrorCode != checkerErrorProbeSafety || got.Outcome != OutcomeUnknown {
+		t.Fatalf("result = %+v, want probe-safety non-success", got)
+	}
+}
+
+func TestServerHandleV2CheckIsolatesUnsafeURLInMixedBatch(t *testing.T) {
+	var calledURLs []string
+	srv, ts := newV2TestServer(func(_ context.Context, req CheckRequest) ProbeResult {
+		calledURLs = append(calledURLs, req.URL)
+		return ProbeResult{CheckResult: CheckResult{
+			BlogID:    req.BlogID,
+			URL:       req.URL,
+			Success:   true,
+			HTTPCode:  200,
+			RequestID: req.RequestID,
+		}, Outcome: OutcomeUp}
+	})
+	defer srv.executor.Shutdown()
+	defer ts.Close()
+
+	body := bytes.NewBuffer(nil)
+	if err := json.NewEncoder(body).Encode(CheckV2BatchRequest{
+		Requests: []CheckV2Request{
+			{RequestID: "req-safe-before", BlogID: 1, URL: "https://example.com/before"},
+			{RequestID: "req-unsafe", BlogID: 2, URL: "http://localhost/admin"},
+			{RequestID: "req-safe-after", BlogID: 3, URL: "https://example.com/after"},
+		},
+	}); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v2/check", body)
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var result CheckV2BatchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(result.Results) != 3 {
+		t.Fatalf("results len = %d, want 3", len(result.Results))
+	}
+	called := make(map[string]bool, len(calledURLs))
+	for _, url := range calledURLs {
+		called[url] = true
+	}
+	if len(calledURLs) != 2 || !called["https://example.com/before"] || !called["https://example.com/after"] {
+		t.Fatalf("called URLs = %#v, want only safe siblings", calledURLs)
+	}
+	if !result.Results[0].Success || result.Results[0].RequestID != "req-safe-before" || result.Results[0].Outcome != OutcomeUp {
+		t.Fatalf("safe-before result = %+v", result.Results[0])
+	}
+	if result.Results[1].Success || result.Results[1].RequestID != "req-unsafe" || result.Results[1].ErrorCode != checkerErrorProbeSafety || result.Results[1].Outcome != OutcomeUnknown {
+		t.Fatalf("unsafe result = %+v", result.Results[1])
+	}
+	if !result.Results[2].Success || result.Results[2].RequestID != "req-safe-after" || result.Results[2].Outcome != OutcomeUp {
+		t.Fatalf("safe-after result = %+v", result.Results[2])
 	}
 }
 

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -1702,9 +1702,12 @@ func TestServerHandleV2CheckReturnsUnsafeURLResult(t *testing.T) {
 }
 
 func TestServerHandleV2CheckIsolatesUnsafeURLInMixedBatch(t *testing.T) {
+	var calledMu sync.Mutex
 	var calledURLs []string
 	srv, ts := newV2TestServer(func(_ context.Context, req CheckRequest) ProbeResult {
+		calledMu.Lock()
 		calledURLs = append(calledURLs, req.URL)
+		calledMu.Unlock()
 		return ProbeResult{CheckResult: CheckResult{
 			BlogID:    req.BlogID,
 			URL:       req.URL,
@@ -1746,6 +1749,8 @@ func TestServerHandleV2CheckIsolatesUnsafeURLInMixedBatch(t *testing.T) {
 	if len(result.Results) != 3 {
 		t.Fatalf("results len = %d, want 3", len(result.Results))
 	}
+	calledMu.Lock()
+	defer calledMu.Unlock()
 	called := make(map[string]bool, len(calledURLs))
 	for _, url := range calledURLs {
 		called[url] = true

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -409,11 +409,62 @@ func TestClientBatchMapsOutOfOrderV2ResultsByRequestID(t *testing.T) {
 	if len(res) != 2 {
 		t.Fatalf("CheckBatch() len = %d, want 2", len(res))
 	}
-	if res[0].RequestID != "two" || res[0].MonitorSiteID != 0 || res[0].BlogID != 2 {
-		t.Fatalf("first result = %+v, want request two metadata", res[0])
+	if res[0].RequestID != "one" || res[0].MonitorSiteID != 101 || res[0].BlogID != 1 {
+		t.Fatalf("first result = %+v, want request one metadata", res[0])
 	}
-	if res[1].RequestID != "one" || res[1].MonitorSiteID != 101 || res[1].BlogID != 1 {
-		t.Fatalf("second result = %+v, want request one metadata", res[1])
+	if res[1].RequestID != "two" || res[1].MonitorSiteID != 0 || res[1].BlogID != 2 {
+		t.Fatalf("second result = %+v, want request two metadata", res[1])
+	}
+}
+
+func TestClientBatchReturnsUnknownForOmittedV2Result(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/check" {
+			http.NotFound(w, r)
+			return
+		}
+		var req CheckV2BatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		if len(req.Requests) != 2 {
+			t.Errorf("request len = %d, want 2", len(req.Requests))
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(CheckV2BatchResponse{Results: []CheckV2Result{{
+			RequestID: req.Requests[1].RequestID,
+			BlogID:    req.Requests[1].BlogID,
+			URL:       req.Requests[1].URL,
+			VantageID: "test-vantage",
+			AgentID:   "test-agent",
+			Outcome:   OutcomeUp,
+			Success:   true,
+			HTTPCode:  200,
+		}}})
+	}))
+	defer ts.Close()
+
+	client := NewVeriflierClient(ts.Listener.Addr().String(), "secret")
+	client.setProtocol(ProtocolV2)
+	res, err := client.CheckBatch(context.Background(), []CheckRequest{
+		{MonitorSiteID: 101, BlogID: 1, URL: "https://example.com/one", RequestID: "one"},
+		{MonitorSiteID: 202, BlogID: 2, URL: "https://example.com/two", RequestID: "two"},
+	})
+	if err != nil {
+		t.Fatalf("CheckBatch() error = %v", err)
+	}
+	if len(res) != 2 {
+		t.Fatalf("CheckBatch() len = %d, want 2", len(res))
+	}
+	if res[0].Success || res[0].Outcome != OutcomeUnknown || res[0].ErrorCode != checkerErrorInternal || res[0].RequestID != "one" || res[0].MonitorSiteID != 101 {
+		t.Fatalf("first result = %+v, want request one unknown", res[0])
+	}
+	if !res[1].Success || res[1].Outcome != OutcomeUp || res[1].RequestID != "two" || res[1].MonitorSiteID != 202 {
+		t.Fatalf("second result = %+v, want request two success", res[1])
 	}
 }
 
@@ -820,11 +871,11 @@ func TestSingleCheckBatcherDoesNotMisattributePartialResultByPosition(t *testing
 	batcher.flush(calls)
 
 	missing := <-calls[0].resp
-	if missing.err == nil {
-		t.Fatalf("missing first result error = nil, result=%+v; want omission error instead of sibling result", missing.result)
+	if missing.err != nil {
+		t.Fatalf("missing first result error = %v, want per-request unknown result", missing.err)
 	}
-	if missing.result != nil {
-		t.Fatalf("missing first result = %+v, want nil result", missing.result)
+	if missing.result == nil || missing.result.RequestID != "one" || missing.result.BlogID != 1 || missing.result.Success || missing.result.Outcome != OutcomeUnknown || missing.result.ErrorCode != checkerErrorInternal {
+		t.Fatalf("missing first result = %+v, want request one unknown", missing.result)
 	}
 
 	got := <-calls[1].resp

--- a/veriflier2/cmd/main.go
+++ b/veriflier2/cmd/main.go
@@ -188,7 +188,7 @@ func performCheck(req veriflier.CheckRequest) veriflier.CheckResult {
 }
 
 func performCheckContext(ctx context.Context, req veriflier.CheckRequest) veriflier.ProbeResult {
-	res := checker.Check(ctx, checker.Request{
+	res := checker.SafeCheck(ctx, checker.Request{
 		MonitorSiteID:       req.MonitorSiteID,
 		BlogID:              req.BlogID,
 		URL:                 req.URL,


### PR DESCRIPTION
## Summary

This PR tightens several production-readiness gaps found by uptime-bench and adversarial review while validating Jetmon v2 against internal-only targets:

- Keeps unsafe, invalid, oversized, or panic-inducing v2 Veriflier batch entries isolated to their own per-request result instead of failing the whole batch.
- Prevents v2 Veriflier client result misattribution when a response is out of order, partial, duplicated, or returns mismatched identity data.
- Recovers checker panics as operational unknowns so one pathological site cannot crash a Monitor worker, API rollout probe, trigger-now request, or Veriflier worker.
- Expands GET/full semantic body detection for high-confidence WordPress, Jetpack, Redis object-cache, and hosting failure pages served with HTTP 200.
- Tightens semantic phrase matching so ordinary troubleshooting articles are not treated as outage pages.
- Emits the streaming scheduler summary through normal operational logs instead of debug-only logs so uptime-bench and operators can collect scheduler telemetry when DEBUG=false.
- Updates the config, data-model, project, roadmap, support, taxonomy, and architecture docs to match the added detection and operational-error behavior.

## Why

Recent production-readiness and uptime-bench runs found three important classes of risk:

1. A malformed, unsafe, or oversized request inside a Veriflier v2 batch could prevent healthy sibling requests from receiving results.
2. Some WordPress failure pages are valid HTTP 200 responses but represent a broken customer-visible site. These need to be detected only in GET/full mode so staged rollout can keep HEAD/legacy and GET/simple behavior conservative.
3. Failure phrases can appear in normal support articles, so semantic detection must require page-like context rather than matching arbitrary body text.

The adversarial follow-up added a fourth hardening theme: batch and worker boundaries must never let one suspicious site poison a sibling result, crash a process, or turn Monitor-side faults into customer-site downtime. `ErrorInternal` is now treated as an operational unknown, audited for operators, and excluded from downtime state changes.

The telemetry change addresses a reporting gap rather than check correctness: deployed test configs run with DEBUG=false, so debug-only scheduler summaries made the streaming telemetry collector report a false failure.

## Validation

Local tests:

- go test ./internal/checker
- go test ./internal/orchestrator
- go test ./internal/veriflier
- go test ./internal/api
- go test ./veriflier2/cmd
- go test ./...

Adversarial local coverage added in this branch:

- v2 Veriflier mixed safe/unsafe batch returns valid sibling results and an unknown probe-safety result for only the unsafe URL.
- v2 Veriflier partial identified responses no longer misattribute sibling results by position.
- v2 CheckBatch now returns results in request order and fills omitted identified results with per-request unknowns.
- Veriflier response conversion keeps local request identity authoritative even if a response carries the wrong blog ID or URL.
- Monitor checker pool panic recovery returns a non-downtime internal operational result.
- Veriflier executor panic recovery returns a per-request unknown non-vote.
- API rollout, canary, trigger-now, and Veriflier command direct probes use the safe checker boundary.
- GET/full detects page-level semantic failures in marked-up title/h1 content while troubleshooting article fixtures remain healthy.
- Oversized direct Veriflier requests are split into site-scoped unknown results instead of aborting sibling checks.

Deployed validation on jetmon-service-host-2 and the v2 Veriflier test host:

- reports/20260524T234737Z-v2-c27c47d-get-full-1k-telemetry-validation: health, target observer, streaming telemetry, and cleanup passed; confirmed normal-log streaming telemetry with DEBUG=false.
- reports/20260525T001149Z-v2-78cc10b-get-full-2900-expanded-content-body: all 28 semantic cohorts detected and recovered; false-positive fatal-article guard stayed clean; streaming telemetry passed.
- reports/20260525T004906Z-v2-78cc10b-get-simple-2900-content-body-mode-gating: all semantic body fixtures stayed at 0 down / 0 recovery as intended; streaming telemetry passed.
- reports/20260525T012645Z-v2-78cc10b-head-legacy-2900-content-body-mode-gating: all semantic body fixtures stayed at 0 down / 0 recovery as intended; streaming telemetry passed.
- reports/20260525T0213Z-v2-78cc10b-get-full-10k-120m-telemetry-steady-soak: 10,000/10,000 targets observed, 0 never seen, 0 stale, 0 failures, 119 streaming telemetry samples, average 34.29 SPS, max lag 2688 ms, pending/result queue depth max 0.
- reports/20260525T1337Z-v2-8a191d6-get-full-2900-expanded-content-body: PASS; 2,900 GET/full semantic targets, 100% target coverage, no stale sites, replay detection passed, streaming telemetry passed.
- reports/20260525T1421Z-v2-8a191d6-get-simple-10k-60m-steady-soak: PASS; 10,000 GET/simple targets, 100% coverage, 0 stale, streaming telemetry passed.
- reports/20260525T1525Z-v2-2c60fd5-poison-batch-public-safe: PASS; suspicious URL failures remained site-scoped while safe controls before and after continued to succeed.
- Live deployed Veriflier oversized payload smoke: PASS; a mixed batch with safe-before, oversized, and safe-after requests returned successful safe results and a site-scoped `probe_safety` unknown for only the oversized request.

All live validation used internal-only targets or public-safe control targets. No WPCOM notification path or live alert path was exercised.