### PR TITLE
Tighten production readiness evidence paths

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -94,7 +94,7 @@ jobs:
               '```',
               '',
               'Images are `linux/amd64` only. On Apple Silicon, add `--platform linux/amd64`. ' +
-              'See [docs/docker-images.md](https://github.com/Automattic/jetmon/blob/v2/docs/docker-images.md) for run examples.',
+              'See [docs/operations-guide.md](https://github.com/Automattic/jetmon/blob/v2/docs/operations-guide.md) for run examples.',
             ].join('\n');
 
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/docs/production-schema.md
+++ b/docs/production-schema.md
@@ -46,6 +46,10 @@ Run these from the same network and credentials the Monitor will use:
 `schema validate` is the deployment gate. It fails if any required table,
 column, or index is missing and never applies DDL.
 
+Validation is intentionally structural. It does not replace applying the
+baseline SQL to a production-like replica and rehearsing container startup,
+preflight, activation, observation, and rollback against that replica.
+
 `schema diff` is read-only. It prints additive SQL that would make the connected
 database satisfy the same structural contract. Treat it as diagnostic help, not
 as a substitute for the reviewed Systems SQL.

--- a/docs/v1-to-v2-migration.md
+++ b/docs/v1-to-v2-migration.md
@@ -25,6 +25,7 @@ deliverer rollout notes into one runbook.
 | WPCOM | Legacy notification path tested. |
 | Operator CLI | Token, base URL, and `--allow-remote` policy are ready. |
 | Canaries | Approved controlled canary file exists. |
+| Rehearsal | Production-like Docker rehearsal covers schema validate, StatsD doctor, API preflight, guided dry-run, small-range execute, observation, and rollback. |
 | Rollback | v1 start command, v2 release path, owner contact known. |
 | Observability | API, dashboard, StatsD, logs visible. |
 

