### PR TITLE
Harden production security posture gates

### DIFF
--- a/config/config-sample.json
+++ b/config/config-sample.json
@@ -1,6 +1,9 @@
 {
 	"DEBUG"             : false,
 	"CONFIG_PROFILE"    : "dev",
+	"PRODUCTION_SECURITY_EXCEPTIONS"         : [],
+	"PRODUCTION_SECURITY_EXCEPTION_REASON"  : "",
+	"PRODUCTION_SECURITY_EXCEPTION_EXPIRES_AT": "",
 	"HOSTNAME"          : "",
 	"STATSD_ADDR"       : "",
 	"STATSD_HOST_PATH"  : "",

--- a/config/config.readme
+++ b/config/config.readme
@@ -88,12 +88,32 @@ starts.
 - Notes: `dev` sets `SCHEMA_MANAGEMENT_MODE=migrate` and disables WPCOM
   notifications unless those keys are explicitly set. `production` sets
   `SCHEMA_MANAGEMENT_MODE=validate`, `CHECK_TARGET_SAFETY_MODE=public_only`,
-  `ROLLOUT_MODE=api-controlled`, and `VERIFLIER_DISCOVERY_MODE=shadow` unless
-  those keys are explicitly set. The Docker Monitor entrypoint also uses
+  `ROLLOUT_MODE=api-controlled`, `VERIFLIER_DISCOVERY_MODE=shadow`, HTTPS
+  Veriflier transport, and normal legacy WPCOM TLS verification unless those
+  keys are explicitly set. The Docker Monitor entrypoint also uses
   `CONFIG_PROFILE=production` as a
   render-time convenience to fill omitted production container defaults such as
   host-local StatsD, `HEAD` / `legacy` rollout checks, and `DEBUG_PORT=0`;
   review the rendered JSON before activation.
+
+### PRODUCTION_SECURITY_EXCEPTIONS
+
+- Default: `[]`
+- Values: `plain_veriflier_transport`, `plain_monitor_api`,
+  `allow_private_targets`, `legacy_wpcom_insecure_tls`
+- Example:
+
+  ```json
+  "PRODUCTION_SECURITY_EXCEPTIONS": ["legacy_wpcom_insecure_tls"],
+  "PRODUCTION_SECURITY_EXCEPTION_REASON": "temporary WPCOM legacy rollout parity",
+  "PRODUCTION_SECURITY_EXCEPTION_EXPIRES_AT": "2026-06-30T00:00:00Z"
+  ```
+
+- Purpose: temporary escape hatch for production fail-closed security checks.
+- Notes: exceptions are accepted only with `CONFIG_PROFILE=production`, a
+  non-empty reason, and a future RFC3339 expiry. Do not use them for normal
+  rollout posture. The Docker entrypoint accepts a comma-separated
+  `PRODUCTION_SECURITY_EXCEPTIONS` render input.
 
 ### SCHEMA_MANAGEMENT_MODE
 
@@ -516,14 +536,14 @@ observed rate/latency, and avoids per-probe healthy freshness writes.
 
 ### WPCOM_NOTIFY_LEGACY_INSECURE_SKIP_VERIFY
 
-- Default: `true`
+- Default: `true`; production profile default: `false`
 - Values: `true`, `false`
 - Example: `"WPCOM_NOTIFY_LEGACY_INSECURE_SKIP_VERIFY": false`
 - Purpose: controls TLS server verification for legacy WPCOM mode.
-- Notes: `true` preserves v1's `rejectUnauthorized=false` behavior for initial
-  compatibility, but it is exposed to man-in-the-middle risk. Set false after
-  the legacy endpoint is confirmed to work with normal TLS verification from
-  the production container network.
+- Notes: `true` preserves v1's `rejectUnauthorized=false` behavior but is
+  exposed to man-in-the-middle risk. Production refuses it unless
+  `PRODUCTION_SECURITY_EXCEPTIONS` includes `legacy_wpcom_insecure_tls` with a
+  reason and future expiry.
 
 ### WPCOM_NOTIFY_MODERN_ENDPOINT
 
@@ -823,6 +843,9 @@ The standalone Veriflier has a separate small JSON file:
   balancer and have Monitors use an HTTPS endpoint.
 - `enable_legacy_http`: optional lab/emergency compatibility switch for
   legacy-compatible `/check` and `/status`; default false.
+- `/v2/status`: unauthenticated requests return only minimal health/protocol
+  readiness. Requests with the correct Bearer token return full version,
+  vantage, capacity, and capability details used by rollout preflight.
 - `check_target_safety_mode`: outbound SSRF safety policy for Veriflier HTTP
   probes. Values match Monitor: `public_only` (default) or
   `allow_private_for_tests`. Keep `public_only` for production and real site

--- a/docker/run-jetmon.sh
+++ b/docker/run-jetmon.sh
@@ -24,6 +24,31 @@ bool_json() {
 	esac
 }
 
+json_string_array() {
+	local raw="${1:-}"
+	if [ -z "$raw" ]; then
+		printf '[]'
+		return
+	fi
+	local first=1
+	local item
+	printf '['
+	IFS=',' read -ra items <<< "$raw"
+	for item in "${items[@]}"; do
+		item="${item#"${item%%[![:space:]]*}"}"
+		item="${item%"${item##*[![:space:]]}"}"
+		if [ -z "$item" ]; then
+			continue
+		fi
+		if [ "$first" -eq 0 ]; then
+			printf ','
+		fi
+		first=0
+		printf '"%s"' "$(sed_escape "$item")"
+	done
+	printf ']'
+}
+
 config_profile_render_value() {
 	local value="${CONFIG_PROFILE:-}"
 	case "$value" in
@@ -46,6 +71,8 @@ render_config() {
 	local target=$1
 	local config_profile
 	config_profile="$(config_profile_render_value)"
+	local production_security_exceptions
+	production_security_exceptions="$(json_string_array "${PRODUCTION_SECURITY_EXCEPTIONS:-}")"
 	local schema_management_mode="${SCHEMA_MANAGEMENT_MODE:-}"
 	local statsd_addr="${STATSD_ADDR:-}"
 	local check_target_safety_mode="${CHECK_TARGET_SAFETY_MODE:-public_only}"
@@ -59,6 +86,8 @@ render_config() {
 	local debug_port="${DEBUG_PORT:-6060}"
 	local wpcom_notify_default=false
 	local wpcom_notify_enable
+	local wpcom_legacy_insecure_default=true
+	local wpcom_legacy_insecure
 	local smtp_use_tls
 	if [ -z "$schema_management_mode" ]; then
 		if [ "$config_profile" = "dev" ]; then
@@ -76,12 +105,17 @@ render_config() {
 		veriflier_transport_scheme="${veriflier_transport_scheme:-https}"
 		debug_port="${DEBUG_PORT:-0}"
 		wpcom_notify_default=true
+		wpcom_legacy_insecure_default=false
 	fi
 	wpcom_notify_enable="$(bool_json WPCOM_NOTIFY_ENABLE "${WPCOM_NOTIFY_ENABLE:-$wpcom_notify_default}")"
+	wpcom_legacy_insecure="$(bool_json WPCOM_NOTIFY_LEGACY_INSECURE_SKIP_VERIFY "${WPCOM_NOTIFY_LEGACY_INSECURE_SKIP_VERIFY:-$wpcom_legacy_insecure_default}")"
 	smtp_use_tls="$(bool_json SMTP_USE_TLS "${SMTP_USE_TLS:-false}")"
 	sed \
 		-e "s|<AUTH_TOKEN>|$(sed_escape "${WPCOM_AUTH_TOKEN:-change_me}")|g" \
 		-e "s|\"CONFIG_PROFILE\"    : \"dev\"|\"CONFIG_PROFILE\"    : \"$(sed_escape "$config_profile")\"|g" \
+		-e "s|\"PRODUCTION_SECURITY_EXCEPTIONS\"         : \\[\\]|\"PRODUCTION_SECURITY_EXCEPTIONS\"         : ${production_security_exceptions}|g" \
+		-e "s|\"PRODUCTION_SECURITY_EXCEPTION_REASON\"  : \"\"|\"PRODUCTION_SECURITY_EXCEPTION_REASON\"  : \"$(sed_escape "${PRODUCTION_SECURITY_EXCEPTION_REASON:-}")\"|g" \
+		-e "s|\"PRODUCTION_SECURITY_EXCEPTION_EXPIRES_AT\": \"\"|\"PRODUCTION_SECURITY_EXCEPTION_EXPIRES_AT\": \"$(sed_escape "${PRODUCTION_SECURITY_EXCEPTION_EXPIRES_AT:-}")\"|g" \
 		-e "s|\"HOSTNAME\"          : \"\"|\"HOSTNAME\"          : \"$(sed_escape "${JETMON_HOSTNAME:-}")\"|g" \
 		-e "s|\"STATSD_ADDR\"       : \"\"|\"STATSD_ADDR\"       : \"$(sed_escape "$statsd_addr")\"|g" \
 		-e "s|\"STATSD_HOST_PATH\"  : \"\"|\"STATSD_HOST_PATH\"  : \"$(sed_escape "${STATSD_HOST_PATH:-}")\"|g" \
@@ -102,6 +136,7 @@ render_config() {
 		-e "s|<VERIFLIER_AUTH_TOKEN>|$(sed_escape "${VERIFLIER_AUTH_TOKEN:-veriflier_1_auth_token}")|g" \
 		-e 's|"API_PORT"       : 0|"API_PORT"       : 8090|g' \
 		-e "s|\"WPCOM_NOTIFY_ENABLE\"          : false|\"WPCOM_NOTIFY_ENABLE\"          : ${wpcom_notify_enable}|g" \
+		-e "s|\"WPCOM_NOTIFY_LEGACY_INSECURE_SKIP_VERIFY\": true|\"WPCOM_NOTIFY_LEGACY_INSECURE_SKIP_VERIFY\": ${wpcom_legacy_insecure}|g" \
 		-e "s|\"CHECK_TARGET_SAFETY_MODE\"     : \"public_only\"|\"CHECK_TARGET_SAFETY_MODE\"     : \"$(sed_escape "$check_target_safety_mode")\"|g" \
 		-e "s|\"DEFAULT_CHECK_METHOD\"         : \"GET\"|\"DEFAULT_CHECK_METHOD\"         : \"$(sed_escape "${default_check_method:-GET}")\"|g" \
 		-e "s|\"DEFAULT_DETECTION_PROFILE\"    : \"full\"|\"DEFAULT_DETECTION_PROFILE\"    : \"$(sed_escape "${default_detection_profile:-full}")\"|g" \

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -158,6 +158,8 @@ Important production render inputs:
 | `VERIFLIER_DISCOVERY_MODE` | `shadow` until registry drift is accepted. |
 | `VERIFLIER_TRANSPORT_SCHEME` | `https` for public Veriflier endpoints. |
 | `WPCOM_NOTIFY_ENABLE` | `true` for production drop-in rollout; false only in isolated labs. |
+| `WPCOM_NOTIFY_LEGACY_INSECURE_SKIP_VERIFY` | `false`; temporary `true` requires a production security exception. |
+| `PRODUCTION_SECURITY_EXCEPTIONS` | Empty unless a documented temporary exception is approved. |
 | `API_PUBLIC_BASE_URL` or `API_TLS_CERT_PATH` / `API_TLS_KEY_PATH` | Required when operators reach the Monitor API over a network path that leaves localhost/private host scope. |
 | `CHECK_HISTORY_MODE_DEFAULT` | `status_change` unless a focused test needs more. |
 | `AUDIT_LOG_MODE_DEFAULT` | `operational` for rollout evidence without read firehose noise. |
@@ -166,6 +168,11 @@ Important production render inputs:
 
 Set production defaults explicitly even when the entrypoint has the same
 fallback. Visible config review matters more than implicit defaults.
+
+Production config validation fails closed for plain Monitor API exposure, plain
+Monitor-to-Veriflier transport, test-only private-target checks, and insecure
+legacy WPCOM TLS. A temporary exception must be explicit, reasoned, and have a
+future expiry in the rendered config.
 
 ## Schema Posture
 

--- a/docs/project.md
+++ b/docs/project.md
@@ -158,6 +158,11 @@ version, capacity, vantage, and capability flags used by rollout gates. Quorum
 may exclude unhealthy vantages but must respect a configured floor so one
 Veriflier cannot confirm downtime alone.
 
+When Veriflier behavior that production rollout depends on is added, removed,
+or materially changed, update the advertised capability flags, the server
+capability values, rollout preflight requirements, `/v2/status` tests, rollout
+preflight tests, and the relevant docs in the same change.
+
 Webhooks and alert contacts consume event transitions through high-water marks,
 create delivery rows, claim rows transactionally, and retry:
 

--- a/docs/project.md
+++ b/docs/project.md
@@ -152,9 +152,11 @@ one v2 host can replace one v1 range.
 
 V2 Monitors call v2 Verifliers over JSON/HTTP(S). Production Verifliers are
 public-web services, so Monitor-to-Veriflier traffic must use HTTPS. Bearer
-tokens are an auth mechanism, not transport security. Quorum may exclude
-unhealthy vantages but must respect a configured floor so one Veriflier cannot
-confirm downtime alone.
+tokens are an auth mechanism, not transport security. Unauthenticated
+`/v2/status` returns minimal health only; authenticated status returns the
+version, capacity, vantage, and capability flags used by rollout gates. Quorum
+may exclude unhealthy vantages but must respect a configured floor so one
+Veriflier cannot confirm downtime alone.
 
 Webhooks and alert contacts consume event transitions through high-water marks,
 create delivery rows, claim rows transactionally, and retry:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -38,6 +38,9 @@ Near-term:
 - validate `/v2/check` and `/v2/status` under production-like load;
 - improve quorum diagnostics for disagreement, overload, and stale vantages;
 - keep a quorum floor that prevents one Veriflier from confirming downtime.
+- add replay-resistant Monitor-to-Veriflier request signing after canary
+  evidence. Prefer HMAC over method, path, body digest, timestamp, and request
+  ID unless Systems wants to own mTLS client-cert lifecycle.
 
 Future options should wait for production evidence: stronger v2 probe metadata,
 peer mesh, central scheduler plus regional agents, always-on multi-region

--- a/docs/v1-to-v2-migration.md
+++ b/docs/v1-to-v2-migration.md
@@ -20,7 +20,7 @@ deliverer rollout notes into one runbook.
 | Gate | Evidence |
 | --- | --- |
 | Schema/config | Systems-applied DDL from [production-schema.md](production-schema.md), `schema validate`, `validate-config`, and API preflight pass. |
-| Verifliers | `/v2/status` and quorum report are green. |
+| Verifliers | Authenticated `/v2/status`, required capability flags, and quorum report are green. |
 | Images | CI-built tags promoted by Systems. |
 | WPCOM | Legacy notification path tested. |
 | Operator CLI | Token, base URL, and `--allow-remote` policy are ready. |
@@ -69,7 +69,7 @@ V2 Monitors use v2 Verifliers over JSON/HTTP(S) only:
 
 | Endpoint | Purpose |
 | --- | --- |
-| `/v2/status` | Health and capacity. |
+| `/v2/status` | Public minimal health; authenticated detailed health, capacity, and capability flags. |
 | `/v2/check` | Batch check request. |
 
 Production Verifliers are public-web services. Do not run production
@@ -81,8 +81,10 @@ trusted proxy/load balancer in front of the Veriflier container. The repo
 includes a Caddy production Compose path that binds public `80/443`, terminates
 TLS with ACME, and leaves the Veriflier app port loopback/private.
 
-Confirm HTTPS reachability, auth token presence, enough healthy vantages for
-quorum, host resource limits, and stdout/stderr logging.
+Confirm HTTPS reachability, auth token presence, required capability flags,
+enough healthy vantages for quorum, host resource limits, and stdout/stderr
+logging. Production Verifliers must not advertise legacy HTTP endpoints unless
+an approved temporary exception exists.
 
 ## Operator Setup
 

--- a/internal/api/handlers_rollout.go
+++ b/internal/api/handlers_rollout.go
@@ -238,16 +238,17 @@ type rolloutComparisonResult struct {
 }
 
 type rolloutVeriflierPreflightResult struct {
-	Name         string   `json:"name,omitempty"`
-	Address      string   `json:"address"`
-	Status       string   `json:"status"`
-	Version      string   `json:"version,omitempty"`
-	Protocols    []string `json:"protocols,omitempty"`
-	VantageID    string   `json:"vantage_id,omitempty"`
-	AgentID      string   `json:"agent_id,omitempty"`
-	Healthy      bool     `json:"healthy"`
-	V2Compatible bool     `json:"v2_compatible"`
-	Error        string   `json:"error,omitempty"`
+	Name         string                 `json:"name,omitempty"`
+	Address      string                 `json:"address"`
+	Status       string                 `json:"status"`
+	Version      string                 `json:"version,omitempty"`
+	Protocols    []string               `json:"protocols,omitempty"`
+	VantageID    string                 `json:"vantage_id,omitempty"`
+	AgentID      string                 `json:"agent_id,omitempty"`
+	Capabilities veriflier.Capabilities `json:"capabilities,omitempty"`
+	Healthy      bool                   `json:"healthy"`
+	V2Compatible bool                   `json:"v2_compatible"`
+	Error        string                 `json:"error,omitempty"`
 }
 
 func (s *Server) handleRolloutCapabilities(w http.ResponseWriter, r *http.Request) {
@@ -1872,10 +1873,17 @@ func (s *Server) rolloutVeriflierPreflight(ctx context.Context, cfg *config.Conf
 		result.Protocols = status.Protocols
 		result.VantageID = status.Vantage.ID
 		result.AgentID = status.Agent.ID
+		result.Capabilities = status.Capabilities
 		result.V2Compatible = stringSliceContains(status.Protocols, veriflier.ProtocolV2)
 		result.Healthy = strings.EqualFold(status.Status, "ok") && result.V2Compatible && result.VantageID != ""
 		if !result.V2Compatible {
 			blockers = append(blockers, fmt.Sprintf("%s does not advertise %s", name, veriflier.ProtocolV2))
+		}
+		if cfg.ConfigProfile == config.ConfigProfileProduction && stringSliceContains(status.Protocols, veriflier.ProtocolLegacy) {
+			blockers = append(blockers, fmt.Sprintf("%s advertises legacy Veriflier HTTP endpoints; disable VERIFLIER_ENABLE_LEGACY_HTTP for production", name))
+		}
+		for _, missing := range missingRequiredVeriflierCapabilities(status.Capabilities) {
+			blockers = append(blockers, fmt.Sprintf("%s missing required Veriflier capability: %s", name, missing))
 		}
 		if result.VantageID == "" {
 			blockers = append(blockers, fmt.Sprintf("%s did not report a quorum-counted vantage id", name))
@@ -2001,6 +2009,26 @@ func stringSliceContains(values []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func missingRequiredVeriflierCapabilities(caps veriflier.Capabilities) []string {
+	var missing []string
+	if !caps.BatchErrorIsolation {
+		missing = append(missing, "batch_error_isolation")
+	}
+	if !caps.AuthRequired {
+		missing = append(missing, "auth_required")
+	}
+	if !caps.ProbeSafetyNonVote {
+		missing = append(missing, "probe_safety_non_vote")
+	}
+	if !caps.StatusDetailAuth {
+		missing = append(missing, "status_detail_auth")
+	}
+	if caps.MaxRequestBodyBytes <= 0 {
+		missing = append(missing, "max_request_body_bytes")
+	}
+	return missing
 }
 
 func (s *Server) countPolicyStageEligible(ctx context.Context, min, max int, method, profile string) (int, error) {

--- a/internal/api/handlers_rollout_test.go
+++ b/internal/api/handlers_rollout_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Automattic/jetmon/internal/checker"
 	"github.com/Automattic/jetmon/internal/checkmode"
+	"github.com/Automattic/jetmon/internal/veriflier"
 	"github.com/DATA-DOG/go-sqlmock"
 )
 
@@ -113,6 +114,32 @@ func TestRolloutOperatorBindsToAPIKeyID(t *testing.T) {
 	req := requestWithKey(http.MethodPost, "/api/v1/rollout/seed", key)
 	if got := rolloutOperator(req); got != "test-consumer#1" {
 		t.Fatalf("rolloutOperator = %q, want test-consumer#1", got)
+	}
+}
+
+func TestMissingRequiredVeriflierCapabilities(t *testing.T) {
+	ok := veriflier.Capabilities{
+		BatchErrorIsolation: true,
+		AuthRequired:        true,
+		ProbeSafetyNonVote:  true,
+		StatusDetailAuth:    true,
+		MaxRequestBodyBytes: 10,
+	}
+	if missing := missingRequiredVeriflierCapabilities(ok); len(missing) != 0 {
+		t.Fatalf("missingRequiredVeriflierCapabilities(ok) = %#v, want none", missing)
+	}
+
+	missing := missingRequiredVeriflierCapabilities(veriflier.Capabilities{})
+	for _, want := range []string{
+		"batch_error_isolation",
+		"auth_required",
+		"probe_safety_non_vote",
+		"status_detail_auth",
+		"max_request_body_bytes",
+	} {
+		if !containsString(missing, want) {
+			t.Fatalf("missing capabilities = %#v, want %s", missing, want)
+		}
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/Automattic/jetmon/internal/checkmode"
 )
@@ -46,6 +47,13 @@ const (
 const (
 	ConfigProfileDev        = "dev"
 	ConfigProfileProduction = "production"
+)
+
+const (
+	ProductionSecurityExceptionPlainVeriflierTransport = "plain_veriflier_transport"
+	ProductionSecurityExceptionPlainMonitorAPI         = "plain_monitor_api"
+	ProductionSecurityExceptionAllowPrivateTargets     = "allow_private_targets"
+	ProductionSecurityExceptionLegacyWPCOMInsecureTLS  = "legacy_wpcom_insecure_tls"
 )
 
 const (
@@ -84,6 +92,13 @@ type Config struct {
 	// ConfigProfile applies a small named set of production posture defaults
 	// before explicit config values are decoded. Explicit keys always win.
 	ConfigProfile string `json:"CONFIG_PROFILE"`
+
+	// ProductionSecurityExceptions are temporary, explicit launch exceptions for
+	// production fail-closed checks. Each exception must have a reason and future
+	// expiry so migration-only weak posture cannot silently linger.
+	ProductionSecurityExceptions       []string `json:"PRODUCTION_SECURITY_EXCEPTIONS"`
+	ProductionSecurityExceptionReason  string   `json:"PRODUCTION_SECURITY_EXCEPTION_REASON"`
+	ProductionSecurityExceptionExpires string   `json:"PRODUCTION_SECURITY_EXCEPTION_EXPIRES_AT"`
 
 	// Hostname is the stable Jetmon identity used for host ownership, process
 	// health, and outbound notification identity.
@@ -531,6 +546,7 @@ func applyConfigProfile(raw []byte, cfg *Config) error {
 		cfg.RolloutMode = RolloutModeAPIControlled
 		cfg.VeriflierDiscoveryMode = VeriflierDiscoveryModeShadow
 		cfg.VeriflierTransportScheme = VeriflierTransportHTTPS
+		cfg.WPCOMNotifyLegacyInsecure = false
 	default:
 		return fmt.Errorf("invalid config: CONFIG_PROFILE must be one of: dev, production")
 	}
@@ -842,6 +858,10 @@ func validate(cfg *Config) error {
 	default:
 		return fmt.Errorf("CONFIG_PROFILE must be one of: dev, production")
 	}
+	exceptions, err := validateProductionSecurityExceptions(cfg)
+	if err != nil {
+		return err
+	}
 	cfg.Hostname = strings.TrimSpace(cfg.Hostname)
 	cfg.StatsDAddr = strings.TrimSpace(cfg.StatsDAddr)
 	if err := validateStatsDAddr(cfg.StatsDAddr); err != nil {
@@ -944,6 +964,11 @@ func validate(cfg *Config) error {
 	default:
 		return fmt.Errorf("WPCOM_NOTIFY_MODE must be one of: legacy, modern")
 	}
+	if cfg.ConfigProfile == ConfigProfileProduction && cfg.WPCOMNotifyEnable &&
+		cfg.WPCOMNotifyMode == WPCOMNotifyModeLegacy && cfg.WPCOMNotifyLegacyInsecure &&
+		!exceptions[ProductionSecurityExceptionLegacyWPCOMInsecureTLS] {
+		return fmt.Errorf("WPCOM_NOTIFY_LEGACY_INSECURE_SKIP_VERIFY=true is refused in production without %s", ProductionSecurityExceptionLegacyWPCOMInsecureTLS)
+	}
 	switch cfg.SchedulerEngine {
 	case "", "streaming":
 		cfg.SchedulerEngine = "streaming"
@@ -983,6 +1008,10 @@ func validate(cfg *Config) error {
 	if cfg.CheckTargetSafetyMode == CheckTargetSafetyModeAllowPrivateForTests && cfg.WPCOMNotifyEnable {
 		return fmt.Errorf("CHECK_TARGET_SAFETY_MODE=allow_private_for_tests requires WPCOM_NOTIFY_ENABLE=false")
 	}
+	if cfg.ConfigProfile == ConfigProfileProduction && cfg.CheckTargetSafetyMode == CheckTargetSafetyModeAllowPrivateForTests &&
+		!exceptions[ProductionSecurityExceptionAllowPrivateTargets] {
+		return fmt.Errorf("CHECK_TARGET_SAFETY_MODE=allow_private_for_tests is refused in production without %s", ProductionSecurityExceptionAllowPrivateTargets)
+	}
 	cfg.VeriflierDiscoveryMode = normalizeVeriflierDiscoveryMode(cfg.VeriflierDiscoveryMode)
 	switch cfg.VeriflierDiscoveryMode {
 	case VeriflierDiscoveryModeStatic, VeriflierDiscoveryModeShadow, VeriflierDiscoveryModeActive:
@@ -997,6 +1026,10 @@ func validate(cfg *Config) error {
 	case VeriflierTransportHTTP, VeriflierTransportHTTPS:
 	default:
 		return fmt.Errorf("VERIFLIER_TRANSPORT_SCHEME must be one of: http, https")
+	}
+	if cfg.ConfigProfile == ConfigProfileProduction && cfg.VeriflierTransportScheme == VeriflierTransportHTTP &&
+		!exceptions[ProductionSecurityExceptionPlainVeriflierTransport] {
+		return fmt.Errorf("VERIFLIER_TRANSPORT_SCHEME=http is refused in production without %s", ProductionSecurityExceptionPlainVeriflierTransport)
 	}
 	cfg.APITLSCertPath = strings.TrimSpace(cfg.APITLSCertPath)
 	cfg.APITLSKeyPath = strings.TrimSpace(cfg.APITLSKeyPath)
@@ -1013,6 +1046,10 @@ func validate(cfg *Config) error {
 		if strings.ToLower(u.Scheme) != "https" {
 			return fmt.Errorf("API_PUBLIC_BASE_URL must use https")
 		}
+	}
+	if cfg.ConfigProfile == ConfigProfileProduction && cfg.APIPort > 0 && !cfg.MonitorAPITransportEncrypted() &&
+		!exceptions[ProductionSecurityExceptionPlainMonitorAPI] {
+		return fmt.Errorf("production API_PORT requires API_TLS_CERT_PATH/API_TLS_KEY_PATH or API_PUBLIC_BASE_URL=https://... without %s", ProductionSecurityExceptionPlainMonitorAPI)
 	}
 	if cfg.LogFormat != "text" && cfg.LogFormat != "json" {
 		return fmt.Errorf("LOG_FORMAT must be 'text' or 'json'")
@@ -1080,8 +1117,59 @@ func validate(cfg *Config) error {
 		if scheme := v.TransportScheme(); scheme != "" && scheme != VeriflierTransportHTTP && scheme != VeriflierTransportHTTPS {
 			return fmt.Errorf("VERIFLIERS[%d] (%s): scheme must be one of: http, https", i, displayName(v, i))
 		}
+		if cfg.ConfigProfile == ConfigProfileProduction && v.TransportScheme() == VeriflierTransportHTTP &&
+			!exceptions[ProductionSecurityExceptionPlainVeriflierTransport] {
+			return fmt.Errorf("VERIFLIERS[%d] (%s): scheme=http is refused in production without %s", i, displayName(v, i), ProductionSecurityExceptionPlainVeriflierTransport)
+		}
 	}
 	return nil
+}
+
+func validateProductionSecurityExceptions(cfg *Config) (map[string]bool, error) {
+	allowed := map[string]struct{}{
+		ProductionSecurityExceptionPlainVeriflierTransport: {},
+		ProductionSecurityExceptionPlainMonitorAPI:         {},
+		ProductionSecurityExceptionAllowPrivateTargets:     {},
+		ProductionSecurityExceptionLegacyWPCOMInsecureTLS:  {},
+	}
+	out := make(map[string]bool, len(cfg.ProductionSecurityExceptions))
+	normalized := make([]string, 0, len(cfg.ProductionSecurityExceptions))
+	for _, raw := range cfg.ProductionSecurityExceptions {
+		exception := strings.TrimSpace(strings.ToLower(raw))
+		if exception == "" {
+			continue
+		}
+		if _, ok := allowed[exception]; !ok {
+			return nil, fmt.Errorf("PRODUCTION_SECURITY_EXCEPTIONS contains unknown exception %q", raw)
+		}
+		out[exception] = true
+		normalized = append(normalized, exception)
+	}
+	cfg.ProductionSecurityExceptions = normalized
+	if len(out) == 0 {
+		cfg.ProductionSecurityExceptionReason = strings.TrimSpace(cfg.ProductionSecurityExceptionReason)
+		cfg.ProductionSecurityExceptionExpires = strings.TrimSpace(cfg.ProductionSecurityExceptionExpires)
+		return out, nil
+	}
+	if cfg.ConfigProfile != ConfigProfileProduction {
+		return nil, fmt.Errorf("PRODUCTION_SECURITY_EXCEPTIONS may only be set when CONFIG_PROFILE=production")
+	}
+	cfg.ProductionSecurityExceptionReason = strings.TrimSpace(cfg.ProductionSecurityExceptionReason)
+	if cfg.ProductionSecurityExceptionReason == "" {
+		return nil, fmt.Errorf("PRODUCTION_SECURITY_EXCEPTION_REASON is required when PRODUCTION_SECURITY_EXCEPTIONS is set")
+	}
+	cfg.ProductionSecurityExceptionExpires = strings.TrimSpace(cfg.ProductionSecurityExceptionExpires)
+	if cfg.ProductionSecurityExceptionExpires == "" {
+		return nil, fmt.Errorf("PRODUCTION_SECURITY_EXCEPTION_EXPIRES_AT is required when PRODUCTION_SECURITY_EXCEPTIONS is set")
+	}
+	expires, err := time.Parse(time.RFC3339, cfg.ProductionSecurityExceptionExpires)
+	if err != nil {
+		return nil, fmt.Errorf("PRODUCTION_SECURITY_EXCEPTION_EXPIRES_AT must be RFC3339: %w", err)
+	}
+	if !expires.After(time.Now().UTC()) {
+		return nil, fmt.Errorf("PRODUCTION_SECURITY_EXCEPTION_EXPIRES_AT must be in the future")
+	}
+	return out, nil
 }
 
 // StatsDMetricHost returns the host path segment used in StatsD metric names.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -525,6 +525,9 @@ func TestLoadProductionProfileAppliesProductionDefaults(t *testing.T) {
 	if cfg.VeriflierTransportScheme != VeriflierTransportHTTPS {
 		t.Fatalf("VeriflierTransportScheme = %q, want https", cfg.VeriflierTransportScheme)
 	}
+	if cfg.WPCOMNotifyLegacyInsecure {
+		t.Fatal("WPCOMNotifyLegacyInsecure = true, want false for production default")
+	}
 }
 
 func TestLoadDevProfileAppliesDevDefaults(t *testing.T) {
@@ -754,6 +757,98 @@ func TestValidateAllowPrivateTargetsRequiresNotificationsDisabled(t *testing.T) 
 	cfg.WPCOMNotifyEnable = false
 	if err := validate(cfg); err != nil {
 		t.Fatalf("validate() rejected test-only private target bypass with notifications disabled: %v", err)
+	}
+}
+
+func TestValidateProductionRejectsUnsafePostureWithoutException(t *testing.T) {
+	tests := []struct {
+		name   string
+		update func(*Config)
+		want   string
+	}{
+		{
+			name: "plain default veriflier transport",
+			update: func(cfg *Config) {
+				cfg.VeriflierTransportScheme = VeriflierTransportHTTP
+			},
+			want: ProductionSecurityExceptionPlainVeriflierTransport,
+		},
+		{
+			name: "plain per-veriflier transport",
+			update: func(cfg *Config) {
+				cfg.VeriflierTransportScheme = VeriflierTransportHTTPS
+				cfg.Verifiers = []VerifierConfig{{Name: "edge", Host: "edge.example", Port: "7803", Scheme: VeriflierTransportHTTP}}
+			},
+			want: ProductionSecurityExceptionPlainVeriflierTransport,
+		},
+		{
+			name: "plain monitor API",
+			update: func(cfg *Config) {
+				cfg.APIPort = 8090
+			},
+			want: ProductionSecurityExceptionPlainMonitorAPI,
+		},
+		{
+			name: "private target bypass",
+			update: func(cfg *Config) {
+				cfg.WPCOMNotifyEnable = false
+				cfg.CheckTargetSafetyMode = CheckTargetSafetyModeAllowPrivateForTests
+			},
+			want: ProductionSecurityExceptionAllowPrivateTargets,
+		},
+		{
+			name: "legacy WPCOM insecure TLS",
+			update: func(cfg *Config) {
+				cfg.WPCOMNotifyEnable = true
+				cfg.WPCOMNotifyMode = WPCOMNotifyModeLegacy
+				cfg.WPCOMNotifyLegacyInsecure = true
+			},
+			want: ProductionSecurityExceptionLegacyWPCOMInsecureTLS,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := baseValidConfig()
+			cfg.ConfigProfile = ConfigProfileProduction
+			cfg.VeriflierTransportScheme = VeriflierTransportHTTPS
+			cfg.WPCOMNotifyLegacyInsecure = false
+			tt.update(cfg)
+			err := validate(cfg)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("validate() error = %v, want %s", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateProductionAllowsTemporarySecurityException(t *testing.T) {
+	cfg := baseValidConfig()
+	cfg.ConfigProfile = ConfigProfileProduction
+	cfg.VeriflierTransportScheme = VeriflierTransportHTTP
+	cfg.ProductionSecurityExceptions = []string{ProductionSecurityExceptionPlainVeriflierTransport}
+	cfg.ProductionSecurityExceptionReason = "temporary rehearsal exception"
+	cfg.ProductionSecurityExceptionExpires = "2099-01-01T00:00:00Z"
+	cfg.WPCOMNotifyLegacyInsecure = false
+
+	if err := validate(cfg); err != nil {
+		t.Fatalf("validate() rejected temporary exception: %v", err)
+	}
+}
+
+func TestValidateProductionSecurityExceptionRequiresReasonAndFutureExpiry(t *testing.T) {
+	cfg := baseValidConfig()
+	cfg.ConfigProfile = ConfigProfileProduction
+	cfg.ProductionSecurityExceptions = []string{ProductionSecurityExceptionPlainMonitorAPI}
+	cfg.ProductionSecurityExceptionExpires = "2099-01-01T00:00:00Z"
+	if err := validate(cfg); err == nil || !strings.Contains(err.Error(), "PRODUCTION_SECURITY_EXCEPTION_REASON") {
+		t.Fatalf("validate() error = %v, want reason failure", err)
+	}
+
+	cfg.ProductionSecurityExceptionReason = "temporary rehearsal exception"
+	cfg.ProductionSecurityExceptionExpires = "2000-01-01T00:00:00Z"
+	if err := validate(cfg); err == nil || !strings.Contains(err.Error(), "must be in the future") {
+		t.Fatalf("validate() error = %v, want expiry failure", err)
 	}
 }
 

--- a/internal/veriflier/client.go
+++ b/internal/veriflier/client.go
@@ -749,6 +749,9 @@ func (c *VeriflierClient) Status(ctx context.Context) (*StatusV2Response, error)
 	if err != nil {
 		return nil, err
 	}
+	if c.authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.authToken)
+	}
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, v2TransportError{endpoint: "/v2/status", err: err}
@@ -775,6 +778,9 @@ func (c *VeriflierClient) statusV2(ctx context.Context) (*StatusV2Response, erro
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
+	}
+	if c.authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/internal/veriflier/server.go
+++ b/internal/veriflier/server.go
@@ -363,7 +363,26 @@ func (s *Server) handleV2Check(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleV2Status(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
+	if r.Header.Get("Authorization") == "" {
+		_ = json.NewEncoder(w).Encode(struct {
+			Status    string   `json:"status"`
+			Protocols []string `json:"protocols"`
+		}{
+			Status:    "OK",
+			Protocols: s.Protocols(),
+		})
+		return
+	}
+	if !s.authorized(r) {
+		incrementMetric("verifier.auth.rejected.count", 1)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
 	_ = json.NewEncoder(w).Encode(s.Status())
 }
 
@@ -396,20 +415,35 @@ func decodeSingleJSONValue(dec *json.Decoder, dst any) error {
 }
 
 func (s *Server) Status() StatusV2Response {
+	return StatusV2Response{
+		Status:       "OK",
+		Version:      s.version,
+		Commit:       s.commit,
+		BuildDate:    s.buildDate,
+		GoVersion:    s.goVersion,
+		Protocols:    s.Protocols(),
+		Vantage:      s.vantage,
+		Agent:        s.agent,
+		Capacity:     s.executor.Capacity(),
+		Capabilities: s.Capabilities(),
+	}
+}
+
+func (s *Server) Protocols() []string {
 	protocols := []string{ProtocolV2}
 	if s.legacy {
 		protocols = append(protocols, ProtocolLegacy)
 	}
-	return StatusV2Response{
-		Status:    "OK",
-		Version:   s.version,
-		Commit:    s.commit,
-		BuildDate: s.buildDate,
-		GoVersion: s.goVersion,
-		Protocols: protocols,
-		Vantage:   s.vantage,
-		Agent:     s.agent,
-		Capacity:  s.executor.Capacity(),
+	return protocols
+}
+
+func (s *Server) Capabilities() Capabilities {
+	return Capabilities{
+		BatchErrorIsolation: true,
+		AuthRequired:        s.authToken != "",
+		ProbeSafetyNonVote:  true,
+		StatusDetailAuth:    true,
+		MaxRequestBodyBytes: maxRequestBodyBytes,
 	}
 }
 

--- a/internal/veriflier/types.go
+++ b/internal/veriflier/types.go
@@ -88,6 +88,9 @@ type Capacity struct {
 // Capabilities are behavior-level guarantees advertised by a Veriflier. Rollout
 // gates should key off these flags instead of a Git commit whenever possible so
 // cherry-picks and backports can still prove the behavior that production needs.
+// If a rollout-critical Veriflier feature is added, removed, or materially
+// changed, update this struct, Server.Capabilities, rollout preflight
+// requirements, tests, and docs in the same change.
 type Capabilities struct {
 	BatchErrorIsolation bool  `json:"batch_error_isolation"`
 	AuthRequired        bool  `json:"auth_required"`

--- a/internal/veriflier/types.go
+++ b/internal/veriflier/types.go
@@ -85,16 +85,28 @@ type Capacity struct {
 	AvgCheckMS     int `json:"avg_check_ms,omitempty"`
 }
 
+// Capabilities are behavior-level guarantees advertised by a Veriflier. Rollout
+// gates should key off these flags instead of a Git commit whenever possible so
+// cherry-picks and backports can still prove the behavior that production needs.
+type Capabilities struct {
+	BatchErrorIsolation bool  `json:"batch_error_isolation"`
+	AuthRequired        bool  `json:"auth_required"`
+	ProbeSafetyNonVote  bool  `json:"probe_safety_non_vote"`
+	StatusDetailAuth    bool  `json:"status_detail_auth"`
+	MaxRequestBodyBytes int64 `json:"max_request_body_bytes,omitempty"`
+}
+
 type StatusV2Response struct {
-	Status    string   `json:"status"`
-	Version   string   `json:"version"`
-	Commit    string   `json:"commit"`
-	BuildDate string   `json:"build_date"`
-	GoVersion string   `json:"go_version"`
-	Protocols []string `json:"protocols"`
-	Vantage   Vantage  `json:"vantage"`
-	Agent     Agent    `json:"agent"`
-	Capacity  Capacity `json:"capacity"`
+	Status       string       `json:"status"`
+	Version      string       `json:"version"`
+	Commit       string       `json:"commit"`
+	BuildDate    string       `json:"build_date"`
+	GoVersion    string       `json:"go_version"`
+	Protocols    []string     `json:"protocols"`
+	Vantage      Vantage      `json:"vantage"`
+	Agent        Agent        `json:"agent"`
+	Capacity     Capacity     `json:"capacity"`
+	Capabilities Capabilities `json:"capabilities"`
 }
 
 type BodyRules struct {

--- a/internal/veriflier/veriflier_test.go
+++ b/internal/veriflier/veriflier_test.go
@@ -1694,6 +1694,54 @@ func TestServerHandleV2Status(t *testing.T) {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
 
+	var publicStatus struct {
+		Status    string   `json:"status"`
+		Version   string   `json:"version"`
+		Protocols []string `json:"protocols"`
+		Vantage   Vantage  `json:"vantage"`
+		Capacity  Capacity `json:"capacity"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&publicStatus); err != nil {
+		t.Fatalf("decode public status: %v", err)
+	}
+	if publicStatus.Status != "OK" {
+		t.Fatalf("public status = %q, want OK", publicStatus.Status)
+	}
+	if publicStatus.Version != "" || publicStatus.Vantage.ID != "" || publicStatus.Capacity.MaxConcurrency != 0 {
+		t.Fatalf("unauthenticated status leaked details: %+v", publicStatus)
+	}
+	if len(publicStatus.Protocols) != 1 || publicStatus.Protocols[0] != ProtocolV2 {
+		t.Fatalf("public protocols = %#v, want v2-only", publicStatus.Protocols)
+	}
+
+	badReq, err := http.NewRequest(http.MethodGet, ts.URL+"/v2/status", nil)
+	if err != nil {
+		t.Fatalf("new bad request: %v", err)
+	}
+	badReq.Header.Set("Authorization", "Bearer wrong")
+	badResp, err := http.DefaultClient.Do(badReq)
+	if err != nil {
+		t.Fatalf("bad auth request error: %v", err)
+	}
+	defer badResp.Body.Close()
+	if badResp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("bad auth status = %d, want 401", badResp.StatusCode)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/v2/status", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer secret")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("authenticated request error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("authenticated status = %d, want 200", resp.StatusCode)
+	}
+
 	var status StatusV2Response
 	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
 		t.Fatalf("decode: %v", err)
@@ -1718,6 +1766,10 @@ func TestServerHandleV2Status(t *testing.T) {
 	}
 	if status.Capacity.MaxConcurrency != 4 {
 		t.Fatalf("max concurrency = %d, want 4", status.Capacity.MaxConcurrency)
+	}
+	if !status.Capabilities.BatchErrorIsolation || !status.Capabilities.AuthRequired ||
+		!status.Capabilities.ProbeSafetyNonVote || !status.Capabilities.StatusDetailAuth {
+		t.Fatalf("capabilities = %+v, want required security capabilities", status.Capabilities)
 	}
 	if len(status.Protocols) != 1 || status.Protocols[0] != ProtocolV2 {
 		t.Fatalf("protocols = %#v, want v2-only by default", status.Protocols)


### PR DESCRIPTION
## Summary

This PR tightens several production security gates that came out of the v1/v2 security review.

Key changes:

- Split Veriflier `/v2/status` into a minimal public health response and an authenticated detailed response.
- Require Bearer auth for detailed Veriflier status fields such as version, commit, Go version, vantage, agent, capacity, and capabilities.
- Add Veriflier capability flags so rollout gates can verify behavior instead of depending on a specific commit SHA.
- Block production rollout preflight when Verifliers advertise legacy protocol support or miss required capability flags.
- Add production fail-closed config validation for plain Veriflier transport, plain Monitor API exposure, private-target test mode, and insecure legacy WPCOM TLS.
- Add explicit temporary production security exceptions with required reason and future expiry.
- Change the production profile default for legacy WPCOM insecure TLS verification to `false`.
- Document the new production posture controls and add replay-resistant Monitor-to-Veriflier request signing to the roadmap as a follow-up.

## Why

The immediate goal is to make weak production posture explicit and hard to miss during rollout. Public Verifliers should not expose detailed operational metadata without auth, production config should not silently accept insecure transport choices, and rollout checks should prove the Veriflier behavior that production depends on.

The HMAC/replay-resistant request signing work is intentionally deferred because it is a larger protocol change. This PR records it as a roadmap item while hardening the launch posture that can be validated now.

## Validation

- `go test -timeout=180s ./...`
- `go vet ./...`
- `make rollout-docs-verify`
- `bash -n docker/run-jetmon.sh`
- `git diff --check`