### PR TITLE
Fix wpcom notification failures by URL-encoding the data param

### DIFF
--- a/lib/wpcom.js
+++ b/lib/wpcom.js
@@ -29,7 +29,7 @@ var wpcom = {
 				port:     443,
 				key:      ssl_key,
 				cert:     ssl_cert,
-				path:     '/jetmon/?data=' + request_str,
+				path:     '/jetmon/?data=' + encodeURIComponent( request_str ),
 				method:   'GET',
 				rejectUnauthorized: false,
 			};


### PR DESCRIPTION
Related to MONI-13
## Summary

Jetmon builds its status-change notification to `jetpack.wordpress.com/jetmon/` as a **GET** request with the JSON payload concatenated **raw** into the query string (`/jetmon/?data=<json>`), with no URL-encoding. Any `monitor_url` (or other field) containing a character that is special in a query string breaks the request:

- **`&` (and `#`)** — sends fine, but splits the query string **server-side**, so PHP's `$_GET['data']` is truncated to invalid JSON and the endpoint responds `"Data parameter is invalid."`
- **spaces / non-Latin-1 characters** — Node's `https.request()` throws `ERR_UNESCAPED_CHARACTERS` **client-side**, before the request is sent.

In both cases the status change is silently dropped: the endpoint never records it and no notification reaches the site owner. This was confirmed in production via temporary endpoint logging — the `&`-truncation accounts for the large majority of the rejected requests (hundreds over a few hours), all `monitor_url`s with `?…&…` query strings.

## Changes

- `lib/wpcom.js`: wrap the payload in `encodeURIComponent()` when building the request path, so `&`, `#`, `+`, spaces and unicode are percent-encoded and the full JSON arrives intact.

```diff
- path:     '/jetmon/?data=' + request_str,
+ path:     '/jetmon/?data=' + encodeURIComponent( request_str ),
```

No endpoint change is required: PHP auto-URL-decodes `$_GET`, so the existing `stripslashes( $_GET['data'] )` in the `/jetmon/` handler keeps working unchanged.

## Affected Components

- WPCOM Integration (`lib/wpcom.js`)

## Testing

1. `cd docker && docker compose up -d`
2. Insert a test site whose `monitor_url` contains a `&` and trigger a status change (see `.claude/rules/running-tests.md`).
3. Confirm the outgoing request path is percent-encoded and the endpoint returns success rather than a 400.

## Deployment Notes

- Requires Systems team deployment to production hosts.
- Client-side only; safe to deploy independently of the wpcom endpoint (no coordinated change needed).
