### PR TITLE
Reorder checks in assign_to_worker

### DIFF
--- a/lib/jetmon.js
+++ b/lib/jetmon.js
@@ -604,11 +604,6 @@ function get_work_dataset( size ) {
  * @returns {null}
  */
 function assign_work_to_worker( pid, size = null ) {
-	const dataset = get_work_dataset( size );
-	if ( !dataset || dataset.length === 0 ) {
-		return false;
-	}
-
 	const worker = getWorker( pid );
 	if ( !worker ) {
 		return false;
@@ -618,6 +613,11 @@ function assign_work_to_worker( pid, size = null ) {
 		return false;
 	}
 
+	const dataset = get_work_dataset( size );
+	if ( !dataset || dataset.length === 0 ) {
+		return false;
+	}
+	
 	worker.send( {
 		pid: worker.pid,
 		request: 'queue-add',


### PR DESCRIPTION
get_work_dataset if pid is halted/dead will just drop all. We don't want that.