### PR TITLE
Add graceful SIGHUP restart for v2 services

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ architecture, data model, operations, API, and rollout docs.
 | `internal/checker/` | Goroutine pool, HTTP checks, httptrace timing |
 | `internal/veriflier/` | JSON-over-HTTP client/server for Veriflier communication |
 | `internal/db/` | MySQL access, `jetpack_monitor_hosts` heartbeat, connection pooling |
-| `internal/config/` | Config loading, SIGHUP hot-reload |
+| `internal/config/` | Config loading and validation |
 | `internal/metrics/` | StatsD client, stats file writer |
 | `internal/wpcom/` | WPCOM API client, circuit breaker |
 | `internal/audit/` | Operational log writes to `jetpack_monitor_audit_log` (WPCOM, retries, verifier RPCs, config reloads) |
@@ -141,7 +141,7 @@ go run -race ./cmd/jetmon2/
 
 ## Configuration
 
-Copy `config/config-sample.json` to `config/config.json`. All keys from the original Jetmon are honoured; new keys are additive. Send SIGHUP to hot-reload config without restarting.
+Copy `config/config-sample.json` to `config/config.json`. All keys from the original Jetmon are honoured; new keys are additive. Send SIGHUP to drain and gracefully re-exec long-running services so rendered config and replaced binaries are picked up.
 
 **Existing keys (unchanged behaviour):**
 - `NUM_WORKERS`: Goroutine pool size (replaces worker process count)
@@ -177,7 +177,7 @@ These interfaces must remain identical to the original Jetmon. Do not change the
 | Runtime logs | stdout/stderr via the service manager or container runtime; v1 `logs/jetmon.log` and `logs/status-change.log` are intentionally not written by v2 unless a future consumer need is confirmed |
 | `stats/` file outputs | `sitespersec`, `sitesqueue`, `totals` — same format |
 | `config/config.json` keys | All existing keys honoured |
-| SIGHUP config reload | Same behaviour |
+| SIGHUP graceful restart | Drain, then re-exec through the configured restart target |
 | SIGINT graceful shutdown | Same behaviour |
 
 ## Site Status Values

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ one-page checklist during rehearsals and rollout windows:
 - Keep `LEGACY_STATUS_PROJECTION_ENABLE` on until legacy readers have moved to
   the v2 API or event tables.
 - Use `SIGINT` or `./jetmon2 drain` for graceful shutdown.
-- Use `SIGHUP` or `./jetmon2 reload` for config reload without restart.
+- Use `SIGHUP` or `./jetmon2 reload` for graceful drain and restart.
 - Use the host dashboard at `/` and the fleet dashboard at `/fleet` during
   rollout windows. Keep `DASHBOARD_BIND_ADDR` on loopback unless the listener is
   protected by trusted operator-network controls.

--- a/cmd/jetmon-deliverer/main.go
+++ b/cmd/jetmon-deliverer/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Automattic/jetmon/internal/deliverer"
 	"github.com/Automattic/jetmon/internal/fleethealth"
 	"github.com/Automattic/jetmon/internal/metrics"
+	"github.com/Automattic/jetmon/internal/processcontrol"
 	"github.com/Automattic/jetmon/internal/processmetrics"
 )
 
@@ -200,7 +201,8 @@ func run() {
 	}()
 
 	if !workersEnabled {
-		waitForShutdown()
+		req := waitForShutdown()
+		stopDBReload()
 		close(stopHealth)
 		publishProcessHealth(fleethealth.StateStopping)
 		ctx, cancel := context.WithTimeout(context.Background(), processHealthWriteTimeout)
@@ -209,6 +211,12 @@ func run() {
 		}
 		cancel()
 		log.Println("jetmon-deliverer: shutdown complete")
+		if req.Restart {
+			log.Println("jetmon-deliverer: re-executing after graceful SIGHUP")
+			if err := processcontrol.ExecSelf(); err != nil {
+				log.Fatalf("jetmon-deliverer: re-exec failed: %v", err)
+			}
+		}
 		return
 	}
 
@@ -217,7 +225,8 @@ func run() {
 		InstanceID:  hostname,
 		Dispatchers: deliverer.BuildAlertDispatchers(cfg),
 	})
-	waitForShutdown()
+	req := waitForShutdown()
+	stopDBReload()
 	close(stopHealth)
 	publishProcessHealth(fleethealth.StateStopping)
 	runtime.Stop()
@@ -227,6 +236,12 @@ func run() {
 	}
 	cancel()
 	log.Println("jetmon-deliverer: shutdown complete")
+	if req.Restart {
+		log.Println("jetmon-deliverer: re-executing after graceful SIGHUP")
+		if err := processcontrol.ExecSelf(); err != nil {
+			log.Fatalf("jetmon-deliverer: re-exec failed: %v", err)
+		}
+	}
 }
 
 func deliveryWorkersShouldStart(cfg *config.Config, hostname string) bool {
@@ -383,11 +398,22 @@ func delivererStatsDHealth(ready bool, checkedAt time.Time) fleethealth.Dependen
 	return entry
 }
 