--- a/scripts/rollout-docker-lab.sh
+++ b/scripts/rollout-docker-lab.sh
@@ -303,7 +303,7 @@ wait_for_checked_sites() {
 		checked="$(sql --batch --skip-column-names -e "
 			SELECT COUNT(*)
 			  FROM jetpack_monitor_sites s
-			  JOIN jetpack_monitor_site_runtime r ON r.blog_id = s.blog_id
+			  JOIN jetpack_monitor_site_runtime r ON r.source_site_id = s.jetpack_monitor_site_id
 			 WHERE s.monitor_active = 1
 			   AND s.bucket_no BETWEEN $BUCKET_MIN AND $BUCKET_MAX
 			   AND r.last_checked_at >= UTC_TIMESTAMP() - INTERVAL 2 MINUTE")"
@@ -321,7 +321,7 @@ policy_count() {
 	sql --batch --skip-column-names -e "
 		SELECT COUNT(*)
 		  FROM jetpack_monitor_sites s
-		  JOIN jetpack_monitor_site_check_config c ON c.blog_id = s.blog_id
+		  JOIN jetpack_monitor_site_check_config c ON c.source_site_id = s.jetpack_monitor_site_id
 		 WHERE s.monitor_active = 1
 		   AND s.bucket_no BETWEEN $BUCKET_MIN AND $BUCKET_MAX
 		   AND c.request_method = '$1'

--- a/scripts/rollout-vm-lab.sh
+++ b/scripts/rollout-vm-lab.sh
@@ -705,7 +705,7 @@ mark_lab_activity() {
 	local db_vm db_ip
 	db_vm="$(vm_name db)"
 	db_ip="$(vm_ip_required "$db_vm")"
-	mysql_lab "$db_ip" jetmon_db -e "INSERT INTO jetpack_monitor_site_runtime (blog_id, last_checked_at) SELECT blog_id, UTC_TIMESTAMP() FROM jetpack_monitor_sites WHERE bucket_no BETWEEN $LAB_BUCKET_MIN AND $LAB_BUCKET_MAX ON DUPLICATE KEY UPDATE last_checked_at = VALUES(last_checked_at)"
+	mysql_lab "$db_ip" jetmon_db -e "INSERT INTO jetpack_monitor_site_runtime (source_site_id, blog_id, last_checked_at) SELECT jetpack_monitor_site_id, blog_id, UTC_TIMESTAMP() FROM jetpack_monitor_sites WHERE bucket_no BETWEEN $LAB_BUCKET_MIN AND $LAB_BUCKET_MAX ON DUPLICATE KEY UPDATE blog_id = VALUES(blog_id), last_checked_at = VALUES(last_checked_at)"
 	pass "lab_activity_marked bucket_range=$LAB_BUCKET_MIN-$LAB_BUCKET_MAX"
 }
 
@@ -713,7 +713,7 @@ clear_lab_activity() {
 	local db_vm db_ip
 	db_vm="$(vm_name db)"
 	db_ip="$(vm_ip_required "$db_vm")"
-	mysql_lab "$db_ip" jetmon_db -e "INSERT INTO jetpack_monitor_site_runtime (blog_id, last_checked_at) SELECT blog_id, NULL FROM jetpack_monitor_sites WHERE bucket_no BETWEEN $LAB_BUCKET_MIN AND $LAB_BUCKET_MAX ON DUPLICATE KEY UPDATE last_checked_at = NULL"
+	mysql_lab "$db_ip" jetmon_db -e "INSERT INTO jetpack_monitor_site_runtime (source_site_id, blog_id, last_checked_at) SELECT jetpack_monitor_site_id, blog_id, NULL FROM jetpack_monitor_sites WHERE bucket_no BETWEEN $LAB_BUCKET_MIN AND $LAB_BUCKET_MAX ON DUPLICATE KEY UPDATE blog_id = VALUES(blog_id), last_checked_at = NULL"
 	pass "lab_activity_cleared bucket_range=$LAB_BUCKET_MIN-$LAB_BUCKET_MAX"
 }
 
@@ -724,7 +724,7 @@ lab_active_site_count() {
 
 lab_checked_site_count() {
 	local db_ip="$1"
-	mysql_lab "$db_ip" --batch --skip-column-names jetmon_db -e "SELECT COUNT(*) FROM jetpack_monitor_sites s JOIN jetpack_monitor_site_runtime r ON r.blog_id = s.blog_id WHERE s.monitor_active = 1 AND s.bucket_no BETWEEN $LAB_BUCKET_MIN AND $LAB_BUCKET_MAX AND r.last_checked_at IS NOT NULL" | tr -d '[:space:]'
+	mysql_lab "$db_ip" --batch --skip-column-names jetmon_db -e "SELECT COUNT(*) FROM jetpack_monitor_sites s JOIN jetpack_monitor_site_runtime r ON r.source_site_id = s.jetpack_monitor_site_id WHERE s.monitor_active = 1 AND s.bucket_no BETWEEN $LAB_BUCKET_MIN AND $LAB_BUCKET_MAX AND r.last_checked_at IS NOT NULL" | tr -d '[:space:]'
 }
 
 wait_for_real_lab_activity() {

--- a/scripts/scale-resilience-lab.sh
+++ b/scripts/scale-resilience-lab.sh
@@ -242,8 +242,8 @@ seed_sites() {
 
 	{
 		printf 'START TRANSACTION;\n'
-		printf 'DELETE FROM jetpack_monitor_site_runtime WHERE blog_id >= 910000000 AND blog_id < %d;\n' "$(( 910000000 + SITE_COUNT ))"
-		printf 'DELETE FROM jetpack_monitor_site_check_config WHERE blog_id >= 910000000 AND blog_id < %d;\n' "$(( 910000000 + SITE_COUNT ))"
+		printf 'DELETE FROM jetpack_monitor_site_runtime WHERE source_site_id IN (SELECT jetpack_monitor_site_id FROM jetpack_monitor_sites WHERE blog_id >= 910000000 AND blog_id < %d);\n' "$(( 910000000 + SITE_COUNT ))"
+		printf 'DELETE FROM jetpack_monitor_site_check_config WHERE source_site_id IN (SELECT jetpack_monitor_site_id FROM jetpack_monitor_sites WHERE blog_id >= 910000000 AND blog_id < %d);\n' "$(( 910000000 + SITE_COUNT ))"
 		printf 'DELETE FROM jetpack_monitor_sites WHERE blog_id >= 910000000 AND blog_id < %d;\n' "$(( 910000000 + SITE_COUNT ))"
 		while (( created < SITE_COUNT )); do
 			blog_id=$(( 910000000 + created ))
@@ -349,7 +349,7 @@ wait_for_checked_since() {
 		checked="$(scalar_sql "
 			SELECT COUNT(DISTINCT s.jetpack_monitor_site_id)
 			  FROM jetpack_monitor_sites s
-			  JOIN jetpack_monitor_site_runtime r ON r.blog_id = s.blog_id
+			  JOIN jetpack_monitor_site_runtime r ON r.source_site_id = s.jetpack_monitor_site_id
 			 WHERE s.monitor_active = 1
 			   AND r.last_checked_at >= TIMESTAMP('$since')")"
 		if [[ "$checked" == "$SITE_COUNT" ]]; then

--- a/scripts/v2-soak-lab.sh
+++ b/scripts/v2-soak-lab.sh
@@ -180,8 +180,8 @@ seed_sites() {
 
 	{
 		printf 'START TRANSACTION;\n'
-		printf 'DELETE FROM jetpack_monitor_site_runtime WHERE blog_id >= 920000000 AND blog_id < %d;\n' "$((920000000 + SITE_COUNT))"
-		printf 'DELETE FROM jetpack_monitor_site_check_config WHERE blog_id >= 920000000 AND blog_id < %d;\n' "$((920000000 + SITE_COUNT))"
+		printf 'DELETE FROM jetpack_monitor_site_runtime WHERE source_site_id IN (SELECT jetpack_monitor_site_id FROM jetpack_monitor_sites WHERE blog_id >= 920000000 AND blog_id < %d);\n' "$((920000000 + SITE_COUNT))"
+		printf 'DELETE FROM jetpack_monitor_site_check_config WHERE source_site_id IN (SELECT jetpack_monitor_site_id FROM jetpack_monitor_sites WHERE blog_id >= 920000000 AND blog_id < %d);\n' "$((920000000 + SITE_COUNT))"
 		printf 'DELETE FROM jetpack_monitor_sites WHERE blog_id >= 920000000 AND blog_id < %d;\n' "$((920000000 + SITE_COUNT))"
 		while ((created < SITE_COUNT)); do
 			blog_id=$((920000000 + created))
@@ -359,7 +359,7 @@ sample_soak() {
 	max_age="$(scalar_sql "
 		SELECT COALESCE(MAX(TIMESTAMPDIFF(SECOND, r.last_checked_at, UTC_TIMESTAMP())), 999999)
 		  FROM jetpack_monitor_sites s
-		  JOIN jetpack_monitor_site_runtime r ON r.blog_id = s.blog_id
+		  JOIN jetpack_monitor_site_runtime r ON r.source_site_id = s.jetpack_monitor_site_id
 		 WHERE s.monitor_active = 1")"
 	history_rows="$(scalar_sql "SELECT COUNT(*) FROM jetpack_monitor_check_history WHERE checked_at >= TIMESTAMP('$sql_since')")"
 	open_events="$(scalar_sql "SELECT COUNT(*) FROM jetpack_monitor_events WHERE ended_at IS NULL")"


### PR DESCRIPTION
## Summary

Addresses the immediate production-readiness concerns found after the schema cleanup merge.

## Changes

- Updates rollout, soak, VM, and scale lab evidence scripts to join v2 runtime/check-config rows by `source_site_id = jetpack_monitor_site_id` instead of `blog_id`.
- Keeps lab cleanup aligned with endpoint identity by deleting v2 side rows through the source site ID from `jetpack_monitor_sites`.
- Updates the Docker publish PR comment to link to the consolidated `docs/operations-guide.md` instead of the deleted `docs/docker-images.md`.
- Documents that `schema validate` is a structural deployment gate, not a substitute for a production-like replica/container rehearsal.
- Adds the production-like Docker rehearsal to the rollout launch gates.

## Validation

- `bash -n scripts/rollout-docker-lab.sh scripts/v2-soak-lab.sh scripts/rollout-vm-lab.sh scripts/scale-resilience-lab.sh`
- stale-reference scan for old `blog_id` lab joins, deleted `production-schema-package` links, and deleted `docs/docker-images.md` link
- `git diff --check`
- `make rollout-docs-verify`

## Docker Doctor

After Docker was restarted, `make rollout-docker-lab-doctor` passed. The cleanup target was run afterward to remove the local lab network. The next evidence gate is the full production-like Docker rollout rehearsal.

