### PR TITLE
Fix status_id dropped from retried status-change notifications

### DIFF
--- a/lib/jetmon.js
+++ b/lib/jetmon.js
@@ -350,12 +350,13 @@ function checkHostStatus( veriflier_host, data ) {
 		if ( HOST_OFFLINE == data.status ) {
 			queuedRetries[ loop ].offline_confirms++;
 			if ( queuedRetries[ loop ].offline_confirms >= PEER_OFFLINE_LIMIT ) {
-				queuedRetries[ loop ].site_status = SITE_DOWN;
-				wpcom.notifyStatusChange( queuedRetries[ loop ],
+				var retryServer = queuedRetries[ loop ];
+				retryServer.site_status = SITE_DOWN;
+				wpcom.notifyStatusChange( retryServer,
 						function( reply ) {
 							if ( ! reply.success ) {
 								logger.error( 'error posting status change, retrying: ' + ( reply?.data || 'no error message' ) );
-								wpcom.notifyStatusChange( queuedRetries[ loop ],
+								wpcom.notifyStatusChange( retryServer,
 										function( reply ) {
 											if ( reply.success )
 												logger.trace( 'posted successfully' );
@@ -364,7 +365,7 @@ function checkHostStatus( veriflier_host, data ) {
 								});
 							}
 				});
-				slogger.trace( 'site_down: ' + JSON.stringify( queuedRetries[ loop ] ) );
+				slogger.trace( 'site_down: ' + JSON.stringify( retryServer ) );
 			}
 		}
 		break;


### PR DESCRIPTION
## Summary

`checkHostStatus` re-reads `queuedRetries[ loop ]` **by index** from inside the notify callback. `processQueuedRetries` splices that array every 5s, so by the time a retry runs the index can resolve to a different entry — one that never had `site_status` set. `status_id` is then dropped from the payload (`JSON.stringify` omits `undefined`) and wpcom rejects it with `"Required parameter is missing."`

**Only the retry is affected.** The first notification is sent synchronously in the same tick as the `site_status` assignment, so nothing can mutate the array in between and it always uses the correct entry. The bug is therefore reachable only when a first send fails and we retry.


## Changes

- Hold the queued entry itself rather than its index, so the retry always notifies for the site that was actually confirmed down.


## Deployment Notes

Requires Systems team deployment. Client-side only, no coordinated wpcom change.

Ref: MONI-14