-func waitForShutdown() {
+type shutdownRequest struct {
+	Signal  os.Signal
+	Restart bool
+}
+
+func waitForShutdown() shutdownRequest {
 	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 	sig := <-sigCh
-	log.Printf("received %s, stopping", sig)
+	req := shutdownRequest{Signal: sig, Restart: processcontrol.IsGracefulRestartSignal(sig)}
+	if req.Restart {
+		log.Printf("received %s, draining before graceful restart", sig)
+	} else {
+		log.Printf("received %s, stopping", sig)
+	}
+	return req
 }
 
 func emailTransportLabel(cfg *config.Config) string {

--- a/cmd/jetmon2/main.go
+++ b/cmd/jetmon2/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -32,6 +33,7 @@ import (
 	"github.com/Automattic/jetmon/internal/fleethealth"
 	"github.com/Automattic/jetmon/internal/metrics"
 	"github.com/Automattic/jetmon/internal/orchestrator"
+	"github.com/Automattic/jetmon/internal/processcontrol"
 	"github.com/Automattic/jetmon/internal/processmetrics"
 	"github.com/Automattic/jetmon/internal/veriflier"
 	"github.com/Automattic/jetmon/internal/wpcom"
@@ -203,17 +205,20 @@ func runServe() {
 		dash.SetFleetSource(newFleetDashboardStore(cfg))
 		go func() {
 			addr := dashboardListenAddr(cfg)
-			if err := dash.Listen(addr); err != nil {
+			if err := dash.Listen(addr); err != nil && !errors.Is(err, http.ErrServerClosed) {
 				log.Printf("dashboard: %v", err)
 			}
 		}()
 	}
 
 	// pprof on localhost only — never expose this on a public interface.
+	var debugSrv *http.Server
 	if cfg.DebugPort > 0 {
+		addr := fmt.Sprintf("127.0.0.1:%d", cfg.DebugPort)
+		debugSrv = dashboard.DebugServer(addr)
 		go func() {
-			addr := fmt.Sprintf("127.0.0.1:%d", cfg.DebugPort)
-			if err := dashboard.ListenDebug(addr); err != nil {
+			log.Printf("debug: pprof listening on %s (localhost only)", addr)
+			if err := debugSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 				log.Printf("debug server: %v", err)
 			}
 		}()
@@ -263,6 +268,8 @@ func runServe() {
 	var healthMu sync.RWMutex
 	var publishMu sync.Mutex
 	var shuttingDown atomic.Bool
+	var restartRequested atomic.Bool
+	var shutdownOnce sync.Once
 	var lastHealth []dashboard.HealthEntry
 	publishHostSnapshot := func(state string, refreshDependencies bool) {
 		publishMu.Lock()
@@ -362,6 +369,52 @@ func runServe() {
 	defer stopRetention()
 	startRetentionBackground(retentionCtx, cfg)
 
+	requestShutdown := func(sig os.Signal, restart bool) {
+		shutdownOnce.Do(func() {
+			if restart {
+				restartRequested.Store(true)
+				log.Printf("received %s, draining before graceful restart", sig)
+			} else {
+				log.Printf("received %s, draining", sig)
+			}
+			shuttingDown.Store(true)
+			stopDBReload()
+			stopRetention()
+			stopHostPublisherOnce.Do(func() { close(stopHostPublisher) })
+			publishHostSnapshot(fleethealth.StateStopping, false)
+			if apiSrv != nil {
+				ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+				if err := apiSrv.Shutdown(ctx); err != nil {
+					log.Printf("api: shutdown error: %v", err)
+				}
+				cancel()
+			}
+			if dash != nil {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				if err := dash.Shutdown(ctx); err != nil {
+					log.Printf("dashboard: shutdown error: %v", err)
+				}
+				cancel()
+			}
+			if debugSrv != nil {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				if err := debugSrv.Shutdown(ctx); err != nil {
+					log.Printf("debug server: shutdown error: %v", err)
+				}
+				cancel()
+			}
+			if deliveryRuntime != nil {
+				deliveryRuntime.Stop()
+			}
+			orch.Stop()
+			// Hard kill if drain takes too long (e.g. a stalled HTTP check).
+			time.AfterFunc(30*time.Second, func() {
+				log.Println("jetmon2: shutdown timeout exceeded, forcing exit")
+				os.Exit(1)
+			})
+		})
+	}
+
 	// Signal handling.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
@@ -370,47 +423,9 @@ func runServe() {
 		for sig := range sigCh {
 			switch sig {
 			case syscall.SIGHUP:
-				log.Println("received SIGHUP, reloading config")
-				if err := config.Reload(); err != nil {
-					log.Printf("config reload failed: %v", err)
-				} else {
-					reloadCtx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-					if changed, err := db.ReloadConfig(reloadCtx); err != nil {
-						log.Printf("db config reload failed: %v", err)
-					} else if changed {
-						log.Printf("db config reloaded: %s", db.Summary())
-					}
-					cancel()
-					wp.Configure(wpcomClientConfig(config.Get(), hostname))
-					audit.SetMode(config.Get().AuditLogModeDefault)
-					if dash != nil {
-						dash.SetFleetSource(newFleetDashboardStore(config.Get()))
-					}
-					logConfigWarnings(config.Get())
-					log.Println("config reloaded; CHECK_DNS_RESOLVERS changes require restart")
-				}
+				requestShutdown(sig, processcontrol.IsGracefulRestartSignal(sig))
 			case syscall.SIGINT, syscall.SIGTERM:
-				log.Println("received shutdown signal, draining")
-				shuttingDown.Store(true)
-				stopDBReload()
-				stopHostPublisherOnce.Do(func() { close(stopHostPublisher) })
-				publishHostSnapshot(fleethealth.StateStopping, false)
-				if apiSrv != nil {
-					ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-					if err := apiSrv.Shutdown(ctx); err != nil {
-						log.Printf("api: shutdown error: %v", err)
-					}
-					cancel()
-				}
-				if deliveryRuntime != nil {
-					deliveryRuntime.Stop()
-				}
-				orch.Stop()
-				// Hard kill if drain takes too long (e.g. a stalled HTTP check).
-				time.AfterFunc(30*time.Second, func() {
-					log.Println("jetmon2: shutdown timeout exceeded, forcing exit")
-					os.Exit(1)
-				})
+				requestShutdown(sig, false)
 			}
 		}
 	}()
@@ -425,6 +440,12 @@ func runServe() {
 	}
 	cancel()
 	log.Println("jetmon2: shutdown complete")
+	if restartRequested.Load() {
+		log.Println("jetmon2: re-executing after graceful SIGHUP")
+		if err := processcontrol.ExecSelf(); err != nil {
+			log.Fatalf("jetmon2: re-exec failed: %v", err)
+		}
+	}
 }
 
 func cmdMigrate() {
@@ -1406,7 +1427,7 @@ func cmdReload() {
 	if err := proc.Signal(syscall.SIGHUP); err != nil {
 		log.Fatalf("signal: %v", err)
 	}
-	fmt.Printf("SIGHUP sent to pid %d\n", pid)
+	fmt.Printf("SIGHUP sent to pid %d - jetmon2 will drain and re-exec\n", pid)
 }
 
 // cmdKeys is the entrypoint for `./jetmon2 keys ...` ops commands. Key

--- a/config/config.readme
+++ b/config/config.readme
@@ -21,8 +21,11 @@ Each JSON key entry uses the same shape:
 - Example: a typical value or small JSON fragment.
 - Notes: operational details, reload behavior, or migration caveats.
 
-`SIGHUP` or `./jetmon2 reload` reloads JSON config. Startup-only settings are
-called out in their notes.
+`SIGHUP` performs a graceful self-reexec for long-running services: stop
+accepting new work, drain in-flight work, and restart through the configured
+re-exec target so startup-only settings, freshly rendered config, and replaced
+on-disk binaries are picked up. Startup-only settings are called out in their
+notes.
 
 ## Docker Render Inputs
 
@@ -62,6 +65,16 @@ starts.
 - Notes: in Docker render modes `always` and `missing`, the entrypoint exports
   this path to the generated file. In render mode `never`, the value points at
   a hand-managed mounted file.
+
+### JETMON_REEXEC_PATH
+
+- Default: unset for bare binaries; Docker entrypoints set this to their own
+  absolute path.
+- Example: `JETMON_REEXEC_PATH=/jetmon/entrypoint.sh`
+- Purpose: optional SIGHUP restart target.
+- Notes: bare binaries re-exec the current executable. Docker containers set
+  this wrapper variable so SIGHUP re-runs the entrypoint, which re-renders JSON
+  config and reruns startup validation before the Go binary starts again.
 
 ## Profiles And Startup Safety
 

--- a/docker/docker-compose.scale-lab.yml
+++ b/docker/docker-compose.scale-lab.yml
@@ -26,6 +26,7 @@ x-jetmon-scale-service: &jetmon_scale_service
     dockerfile: docker/Dockerfile_jetmon
   init: true
   restart: unless-stopped
+  stop_grace_period: 45s
   user: "${UID:-1000}:${GID:-1000}"
   volumes:
     - ../config:/jetmon/config
@@ -51,6 +52,7 @@ x-veriflier-scale-service: &veriflier_scale_service
     dockerfile: docker/Dockerfile_veriflier
   init: true
   restart: unless-stopped
+  stop_grace_period: 45s
   environment:
     VERIFLIER_AUTH_TOKEN: ${VERIFLIER_AUTH_TOKEN:-veriflier_1_auth_token}
     VERIFLIER_PORT: "7803"

--- a/docker/docker-compose.veriflier-prod.yml
+++ b/docker/docker-compose.veriflier-prod.yml
@@ -3,6 +3,7 @@ services:
     image: ${VERIFLIER_IMAGE:-ghcr.io/automattic/veriflier:latest}
     init: true
     restart: unless-stopped
+    stop_grace_period: 45s
     ports:
       - "${VERIFLIER_BIND_ADDR:-0.0.0.0}:${VERIFLIER_HOST_PORT:-7803}:7803"
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       dockerfile: docker/Dockerfile_jetmon
     init: true
     restart: unless-stopped
+    stop_grace_period: 45s
     user: "${UID:-1000}:${GID:-1000}"
     volumes:
       - ../config:/jetmon/config
@@ -101,6 +102,7 @@ services:
       dockerfile: docker/Dockerfile_veriflier
     init: true
     restart: unless-stopped
+    stop_grace_period: 45s
     volumes:
       - ../veriflier2/config:/opt/veriflier/config
     ports:

--- a/docker/run-jetmon.sh
+++ b/docker/run-jetmon.sh
@@ -174,6 +174,7 @@ configure_runtime_config() {
 # runs as ${UID:-1000}:${GID:-1000} via docker-compose — write to stats/ instead,
 # which the Dockerfile chmods 0777 specifically so reload/drain commands work.
 export JETMON_PID_FILE="${JETMON_PID_FILE:-/jetmon/stats/jetmon2.pid}"
+export JETMON_REEXEC_PATH="${JETMON_REEXEC_PATH:-/jetmon/entrypoint.sh}"
 export VERIFLIER_PORT="${VERIFLIER_PORT:-${VERIFLIER_GRPC_PORT:-7803}}"
 config_mode="$(render_mode)"
 

--- a/docker/run-veriflier.sh
+++ b/docker/run-veriflier.sh
@@ -106,6 +106,7 @@ export VERIFLIER_PORT="${VERIFLIER_PORT:-${VERIFLIER_GRPC_PORT:-7803}}"
 export VERIFLIER_VANTAGE_ID="${VERIFLIER_VANTAGE_ID:-local-veriflier}"
 export VERIFLIER_REGION="${VERIFLIER_REGION:-local}"
 export VERIFLIER_PROVIDER="${VERIFLIER_PROVIDER:-docker}"
+export JETMON_REEXEC_PATH="${JETMON_REEXEC_PATH:-/opt/veriflier/entrypoint.sh}"
 config_mode="$(render_mode)"
 
 configure_runtime_config "$config_mode"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -319,9 +319,12 @@ belongs in audit, check history, telemetry reports, dashboards, and StatsD.
 
 ## Config And Signal Handling
 
-Config is loaded from rendered JSON. SIGHUP and `jetmon2 reload` re-read config
-under a lock; new settings apply to subsequent scheduler ticks or rebuilt
-clients where supported.
+Config is loaded from rendered JSON. SIGHUP and `jetmon2 reload` perform a
+graceful self-reexec for long-running services: the process stops accepting new
+work, drains in-flight work, then replaces itself with the configured re-exec
+target. Bare binaries re-exec the current executable; Docker entrypoints set
+`JETMON_REEXEC_PATH` to themselves so config rendering and startup validation
+run again before the Go binary starts.
 
 Shutdown is graceful:
 
@@ -333,6 +336,10 @@ SIGINT/SIGTERM
   -> wait for in-flight checks
   -> release bucket ownership
   -> exit
+
+SIGHUP
+  -> same drain path
+  -> exec configured restart target
 ```
 
 Hard process loss is handled by process supervision plus stale-heartbeat bucket

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,7 +19,10 @@ and operator control into clearer v2-owned surfaces.
 - Added dynamic bucket ownership through `jetpack_monitor_hosts`, with pinned
   bucket ranges retained for migration windows.
 - Added graceful drain/reload commands, PID-file fixes, and localhost-only
-  pprof on `DEBUG_PORT`.
+  pprof on `DEBUG_PORT`. SIGHUP reload now drains and self-reexecs
+  long-running v2 services so startup-only config and replaced binaries take
+  effect cleanly; Docker containers re-exec through their entrypoint so config
+  rendering and startup validation run again before the binary restarts.
 - Added process resource metrics, true RSS reporting, and StatsD host-path
   configuration compatible with v1 metric naming.
 

--- a/docs/docker-images.md
+++ b/docs/docker-images.md
@@ -241,6 +241,9 @@ docker exec jetmon ./jetmon2 reload
 docker exec jetmon ./jetmon2 drain
 ```
 
+Compose services should keep `stop_grace_period` longer than Jetmon's drain
+budget. The repo Compose files use `45s` for Monitor and Veriflier services.
+
 For scenario-specific commands covering Monitor, Veriflier, and Deliverer
 updates, see the update and restart playbook in
 [operations-guide.md](operations-guide.md#update-and-restart-playbook).

--- a/docs/docker-images.md
+++ b/docs/docker-images.md
@@ -40,6 +40,11 @@ The Docker entrypoints render JSON config from environment inputs on every
 container start by default. The binaries read the rendered JSON; they do not
 read these settings directly from the environment after startup.
 
+On SIGHUP, Docker containers drain and re-exec through their entrypoint
+(`JETMON_REEXEC_PATH`) so render mode `always` re-renders config before the
+binary starts again. Changing Compose environment still requires recreating the
+container so the new environment exists inside the process.
+
 Render modes:
 
 | Variable | Default | Meaning |
@@ -220,10 +225,16 @@ Stronger smoke checks with the same rendered config:
 ./jetmon2 doctor --require-statsd
 ```
 
-## Reload And Drain
+## Restart And Drain
 
-`reload` and `drain` use `/jetmon/stats/jetmon2.pid`, so `/jetmon/stats` must be
-writable:
+`reload` sends SIGHUP. For long-running services this now means graceful
+self-reexec: stop accepting work, drain in-flight work, and restart through the
+configured re-exec target. Docker containers re-run their entrypoint before the
+binary starts again; bare binaries re-exec the executable directly. `drain`
+sends SIGINT and exits after the same drain path without re-exec.
+
+`reload` and `drain` use `/jetmon/stats/jetmon2.pid`, so `/jetmon/stats` must
+be writable:
 
 ```bash
 docker exec jetmon ./jetmon2 reload

--- a/docs/docker-images.md
+++ b/docs/docker-images.md
@@ -241,6 +241,10 @@ docker exec jetmon ./jetmon2 reload
 docker exec jetmon ./jetmon2 drain
 ```
 
+For scenario-specific commands covering Monitor, Veriflier, and Deliverer
+updates, see the update and restart playbook in
+[operations-guide.md](operations-guide.md#update-and-restart-playbook).
+
 ## Test A PR Image
 
 ```bash

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -124,6 +124,218 @@ or container runtime.
 
 SIGINT/SIGTERM keep the same drain behavior but exit instead of re-execing.
 
+## Update And Restart Playbook
+
+Run these actions rolling, one host or one service instance at a time. Service
+names below use the standard Compose names: `jetmon` for Monitor, `veriflier`
+for Veriflier, and `jetmon-deliverer` for standalone delivery. Skip services
+that are not present in a given stack.
+
+### Mounted JSON Config Changed
+
+Use when the running container already sees the updated JSON file.
+
+Monitor:
+
+```bash
+docker compose kill -s HUP jetmon
+# or
+docker exec jetmon ./jetmon2 reload
+```
+
+Veriflier:
+
+```bash
+docker compose kill -s HUP veriflier
+```
+
+Deliverer:
+
+```bash
+docker compose kill -s HUP jetmon-deliverer
+```
+
+Potential downtime risk: near-zero when rolling. Each process drains before
+restart. A single Veriflier may be briefly unavailable, so keep quorum capacity
+in mind.
+
+### Compose Environment Changed
+
+Use recreate, not SIGHUP. Existing containers do not receive new Compose
+environment values.
+
+Monitor:
+
+```bash
+docker compose up -d --no-deps --force-recreate jetmon
+```
+
+Veriflier:
+
+```bash
+docker compose up -d --no-deps --force-recreate veriflier
+```
+
+Deliverer:
+
+```bash
+docker compose up -d --no-deps --force-recreate jetmon-deliverer
+```
+
+Potential downtime risk: low when rolling and `stop_grace_period` is long
+enough for Jetmon to drain.
+
+### New Image Or Code Deploy
+
+Use this as the normal production deploy path.
+
+Monitor:
+
+```bash
+docker compose pull jetmon
+docker compose up -d --no-deps --force-recreate jetmon
+```
+
+Veriflier:
+
+```bash
+docker compose pull veriflier
+docker compose up -d --no-deps --force-recreate veriflier
+```
+
+Deliverer:
+
+```bash
+docker compose pull jetmon-deliverer
+docker compose up -d --no-deps --force-recreate jetmon-deliverer
+```
+
+Potential downtime risk: low when rolling. Do not restart multiple Monitors or
+multiple Verifliers at the same time unless there is confirmed spare capacity
+and quorum coverage.
+
+### Non-Container Binary Replaced
+
+Use SIGHUP so the service drains and execs the replaced binary from disk.
+
+Monitor:
+
+```bash
+./jetmon2 reload
+# or
+kill -HUP "$(cat /run/jetmon2/jetmon2.pid)"
+```
+
+Veriflier:
+
+```bash
+kill -HUP "$(pidof veriflier2)"
+```
+
+Deliverer:
+
+```bash
+kill -HUP "$(pidof jetmon-deliverer)"
+```
+
+Potential downtime risk: near-zero when peer capacity is healthy.
+
+### DB Server Map Changed
+
+Ordinary `db-servers.php` content changes do not need a restart. Monitor and
+Deliverer hot-reload validated map changes on the configured cadence.
+
+Monitor:
+
+```bash
+./jetmon2 api request --pretty GET /api/v1/monitor/db-config
+```
+
+Veriflier:
+
+```bash
+# no action; Verifliers do not use the DB server map
+```
+
+Deliverer:
+
+```bash
+# no restart; confirm deliverer process health in /fleet or
+# jetpack_monitor_process_health after the reload cadence
+```
+
+Potential downtime risk: zero for content-only map changes. Recreate or SIGHUP
+only when changing the map path, dataset, datacenter, address preference, or
+container environment.
+
+### Gracefully Remove From Service
+
+Use when intentionally taking capacity out of the fleet.
+
+Monitor:
+
+```bash
+docker exec jetmon ./jetmon2 drain
+# or
+docker compose kill -s INT jetmon
+```
+
+Veriflier:
+
+```bash
+docker compose kill -s INT veriflier
+```
+
+Deliverer:
+
+```bash
+docker compose kill -s INT jetmon-deliverer
+```
+
+Potential downtime risk: intentional capacity reduction. Safe only when enough
+peer Monitors, Verifliers, and delivery workers remain.
+
+### Simple Operational Restart
+
+Use SIGHUP when no image, Compose environment, or container definition changed.
+
+Monitor:
+
+```bash
+docker compose kill -s HUP jetmon
+```
+
+Veriflier:
+
+```bash
+docker compose kill -s HUP veriflier
+```
+
+Deliverer:
+
+```bash
+docker compose kill -s HUP jetmon-deliverer
+```
+
+Potential downtime risk: near-zero when healthy. Prefer this over
+`docker compose restart` for a Jetmon-aware restart. Treat `docker compose
+restart` as a generic operational restart, not a deploy mechanism.
+
+### Full Fleet Deploy Order
+
+Use this order for production fleet changes:
+
+```text
+1. Recreate Verifliers one at a time.
+2. Recreate Monitors one at a time.
+3. Recreate Deliverer/API owners one at a time.
+4. Verify API, dashboard, and process health after each step.
+```
+
+Potential downtime risk: low when rolling, high if restarted all at once. A
+simultaneous fleet restart can reduce bucket coverage, Veriflier quorum, and
+delivery availability at the same time.
+
 When `DB_SERVER_MAP_PATH` is set, Jetmon reads the WPCOM-style `db-servers.php`
 map, builds separate read/write pools from the `misc` dataset, and hot-reloads
 validated changes on the configured refresh cadence. Check the current state

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -104,6 +104,26 @@ Run `./jetmon2 migrate` only as an explicit schema-change action in environments
 where the operator is allowed to apply DDL. Do not rely on automatic production
 migrations.
 
+## Graceful Restart
+
+SIGHUP is the zero-disruption restart signal for long-running v2 services.
+Monitor, Deliverer, and Veriflier stop accepting new work, drain in-flight work,
+then re-exec through the configured restart target. Bare binaries re-exec the
+current executable. Docker containers set `JETMON_REEXEC_PATH` to their
+entrypoint so rendered config and startup validation run again before the binary
+starts. Use this after rendered config changes or after a deployment has
+replaced the on-disk binary.
+For Monitor, the helper command sends SIGHUP through the PID file:
+
+```bash
+./jetmon2 reload
+```
+
+For standalone Deliverer and Veriflier, send SIGHUP through the service manager
+or container runtime.
+
+SIGINT/SIGTERM keep the same drain behavior but exit instead of re-execing.
+
 When `DB_SERVER_MAP_PATH` is set, Jetmon reads the WPCOM-style `db-servers.php`
 map, builds separate read/write pools from the `misc` dataset, and hot-reloads
 validated changes on the configured refresh cadence. Check the current state

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -182,8 +182,9 @@ Deliverer:
 docker compose up -d --no-deps --force-recreate jetmon-deliverer
 ```
 
-Potential downtime risk: low when rolling and `stop_grace_period` is long
-enough for Jetmon to drain.
+Potential downtime risk: low when rolling. The repo Compose files set
+`stop_grace_period: 45s`, which is longer than Jetmon's 30s drain budget; keep
+the same margin in production overrides.
 
 ### New Image Or Code Deploy
 

--- a/docs/production-teamcity-rollout.md
+++ b/docs/production-teamcity-rollout.md
@@ -110,6 +110,11 @@ The Monitor and deliverer re-parse the map on the refresh cadence. Changed maps
 are validated before publication. If parsing or validation fails, the process
 keeps the previous working pools and logs the failure without secrets.
 
+SIGHUP is the graceful restart path for production containers. It stops intake,
+drains in-flight work, then re-execs through the Docker entrypoint so rendered
+config, startup validation, and replaced on-disk binaries are picked up without
+an ungraceful kill. SIGINT and SIGTERM drain and exit without re-exec.
+
 Inspect reload state through the API:
 
 ```bash

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -61,12 +61,18 @@ Open work:
   explicit endpoint identity, using the existing `jetpack_monitor_site_id` row
   as the durable source during migration. This is required for the real
   production cohort where one `blog_id` has multiple active monitor URLs.
-- [ ] Define and validate a zero-disruption reload/update contract for every
+- [x] Define and validate a zero-disruption reload/update contract for every
   long-running v2 service. SIGHUP or the service-manager equivalent should stop
   accepting new work, drain in-flight checks/deliveries, reload configuration
   and deployed code as appropriate for the deployment model, then resume cleanly
-  with operator-visible status and failure handling. Cover Monitor, Veriflier,
-  deliverer, API/dashboard, StatsD reporting, and Docker Compose rollout paths.
+  with operator-visible status and failure handling. Implemented as graceful
+  SIGHUP self-reexec for Monitor, standalone Deliverer, and Veriflier. Monitor
+  drains scheduler/API/dashboard/delivery work before re-exec; Veriflier drains
+  in-flight RPCs; Deliverer drains claimed deliveries. Docker entrypoints set
+  `JETMON_REEXEC_PATH` so config rendering and startup validation run before
+  the binary restarts. `jetmon2 reload` sends the Monitor PID-file SIGHUP;
+  standalone service managers should send SIGHUP to Deliverer and Veriflier
+  processes.
 
 ## Config And Compatibility Cleanup
 

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -88,6 +89,8 @@ type Server struct {
 	health      []HealthEntry
 	sseClients  map[string]chan string
 	sseMu       sync.Mutex
+	serverMu    sync.Mutex
+	httpSrv     *http.Server
 	hostname    string
 	fleetSource FleetSource
 }
@@ -150,7 +153,21 @@ func (s *Server) Listen(addr string) error {
 		ReadHeaderTimeout: 5 * time.Second,
 		IdleTimeout:       120 * time.Second,
 	}
+	s.serverMu.Lock()
+	s.httpSrv = srv
+	s.serverMu.Unlock()
 	return srv.ListenAndServe()
+}
+
+// Shutdown drains in-flight dashboard requests up to ctx's deadline.
+func (s *Server) Shutdown(ctx context.Context) error {
+	s.serverMu.Lock()
+	srv := s.httpSrv
+	s.serverMu.Unlock()
+	if srv == nil {
+		return nil
+	}
+	return srv.Shutdown(ctx)
 }
 
 // ListenDebug starts a localhost-only pprof/debug server on the given address.
@@ -158,7 +175,18 @@ func (s *Server) Listen(addr string) error {
 func ListenDebug(addr string) error {
 	// net/http/pprof registers itself on http.DefaultServeMux via init().
 	log.Printf("debug: pprof listening on %s (localhost only)", addr)
-	return http.ListenAndServe(addr, http.DefaultServeMux)
+	return DebugServer(addr).ListenAndServe()
+}
+
+// DebugServer returns the localhost-only pprof/debug server so callers can
+// gracefully stop it during process re-exec.
+func DebugServer(addr string) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		Handler:           http.DefaultServeMux,
+		ReadHeaderTimeout: 5 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
 }
 
 func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {

--- a/internal/processcontrol/reexec.go
+++ b/internal/processcontrol/reexec.go
@@ -1,0 +1,50 @@
+package processcontrol
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+const reexecPathEnv = "JETMON_REEXEC_PATH"
+
+// IsGracefulRestartSignal reports whether sig requests a graceful drain followed
+// by self-reexec.
+func IsGracefulRestartSignal(sig os.Signal) bool {
+	return sig == syscall.SIGHUP
+}
+
+// ExecSelf replaces the current process with the configured re-exec target and
+// original argv/env. Docker entrypoints set JETMON_REEXEC_PATH to themselves so
+// SIGHUP re-runs config rendering before the Go binary starts again. Bare
+// binary installs fall back to the current executable path. Callers must
+// complete graceful shutdown before invoking this; syscall.Exec does not run
+// deferred cleanup handlers.
+func ExecSelf() error {
+	target, argv, err := ReexecTarget(os.Args, os.Getenv, os.Executable)
+	if err != nil {
+		return err
+	}
+	if err := syscall.Exec(target, argv, os.Environ()); err != nil {
+		return fmt.Errorf("exec %s: %w", target, err)
+	}
+	return nil
+}
+
+// ReexecTarget resolves the executable and argv that ExecSelf will use. It is
+// exported for tests and diagnostics; production callers should use ExecSelf.
+func ReexecTarget(args []string, getenv func(string) string, executable func() (string, error)) (string, []string, error) {
+	target := getenv(reexecPathEnv)
+	if target == "" {
+		exe, err := executable()
+		if err != nil {
+			return "", nil, fmt.Errorf("resolve executable: %w", err)
+		}
+		target = exe
+	}
+	argv := []string{target}
+	if len(args) > 1 {
+		argv = append(argv, args[1:]...)
+	}
+	return target, argv, nil
+}

--- a/internal/processcontrol/reexec_test.go
+++ b/internal/processcontrol/reexec_test.go
@@ -1,0 +1,79 @@
+package processcontrol
+
+import (
+	"errors"
+	"reflect"
+	"syscall"
+	"testing"
+)
+
+func TestIsGracefulRestartSignal(t *testing.T) {
+	if !IsGracefulRestartSignal(syscall.SIGHUP) {
+		t.Fatal("SIGHUP should request graceful restart")
+	}
+	if IsGracefulRestartSignal(syscall.SIGTERM) {
+		t.Fatal("SIGTERM should request shutdown without re-exec")
+	}
+	if IsGracefulRestartSignal(syscall.SIGINT) {
+		t.Fatal("SIGINT should request shutdown without re-exec")
+	}
+}
+
+func TestReexecTargetFallsBackToExecutable(t *testing.T) {
+	target, argv, err := ReexecTarget(
+		[]string{"jetmon2", "serve", "--flag"},
+		func(string) string { return "" },
+		func() (string, error) { return "/usr/local/bin/jetmon2", nil },
+	)
+	if err != nil {
+		t.Fatalf("ReexecTarget returned error: %v", err)
+	}
+	if target != "/usr/local/bin/jetmon2" {
+		t.Fatalf("target = %q, want executable fallback", target)
+	}
+	wantArgv := []string{"/usr/local/bin/jetmon2", "serve", "--flag"}
+	if !reflect.DeepEqual(argv, wantArgv) {
+		t.Fatalf("argv = %#v, want %#v", argv, wantArgv)
+	}
+}
+
+func TestReexecTargetUsesEntrypointOverride(t *testing.T) {
+	target, argv, err := ReexecTarget(
+		[]string{"./jetmon2"},
+		func(key string) string {
+			if key == reexecPathEnv {
+				return "/jetmon/entrypoint.sh"
+			}
+			return ""
+		},
+		func() (string, error) { return "", errors.New("should not resolve executable") },
+	)
+	if err != nil {
+		t.Fatalf("ReexecTarget returned error: %v", err)
+	}
+	if target != "/jetmon/entrypoint.sh" {
+		t.Fatalf("target = %q, want entrypoint override", target)
+	}
+	wantArgv := []string{"/jetmon/entrypoint.sh"}
+	if !reflect.DeepEqual(argv, wantArgv) {
+		t.Fatalf("argv = %#v, want %#v", argv, wantArgv)
+	}
+}
+
+func TestReexecTargetHandlesEmptyArgs(t *testing.T) {
+	target, argv, err := ReexecTarget(
+		nil,
+		func(string) string { return "" },
+		func() (string, error) { return "/usr/local/bin/veriflier2", nil },
+	)
+	if err != nil {
+		t.Fatalf("ReexecTarget returned error: %v", err)
+	}
+	if target != "/usr/local/bin/veriflier2" {
+		t.Fatalf("target = %q, want executable fallback", target)
+	}
+	wantArgv := []string{"/usr/local/bin/veriflier2"}
+	if !reflect.DeepEqual(argv, wantArgv) {
+		t.Fatalf("argv = %#v, want %#v", argv, wantArgv)
+	}
+}

--- a/veriflier2/cmd/main.go
+++ b/veriflier2/cmd/main.go
@@ -14,12 +14,14 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
 	"github.com/Automattic/jetmon/internal/checker"
 	"github.com/Automattic/jetmon/internal/config"
 	"github.com/Automattic/jetmon/internal/metrics"
+	"github.com/Automattic/jetmon/internal/processcontrol"
 	"github.com/Automattic/jetmon/internal/veriflier"
 )
 
@@ -118,11 +120,19 @@ func main() {
 
 	// Graceful shutdown: SIGINT/SIGTERM triggers Shutdown(ctx) with a drain
 	// budget so in-flight checks can complete before the listener closes.
+	// SIGHUP uses the same drain path and then re-execs through the configured
+	// restart target so replaced binaries and rendered config are picked up.
+	var restartRequested atomic.Bool
 	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 	go func() {
 		sig := <-sigCh
-		log.Printf("veriflier2: %s received, draining (up to %s)", sig, shutdownGracePeriod)
+		if processcontrol.IsGracefulRestartSignal(sig) {
+			restartRequested.Store(true)
+			log.Printf("veriflier2: %s received, draining before graceful restart (up to %s)", sig, shutdownGracePeriod)
+		} else {
+			log.Printf("veriflier2: %s received, draining (up to %s)", sig, shutdownGracePeriod)
+		}
 		ctx, cancel := context.WithTimeout(context.Background(), shutdownGracePeriod)
 		defer cancel()
 		if err := srv.Shutdown(ctx); err != nil {
@@ -134,7 +144,14 @@ func main() {
 	if err := srv.Listen(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Fatalf("listen: %v", err)
 	}
+	stopResourceStats()
 	log.Println("veriflier2: shutdown complete")
+	if restartRequested.Load() {
+		log.Println("veriflier2: re-executing after graceful SIGHUP")
+		if err := processcontrol.ExecSelf(); err != nil {
+			log.Fatalf("veriflier2: re-exec failed: %v", err)
+		}
+	}
 }
 
 type resourceStatsEmitter interface {


### PR DESCRIPTION
## Summary

Adds a graceful SIGHUP restart path for the long-running Jetmon v2 services. Monitor, standalone Deliverer, and Veriflier now stop accepting new work, drain in-flight work, and then re-exec through the configured restart target so replaced binaries and rendered config are picked up without an ungraceful kill.

For operator-facing reload/restart procedures, use [`docs/operations-guide.md`](docs/operations-guide.md), especially the new update and restart playbook. That guide is the canonical place for deciding whether to use SIGHUP, `jetmon2 reload`, `docker compose up --force-recreate`, or a rolling image deploy.

## Key Changes

- Adds graceful SIGHUP restart behavior for long-running v2 services: Monitor, standalone Deliverer, and Veriflier.
- Changes SIGHUP from in-place config reload to "stop accepting new work, drain in-flight work, then re-exec," allowing replaced binaries and rendered config to be picked up cleanly.
- Keeps SIGINT/SIGTERM as graceful drain-and-exit behavior.
- Adds shared `internal/processcontrol` helpers for restart signal detection, re-exec target resolution, argv/env preservation, and Docker entrypoint support.
- Updates `jetmon2 reload` to send SIGHUP and report that the Monitor will drain and re-exec.
- Extends Monitor shutdown/restart handling to drain or stop the scheduler, API server, dashboard, pprof server, delivery runtime, DB config reloader, retention worker, and fleet health publisher before re-exec.
- Extends standalone Deliverer handling so SIGHUP drains claimed delivery work and re-execs, including when the process is idle because ownership config disables workers.
- Extends Veriflier handling so SIGHUP drains in-flight RPC/check work before re-exec.
- Sets `JETMON_REEXEC_PATH` in Docker entrypoints so container SIGHUP restarts re-run entrypoint config rendering and startup validation before launching the Go binary again.
- Adds `stop_grace_period: 45s` to Monitor and Veriflier Compose services across local, scale-lab, and production Veriflier Compose configs, giving Docker more than Jetmon's 30-second drain budget.
- Adds an operations playbook in [`docs/operations-guide.md`](docs/operations-guide.md) covering mounted JSON config changes, Compose environment changes, image/code deploys, non-container binary replacement, DB server-map changes, graceful capacity removal, simple operational restarts, and full fleet deploy order.
- Clarifies downtime risk and recommended commands for each restart/deploy scenario in [`docs/operations-guide.md`](docs/operations-guide.md).
- Updates architecture, Docker image, README, AGENTS, config, changelog, production rollout, and roadmap docs so SIGHUP is consistently described as graceful drain-and-reexec.
- Marks the zero-disruption reload/update roadmap item as implemented.
- Adds tests for process-control re-exec target behavior.

## Validation

- `go test ./...`
- `make all`
- `go test ./internal/processcontrol ./cmd/jetmon2 ./cmd/jetmon-deliverer ./veriflier2/cmd ./internal/veriflier`
- `docker compose -f docker/docker-compose.yml config`
- `docker compose -f docker/docker-compose.yml -f docker/docker-compose.scale-lab.yml config`
- `VERIFLIER_AUTH_TOKEN=test VERIFLIER_VANTAGE_ID=test VERIFLIER_REGION=test docker compose -f docker/docker-compose.veriflier-prod.yml config`
